### PR TITLE
feat(ui): add visual indicator when in demo mode

### DIFF
--- a/web-app/src/components/layout/AppShell.test.tsx
+++ b/web-app/src/components/layout/AppShell.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AppShell } from "./AppShell";
+import { useAuthStore } from "@/stores/auth";
+import { setLocale } from "@/i18n";
+
+// Mock the auth store
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn(),
+}));
+
+describe("AppShell", () => {
+  const mockLogout = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLocale("en");
+  });
+
+  function renderAppShell() {
+    return render(
+      <MemoryRouter>
+        <AppShell />
+      </MemoryRouter>,
+    );
+  }
+
+  describe("demo mode banner", () => {
+    it("renders demo banner when isDemoMode is true", () => {
+      vi.mocked(useAuthStore).mockReturnValue({
+        status: "authenticated",
+        user: {
+          id: "demo-user",
+          firstName: "Demo",
+          lastName: "User",
+          occupations: [{ id: "demo-referee", type: "referee" }],
+        },
+        logout: mockLogout,
+        activeOccupationId: "demo-referee",
+        setActiveOccupation: vi.fn(),
+        isDemoMode: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderAppShell();
+
+      expect(
+        screen.getByText("Demo Mode - Viewing sample data"),
+      ).toBeInTheDocument();
+    });
+
+    it("does NOT render demo banner when isDemoMode is false", () => {
+      vi.mocked(useAuthStore).mockReturnValue({
+        status: "authenticated",
+        user: {
+          id: "real-user",
+          firstName: "John",
+          lastName: "Doe",
+          occupations: [{ id: "ref-1", type: "referee" }],
+        },
+        logout: mockLogout,
+        activeOccupationId: "ref-1",
+        setActiveOccupation: vi.fn(),
+        isDemoMode: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderAppShell();
+
+      expect(
+        screen.queryByText("Demo Mode - Viewing sample data"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("has proper accessibility attributes", () => {
+      vi.mocked(useAuthStore).mockReturnValue({
+        status: "authenticated",
+        user: {
+          id: "demo-user",
+          firstName: "Demo",
+          lastName: "User",
+          occupations: [{ id: "demo-referee", type: "referee" }],
+        },
+        logout: mockLogout,
+        activeOccupationId: "demo-referee",
+        setActiveOccupation: vi.fn(),
+        isDemoMode: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderAppShell();
+
+      const banner = screen.getByRole("alert");
+      expect(banner).toBeInTheDocument();
+      expect(banner).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("displays correct translation for German locale", () => {
+      setLocale("de");
+
+      vi.mocked(useAuthStore).mockReturnValue({
+        status: "authenticated",
+        user: {
+          id: "demo-user",
+          firstName: "Demo",
+          lastName: "User",
+          occupations: [{ id: "demo-referee", type: "referee" }],
+        },
+        logout: mockLogout,
+        activeOccupationId: "demo-referee",
+        setActiveOccupation: vi.fn(),
+        isDemoMode: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderAppShell();
+
+      expect(
+        screen.getByText("Demo-Modus - Beispieldaten werden angezeigt"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays correct translation for French locale", () => {
+      setLocale("fr");
+
+      vi.mocked(useAuthStore).mockReturnValue({
+        status: "authenticated",
+        user: {
+          id: "demo-user",
+          firstName: "Demo",
+          lastName: "User",
+          occupations: [{ id: "demo-referee", type: "referee" }],
+        },
+        logout: mockLogout,
+        activeOccupationId: "demo-referee",
+        setActiveOccupation: vi.fn(),
+        isDemoMode: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderAppShell();
+
+      expect(
+        screen.getByText("Mode Démo - Données d'exemple"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays correct translation for Italian locale", () => {
+      setLocale("it");
+
+      vi.mocked(useAuthStore).mockReturnValue({
+        status: "authenticated",
+        user: {
+          id: "demo-user",
+          firstName: "Demo",
+          lastName: "User",
+          occupations: [{ id: "demo-referee", type: "referee" }],
+        },
+        logout: mockLogout,
+        activeOccupationId: "demo-referee",
+        setActiveOccupation: vi.fn(),
+        isDemoMode: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderAppShell();
+
+      expect(
+        screen.getByText("Modalità Demo - Dati di esempio"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/web-app/src/components/layout/AppShell.test.tsx
+++ b/web-app/src/components/layout/AppShell.test.tsx
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AppShell } from "./AppShell";
-import { useAuthStore, type AuthStatus, type UserProfile } from "@/stores/auth";
-import { setLocale } from "@/i18n";
+import { useAuthStore, type UserProfile } from "@/stores/auth";
+import { setLocale, type Locale } from "@/i18n";
 
 // Mock the auth store
 vi.mock("@/stores/auth", () => ({
@@ -12,23 +12,18 @@ vi.mock("@/stores/auth", () => ({
 
 /**
  * Create a mock auth store return value with sensible defaults.
- * Only specify the properties you need to override for your test.
+ * Accepts Partial<ReturnType<typeof useAuthStore>> to allow overriding any property.
  */
 function createMockAuthStore(
-  overrides: {
-    status?: AuthStatus;
-    user?: UserProfile | null;
-    isDemoMode?: boolean;
-    activeOccupationId?: string | null;
-  } = {},
+  overrides: Partial<ReturnType<typeof useAuthStore>> = {},
 ) {
   return {
-    status: overrides.status ?? "authenticated",
-    user: overrides.user ?? null,
+    status: "authenticated" as const,
+    user: null,
     error: null,
     csrfToken: null,
-    isDemoMode: overrides.isDemoMode ?? false,
-    activeOccupationId: overrides.activeOccupationId ?? null,
+    isDemoMode: false,
+    activeOccupationId: null,
     _checkSessionPromise: null,
     login: vi.fn(),
     logout: vi.fn(),
@@ -36,6 +31,7 @@ function createMockAuthStore(
     setUser: vi.fn(),
     setDemoAuthenticated: vi.fn(),
     setActiveOccupation: vi.fn(),
+    ...overrides,
   };
 }
 
@@ -116,58 +112,27 @@ describe("AppShell", () => {
       expect(banner).toHaveAttribute("aria-live", "polite");
     });
 
-    it("displays correct translation for German locale", () => {
-      setLocale("de");
+    it.each<{ locale: Locale; expected: string }>([
+      { locale: "de", expected: "Demo-Modus - Beispieldaten werden angezeigt" },
+      { locale: "fr", expected: "Mode Démo - Données d'exemple" },
+      { locale: "it", expected: "Modalità Demo - Dati di esempio" },
+    ])(
+      "displays correct translation for $locale locale",
+      ({ locale, expected }) => {
+        setLocale(locale);
 
-      vi.mocked(useAuthStore).mockReturnValue(
-        createMockAuthStore({
-          user: demoUser,
-          isDemoMode: true,
-          activeOccupationId: "demo-referee",
-        }),
-      );
+        vi.mocked(useAuthStore).mockReturnValue(
+          createMockAuthStore({
+            user: demoUser,
+            isDemoMode: true,
+            activeOccupationId: "demo-referee",
+          }),
+        );
 
-      renderAppShell();
+        renderAppShell();
 
-      expect(
-        screen.getByText("Demo-Modus - Beispieldaten werden angezeigt"),
-      ).toBeInTheDocument();
-    });
-
-    it("displays correct translation for French locale", () => {
-      setLocale("fr");
-
-      vi.mocked(useAuthStore).mockReturnValue(
-        createMockAuthStore({
-          user: demoUser,
-          isDemoMode: true,
-          activeOccupationId: "demo-referee",
-        }),
-      );
-
-      renderAppShell();
-
-      expect(
-        screen.getByText("Mode Démo - Données d'exemple"),
-      ).toBeInTheDocument();
-    });
-
-    it("displays correct translation for Italian locale", () => {
-      setLocale("it");
-
-      vi.mocked(useAuthStore).mockReturnValue(
-        createMockAuthStore({
-          user: demoUser,
-          isDemoMode: true,
-          activeOccupationId: "demo-referee",
-        }),
-      );
-
-      renderAppShell();
-
-      expect(
-        screen.getByText("Modalità Demo - Dati di esempio"),
-      ).toBeInTheDocument();
-    });
+        expect(screen.getByText(expected)).toBeInTheDocument();
+      },
+    );
   });
 });

--- a/web-app/src/components/layout/AppShell.test.tsx
+++ b/web-app/src/components/layout/AppShell.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AppShell } from "./AppShell";
-import { useAuthStore } from "@/stores/auth";
+import { useAuthStore, type AuthStatus, type UserProfile } from "@/stores/auth";
 import { setLocale } from "@/i18n";
 
 // Mock the auth store
@@ -10,9 +10,50 @@ vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn(),
 }));
 
-describe("AppShell", () => {
-  const mockLogout = vi.fn();
+/**
+ * Create a mock auth store return value with sensible defaults.
+ * Only specify the properties you need to override for your test.
+ */
+function createMockAuthStore(
+  overrides: {
+    status?: AuthStatus;
+    user?: UserProfile | null;
+    isDemoMode?: boolean;
+    activeOccupationId?: string | null;
+  } = {},
+) {
+  return {
+    status: overrides.status ?? "authenticated",
+    user: overrides.user ?? null,
+    error: null,
+    csrfToken: null,
+    isDemoMode: overrides.isDemoMode ?? false,
+    activeOccupationId: overrides.activeOccupationId ?? null,
+    _checkSessionPromise: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    checkSession: vi.fn(),
+    setUser: vi.fn(),
+    setDemoAuthenticated: vi.fn(),
+    setActiveOccupation: vi.fn(),
+  };
+}
 
+const demoUser: UserProfile = {
+  id: "demo-user",
+  firstName: "Demo",
+  lastName: "User",
+  occupations: [{ id: "demo-referee", type: "referee" }],
+};
+
+const realUser: UserProfile = {
+  id: "real-user",
+  firstName: "John",
+  lastName: "Doe",
+  occupations: [{ id: "ref-1", type: "referee" }],
+};
+
+describe("AppShell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setLocale("en");
@@ -28,20 +69,13 @@ describe("AppShell", () => {
 
   describe("demo mode banner", () => {
     it("renders demo banner when isDemoMode is true", () => {
-      vi.mocked(useAuthStore).mockReturnValue({
-        status: "authenticated",
-        user: {
-          id: "demo-user",
-          firstName: "Demo",
-          lastName: "User",
-          occupations: [{ id: "demo-referee", type: "referee" }],
-        },
-        logout: mockLogout,
-        activeOccupationId: "demo-referee",
-        setActiveOccupation: vi.fn(),
-        isDemoMode: true,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: demoUser,
+          isDemoMode: true,
+          activeOccupationId: "demo-referee",
+        }),
+      );
 
       renderAppShell();
 
@@ -51,20 +85,13 @@ describe("AppShell", () => {
     });
 
     it("does NOT render demo banner when isDemoMode is false", () => {
-      vi.mocked(useAuthStore).mockReturnValue({
-        status: "authenticated",
-        user: {
-          id: "real-user",
-          firstName: "John",
-          lastName: "Doe",
-          occupations: [{ id: "ref-1", type: "referee" }],
-        },
-        logout: mockLogout,
-        activeOccupationId: "ref-1",
-        setActiveOccupation: vi.fn(),
-        isDemoMode: false,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: realUser,
+          isDemoMode: false,
+          activeOccupationId: "ref-1",
+        }),
+      );
 
       renderAppShell();
 
@@ -74,20 +101,13 @@ describe("AppShell", () => {
     });
 
     it("has proper accessibility attributes", () => {
-      vi.mocked(useAuthStore).mockReturnValue({
-        status: "authenticated",
-        user: {
-          id: "demo-user",
-          firstName: "Demo",
-          lastName: "User",
-          occupations: [{ id: "demo-referee", type: "referee" }],
-        },
-        logout: mockLogout,
-        activeOccupationId: "demo-referee",
-        setActiveOccupation: vi.fn(),
-        isDemoMode: true,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: demoUser,
+          isDemoMode: true,
+          activeOccupationId: "demo-referee",
+        }),
+      );
 
       renderAppShell();
 
@@ -99,20 +119,13 @@ describe("AppShell", () => {
     it("displays correct translation for German locale", () => {
       setLocale("de");
 
-      vi.mocked(useAuthStore).mockReturnValue({
-        status: "authenticated",
-        user: {
-          id: "demo-user",
-          firstName: "Demo",
-          lastName: "User",
-          occupations: [{ id: "demo-referee", type: "referee" }],
-        },
-        logout: mockLogout,
-        activeOccupationId: "demo-referee",
-        setActiveOccupation: vi.fn(),
-        isDemoMode: true,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: demoUser,
+          isDemoMode: true,
+          activeOccupationId: "demo-referee",
+        }),
+      );
 
       renderAppShell();
 
@@ -124,20 +137,13 @@ describe("AppShell", () => {
     it("displays correct translation for French locale", () => {
       setLocale("fr");
 
-      vi.mocked(useAuthStore).mockReturnValue({
-        status: "authenticated",
-        user: {
-          id: "demo-user",
-          firstName: "Demo",
-          lastName: "User",
-          occupations: [{ id: "demo-referee", type: "referee" }],
-        },
-        logout: mockLogout,
-        activeOccupationId: "demo-referee",
-        setActiveOccupation: vi.fn(),
-        isDemoMode: true,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: demoUser,
+          isDemoMode: true,
+          activeOccupationId: "demo-referee",
+        }),
+      );
 
       renderAppShell();
 
@@ -149,20 +155,13 @@ describe("AppShell", () => {
     it("displays correct translation for Italian locale", () => {
       setLocale("it");
 
-      vi.mocked(useAuthStore).mockReturnValue({
-        status: "authenticated",
-        user: {
-          id: "demo-user",
-          firstName: "Demo",
-          lastName: "User",
-          occupations: [{ id: "demo-referee", type: "referee" }],
-        },
-        logout: mockLogout,
-        activeOccupationId: "demo-referee",
-        setActiveOccupation: vi.fn(),
-        isDemoMode: true,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: demoUser,
+          isDemoMode: true,
+          activeOccupationId: "demo-referee",
+        }),
+      );
 
       renderAppShell();
 

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -18,8 +18,14 @@ const navItems = [
 export function AppShell() {
   const location = useLocation();
   const { t } = useTranslation();
-  const { status, user, logout, activeOccupationId, setActiveOccupation } =
-    useAuthStore();
+  const {
+    status,
+    user,
+    logout,
+    activeOccupationId,
+    setActiveOccupation,
+    isDemoMode,
+  } = useAuthStore();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const getOccupationLabel = useCallback(
@@ -147,6 +153,21 @@ export function AppShell() {
           </div>
         </div>
       </header>
+
+      {/* Demo mode banner */}
+      {isDemoMode && (
+        <div
+          className="bg-amber-100 dark:bg-amber-900/50 border-b border-amber-200 dark:border-amber-800"
+          role="alert"
+          aria-live="polite"
+        >
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
+            <p className="text-sm text-amber-800 dark:text-amber-200 text-center font-medium">
+              {t("common.demoModeBanner")}
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Main content
           pb-16 (4rem/64px) provides padding to prevent content from being hidden

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -33,6 +33,7 @@ interface Translations {
     location: string;
     position: string;
     requiredLevel: string;
+    demoModeBanner: string;
   };
   auth: {
     login: string;
@@ -155,6 +156,7 @@ const en: Translations = {
     location: "Location",
     position: "Position",
     requiredLevel: "Required Level",
+    demoModeBanner: "Demo Mode - Viewing sample data",
   },
   auth: {
     login: "Login",
@@ -281,6 +283,7 @@ const de: Translations = {
     location: "Ort",
     position: "Position",
     requiredLevel: "Erforderliches Niveau",
+    demoModeBanner: "Demo-Modus - Beispieldaten werden angezeigt",
   },
   auth: {
     login: "Anmelden",
@@ -407,6 +410,7 @@ const fr: Translations = {
     location: "Lieu",
     position: "Position",
     requiredLevel: "Niveau requis",
+    demoModeBanner: "Mode Démo - Données d'exemple",
   },
   auth: {
     login: "Connexion",
@@ -533,6 +537,7 @@ const it: Translations = {
     location: "Luogo",
     position: "Posizione",
     requiredLevel: "Livello richiesto",
+    demoModeBanner: "Modalità Demo - Dati di esempio",
   },
   auth: {
     login: "Accesso",


### PR DESCRIPTION
## Summary
- Add persistent amber-colored banner below header when in demo mode
- Banner displays "Demo Mode - Viewing sample data" (translated to all 4 languages)
- Includes proper accessibility attributes (`role="alert"`, `aria-live="polite"`)

Closes #13

## Test plan
- [ ] Start the app and click "Try Demo Mode" on the login page
- [ ] Verify amber banner appears below the header
- [ ] Navigate between pages and verify banner remains visible
- [ ] Change language in settings and verify banner text updates
- [ ] Test in dark mode to verify proper styling
- [ ] Log out and log back in with real credentials - verify banner does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)