### PR TITLE
feat(validation): Add tabbed modal shell for game validation workflow

### DIFF
--- a/PLAN-issue-34.md
+++ b/PLAN-issue-34.md
@@ -1,0 +1,216 @@
+# Implementation Plan: Issue #34 - Tabbed Modal Shell for Game Validation
+
+## Overview
+
+Transform `ValidateGameModal` from a basic score-entry component into a comprehensive tabbed validation system with 4 tabs: Home Roster, Away Roster, Scorer, and Scoresheet.
+
+## Current State
+
+- `ValidateGameModal` (`web-app/src/components/features/ValidateGameModal.tsx`) is a simple form modal with score inputs
+- No reusable Tabs component exists in `components/ui/`
+- Tab pattern exists in `AssignmentsPage.tsx` but is inline and page-specific
+
+## Implementation Steps
+
+### Step 1: Create Reusable Tabs Component
+
+**File**: `web-app/src/components/ui/Tabs.tsx`
+
+Create a fully accessible, reusable Tabs component with:
+- Generic tab configuration via props
+- Keyboard navigation (Arrow Left/Right between tabs)
+- Horizontal scroll support for overflow on mobile
+- Support for badge rendering (e.g., "Optional" on Scoresheet tab)
+- Dark mode support
+- ARIA attributes for accessibility (`role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`, `aria-controls`)
+
+**Props interface**:
+```typescript
+interface Tab {
+  id: string;
+  label: string;
+  badge?: string;
+}
+
+interface TabsProps {
+  tabs: Tab[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  ariaLabel: string;
+}
+```
+
+### Step 2: Create Tabs Component Tests
+
+**File**: `web-app/src/components/ui/Tabs.test.tsx`
+
+Test cases:
+- Renders all tabs with correct labels
+- Shows active tab styling
+- Renders badge when provided
+- Calls onTabChange when tab clicked
+- Arrow key navigation (Left/Right cycles through tabs)
+- Horizontal scroll container exists for overflow
+- Proper ARIA attributes
+
+### Step 3: Create Validation Directory Structure
+
+Create directory: `web-app/src/components/features/validation/`
+
+Files to create:
+- `index.ts` - Re-exports all validation components
+- `HomeRosterPanel.tsx` - Placeholder panel for home team roster
+- `AwayRosterPanel.tsx` - Placeholder panel for away team roster
+- `ScorerPanel.tsx` - Placeholder panel for scorer identification
+- `ScoresheetPanel.tsx` - Placeholder panel for scoresheet upload
+
+### Step 4: Create Placeholder Panel Components
+
+Each panel component will:
+- Accept `assignment: Assignment` prop
+- Display placeholder content indicating future functionality
+- Be independently testable
+- Support dark mode
+
+**Example structure** (same for all panels):
+```typescript
+interface PanelProps {
+  assignment: Assignment;
+}
+
+export function HomeRosterPanel({ assignment }: PanelProps) {
+  // Placeholder implementation
+}
+```
+
+### Step 5: Create Panel Tests
+
+**File**: `web-app/src/components/features/validation/panels.test.tsx`
+
+Test that each panel:
+- Renders without crashing
+- Displays placeholder content
+- Accepts assignment prop
+
+### Step 6: Refactor ValidateGameModal
+
+**File**: `web-app/src/components/features/ValidateGameModal.tsx`
+
+Changes:
+1. Remove all score-entry form state and logic (homeScore, awayScore, sets, errors)
+2. Remove form validation logic
+3. Add tab state management with 4 tabs
+4. Import and use the new `Tabs` component
+5. Import and conditionally render panel components based on active tab
+6. Keep existing modal patterns:
+   - Escape key handling
+   - Backdrop click dismissal
+   - ARIA attributes for modal
+   - Dark mode support
+7. Update modal width for tabbed content (may need `max-w-lg` or `max-w-xl`)
+
+**Tab configuration**:
+```typescript
+const VALIDATION_TABS = [
+  { id: 'home-roster', label: t('validation.homeRoster') },
+  { id: 'away-roster', label: t('validation.awayRoster') },
+  { id: 'scorer', label: t('validation.scorer') },
+  { id: 'scoresheet', label: t('validation.scoresheet'), badge: t('common.optional') },
+];
+```
+
+### Step 7: Add Translation Keys
+
+**File**: `web-app/src/i18n/index.ts`
+
+Add a new `validation` section to the `Translations` interface and all language objects (en, de, fr, it):
+
+```typescript
+// Add to Translations interface
+validation: {
+  homeRoster: string;
+  awayRoster: string;
+  scorer: string;
+  scoresheet: string;
+  homeRosterPlaceholder: string;
+  awayRosterPlaceholder: string;
+  scorerPlaceholder: string;
+  scoresheetPlaceholder: string;
+};
+
+// Also add to common section
+optional: string;
+```
+
+**English translations**:
+```typescript
+validation: {
+  homeRoster: "Home Roster",
+  awayRoster: "Away Roster",
+  scorer: "Scorer",
+  scoresheet: "Scoresheet",
+  homeRosterPlaceholder: "Home team roster verification will be available here.",
+  awayRosterPlaceholder: "Away team roster verification will be available here.",
+  scorerPlaceholder: "Scorer identification will be available here.",
+  scoresheetPlaceholder: "Scoresheet upload will be available here.",
+},
+// common.optional: "Optional"
+```
+
+**German, French, Italian translations** will follow the same structure with appropriate translations.
+
+### Step 8: Update ValidateGameModal Tests
+
+**File**: `web-app/src/components/features/ValidateGameModal.test.tsx`
+
+Update/create tests for:
+- Modal renders with tabs
+- All 4 tabs are visible
+- Tab switching works
+- "Optional" badge shows only on Scoresheet tab
+- Arrow key navigation between tabs
+- Escape key closes modal
+- Backdrop click closes modal
+- Correct panel content displays for active tab
+
+### Step 9: Run CI Validation
+
+```bash
+cd web-app
+npm run generate:api
+npm run lint
+npm test
+npm run build
+```
+
+## File Change Summary
+
+### New Files
+- `web-app/src/components/ui/Tabs.tsx`
+- `web-app/src/components/ui/Tabs.test.tsx`
+- `web-app/src/components/features/validation/index.ts`
+- `web-app/src/components/features/validation/HomeRosterPanel.tsx`
+- `web-app/src/components/features/validation/AwayRosterPanel.tsx`
+- `web-app/src/components/features/validation/ScorerPanel.tsx`
+- `web-app/src/components/features/validation/ScoresheetPanel.tsx`
+- `web-app/src/components/features/validation/panels.test.tsx`
+
+### Modified Files
+- `web-app/src/components/features/ValidateGameModal.tsx`
+- `web-app/src/i18n/index.ts` (add validation section to interface and all 4 language objects)
+
+### Possibly New/Modified
+- `web-app/src/components/features/ValidateGameModal.test.tsx` (create if doesn't exist)
+
+## Design Decisions
+
+1. **Tabs as controlled component**: The parent (ValidateGameModal) manages tab state, making the Tabs component reusable
+2. **Panel components are simple**: Each panel is a placeholder - detailed implementation deferred per issue requirements
+3. **Consistent styling**: Using existing orange-500 accent color from AssignmentsPage tabs
+4. **Mobile-first**: Horizontal scroll for tab overflow on small screens
+5. **Accessibility**: Full keyboard navigation and ARIA support
+
+## Dependencies
+
+- No new npm packages required
+- Uses existing patterns from the codebase

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ValidateGameModal } from "./ValidateGameModal";
+import type { Assignment } from "@/api/client";
+
+function createMockAssignment(
+  overrides: Partial<Assignment> = {},
+): Assignment {
+  return {
+    __identity: "assignment-1",
+    refereePosition: "head-one",
+    refereeGame: {
+      game: {
+        __identity: "game-1",
+        startingDateTime: "2025-12-15T14:00:00Z",
+        encounter: {
+          teamHome: { name: "VBC Zürich" },
+          teamAway: { name: "VBC Basel" },
+        },
+        hall: {
+          name: "Sporthalle Zürich",
+          primaryPostalAddress: {
+            city: "Zürich",
+          },
+        },
+      },
+    },
+    ...overrides,
+  } as Assignment;
+}
+
+describe("ValidateGameModal", () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  describe("rendering", () => {
+    it("does not render when isOpen is false", () => {
+      const { container } = render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={false}
+          onClose={mockOnClose}
+        />,
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders modal with correct title when open", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+      expect(screen.getByRole("dialog", { hidden: true })).toBeInTheDocument();
+      expect(screen.getByText("Validate Game Details")).toBeInTheDocument();
+    });
+
+    it("displays team names", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+      expect(screen.getByText("VBC Zürich vs VBC Basel")).toBeInTheDocument();
+    });
+
+    it("renders all 4 tabs", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+      expect(
+        screen.getByRole("tab", { name: /Home Roster/i, hidden: true }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: /Away Roster/i, hidden: true }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: /Scorer/i, hidden: true }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: /Scoresheet/i, hidden: true }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows Optional badge only on Scoresheet tab", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+      const optionalBadges = screen.getAllByText("Optional");
+      expect(optionalBadges).toHaveLength(1);
+
+      const scoresheetTab = screen.getByRole("tab", {
+        name: /Scoresheet/i,
+        hidden: true,
+      });
+      expect(scoresheetTab).toContainElement(optionalBadges[0] ?? null);
+    });
+  });
+
+  describe("tab navigation", () => {
+    it("shows Home Roster panel by default", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+      expect(
+        screen.getByText("Home team roster verification will be available here."),
+      ).toBeInTheDocument();
+    });
+
+    it("switches to Away Roster panel when tab is clicked", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("tab", { name: /Away Roster/i, hidden: true }),
+      );
+
+      expect(
+        screen.getByText("Away team roster verification will be available here."),
+      ).toBeInTheDocument();
+    });
+
+    it("switches to Scorer panel when tab is clicked", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("tab", { name: /Scorer/i, hidden: true }),
+      );
+
+      expect(
+        screen.getByText("Scorer identification will be available here."),
+      ).toBeInTheDocument();
+    });
+
+    it("switches to Scoresheet panel when tab is clicked", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("tab", { name: /Scoresheet/i, hidden: true }),
+      );
+
+      expect(
+        screen.getByText("Scoresheet upload will be available here."),
+      ).toBeInTheDocument();
+    });
+
+    it("navigates tabs with arrow keys", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const homeRosterTab = screen.getByRole("tab", {
+        name: /Home Roster/i,
+        hidden: true,
+      });
+      fireEvent.keyDown(homeRosterTab, { key: "ArrowRight" });
+
+      expect(
+        screen.getByText("Away team roster verification will be available here."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("modal interactions", () => {
+    it("calls onClose when Close button is clicked", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Close/i, hidden: true }),
+      );
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when Escape key is pressed", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when backdrop is clicked", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const backdrop = screen.getByRole("dialog", { hidden: true }).parentElement;
+      fireEvent.click(backdrop!);
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not close when clicking inside the modal", () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const dialog = screen.getByRole("dialog", { hidden: true });
+      fireEvent.click(dialog);
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -108,7 +108,7 @@ describe("ValidateGameModal", () => {
         name: /Scoresheet/i,
         hidden: true,
       });
-      expect(scoresheetTab).toContainElement(optionalBadges[0] ?? null);
+      expect(scoresheetTab).toContainElement(optionalBadges[0]!);
     });
   });
 
