### PR TITLE
feat(assignments): restrict game report to NLA and NLB games

### DIFF
--- a/web-app/src/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/hooks/useAssignmentActions.test.ts
@@ -214,9 +214,56 @@ describe("useAssignmentActions", () => {
       result.current.handleGenerateReport(nonEligibleAssignment);
     });
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      "Game reports are only available for NLA and NLB games.",
-    );
+    // Verify alert was called (translation key: assignments.gameReportNotAvailable)
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(createElementSpy).not.toHaveBeenCalledWith("a");
+
+    alertSpy.mockRestore();
+  });
+
+  it("should handle generate report action for NLB games", () => {
+    const { result } = renderHook(() => useAssignmentActions());
+    const createElementSpy = vi.spyOn(document, "createElement");
+
+    const nlbAssignment = createMockAssignment("NLB");
+
+    act(() => {
+      result.current.handleGenerateReport(nlbAssignment);
+    });
+
+    expect(createElementSpy).toHaveBeenCalledWith("a");
+  });
+
+  it("should block generate report when league data is undefined", () => {
+    const { result } = renderHook(() => useAssignmentActions());
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    const createElementSpy = vi.spyOn(document, "createElement");
+
+    // Create assignment without league data
+    const assignmentWithoutLeague: Assignment = {
+      __identity: "test-assignment-1",
+      refereePosition: "head-one",
+      refereeConvocationStatus: "active",
+      refereeGame: {
+        game: {
+          startingDateTime: "2025-12-15T18:00:00Z",
+          encounter: {
+            teamHome: { name: "Team A" },
+            teamAway: { name: "Team B" },
+          },
+          hall: {
+            name: "Main Arena",
+          },
+        },
+      },
+    } as Assignment;
+
+    act(() => {
+      result.current.handleGenerateReport(assignmentWithoutLeague);
+    });
+
+    // Verify alert was called (translation key: assignments.gameReportNotAvailable)
+    expect(alertSpy).toHaveBeenCalledTimes(1);
     expect(createElementSpy).not.toHaveBeenCalledWith("a");
 
     alertSpy.mockRestore();

--- a/web-app/src/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/hooks/useAssignmentActions.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/stores/auth");
 vi.mock("@/stores/demo");
 vi.mock("@/stores/settings");
 
-function createMockAssignment(): Assignment {
+function createMockAssignment(leagueName = "NLA"): Assignment {
   return {
     __identity: "test-assignment-1",
     refereePosition: "head-one",
@@ -25,6 +25,15 @@ function createMockAssignment(): Assignment {
         },
         hall: {
           name: "Main Arena",
+        },
+        group: {
+          phase: {
+            league: {
+              leagueCategory: {
+                name: leagueName,
+              },
+            },
+          },
         },
       },
     },
@@ -182,7 +191,7 @@ describe("useAssignmentActions", () => {
     expect(result.current.editCompensationModal.assignment).toBeNull();
   });
 
-  it("should handle generate report action", () => {
+  it("should handle generate report action for NLA/NLB games", () => {
     const { result } = renderHook(() => useAssignmentActions());
 
     const createElementSpy = vi.spyOn(document, "createElement");
@@ -192,6 +201,25 @@ describe("useAssignmentActions", () => {
     });
 
     expect(createElementSpy).toHaveBeenCalledWith("a");
+  });
+
+  it("should block generate report for non-NLA/NLB games", () => {
+    const { result } = renderHook(() => useAssignmentActions());
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    const createElementSpy = vi.spyOn(document, "createElement");
+
+    const nonEligibleAssignment = createMockAssignment("1L");
+
+    act(() => {
+      result.current.handleGenerateReport(nonEligibleAssignment);
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Game reports are only available for NLA and NLB games.",
+    );
+    expect(createElementSpy).not.toHaveBeenCalledWith("a");
+
+    alertSpy.mockRestore();
   });
 
   it("should handle add to exchange action", () => {

--- a/web-app/src/hooks/useAssignmentActions.ts
+++ b/web-app/src/hooks/useAssignmentActions.ts
@@ -2,7 +2,11 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import type { Assignment } from "@/api/client";
 import { downloadPDF } from "@/utils/assignment-actions";
 import { logger } from "@/utils/logger";
-import { getTeamNames, MODAL_CLEANUP_DELAY } from "@/utils/assignment-helpers";
+import {
+  getTeamNames,
+  isGameReportEligible,
+  MODAL_CLEANUP_DELAY,
+} from "@/utils/assignment-helpers";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { useSettingsStore } from "@/stores/settings";
@@ -103,6 +107,14 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
 
   const handleGenerateReport = useCallback(
     (assignment: Assignment) => {
+      if (!isGameReportEligible(assignment)) {
+        logger.debug(
+          "[useAssignmentActions] Game report not available for this league",
+        );
+        alert(t("assignments.gameReportNotAvailable"));
+        return;
+      }
+
       if (isDemoMode) {
         logger.debug("[useAssignmentActions] Demo mode: PDF download disabled");
         // TODO(#77): Replace alert with toast notification when notification system is implemented
@@ -133,7 +145,7 @@ This is a mock PDF report.`;
         assignment.__identity,
       );
     },
-    [isDemoMode],
+    [isDemoMode, t],
   );
 
   const handleAddToExchange = useCallback(

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -72,6 +72,7 @@ interface Translations {
     homeScore: string;
     awayScore: string;
     numberOfSets: string;
+    gameReportNotAvailable: string;
   };
   compensations: {
     title: string;
@@ -213,6 +214,8 @@ const en: Translations = {
     homeScore: "Home Score",
     awayScore: "Away Score",
     numberOfSets: "Number of Sets",
+    gameReportNotAvailable:
+      "Game reports are only available for NLA and NLB games.",
   },
   compensations: {
     title: "Compensations",
@@ -365,6 +368,8 @@ const de: Translations = {
     homeScore: "Heimscore",
     awayScore: "Gastscore",
     numberOfSets: "Anzahl Sätze",
+    gameReportNotAvailable:
+      "Spielberichte sind nur für NLA- und NLB-Spiele verfügbar.",
   },
   compensations: {
     title: "Entschädigungen",
@@ -518,6 +523,8 @@ const fr: Translations = {
     homeScore: "Score domicile",
     awayScore: "Score visiteur",
     numberOfSets: "Nombre de sets",
+    gameReportNotAvailable:
+      "Les rapports de match sont uniquement disponibles pour les matchs NLA et NLB.",
   },
   compensations: {
     title: "Indemnités",
@@ -671,6 +678,8 @@ const it: Translations = {
     homeScore: "Punteggio casa",
     awayScore: "Punteggio ospite",
     numberOfSets: "Numero di set",
+    gameReportNotAvailable:
+      "I rapporti delle partite sono disponibili solo per le partite NLA e NLB.",
   },
   compensations: {
     title: "Compensi",

--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -43,3 +43,19 @@ export function getTeamNamesFromCompensation(
 ): { homeTeam: string; awayTeam: string } {
   return extractTeamNames(compensation.refereeGame?.game);
 }
+
+/**
+ * League categories that are eligible for game report generation.
+ * Only NLA and NLB games support game reports.
+ */
+const GAME_REPORT_ELIGIBLE_LEAGUES = ["NLA", "NLB"];
+
+/**
+ * Checks if an assignment is eligible for game report generation.
+ * Only NLA and NLB games are eligible.
+ */
+export function isGameReportEligible(assignment: Assignment): boolean {
+  const leagueName =
+    assignment.refereeGame?.game?.group?.phase?.league?.leagueCategory?.name;
+  return leagueName !== undefined && GAME_REPORT_ELIGIBLE_LEAGUES.includes(leagueName);
+}

--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -51,7 +51,9 @@ export function getTeamNamesFromCompensation(
  * - NLA: Nationalliga A (top tier, men's and women's)
  * - NLB: Nationalliga B (second tier, men's and women's)
  * - 1L: 1. Liga (third tier, national)
- * - 2L, 3L, 4L: Lower leagues (regional)
+ * - 2L-5L: Lower leagues (regional, depth varies by region)
+ * - Junior leagues: U14, U16, U18, U20, U23, SAR
+ *   (in French: M14, M16, M18, M20, M23)
  *
  * Game reports are only available for NLA and NLB games
  * as they require official documentation for Swiss Volley.

--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -46,13 +46,29 @@ export function getTeamNamesFromCompensation(
 
 /**
  * League categories that are eligible for game report generation.
- * Only NLA and NLB games support game reports.
+ *
+ * Swiss volleyball league hierarchy (top to bottom):
+ * - NLA: Nationalliga A (top tier, men's and women's)
+ * - NLB: Nationalliga B (second tier, men's and women's)
+ * - 1L: 1. Liga (third tier, national)
+ * - 2L, 3L, 4L: Lower leagues (regional)
+ *
+ * Game reports are only available for NLA and NLB games
+ * as they require official documentation for Swiss Volley.
  */
 const GAME_REPORT_ELIGIBLE_LEAGUES = ["NLA", "NLB"];
 
 /**
  * Checks if an assignment is eligible for game report generation.
- * Only NLA and NLB games are eligible.
+ *
+ * Game reports are only available for NLA (Nationalliga A) and NLB
+ * (Nationalliga B) games, the top two tiers of Swiss volleyball.
+ * Games in other leagues (1L and below) do not require official
+ * game reports through this system.
+ *
+ * @param assignment - The referee assignment to check
+ * @returns true if the assignment's league is NLA or NLB, false otherwise
+ *          (including when league data is undefined)
  */
 export function isGameReportEligible(assignment: Assignment): boolean {
   const leagueName =


### PR DESCRIPTION
Game reports are now only available for NLA and NLB league games.
When attempting to generate a report for other leagues (1L, 2L, etc.),
users see a localized message explaining the restriction.

- Add isGameReportEligible helper function to check league eligibility
- Add translation strings for all four languages (en, de, fr, it)
- Update handleGenerateReport to check league before proceeding
- Add tests for both eligible and non-eligible leagues