### PR TITLE
fix(tests): use React cleanup pattern for ExchangeConfirmationModal

### DIFF
--- a/web-app/src/components/features/ExchangeConfirmationModal.tsx
+++ b/web-app/src/components/features/ExchangeConfirmationModal.tsx
@@ -45,6 +45,14 @@ export function ExchangeConfirmationModal({
 
   const isSubmittingRef = useRef(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const ignoreRef = useRef(false);
+
+  useEffect(() => {
+    ignoreRef.current = false;
+    return () => {
+      ignoreRef.current = true;
+    };
+  }, []);
 
   const handleConfirm = useCallback(async () => {
     if (isSubmittingRef.current) return;
@@ -58,13 +66,18 @@ export function ExchangeConfirmationModal({
         "[ExchangeConfirmationModal] Failed to confirm action:",
         error,
       );
+      if (!ignoreRef.current) {
+        isSubmittingRef.current = false;
+        setIsSubmitting(false);
+      }
       return;
-    } finally {
-      isSubmittingRef.current = false;
-      setIsSubmitting(false);
     }
 
-    onClose();
+    if (!ignoreRef.current) {
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
+      onClose();
+    }
   }, [onConfirm, onClose]);
 
   if (!isOpen) return null;


### PR DESCRIPTION
Replace isMounted ref pattern with proper useEffect cleanup following React 19 best practices. The cleanup function sets an ignore flag that prevents state updates after component unmount.

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)