### PR TITLE
refactor(demo): remove isDemoMode duplication from demo store

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -151,7 +151,7 @@ const queryClient = new QueryClient({
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { status, checkSession, isDemoMode } = useAuthStore();
-  const { assignments, enableDemoMode } = useDemoStore();
+  const { assignments, initializeDemoData } = useDemoStore();
   const [isVerifying, setIsVerifying] = useState(
     () => status === "authenticated",
   );
@@ -160,9 +160,9 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   // Regenerate demo data on page load if demo mode is enabled but data is empty
   useEffect(() => {
     if (isDemoMode && assignments.length === 0) {
-      enableDemoMode();
+      initializeDemoData();
     }
-  }, [isDemoMode, assignments.length, enableDemoMode]);
+  }, [isDemoMode, assignments.length, initializeDemoData]);
 
   // Verify persisted session is still valid on mount
   useEffect(() => {

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -9,7 +9,7 @@ import { LanguageSwitcher } from "@/components/ui/LanguageSwitcher";
 export function LoginPage() {
   const navigate = useNavigate();
   const { login, status, error, setDemoAuthenticated } = useAuthStore();
-  const { enableDemoMode } = useDemoStore();
+  const { initializeDemoData } = useDemoStore();
   const { t } = useTranslation();
 
   const [username, setUsername] = useState("");
@@ -19,7 +19,7 @@ export function LoginPage() {
   const isLoading = status === "loading";
 
   function handleDemoLogin() {
-    enableDemoMode();
+    initializeDemoData();
     setDemoAuthenticated();
     navigate("/");
   }

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -377,6 +377,9 @@ export const useAuthStore = create<AuthState>()(
       },
 
       logout: async () => {
+        // Import here to avoid circular dependency at module load time
+        const { useDemoStore } = await import("./demo");
+
         try {
           // Call server logout endpoint to invalidate session
           // The server responds with 303 redirect to /login
@@ -387,6 +390,11 @@ export const useAuthStore = create<AuthState>()(
         } catch (error) {
           // Log but don't block logout - we still want to clear local state
           console.error("Logout request failed:", error);
+        }
+
+        // Clear demo data if exiting demo mode
+        if (get().isDemoMode) {
+          useDemoStore.getState().clearDemoData();
         }
 
         // Clear local state regardless of server response

--- a/web-app/src/stores/demo.test.ts
+++ b/web-app/src/stores/demo.test.ts
@@ -5,7 +5,6 @@ describe("useDemoStore", () => {
   beforeEach(() => {
     // Reset store state before each test
     useDemoStore.setState({
-      isDemoMode: false,
       assignments: [],
       compensations: [],
       exchanges: [],
@@ -13,12 +12,7 @@ describe("useDemoStore", () => {
   });
 
   describe("initial state", () => {
-    it("starts with isDemoMode false", () => {
-      const state = useDemoStore.getState();
-      expect(state.isDemoMode).toBe(false);
-    });
-
-    it("starts with empty data arrays (lazy loading)", () => {
+    it("starts with empty data arrays", () => {
       const state = useDemoStore.getState();
       expect(state.assignments).toHaveLength(0);
       expect(state.compensations).toHaveLength(0);
@@ -26,20 +20,15 @@ describe("useDemoStore", () => {
     });
   });
 
-  describe("enableDemoMode", () => {
-    it("sets isDemoMode to true", () => {
-      useDemoStore.getState().enableDemoMode();
-      expect(useDemoStore.getState().isDemoMode).toBe(true);
-    });
-
-    it("generates demo data only when enabled (lazy loading)", () => {
-      // Before enabling, data should be empty
+  describe("initializeDemoData", () => {
+    it("populates demo data arrays", () => {
+      // Before initializing, data should be empty
       expect(useDemoStore.getState().assignments).toHaveLength(0);
 
-      // Enable demo mode
-      useDemoStore.getState().enableDemoMode();
+      // Initialize demo data
+      useDemoStore.getState().initializeDemoData();
 
-      // After enabling, data should be populated
+      // After initializing, data should be populated
       const state = useDemoStore.getState();
       expect(state.assignments.length).toBeGreaterThan(0);
       expect(state.compensations.length).toBeGreaterThan(0);
@@ -47,7 +36,7 @@ describe("useDemoStore", () => {
     });
 
     it("generates valid assignment data", () => {
-      useDemoStore.getState().enableDemoMode();
+      useDemoStore.getState().initializeDemoData();
 
       const { assignments } = useDemoStore.getState();
       expect(assignments.length).toBeGreaterThan(0);
@@ -60,7 +49,7 @@ describe("useDemoStore", () => {
     });
 
     it("generates valid compensation data", () => {
-      useDemoStore.getState().enableDemoMode();
+      useDemoStore.getState().initializeDemoData();
 
       const { compensations } = useDemoStore.getState();
       expect(compensations.length).toBeGreaterThan(0);
@@ -74,7 +63,7 @@ describe("useDemoStore", () => {
     });
 
     it("generates valid exchange data", () => {
-      useDemoStore.getState().enableDemoMode();
+      useDemoStore.getState().initializeDemoData();
 
       const { exchanges } = useDemoStore.getState();
       expect(exchanges.length).toBeGreaterThan(0);
@@ -86,20 +75,14 @@ describe("useDemoStore", () => {
     });
   });
 
-  describe("disableDemoMode", () => {
-    it("sets isDemoMode to false", () => {
-      useDemoStore.getState().enableDemoMode();
-      useDemoStore.getState().disableDemoMode();
-      expect(useDemoStore.getState().isDemoMode).toBe(false);
-    });
-
-    it("clears demo data when disabled", () => {
-      // Enable and verify data exists
-      useDemoStore.getState().enableDemoMode();
+  describe("clearDemoData", () => {
+    it("clears all demo data", () => {
+      // Initialize and verify data exists
+      useDemoStore.getState().initializeDemoData();
       expect(useDemoStore.getState().assignments.length).toBeGreaterThan(0);
 
-      // Disable and verify data is cleared
-      useDemoStore.getState().disableDemoMode();
+      // Clear and verify data is empty
+      useDemoStore.getState().clearDemoData();
       const state = useDemoStore.getState();
       expect(state.assignments).toHaveLength(0);
       expect(state.compensations).toHaveLength(0);
@@ -109,7 +92,7 @@ describe("useDemoStore", () => {
 
   describe("refreshData", () => {
     it("regenerates demo data with fresh dates", () => {
-      useDemoStore.getState().enableDemoMode();
+      useDemoStore.getState().initializeDemoData();
       const initialAssignments = useDemoStore.getState().assignments;
 
       // Refresh data
@@ -120,18 +103,6 @@ describe("useDemoStore", () => {
       expect(refreshedAssignments.length).toBe(initialAssignments.length);
       // New instances should have new date values
       expect(refreshedAssignments).not.toBe(initialAssignments);
-    });
-
-    it("does nothing if demo mode is disabled", () => {
-      // Ensure we start with empty data
-      expect(useDemoStore.getState().assignments).toHaveLength(0);
-
-      // Try to refresh without enabling demo mode
-      useDemoStore.getState().refreshData();
-
-      // Data should still be empty
-      const { assignments } = useDemoStore.getState();
-      expect(assignments).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Remove `isDemoMode` from `useDemoStore` - it duplicated state from `useAuthStore`
- Rename `enableDemoMode` → `initializeDemoData` (just populates data arrays)
- Rename `disableDemoMode` → `clearDemoData` (just clears data arrays)
- Remove internal `isDemoMode` guards from demo store actions

## Motivation
The `isDemoMode` flag was tracked in two places:
- `useAuthStore.isDemoMode` - the source of truth
- `useDemoStore.isDemoMode` - a duplicate

This created potential for state sync issues. Now `useAuthStore` is the single source of truth for demo mode status, and `useDemoStore` only manages the demo data.

## Changes
- `web-app/src/stores/demo.ts` - Remove `isDemoMode`, rename actions, remove guards
- `web-app/src/pages/LoginPage.tsx` - Use `initializeDemoData` instead of `enableDemoMode`
- `web-app/src/App.tsx` - Use `initializeDemoData` instead of `enableDemoMode`
- `web-app/src/stores/demo.test.ts` - Update tests for new API

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (327 tests)
- [x] `npm run build` completes successfully

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)