@@ -256,6 +256,47 @@ describe("ValidateGameModal", () => {
       const dialog = screen.getByRole("dialog", { hidden: true });
       fireEvent.click(dialog);
       expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it("resets to first tab when modal is reopened", () => {
+      const { rerender } = render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      // Switch to Scoresheet tab
+      fireEvent.click(
+        screen.getByRole("tab", { name: /Scoresheet/i, hidden: true }),
+      );
+      expect(
+        screen.getByText("Scoresheet upload will be available here."),
+      ).toBeInTheDocument();
+
+      // Close modal
+      rerender(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={false}
+          onClose={mockOnClose}
+        />,
+      );
+
+      // Reopen modal
+      rerender(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      // Should be back to Home Roster
+      expect(
+        screen.getByText("Home team roster verification will be available here."),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -54,12 +54,6 @@ export function ValidateGameModal({
     }
   }, [isOpen, onClose]);
 
-  useEffect(() => {
-    if (!isOpen) {
-      setActiveTab("home-roster");
-    }
-  }, [isOpen]);
-
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (e.target === e.currentTarget) {

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -41,12 +41,16 @@ export function ValidateGameModal({
     },
   ];
 
+  // Reset to first tab when modal opens for consistent UX
   useEffect(() => {
     if (!isOpen) return;
-
-    // Reset to first tab when modal opens for consistent UX
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveTab("home-roster");
+  }, [isOpen]);
+
+  // Handle Escape key to close modal
+  useEffect(() => {
+    if (!isOpen) return;
 
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -1,8 +1,14 @@
 import { useState, useCallback, useEffect } from "react";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
-import { logger } from "@/utils/logger";
 import { getTeamNames } from "@/utils/assignment-helpers";
+import { Tabs, TabPanel } from "@/components/ui/Tabs";
+import {
+  HomeRosterPanel,
+  AwayRosterPanel,
+  ScorerPanel,
+  ScoresheetPanel,
+} from "@/components/features/validation";
 
 interface ValidateGameModalProps {
   assignment: Assignment;
@@ -10,20 +16,30 @@ interface ValidateGameModalProps {
   onClose: () => void;
 }
 
+type ValidationTabId =
+  | "home-roster"
+  | "away-roster"
+  | "scorer"
+  | "scoresheet";
+
 export function ValidateGameModal({
   assignment,
   isOpen,
   onClose,
 }: ValidateGameModalProps) {
   const { t } = useTranslation();
-  const [homeScore, setHomeScore] = useState("");
-  const [awayScore, setAwayScore] = useState("");
-  const [sets, setSets] = useState("");
-  const [errors, setErrors] = useState<{
-    homeScore?: string;
-    awayScore?: string;
-    sets?: string;
-  }>({});
+  const [activeTab, setActiveTab] = useState<ValidationTabId>("home-roster");
+
+  const tabs = [
+    { id: "home-roster", label: t("validation.homeRoster") },
+    { id: "away-roster", label: t("validation.awayRoster") },
+    { id: "scorer", label: t("validation.scorer") },
+    {
+      id: "scoresheet",
+      label: t("validation.scoresheet"),
+      badge: t("common.optional"),
+    },
+  ];
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -38,48 +54,11 @@ export function ValidateGameModal({
     }
   }, [isOpen, onClose]);
 
-  const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
-      e.preventDefault();
-      setErrors({});
-
-      const newErrors: {
-        homeScore?: string;
-        awayScore?: string;
-        sets?: string;
-      } = {};
-
-      const home = parseInt(homeScore, 10);
-      if (homeScore && (isNaN(home) || home < 0)) {
-        newErrors.homeScore = "Please enter a valid positive number";
-      }
-
-      const away = parseInt(awayScore, 10);
-      if (awayScore && (isNaN(away) || away < 0)) {
-        newErrors.awayScore = "Please enter a valid positive number";
-      }
-
-      const numSets = parseInt(sets, 10);
-      if (sets && (isNaN(numSets) || numSets < 3 || numSets > 5)) {
-        newErrors.sets = "Please enter a number between 3 and 5";
-      }
-
-      if (Object.keys(newErrors).length > 0) {
-        setErrors(newErrors);
-        return;
-      }
-
-      logger.debug("[ValidateGameModal] Mock submit:", {
-        assignmentId: assignment.__identity,
-        homeScore,
-        awayScore,
-        sets,
-      });
-
-      onClose();
-    },
-    [assignment, homeScore, awayScore, sets, onClose],
-  );
+  useEffect(() => {
+    if (!isOpen) {
+      setActiveTab("home-roster");
+    }
+  }, [isOpen]);
 
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -89,6 +68,10 @@ export function ValidateGameModal({
     },
     [onClose],
   );
+
+  const handleTabChange = useCallback((tabId: string) => {
+    setActiveTab(tabId as ValidationTabId);
+  }, []);
 
   if (!isOpen) return null;
 
@@ -101,14 +84,14 @@ export function ValidateGameModal({
       aria-hidden="true"
     >
       <div
-        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full p-6"
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-lg w-full p-6"
         role="dialog"
         aria-modal="true"
         aria-labelledby="validate-game-title"
       >
         <h2
           id="validate-game-title"
-          className="text-xl font-semibold text-gray-900 dark:text-white mb-4"
+          className="text-xl font-semibold text-gray-900 dark:text-white mb-2"
         >
           {t("assignments.validateGame")}
         </h2>
@@ -119,114 +102,38 @@ export function ValidateGameModal({
           </div>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label
-                htmlFor="homeScore"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
-                {homeTeam} {t("assignments.homeScore")}
-              </label>
-              <input
-                id="homeScore"
-                type="number"
-                min="0"
-                value={homeScore}
-                onChange={(e) => setHomeScore(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
-                placeholder="0"
-                aria-invalid={errors.homeScore ? "true" : "false"}
-                aria-describedby={
-                  errors.homeScore ? "homeScore-error" : undefined
-                }
-              />
-              {errors.homeScore && (
-                <p
-                  id="homeScore-error"
-                  className="mt-1 text-sm text-red-600 dark:text-red-400"
-                >
-                  {errors.homeScore}
-                </p>
-              )}
-            </div>
+        <Tabs
+          tabs={tabs}
+          activeTab={activeTab}
+          onTabChange={handleTabChange}
+          ariaLabel={t("assignments.validateGame")}
+        />
 
-            <div>
-              <label
-                htmlFor="awayScore"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
-                {awayTeam} {t("assignments.awayScore")}
-              </label>
-              <input
-                id="awayScore"
-                type="number"
-                min="0"
-                value={awayScore}
-                onChange={(e) => setAwayScore(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
-                placeholder="0"
-                aria-invalid={errors.awayScore ? "true" : "false"}
-                aria-describedby={
-                  errors.awayScore ? "awayScore-error" : undefined
-                }
-              />
-              {errors.awayScore && (
-                <p
-                  id="awayScore-error"
-                  className="mt-1 text-sm text-red-600 dark:text-red-400"
-                >
-                  {errors.awayScore}
-                </p>
-              )}
-            </div>
-          </div>
+        <TabPanel tabId="home-roster" activeTab={activeTab}>
+          <HomeRosterPanel assignment={assignment} />
+        </TabPanel>
 
-          <div>
-            <label
-              htmlFor="sets"
-              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-            >
-              {t("assignments.numberOfSets")}
-            </label>
-            <input
-              id="sets"
-              type="number"
-              min="3"
-              max="5"
-              value={sets}
-              onChange={(e) => setSets(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
-              placeholder="3"
-              aria-invalid={errors.sets ? "true" : "false"}
-              aria-describedby={errors.sets ? "sets-error" : undefined}
-            />
-            {errors.sets && (
-              <p
-                id="sets-error"
-                className="mt-1 text-sm text-red-600 dark:text-red-400"
-              >
-                {errors.sets}
-              </p>
-            )}
-          </div>
+        <TabPanel tabId="away-roster" activeTab={activeTab}>
+          <AwayRosterPanel assignment={assignment} />
+        </TabPanel>
 
-          <div className="flex gap-3 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 px-4 py-2 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500"
-            >
-              {t("common.close")}
-            </button>
-            <button
-              type="submit"
-              className="flex-1 px-4 py-2 text-white bg-purple-600 rounded-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
-            >
-              {t("common.confirm")}
-            </button>
-          </div>
-        </form>
+        <TabPanel tabId="scorer" activeTab={activeTab}>
+          <ScorerPanel assignment={assignment} />
+        </TabPanel>
+
+        <TabPanel tabId="scoresheet" activeTab={activeTab}>
+          <ScoresheetPanel assignment={assignment} />
+        </TabPanel>
+
+        <div className="flex justify-end pt-4 border-t border-gray-200 dark:border-gray-700 mt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500"
+          >
+            {t("common.close")}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -42,16 +42,16 @@ export function ValidateGameModal({
   ];
 
   useEffect(() => {
+    if (!isOpen) return;
+
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isOpen) {
+      if (e.key === "Escape") {
         onClose();
       }
     };
 
-    if (isOpen) {
-      document.addEventListener("keydown", handleEscape);
-      return () => document.removeEventListener("keydown", handleEscape);
-    }
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
   }, [isOpen, onClose]);
 
   const handleBackdropClick = useCallback(

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -44,6 +44,10 @@ export function ValidateGameModal({
   useEffect(() => {
     if (!isOpen) return;
 
+    // Reset to first tab when modal opens for consistent UX
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setActiveTab("home-roster");
+
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         onClose();

--- a/web-app/src/components/features/validation/AwayRosterPanel.tsx
+++ b/web-app/src/components/features/validation/AwayRosterPanel.tsx
@@ -1,0 +1,23 @@
+import type { Assignment } from "@/api/client";
+import { useTranslation } from "@/hooks/useTranslation";
+import { getTeamNames } from "@/utils/assignment-helpers";
+
+interface AwayRosterPanelProps {
+  assignment: Assignment;
+}
+
+export function AwayRosterPanel({ assignment }: AwayRosterPanelProps) {
+  const { t } = useTranslation();
+  const { awayTeam } = getTeamNames(assignment);
+
+  return (
+    <div className="py-4">
+      <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
+        {awayTeam}
+      </h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {t("validation.awayRosterPlaceholder")}
+      </p>
+    </div>
+  );
+}

--- a/web-app/src/components/features/validation/HomeRosterPanel.tsx
+++ b/web-app/src/components/features/validation/HomeRosterPanel.tsx
@@ -1,0 +1,23 @@
+import type { Assignment } from "@/api/client";
+import { useTranslation } from "@/hooks/useTranslation";
+import { getTeamNames } from "@/utils/assignment-helpers";
+
+interface HomeRosterPanelProps {
+  assignment: Assignment;
+}
+
+export function HomeRosterPanel({ assignment }: HomeRosterPanelProps) {
+  const { t } = useTranslation();
+  const { homeTeam } = getTeamNames(assignment);
+
+  return (
+    <div className="py-4">
+      <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
+        {homeTeam}
+      </h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {t("validation.homeRosterPlaceholder")}
+      </p>
+    </div>
+  );
+}

--- a/web-app/src/components/features/validation/ScorerPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerPanel.tsx
@@ -1,0 +1,18 @@
+import type { Assignment } from "@/api/client";
+import { useTranslation } from "@/hooks/useTranslation";
+
+interface ScorerPanelProps {
+  assignment: Assignment;
+}
+
+export function ScorerPanel({ assignment: _assignment }: ScorerPanelProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="py-4">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {t("validation.scorerPlaceholder")}
+      </p>
+    </div>
+  );
+}

--- a/web-app/src/components/features/validation/ScorerPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerPanel.tsx
@@ -5,7 +5,8 @@ interface ScorerPanelProps {
   assignment: Assignment;
 }
 
-export function ScorerPanel({ assignment: _assignment }: ScorerPanelProps) {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function ScorerPanel(_props: ScorerPanelProps) {
   const { t } = useTranslation();
 
   return (

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -5,9 +5,8 @@ interface ScoresheetPanelProps {
   assignment: Assignment;
 }
 
-export function ScoresheetPanel({
-  assignment: _assignment,
-}: ScoresheetPanelProps) {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function ScoresheetPanel(_props: ScoresheetPanelProps) {
   const { t } = useTranslation();
 
   return (

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -1,0 +1,20 @@
+import type { Assignment } from "@/api/client";
+import { useTranslation } from "@/hooks/useTranslation";
+
+interface ScoresheetPanelProps {
+  assignment: Assignment;
+}
+
+export function ScoresheetPanel({
+  assignment: _assignment,
+}: ScoresheetPanelProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="py-4">
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {t("validation.scoresheetPlaceholder")}
+      </p>
+    </div>
+  );
+}

--- a/web-app/src/components/features/validation/index.ts
+++ b/web-app/src/components/features/validation/index.ts
@@ -1,0 +1,4 @@
+export { HomeRosterPanel } from "./HomeRosterPanel";
+export { AwayRosterPanel } from "./AwayRosterPanel";
+export { ScorerPanel } from "./ScorerPanel";
+export { ScoresheetPanel } from "./ScoresheetPanel";

--- a/web-app/src/components/features/validation/panels.test.tsx
+++ b/web-app/src/components/features/validation/panels.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HomeRosterPanel } from "./HomeRosterPanel";
+import { AwayRosterPanel } from "./AwayRosterPanel";
+import { ScorerPanel } from "./ScorerPanel";
+import { ScoresheetPanel } from "./ScoresheetPanel";
+import type { Assignment } from "@/api/client";
+
+function createMockAssignment(
+  overrides: Partial<Assignment> = {},
+): Assignment {
+  return {
+    __identity: "assignment-1",
+    refereePosition: "head-one",
+    refereeGame: {
+      game: {
+        __identity: "game-1",
+        startingDateTime: "2025-12-15T14:00:00Z",
+        encounter: {
+          teamHome: { name: "VBC Zürich" },
+          teamAway: { name: "VBC Basel" },
+        },
+        hall: {
+          name: "Sporthalle Zürich",
+          primaryPostalAddress: {
+            city: "Zürich",
+          },
+        },
+      },
+    },
+    ...overrides,
+  } as Assignment;
+}
+
+describe("HomeRosterPanel", () => {
+  it("renders without crashing", () => {
+    render(<HomeRosterPanel assignment={createMockAssignment()} />);
+    expect(
+      screen.getByText(
+        "Home team roster verification will be available here.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("displays home team name", () => {
+    render(<HomeRosterPanel assignment={createMockAssignment()} />);
+    expect(screen.getByText("VBC Zürich")).toBeInTheDocument();
+  });
+});
+
+describe("AwayRosterPanel", () => {
+  it("renders without crashing", () => {
+    render(<AwayRosterPanel assignment={createMockAssignment()} />);
+    expect(
+      screen.getByText(
+        "Away team roster verification will be available here.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("displays away team name", () => {
+    render(<AwayRosterPanel assignment={createMockAssignment()} />);
+    expect(screen.getByText("VBC Basel")).toBeInTheDocument();
+  });
+});
+
+describe("ScorerPanel", () => {
+  it("renders without crashing", () => {
+    render(<ScorerPanel assignment={createMockAssignment()} />);
+    expect(
+      screen.getByText("Scorer identification will be available here."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ScoresheetPanel", () => {
+  it("renders without crashing", () => {
+    render(<ScoresheetPanel assignment={createMockAssignment()} />);
+    expect(
+      screen.getByText("Scoresheet upload will be available here."),
+    ).toBeInTheDocument();
+  });
+});

--- a/web-app/src/components/ui/Tabs.test.tsx
+++ b/web-app/src/components/ui/Tabs.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Tabs, TabPanel } from "./Tabs";
+
+const mockTabs = [
+  { id: "tab1", label: "Tab 1" },
+  { id: "tab2", label: "Tab 2" },
+  { id: "tab3", label: "Tab 3", badge: "Optional" },
+];
+
+describe("Tabs", () => {
+  it("renders all tabs with correct labels", () => {
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab1"
+        onTabChange={vi.fn()}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    expect(screen.getByText("Tab 1")).toBeInTheDocument();
+    expect(screen.getByText("Tab 2")).toBeInTheDocument();
+    expect(screen.getByText("Tab 3")).toBeInTheDocument();
+  });
+
+  it("shows active tab with aria-selected true", () => {
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab2"
+        onTabChange={vi.fn()}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    const activeTab = screen.getByRole("tab", { name: /Tab 2/i });
+    expect(activeTab).toHaveAttribute("aria-selected", "true");
+
+    const inactiveTab = screen.getByRole("tab", { name: /Tab 1/i });
+    expect(inactiveTab).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("renders badge when provided", () => {
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab1"
+        onTabChange={vi.fn()}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    expect(screen.getByText("Optional")).toBeInTheDocument();
+  });
+
+  it("calls onTabChange when tab is clicked", () => {
+    const handleTabChange = vi.fn();
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab1"
+        onTabChange={handleTabChange}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: /Tab 2/i }));
+    expect(handleTabChange).toHaveBeenCalledWith("tab2");
+  });
+
+  it("navigates to next tab with ArrowRight key", () => {
+    const handleTabChange = vi.fn();
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab1"
+        onTabChange={handleTabChange}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    const firstTab = screen.getByRole("tab", { name: /Tab 1/i });
+    fireEvent.keyDown(firstTab, { key: "ArrowRight" });
+
+    expect(handleTabChange).toHaveBeenCalledWith("tab2");
+  });
+
+  it("navigates to previous tab with ArrowLeft key", () => {
+    const handleTabChange = vi.fn();
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab2"
+        onTabChange={handleTabChange}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    const secondTab = screen.getByRole("tab", { name: /Tab 2/i });
+    fireEvent.keyDown(secondTab, { key: "ArrowLeft" });
+
+    expect(handleTabChange).toHaveBeenCalledWith("tab1");
+  });
+
+  it("wraps around when navigating past last tab", () => {
+    const handleTabChange = vi.fn();
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab3"
+        onTabChange={handleTabChange}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    const lastTab = screen.getByRole("tab", { name: /Tab 3/i });
+    fireEvent.keyDown(lastTab, { key: "ArrowRight" });
+
+    expect(handleTabChange).toHaveBeenCalledWith("tab1");
+  });
+
+  it("wraps around when navigating before first tab", () => {
+    const handleTabChange = vi.fn();
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab1"
+        onTabChange={handleTabChange}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    const firstTab = screen.getByRole("tab", { name: /Tab 1/i });
+    fireEvent.keyDown(firstTab, { key: "ArrowLeft" });
+
+    expect(handleTabChange).toHaveBeenCalledWith("tab3");
+  });
+
+  it("has correct ARIA attributes on tablist", () => {
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab1"
+        onTabChange={vi.fn()}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toHaveAttribute("aria-label", "Test tabs");
+  });
+
+  it("has correct tabIndex on tabs (0 for active, -1 for inactive)", () => {
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab2"
+        onTabChange={vi.fn()}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    const activeTab = screen.getByRole("tab", { name: /Tab 2/i });
+    expect(activeTab).toHaveAttribute("tabIndex", "0");
+
+    const inactiveTab = screen.getByRole("tab", { name: /Tab 1/i });
+    expect(inactiveTab).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("has overflow-x-auto class for horizontal scrolling", () => {
+    render(
+      <Tabs
+        tabs={mockTabs}
+        activeTab="tab1"
+        onTabChange={vi.fn()}
+        ariaLabel="Test tabs"
+      />,
+    );
+
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toHaveClass("overflow-x-auto");
+  });
+});
+
+describe("TabPanel", () => {
+  it("renders content when active", () => {
+    render(
+      <TabPanel tabId="tab1" activeTab="tab1">
+        Panel content
+      </TabPanel>,
+    );
+
+    expect(screen.getByText("Panel content")).toBeInTheDocument();
+  });
+
+  it("hides content when not active", () => {
+    render(
+      <TabPanel tabId="tab1" activeTab="tab2">
+        Panel content
+      </TabPanel>,
+    );
+
+    const panel = screen.getByRole("tabpanel", { hidden: true });
+    expect(panel).toHaveAttribute("hidden");
+  });
+
+  it("has correct ARIA attributes", () => {
+    render(
+      <TabPanel tabId="test-tab" activeTab="test-tab">
+        Panel content
+      </TabPanel>,
+    );
+
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveAttribute("id", "tabpanel-test-tab");
+    expect(panel).toHaveAttribute("aria-labelledby", "tab-test-tab");
+  });
+});

--- a/web-app/src/components/ui/Tabs.tsx
+++ b/web-app/src/components/ui/Tabs.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useRef } from "react";
+
+export interface Tab {
+  id: string;
+  label: string;
+  badge?: string;
+}
+
+interface TabsProps {
+  tabs: Tab[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  ariaLabel: string;
+}
+
+export function Tabs({ tabs, activeTab, onTabChange, ariaLabel }: TabsProps) {
+  const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
+      let nextIndex: number | null = null;
+
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        nextIndex = (currentIndex + 1) % tabs.length;
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+      }
+
+      if (nextIndex !== null) {
+        const nextTab = tabs[nextIndex];
+        onTabChange(nextTab.id);
+        tabRefs.current.get(nextTab.id)?.focus();
+      }
+    },
+    [tabs, onTabChange],
+  );
+
+  const setTabRef = useCallback(
+    (tabId: string) => (el: HTMLButtonElement | null) => {
+      if (el) {
+        tabRefs.current.set(tabId, el);
+      } else {
+        tabRefs.current.delete(tabId);
+      }
+    },
+    [],
+  );
+
+  return (
+    <div
+      className="overflow-x-auto scrollbar-hide"
+      role="tablist"
+      aria-label={ariaLabel}
+    >
+      <div className="flex gap-1 min-w-max border-b border-gray-200 dark:border-gray-700">
+        {tabs.map((tab, index) => {
+          const isActive = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              ref={setTabRef(tab.id)}
+              role="tab"
+              id={`tab-${tab.id}`}
+              aria-selected={isActive}
+              aria-controls={`tabpanel-${tab.id}`}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => onTabChange(tab.id)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              className={`
+                px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2
+                dark:focus-visible:ring-offset-gray-800
+                ${
+                  isActive
+                    ? "border-orange-500 text-orange-600 dark:text-orange-400"
+                    : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600"
+                }
+              `}
+            >
+              {tab.label}
+              {tab.badge && (
+                <span className="ml-2 px-1.5 py-0.5 rounded text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">
+                  {tab.badge}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface TabPanelProps {
+  tabId: string;
+  activeTab: string;
+  children: React.ReactNode;
+}
+
+export function TabPanel({ tabId, activeTab, children }: TabPanelProps) {
+  const isActive = activeTab === tabId;
+
+  return (
+    <div
+      role="tabpanel"
+      id={`tabpanel-${tabId}`}
+      aria-labelledby={`tab-${tabId}`}
+      hidden={!isActive}
+    >
+      {isActive && children}
+    </div>
+  );
+}

--- a/web-app/src/components/ui/Tabs.tsx
+++ b/web-app/src/components/ui/Tabs.tsx
@@ -30,8 +30,10 @@ export function Tabs({ tabs, activeTab, onTabChange, ariaLabel }: TabsProps) {
 
       if (nextIndex !== null) {
         const nextTab = tabs[nextIndex];
-        onTabChange(nextTab.id);
-        tabRefs.current.get(nextTab.id)?.focus();
+        if (nextTab) {
+          onTabChange(nextTab.id);
+          tabRefs.current.get(nextTab.id)?.focus();
+        }
       }
     },
     [tabs, onTabChange],

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -34,6 +34,7 @@ interface Translations {
     position: string;
     requiredLevel: string;
     demoModeBanner: string;
+    optional: string;
   };
   auth: {
     login: string;
@@ -150,6 +151,16 @@ interface Translations {
     dataSource: string;
     disclaimer: string;
   };
+  validation: {
+    homeRoster: string;
+    awayRoster: string;
+    scorer: string;
+    scoresheet: string;
+    homeRosterPlaceholder: string;
+    awayRosterPlaceholder: string;
+    scorerPlaceholder: string;
+    scoresheetPlaceholder: string;
+  };
 }
 
 // English translations (default/fallback)
@@ -175,6 +186,7 @@ const en: Translations = {
     position: "Position",
     requiredLevel: "Required Level",
     demoModeBanner: "Demo Mode - Viewing sample data",
+    optional: "Optional",
   },
   auth: {
     login: "Login",
@@ -302,6 +314,18 @@ const en: Translations = {
     disclaimer:
       "Unofficial app for personal use. All data is property of Swiss Volley.",
   },
+  validation: {
+    homeRoster: "Home Roster",
+    awayRoster: "Away Roster",
+    scorer: "Scorer",
+    scoresheet: "Scoresheet",
+    homeRosterPlaceholder:
+      "Home team roster verification will be available here.",
+    awayRosterPlaceholder:
+      "Away team roster verification will be available here.",
+    scorerPlaceholder: "Scorer identification will be available here.",
+    scoresheetPlaceholder: "Scoresheet upload will be available here.",
+  },
 };
 
 // German translations
@@ -327,6 +351,7 @@ const de: Translations = {
     position: "Position",
     requiredLevel: "Erforderliches Niveau",
     demoModeBanner: "Demo-Modus - Beispieldaten werden angezeigt",
+    optional: "Optional",
   },
   auth: {
     login: "Anmelden",
@@ -455,6 +480,19 @@ const de: Translations = {
     disclaimer:
       "Inoffizielle App für den persönlichen Gebrauch. Alle Daten sind Eigentum von Swiss Volley.",
   },
+  validation: {
+    homeRoster: "Heimkader",
+    awayRoster: "Gastkader",
+    scorer: "Schreiber",
+    scoresheet: "Spielbericht",
+    homeRosterPlaceholder:
+      "Die Überprüfung des Heimkaders wird hier verfügbar sein.",
+    awayRosterPlaceholder:
+      "Die Überprüfung des Gastkaders wird hier verfügbar sein.",
+    scorerPlaceholder: "Die Schreiberidentifikation wird hier verfügbar sein.",
+    scoresheetPlaceholder:
+      "Der Upload des Spielberichts wird hier verfügbar sein.",
+  },
 };
 
 // French translations
@@ -480,6 +518,7 @@ const fr: Translations = {
     position: "Position",
     requiredLevel: "Niveau requis",
     demoModeBanner: "Mode Démo - Données d'exemple",
+    optional: "Optionnel",
   },
   auth: {
     login: "Connexion",
@@ -608,6 +647,19 @@ const fr: Translations = {
     disclaimer:
       "Application non officielle pour usage personnel. Toutes les données sont la propriété de Swiss Volley.",
   },
+  validation: {
+    homeRoster: "Effectif domicile",
+    awayRoster: "Effectif visiteur",
+    scorer: "Marqueur",
+    scoresheet: "Feuille de match",
+    homeRosterPlaceholder:
+      "La vérification de l'effectif domicile sera disponible ici.",
+    awayRosterPlaceholder:
+      "La vérification de l'effectif visiteur sera disponible ici.",
+    scorerPlaceholder: "L'identification du marqueur sera disponible ici.",
+    scoresheetPlaceholder:
+      "Le téléchargement de la feuille de match sera disponible ici.",
+  },
 };
 
 // Italian translations
@@ -633,6 +685,7 @@ const it: Translations = {
     position: "Posizione",
     requiredLevel: "Livello richiesto",
     demoModeBanner: "Modalità Demo - Dati di esempio",
+    optional: "Opzionale",
   },
   auth: {
     login: "Accesso",
@@ -759,6 +812,18 @@ const it: Translations = {
     dataSource: "Dati da volleymanager.volleyball.ch",
     disclaimer:
       "App non ufficiale per uso personale. Tutti i dati sono proprietà di Swiss Volley.",
+  },
+  validation: {
+    homeRoster: "Rosa di casa",
+    awayRoster: "Rosa ospite",
+    scorer: "Segnapunti",
+    scoresheet: "Referto",
+    homeRosterPlaceholder:
+      "La verifica della rosa di casa sarà disponibile qui.",
+    awayRosterPlaceholder:
+      "La verifica della rosa ospite sarà disponibile qui.",
+    scorerPlaceholder: "L'identificazione del segnapunti sarà disponibile qui.",
+    scoresheetPlaceholder: "Il caricamento del referto sarà disponibile qui.",
   },
 };
 


### PR DESCRIPTION
## Summary
- Transform `ValidateGameModal` from a basic score-entry form into a tabbed validation workflow
- Create reusable `Tabs` component with keyboard navigation (arrow keys) and full ARIA accessibility
- Add 4 placeholder validation panels: Home Roster, Away Roster, Scorer, Scoresheet (with "Optional" badge)
- Add translations for all 4 languages (en, de, fr, it)

## Test plan
- [ ] Verify all 4 tabs render correctly in the modal
- [ ] Test tab switching via click
- [ ] Test arrow key navigation between tabs
- [ ] Verify "Optional" badge appears only on Scoresheet tab
- [ ] Test Escape key closes the modal
- [ ] Test backdrop click closes the modal
- [ ] Verify horizontal scroll works on mobile when tabs overflow
- [ ] Run `npm run lint && npm test && npm run build` in web-app/

Closes #34
