### PR TITLE
fix: prevent API calls in demo mode during session verification

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -153,7 +153,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { status, checkSession, isDemoMode } = useAuthStore();
   const { assignments, initializeDemoData } = useDemoStore();
   const [isVerifying, setIsVerifying] = useState(
-    () => status === "authenticated",
+    () => status === "authenticated" && !isDemoMode,
   );
   const [verifyError, setVerifyError] = useState<string | null>(null);
 
@@ -166,7 +166,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 
   // Verify persisted session is still valid on mount
   useEffect(() => {
-    if (!isVerifying) return;
+    if (!isVerifying || isDemoMode) return;
 
     let cancelled = false;
     checkSession()
@@ -185,7 +185,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [isVerifying, checkSession]);
+  }, [isVerifying, checkSession, isDemoMode]);
 
   // Show loading state while verifying session
   if (status === "loading" || isVerifying) {

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -152,9 +152,8 @@ const queryClient = new QueryClient({
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { status, checkSession, isDemoMode } = useAuthStore();
   const { assignments, initializeDemoData } = useDemoStore();
-  const [isVerifying, setIsVerifying] = useState(
-    () => status === "authenticated" && !isDemoMode,
-  );
+  const shouldVerifySession = status === "authenticated" && !isDemoMode;
+  const [isVerifying, setIsVerifying] = useState(() => shouldVerifySession);
   const [verifyError, setVerifyError] = useState<string | null>(null);
 
   // Regenerate demo data on page load if demo mode is enabled but data is empty


### PR DESCRIPTION
Fixes #21

### Summary

This PR fixes the race condition that caused API calls to be made in demo mode, resulting in 406 errors from the proxy server.

### Changes

- Initialize `isVerifying` state with demo mode check to prevent `ProtectedRoute` from calling `checkSession()` when in demo mode
- Add early return in useEffect if demo mode is active
- Add `isDemoMode` to useEffect dependency array

### Impact

- No more unnecessary API calls in demo mode
- Cleaner browser console without 406 errors
- No functional changes to demo mode behavior

----

Generated with [Claude Code](https://claude.ai/code)