### PR TITLE
fix: disable 'Add to Exchange' for past assignments

### DIFF
--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -58,6 +58,8 @@ export function AssignmentsPage() {
         onAddToExchange: handleAddToExchange,
       });
 
+      const isGameInFuture = assignment.refereeGame?.isGameInFuture === "1";
+
       // Action array ordering: first item = furthest from card = full swipe default
       // When swiping left, actions appear right-to-left from the card edge
       return {
@@ -70,7 +72,8 @@ export function AssignmentsPage() {
         ],
         // Swipe right reveals: card -> [Exchange]
         // Full swipe right triggers: addToExchange
-        right: [actions.addToExchange],
+        // Only show exchange action for upcoming assignments
+        right: isGameInFuture ? [actions.addToExchange] : [],
       };
     },
     [


### PR DESCRIPTION
Fixes #22

Past assignments (games that have already occurred) should not show the 'Add to Exchange' swipe action since it makes no logical sense to find a replacement referee for a game that has already been played.

## Changes
- Check `refereeGame.isGameInFuture` field in getSwipeConfig
- Return empty array for right swipe actions on past assignments
- Keep left swipe actions available (validate, edit, report still useful)

Generated with [Claude Code](https://claude.ai/code)