### PR TITLE
refactor(demo): flow demo data through hooks instead of pages

### DIFF
--- a/web-app/src/hooks/useConvocations.test.tsx
+++ b/web-app/src/hooks/useConvocations.test.tsx
@@ -12,6 +12,8 @@ import {
 } from "./useConvocations";
 import * as apiModule from "@/api/client";
 import * as authStore from "@/stores/auth";
+import * as demoStore from "@/stores/demo";
+import { addDays, subDays } from "date-fns";
 
 vi.mock("@/api/client", () => ({
   api: {
@@ -26,6 +28,10 @@ vi.mock("@/api/client", () => ({
 
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn(),
+}));
+
+vi.mock("@/stores/demo", () => ({
+  useDemoStore: vi.fn(),
 }));
 
 function createWrapper() {
@@ -47,6 +53,14 @@ function createWrapper() {
 describe("useConvocations - Demo Mode Guards", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default demo store mock with empty arrays
+    vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+      selector({
+        assignments: [],
+        compensations: [],
+        exchanges: [],
+      } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+    );
   });
 
   describe("useAssignments", () => {
@@ -305,6 +319,444 @@ describe("useConvocations - Demo Mode Guards", () => {
       expect(apiModule.api.withdrawFromExchange).toHaveBeenCalledWith(
         "test-exchange-id",
       );
+    });
+  });
+});
+
+describe("useConvocations - Demo Mode Data Filtering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useAssignments", () => {
+    it("should filter demo assignments by date range for upcoming period", async () => {
+      const now = new Date();
+      const futureDate = addDays(now, 5).toISOString();
+      const pastDate = subDays(now, 5).toISOString();
+
+      const mockDemoAssignments = [
+        {
+          __identity: "future-1",
+          refereeGame: { game: { startingDateTime: futureDate } },
+        },
+        {
+          __identity: "past-1",
+          refereeGame: { game: { startingDateTime: pastDate } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: mockDemoAssignments,
+          compensations: [],
+          exchanges: [],
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useAssignments("upcoming"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toHaveLength(1);
+      expect(result.current.data?.[0]?.__identity).toBe("future-1");
+    });
+
+    it("should filter demo assignments by date range for past period", async () => {
+      const now = new Date();
+      const futureDate = addDays(now, 5).toISOString();
+      const pastDate = subDays(now, 5).toISOString();
+
+      const mockDemoAssignments = [
+        {
+          __identity: "future-1",
+          refereeGame: { game: { startingDateTime: futureDate } },
+        },
+        {
+          __identity: "past-1",
+          refereeGame: { game: { startingDateTime: pastDate } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: mockDemoAssignments,
+          compensations: [],
+          exchanges: [],
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useAssignments("past"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toHaveLength(1);
+      expect(result.current.data?.[0]?.__identity).toBe("past-1");
+    });
+
+    it("should sort upcoming demo assignments in ascending order", async () => {
+      const now = new Date();
+      const laterDate = addDays(now, 10).toISOString();
+      const soonerDate = addDays(now, 2).toISOString();
+
+      const mockDemoAssignments = [
+        {
+          __identity: "later",
+          refereeGame: { game: { startingDateTime: laterDate } },
+        },
+        {
+          __identity: "sooner",
+          refereeGame: { game: { startingDateTime: soonerDate } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: mockDemoAssignments,
+          compensations: [],
+          exchanges: [],
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useAssignments("upcoming"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.[0]?.__identity).toBe("sooner");
+      expect(result.current.data?.[1]?.__identity).toBe("later");
+    });
+  });
+
+  describe("useAssignmentDetails", () => {
+    it("should return demo assignment by ID when found", async () => {
+      const mockDemoAssignments = [
+        { __identity: "assignment-1", refereePosition: "head-one" },
+        { __identity: "assignment-2", refereePosition: "linesman-one" },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: mockDemoAssignments,
+          compensations: [],
+          exchanges: [],
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(
+        () => useAssignmentDetails("assignment-2"),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.__identity).toBe("assignment-2");
+      expect(result.current.data?.refereePosition).toBe("linesman-one");
+    });
+
+    it("should return error when demo assignment not found", async () => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: [],
+          compensations: [],
+          exchanges: [],
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(
+        () => useAssignmentDetails("non-existent"),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error?.message).toBe("Assignment not found");
+    });
+  });
+
+  describe("useCompensations", () => {
+    it("should filter demo compensations by paid status", async () => {
+      const mockDemoCompensations = [
+        {
+          __identity: "comp-paid",
+          convocationCompensation: { paymentDone: true },
+          refereeGame: { game: { startingDateTime: "2025-01-01T10:00:00Z" } },
+        },
+        {
+          __identity: "comp-unpaid",
+          convocationCompensation: { paymentDone: false },
+          refereeGame: { game: { startingDateTime: "2025-01-02T10:00:00Z" } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: [],
+          compensations: mockDemoCompensations,
+          exchanges: [],
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useCompensations(true), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toHaveLength(1);
+      expect(result.current.data?.[0]?.__identity).toBe("comp-paid");
+    });
+
+    it("should return all demo compensations when no filter", async () => {
+      const mockDemoCompensations = [
+        {
+          __identity: "comp-paid",
+          convocationCompensation: { paymentDone: true },
+          refereeGame: { game: { startingDateTime: "2025-01-01T10:00:00Z" } },
+        },
+        {
+          __identity: "comp-unpaid",
+          convocationCompensation: { paymentDone: false },
+          refereeGame: { game: { startingDateTime: "2025-01-02T10:00:00Z" } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: [],
+          compensations: mockDemoCompensations,
+          exchanges: [],
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useCompensations(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toHaveLength(2);
+    });
+
+    it("should sort demo compensations in descending date order", async () => {
+      const mockDemoCompensations = [
+        {
+          __identity: "comp-older",
+          convocationCompensation: { paymentDone: true },
+          refereeGame: { game: { startingDateTime: "2025-01-01T10:00:00Z" } },
+        },
+        {
+          __identity: "comp-newer",
+          convocationCompensation: { paymentDone: true },
+          refereeGame: { game: { startingDateTime: "2025-01-15T10:00:00Z" } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: [],
+          compensations: mockDemoCompensations,
+          exchanges: [],
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useCompensations(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.[0]?.__identity).toBe("comp-newer");
+      expect(result.current.data?.[1]?.__identity).toBe("comp-older");
+    });
+  });
+
+  describe("useGameExchanges", () => {
+    it("should filter demo exchanges by status", async () => {
+      const mockDemoExchanges = [
+        {
+          __identity: "exchange-open",
+          status: "open",
+          refereeGame: { game: { startingDateTime: "2025-01-01T10:00:00Z" } },
+        },
+        {
+          __identity: "exchange-applied",
+          status: "applied",
+          refereeGame: { game: { startingDateTime: "2025-01-02T10:00:00Z" } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: [],
+          compensations: [],
+          exchanges: mockDemoExchanges,
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useGameExchanges("open"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toHaveLength(1);
+      expect(result.current.data?.[0]?.__identity).toBe("exchange-open");
+    });
+
+    it("should return all demo exchanges when status is all", async () => {
+      const mockDemoExchanges = [
+        {
+          __identity: "exchange-open",
+          status: "open",
+          refereeGame: { game: { startingDateTime: "2025-01-01T10:00:00Z" } },
+        },
+        {
+          __identity: "exchange-applied",
+          status: "applied",
+          refereeGame: { game: { startingDateTime: "2025-01-02T10:00:00Z" } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: [],
+          compensations: [],
+          exchanges: mockDemoExchanges,
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useGameExchanges("all"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data).toHaveLength(2);
+    });
+
+    it("should sort demo exchanges in ascending date order", async () => {
+      const mockDemoExchanges = [
+        {
+          __identity: "exchange-later",
+          status: "open",
+          refereeGame: { game: { startingDateTime: "2025-01-15T10:00:00Z" } },
+        },
+        {
+          __identity: "exchange-sooner",
+          status: "open",
+          refereeGame: { game: { startingDateTime: "2025-01-01T10:00:00Z" } },
+        },
+      ];
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          assignments: [],
+          compensations: [],
+          exchanges: mockDemoExchanges,
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() => useGameExchanges("open"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.[0]?.__identity).toBe("exchange-sooner");
+      expect(result.current.data?.[1]?.__identity).toBe("exchange-later");
     });
   });
 });

--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -22,6 +22,28 @@ import { useDemoStore } from "@/stores/demo";
 const DEFAULT_PAGE_SIZE = 100;
 const DEFAULT_DATE_RANGE_DAYS = 365;
 
+// Helper to create mock query results for demo mode
+// Type assertion is necessary because we're creating a partial mock of UseQueryResult
+// that satisfies the interface without all internal TanStack Query state
+function createDemoQueryResult<T>(
+  baseQuery: UseQueryResult<T, Error>,
+  data: T,
+  options: { isError?: boolean; error?: Error } = {},
+): UseQueryResult<T, Error> {
+  const isError = options.isError ?? false;
+  return {
+    ...baseQuery,
+    data,
+    isLoading: false,
+    isFetching: false,
+    isSuccess: !isError,
+    isError,
+    error: options.error ?? null,
+    status: isError ? "error" : "success",
+    fetchStatus: "idle",
+  } as UseQueryResult<T, Error>;
+}
+
 // Query keys
 export const queryKeys = {
   assignments: (config?: SearchConfiguration) =>
@@ -134,17 +156,7 @@ export function useAssignments(
         return period === "past" ? dateB - dateA : dateA - dateB;
       });
 
-    return {
-      ...query,
-      data: filteredData,
-      isLoading: false,
-      isFetching: false,
-      isSuccess: true,
-      isError: false,
-      error: null,
-      status: "success",
-      fetchStatus: "idle",
-    } as UseQueryResult<Assignment[], Error>;
+    return createDemoQueryResult(query, filteredData);
   }
 
   return query;
@@ -182,17 +194,10 @@ export function useAssignmentDetails(
       (a) => a.__identity === assignmentId,
     );
 
-    return {
-      ...query,
-      data: demoAssignment,
-      isLoading: false,
-      isFetching: false,
-      isSuccess: !!demoAssignment,
+    return createDemoQueryResult(query, demoAssignment as Assignment, {
       isError: !demoAssignment,
-      error: demoAssignment ? null : new Error("Assignment not found"),
-      status: demoAssignment ? "success" : "error",
-      fetchStatus: "idle",
-    } as UseQueryResult<Assignment, Error>;
+      error: demoAssignment ? undefined : new Error("Assignment not found"),
+    });
   }
 
   return query;
@@ -250,17 +255,7 @@ export function useCompensations(
         return dateB - dateA;
       });
 
-    return {
-      ...query,
-      data: filteredData,
-      isLoading: false,
-      isFetching: false,
-      isSuccess: true,
-      isError: false,
-      error: null,
-      status: "success",
-      fetchStatus: "idle",
-    } as UseQueryResult<CompensationRecord[], Error>;
+    return createDemoQueryResult(query, filteredData);
   }
 
   return query;
@@ -353,17 +348,7 @@ export function useGameExchanges(
         return dateA - dateB;
       });
 
-    return {
-      ...query,
-      data: filteredData,
-      isLoading: false,
-      isFetching: false,
-      isSuccess: true,
-      isError: false,
-      error: null,
-      status: "success",
-      fetchStatus: "idle",
-    } as UseQueryResult<GameExchange[], Error>;
+    return createDemoQueryResult(query, filteredData);
   }
 
   return query;

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -3,8 +3,6 @@ import {
   useUpcomingAssignments,
   usePastAssignments,
 } from "@/hooks/useConvocations";
-import { useAuthStore } from "@/stores/auth";
-import { useDemoStore } from "@/stores/demo";
 import { AssignmentCard } from "@/components/features/AssignmentCard";
 import { SwipeableCard } from "@/components/ui/SwipeableCard";
 import {
@@ -23,9 +21,7 @@ type TabType = "upcoming" | "past";
 
 export function AssignmentsPage() {
   const [activeTab, setActiveTab] = useState<TabType>("upcoming");
-  const { isDemoMode } = useAuthStore();
   const { t } = useTranslation();
-  const { assignments: demoAssignments } = useDemoStore();
 
   const {
     editCompensationModal,
@@ -48,34 +44,9 @@ export function AssignmentsPage() {
     refetch: refetchPast,
   } = usePastAssignments();
 
-  // Use demo data if in demo mode
-  const now = new Date();
-  const demoUpcoming = demoAssignments.filter((a) => {
-    const gameDate = a.refereeGame?.game?.startingDateTime;
-    return gameDate && new Date(gameDate) >= now;
-  });
-  const demoPast = demoAssignments.filter((a) => {
-    const gameDate = a.refereeGame?.game?.startingDateTime;
-    return gameDate && new Date(gameDate) < now;
-  });
-
-  const data = isDemoMode
-    ? activeTab === "upcoming"
-      ? demoUpcoming
-      : demoPast
-    : activeTab === "upcoming"
-      ? upcomingData
-      : pastData;
-  const isLoading = isDemoMode
-    ? false
-    : activeTab === "upcoming"
-      ? upcomingLoading
-      : pastLoading;
-  const error = isDemoMode
-    ? null
-    : activeTab === "upcoming"
-      ? upcomingError
-      : pastError;
+  const data = activeTab === "upcoming" ? upcomingData : pastData;
+  const isLoading = activeTab === "upcoming" ? upcomingLoading : pastLoading;
+  const error = activeTab === "upcoming" ? upcomingError : pastError;
   const refetch = activeTab === "upcoming" ? refetchUpcoming : refetchPast;
 
   const getSwipeConfig = useCallback(

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -1,12 +1,10 @@
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import {
   useCompensations,
   usePaidCompensations,
   useUnpaidCompensations,
   useCompensationTotals,
 } from "@/hooks/useConvocations";
-import { useAuthStore } from "@/stores/auth";
-import { useDemoStore } from "@/stores/demo";
 import { CompensationCard } from "@/components/features/CompensationCard";
 import { EditCompensationModal } from "@/components/features/EditCompensationModal";
 import { SwipeableCard } from "@/components/ui/SwipeableCard";
@@ -25,9 +23,7 @@ type FilterType = "all" | "paid" | "unpaid";
 
 export function CompensationsPage() {
   const [filter, setFilter] = useState<FilterType>("all");
-  const { isDemoMode } = useAuthStore();
   const { t } = useTranslation();
-  const { compensations: demoCompensations } = useDemoStore();
   const { editCompensationModal, handleGeneratePDF } = useCompensationActions();
 
   const {
@@ -49,45 +45,7 @@ export function CompensationsPage() {
     refetch: refetchUnpaid,
   } = useUnpaidCompensations();
 
-  const apiTotals = useCompensationTotals();
-
-  // Calculate demo totals
-  const demoTotals = useMemo(() => {
-    const paid = demoCompensations
-      .filter((c) => c.convocationCompensation?.paymentDone)
-      .reduce(
-        (sum, c) =>
-          sum +
-          (c.convocationCompensation?.gameCompensation || 0) +
-          (c.convocationCompensation?.travelExpenses || 0),
-        0,
-      );
-    const unpaid = demoCompensations
-      .filter((c) => !c.convocationCompensation?.paymentDone)
-      .reduce(
-        (sum, c) =>
-          sum +
-          (c.convocationCompensation?.gameCompensation || 0) +
-          (c.convocationCompensation?.travelExpenses || 0),
-        0,
-      );
-    return { paid, unpaid };
-  }, [demoCompensations]);
-
-  const totals = isDemoMode ? demoTotals : apiTotals;
-
-  // Filter demo data
-  const demoPaid = demoCompensations.filter(
-    (c) => c.convocationCompensation?.paymentDone,
-  );
-  const demoUnpaid = demoCompensations.filter(
-    (c) => !c.convocationCompensation?.paymentDone,
-  );
-  const demoDataMap = {
-    all: demoCompensations,
-    paid: demoPaid,
-    unpaid: demoUnpaid,
-  };
+  const totals = useCompensationTotals();
 
   const dataMap = { all: allData, paid: paidData, unpaid: unpaidData };
   const loadingMap = {
@@ -102,9 +60,9 @@ export function CompensationsPage() {
     unpaid: refetchUnpaid,
   };
 
-  const data = isDemoMode ? demoDataMap[filter] : dataMap[filter];
-  const isLoading = isDemoMode ? false : loadingMap[filter];
-  const error = isDemoMode ? null : errorMap[filter];
+  const data = dataMap[filter];
+  const isLoading = loadingMap[filter];
+  const error = errorMap[filter];
   const refetch = refetchMap[filter];
 
   const getSwipeConfig = (compensation: CompensationRecord): SwipeConfig => {

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -1,7 +1,5 @@
 import { useState, useCallback } from "react";
 import { useGameExchanges, type ExchangeStatus } from "@/hooks/useConvocations";
-import { useAuthStore } from "@/stores/auth";
-import { useDemoStore } from "@/stores/demo";
 import { useExchangeActions } from "@/hooks/useExchangeActions";
 import { createExchangeActions } from "@/utils/exchange-actions";
 import { ExchangeCard } from "@/components/features/ExchangeCard";
@@ -19,16 +17,9 @@ import { useTranslation } from "@/hooks/useTranslation";
 
 export function ExchangePage() {
   const [statusFilter, setStatusFilter] = useState<ExchangeStatus>("open");
-  const { isDemoMode } = useAuthStore();
   const { t } = useTranslation();
-  const { exchanges: demoExchanges } = useDemoStore();
 
-  const {
-    data: apiData,
-    isLoading: apiLoading,
-    error: apiError,
-    refetch,
-  } = useGameExchanges(statusFilter);
+  const { data, isLoading, error, refetch } = useGameExchanges(statusFilter);
 
   const {
     takeOverModal,
@@ -36,13 +27,6 @@ export function ExchangePage() {
     handleTakeOver,
     handleRemoveFromExchange,
   } = useExchangeActions();
-
-  // Filter demo data by status
-  const demoFiltered = demoExchanges.filter((e) => e.status === statusFilter);
-
-  const data = isDemoMode ? demoFiltered : apiData;
-  const isLoading = isDemoMode ? false : apiLoading;
-  const error = isDemoMode ? null : apiError;
 
   const getSwipeConfig = useCallback(
     (exchange: GameExchange): SwipeConfig => {


### PR DESCRIPTION
## Summary
- Centralizes demo mode logic in data-fetching hooks so pages are unaware of the data source
- Eliminates the dual data pipeline where pages had to query both demo store and API hooks
- `useAssignments`: returns filtered/sorted demo data when `isDemoMode`
- `useAssignmentDetails`: returns demo assignment by ID when `isDemoMode`
- `useCompensations`: returns filtered demo data when `isDemoMode`
- `useGameExchanges`: returns filtered demo data when `isDemoMode`
- Pages simplified by removing `useDemoStore` and `isDemoMode` checks

## Test plan
- [ ] Verify demo mode works correctly on Assignments page (upcoming/past tabs)
- [ ] Verify demo mode works correctly on Compensations page (all/paid/unpaid filters)
- [ ] Verify demo mode works correctly on Exchange page (open/applied tabs)
- [ ] Verify real API mode still works when logged in with actual credentials
- [ ] Verify compensation totals display correctly in demo mode

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)