### PR TITLE
fix: disable edit action for paid compensations

### DIFF
--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -71,8 +71,12 @@ export function CompensationsPage() {
       onGeneratePDF: handleGeneratePDF,
     });
 
+    const isPaid = compensation.convocationCompensation?.paymentDone;
+
     return {
-      left: [actions.editCompensation, actions.generatePDF],
+      left: isPaid
+        ? [actions.generatePDF]
+        : [actions.editCompensation, actions.generatePDF],
     };
   };
 


### PR DESCRIPTION
## Summary
- Paid compensations now only show the 'Generate PDF' action when swiped
- The 'Edit Compensation' action is hidden for items with `paymentDone: true`
- Prevents users from attempting to edit already-processed payments

## Test plan
- [ ] Navigate to Compensations page
- [ ] Swipe on a paid compensation (marked with ✓) - should only show PDF action
- [ ] Swipe on an unpaid compensation (marked with ○) - should show both Edit and PDF actions

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)