### PR TITLE
Update past games tab to show closed validation

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -97,6 +97,8 @@ export type Team = Schemas["Team"];
 export type Hall = Schemas["Hall"];
 export type RefereeGame = Schemas["RefereeGame"];
 export type PersonSummary = Schemas["PersonSummary"];
+export type AssociationSettings = Schemas["AssociationSettings"];
+export type Season = Schemas["Season"];
 
 // API response types
 export type AssignmentsResponse = Schemas["AssignmentsResponse"];
@@ -473,6 +475,19 @@ export const api = {
       "/indoorvolleyball.refadmin/api%5crefereegameexchange",
       "PUT",
       { gameExchange: exchangeId, action: "withdraw" },
+    );
+  },
+
+  // Settings
+  async getAssociationSettings(): Promise<Schemas["AssociationSettings"]> {
+    return apiRequest(
+      "/indoorvolleyball.refadmin/api%5ccrefereeassociationsettings/getRefereeAssociationSettingsOfActiveParty",
+    );
+  },
+
+  async getActiveSeason(): Promise<Schemas["Season"]> {
+    return apiRequest(
+      "/sportmanager.indoorvolleyball/api%5ccindoorseason/getActiveIndoorSeason",
     );
   },
 };

--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -225,6 +225,10 @@ export function useValidationClosedAssignments(): UseQueryResult<
   const demoAssignments = useDemoStore((state) => state.assignments);
 
   // Fetch settings and season for filtering
+  // Note: In demo mode, these queries are disabled (enabled: !isDemoMode),
+  // so settings and season will be undefined, causing fallback to defaults:
+  // - deadlineHours falls back to DEFAULT_VALIDATION_DEADLINE_HOURS (6 hours)
+  // - seasonStart falls back to 365 days ago
   const { data: settings } = useAssociationSettings();
   const { data: season } = useActiveSeason();
 

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -60,6 +60,7 @@ interface Translations {
     title: string;
     upcoming: string;
     past: string;
+    validationClosed: string;
     noAssignments: string;
     confirmed: string;
     pending: string;
@@ -202,6 +203,7 @@ const en: Translations = {
     title: "Assignments",
     upcoming: "Upcoming",
     past: "Past",
+    validationClosed: "Validation Closed",
     noAssignments: "No assignments found",
     confirmed: "Confirmed",
     pending: "Pending",
@@ -356,6 +358,7 @@ const de: Translations = {
     title: "Einsätze",
     upcoming: "Bevorstehend",
     past: "Vergangen",
+    validationClosed: "Validierung geschlossen",
     noAssignments: "Keine Einsätze gefunden",
     confirmed: "Bestätigt",
     pending: "Ausstehend",
@@ -511,6 +514,7 @@ const fr: Translations = {
     title: "Désignations",
     upcoming: "À venir",
     past: "Passées",
+    validationClosed: "Validation fermée",
     noAssignments: "Aucune désignation trouvée",
     confirmed: "Confirmé",
     pending: "En attente",
@@ -666,6 +670,7 @@ const it: Translations = {
     title: "Designazioni",
     upcoming: "In programma",
     past: "Passate",
+    validationClosed: "Validazione chiusa",
     noAssignments: "Nessuna designazione trovata",
     confirmed: "Confermato",
     pending: "In attesa",

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -62,6 +62,7 @@ interface Translations {
     upcoming: string;
     past: string;
     validationClosed: string;
+    loading: string;
     noAssignments: string;
     noUpcomingTitle: string;
     noUpcomingDescription: string;
@@ -220,6 +221,7 @@ const en: Translations = {
     upcoming: "Upcoming",
     past: "Past",
     validationClosed: "Validation Closed",
+    loading: "Loading assignments...",
     noAssignments: "No assignments found",
     noUpcomingTitle: "No upcoming assignments",
     noUpcomingDescription: "You have no upcoming referee assignments scheduled.",
@@ -392,6 +394,7 @@ const de: Translations = {
     upcoming: "Bevorstehend",
     past: "Vergangen",
     validationClosed: "Validierung geschlossen",
+    loading: "Einsätze werden geladen...",
     noAssignments: "Keine Einsätze gefunden",
     noUpcomingTitle: "Keine bevorstehenden Einsätze",
     noUpcomingDescription: "Sie haben keine bevorstehenden Schiedsrichtereinsätze geplant.",
@@ -566,6 +569,7 @@ const fr: Translations = {
     upcoming: "À venir",
     past: "Passées",
     validationClosed: "Validation fermée",
+    loading: "Chargement des désignations...",
     noAssignments: "Aucune désignation trouvée",
     noUpcomingTitle: "Aucune désignation à venir",
     noUpcomingDescription: "Vous n'avez aucune désignation d'arbitre prévue.",
@@ -740,6 +744,7 @@ const it: Translations = {
     upcoming: "In programma",
     past: "Passate",
     validationClosed: "Validazione chiusa",
+    loading: "Caricamento designazioni...",
     noAssignments: "Nessuna designazione trovata",
     noUpcomingTitle: "Nessuna designazione in programma",
     noUpcomingDescription: "Non hai designazioni arbitrali in programma.",

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -62,6 +62,10 @@ interface Translations {
     past: string;
     validationClosed: string;
     noAssignments: string;
+    noUpcomingTitle: string;
+    noUpcomingDescription: string;
+    noClosedTitle: string;
+    noClosedDescription: string;
     confirmed: string;
     pending: string;
     cancelled: string;
@@ -205,6 +209,10 @@ const en: Translations = {
     past: "Past",
     validationClosed: "Validation Closed",
     noAssignments: "No assignments found",
+    noUpcomingTitle: "No upcoming assignments",
+    noUpcomingDescription: "You have no upcoming referee assignments scheduled.",
+    noClosedTitle: "No closed assignments",
+    noClosedDescription: "No assignments with closed validation in this season.",
     confirmed: "Confirmed",
     pending: "Pending",
     cancelled: "Cancelled",
@@ -360,6 +368,10 @@ const de: Translations = {
     past: "Vergangen",
     validationClosed: "Validierung geschlossen",
     noAssignments: "Keine Einsätze gefunden",
+    noUpcomingTitle: "Keine bevorstehenden Einsätze",
+    noUpcomingDescription: "Sie haben keine bevorstehenden Schiedsrichtereinsätze geplant.",
+    noClosedTitle: "Keine abgeschlossenen Einsätze",
+    noClosedDescription: "Keine Einsätze mit abgeschlossener Validierung in dieser Saison.",
     confirmed: "Bestätigt",
     pending: "Ausstehend",
     cancelled: "Abgesagt",
@@ -516,6 +528,10 @@ const fr: Translations = {
     past: "Passées",
     validationClosed: "Validation fermée",
     noAssignments: "Aucune désignation trouvée",
+    noUpcomingTitle: "Aucune désignation à venir",
+    noUpcomingDescription: "Vous n'avez aucune désignation d'arbitre prévue.",
+    noClosedTitle: "Aucune désignation clôturée",
+    noClosedDescription: "Aucune désignation avec validation fermée cette saison.",
     confirmed: "Confirmé",
     pending: "En attente",
     cancelled: "Annulé",
@@ -672,6 +688,10 @@ const it: Translations = {
     past: "Passate",
     validationClosed: "Validazione chiusa",
     noAssignments: "Nessuna designazione trovata",
+    noUpcomingTitle: "Nessuna designazione in programma",
+    noUpcomingDescription: "Non hai designazioni arbitrali in programma.",
+    noClosedTitle: "Nessuna designazione chiusa",
+    noClosedDescription: "Nessuna designazione con validazione chiusa in questa stagione.",
     confirmed: "Confermato",
     pending: "In attesa",
     cancelled: "Annullato",

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -145,7 +145,7 @@ export function AssignmentsPage() {
         aria-labelledby={activeTab === "upcoming" ? "upcoming-tab" : "validation-closed-tab"}
         className="space-y-3"
       >
-        {isLoading && <LoadingState message="Loading assignments..." />}
+        {isLoading && <LoadingState message={t("assignments.loading")} />}
 
         {error && (
           <ErrorState

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -86,9 +86,17 @@ export function AssignmentsPage() {
 
   return (
     <div className="space-y-3">
-      {/* Tabs */}
-      <div className="flex gap-2 border-b border-gray-200 dark:border-gray-700">
+      {/* Tabs - WAI-ARIA tab pattern */}
+      <div
+        role="tablist"
+        aria-label={t("assignments.title")}
+        className="flex gap-2 border-b border-gray-200 dark:border-gray-700"
+      >
         <button
+          role="tab"
+          aria-selected={activeTab === "upcoming"}
+          aria-controls="upcoming-tabpanel"
+          id="upcoming-tab"
           onClick={() => setActiveTab("upcoming")}
           className={`
             px-4 py-2 text-sm font-medium border-b-2 transition-colors
@@ -107,6 +115,10 @@ export function AssignmentsPage() {
           )}
         </button>
         <button
+          role="tab"
+          aria-selected={activeTab === "validationClosed"}
+          aria-controls="validation-closed-tabpanel"
+          id="validation-closed-tab"
           onClick={() => setActiveTab("validationClosed")}
           className={`
             px-4 py-2 text-sm font-medium border-b-2 transition-colors
@@ -127,7 +139,12 @@ export function AssignmentsPage() {
       </div>
 
       {/* Content */}
-      <div className="space-y-3">
+      <div
+        role="tabpanel"
+        id={activeTab === "upcoming" ? "upcoming-tabpanel" : "validation-closed-tabpanel"}
+        aria-labelledby={activeTab === "upcoming" ? "upcoming-tab" : "validation-closed-tab"}
+        className="space-y-3"
+      >
         {isLoading && <LoadingState message="Loading assignments..." />}
 
         {error && (
@@ -143,7 +160,7 @@ export function AssignmentsPage() {
 
         {!isLoading && !error && data && data.length === 0 && (
           <EmptyState
-            icon={activeTab === "upcoming" ? "📅" : "✓"}
+            icon={activeTab === "upcoming" ? "📅" : "🔒"}
             title={
               activeTab === "upcoming"
                 ? t("assignments.noUpcomingTitle")

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import {
   useUpcomingAssignments,
-  usePastAssignments,
+  useValidationClosedAssignments,
 } from "@/hooks/useConvocations";
 import { AssignmentCard } from "@/components/features/AssignmentCard";
 import { SwipeableCard } from "@/components/ui/SwipeableCard";
@@ -17,7 +17,7 @@ import { ValidateGameModal } from "@/components/features/ValidateGameModal";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 
-type TabType = "upcoming" | "past";
+type TabType = "upcoming" | "validationClosed";
 
 export function AssignmentsPage() {
   const [activeTab, setActiveTab] = useState<TabType>("upcoming");
@@ -38,16 +38,16 @@ export function AssignmentsPage() {
   } = useUpcomingAssignments();
 
   const {
-    data: pastData,
-    isLoading: pastLoading,
-    error: pastError,
-    refetch: refetchPast,
-  } = usePastAssignments();
+    data: validationClosedData,
+    isLoading: validationClosedLoading,
+    error: validationClosedError,
+    refetch: refetchValidationClosed,
+  } = useValidationClosedAssignments();
 
-  const data = activeTab === "upcoming" ? upcomingData : pastData;
-  const isLoading = activeTab === "upcoming" ? upcomingLoading : pastLoading;
-  const error = activeTab === "upcoming" ? upcomingError : pastError;
-  const refetch = activeTab === "upcoming" ? refetchUpcoming : refetchPast;
+  const data = activeTab === "upcoming" ? upcomingData : validationClosedData;
+  const isLoading = activeTab === "upcoming" ? upcomingLoading : validationClosedLoading;
+  const error = activeTab === "upcoming" ? upcomingError : validationClosedError;
+  const refetch = activeTab === "upcoming" ? refetchUpcoming : refetchValidationClosed;
 
   const getSwipeConfig = useCallback(
     (assignment: Assignment) => {
@@ -107,17 +107,22 @@ export function AssignmentsPage() {
           )}
         </button>
         <button
-          onClick={() => setActiveTab("past")}
+          onClick={() => setActiveTab("validationClosed")}
           className={`
             px-4 py-2 text-sm font-medium border-b-2 transition-colors
             ${
-              activeTab === "past"
+              activeTab === "validationClosed"
                 ? "border-orange-500 text-orange-600 dark:text-orange-400"
                 : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
             }
           `}
         >
-          {t("assignments.past")}
+          {t("assignments.validationClosed")}
+          {validationClosedData && validationClosedData.length > 0 && (
+            <span className="ml-2 px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-xs">
+              {validationClosedData.length}
+            </span>
+          )}
         </button>
       </div>
 
@@ -138,16 +143,16 @@ export function AssignmentsPage() {
 
         {!isLoading && !error && data && data.length === 0 && (
           <EmptyState
-            icon={activeTab === "upcoming" ? "📅" : "📜"}
+            icon={activeTab === "upcoming" ? "📅" : "✓"}
             title={
               activeTab === "upcoming"
                 ? "No upcoming assignments"
-                : "No past assignments"
+                : "No closed assignments"
             }
             description={
               activeTab === "upcoming"
                 ? "You have no upcoming referee assignments scheduled."
-                : "No past assignments found in the selected period."
+                : "No assignments with closed validation in this season."
             }
           />
         )}

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -146,13 +146,13 @@ export function AssignmentsPage() {
             icon={activeTab === "upcoming" ? "📅" : "✓"}
             title={
               activeTab === "upcoming"
-                ? "No upcoming assignments"
-                : "No closed assignments"
+                ? t("assignments.noUpcomingTitle")
+                : t("assignments.noClosedTitle")
             }
             description={
               activeTab === "upcoming"
-                ? "You have no upcoming referee assignments scheduled."
-                : "No assignments with closed validation in this season."
+                ? t("assignments.noUpcomingDescription")
+                : t("assignments.noClosedDescription")
             }
           />
         )}

--- a/web-app/src/utils/assignment-helpers.test.ts
+++ b/web-app/src/utils/assignment-helpers.test.ts
@@ -8,6 +8,9 @@ import {
 } from "./assignment-helpers";
 import type { Assignment } from "@/api/client";
 
+// Test constants
+const EXTENDED_VALIDATION_DEADLINE_HOURS = 24;
+
 describe("assignment-helpers", () => {
   describe("MODAL_CLEANUP_DELAY", () => {
     it("should be defined as 300ms", () => {
@@ -81,66 +84,66 @@ describe("assignment-helpers", () => {
     });
 
     it("should return true when validation deadline has passed", () => {
-      // Game started 10 hours ago, deadline is 6 hours
+      // Game started 10 hours ago, deadline is DEFAULT_VALIDATION_DEADLINE_HOURS
       const gameStart = new Date("2025-01-15T02:00:00Z").toISOString();
-      expect(isValidationClosed(gameStart, 6)).toBe(true);
+      expect(isValidationClosed(gameStart, DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(true);
     });
 
     it("should return false when within validation window", () => {
-      // Game started 3 hours ago, deadline is 6 hours
+      // Game started 3 hours ago, deadline is DEFAULT_VALIDATION_DEADLINE_HOURS
       const gameStart = new Date("2025-01-15T09:00:00Z").toISOString();
-      expect(isValidationClosed(gameStart, 6)).toBe(false);
+      expect(isValidationClosed(gameStart, DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(false);
     });
 
     it("should return false for future games", () => {
       // Game starts in 2 hours
       const gameStart = new Date("2025-01-15T14:00:00Z").toISOString();
-      expect(isValidationClosed(gameStart, 6)).toBe(false);
+      expect(isValidationClosed(gameStart, DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(false);
     });
 
     it("should return false exactly at the deadline boundary", () => {
-      // Game started exactly 6 hours ago - validation just closed
+      // Game started exactly DEFAULT_VALIDATION_DEADLINE_HOURS ago - validation just closed
       const gameStart = new Date("2025-01-15T06:00:00Z").toISOString();
-      // At exactly 6 hours, now > deadline is false (deadline = 12:00, now = 12:00)
-      expect(isValidationClosed(gameStart, 6)).toBe(false);
+      // At exactly the deadline, now > deadline is false (deadline = 12:00, now = 12:00)
+      expect(isValidationClosed(gameStart, DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(false);
     });
 
     it("should return true just after the deadline", () => {
-      // Game started 6 hours and 1 second ago
+      // Game started DEFAULT_VALIDATION_DEADLINE_HOURS and 1 second ago
       const gameStart = new Date("2025-01-15T05:59:59Z").toISOString();
-      expect(isValidationClosed(gameStart, 6)).toBe(true);
+      expect(isValidationClosed(gameStart, DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(true);
     });
 
     it("should use default deadline when not specified", () => {
-      // Game started 10 hours ago, default deadline is 6 hours
+      // Game started 10 hours ago, default deadline is DEFAULT_VALIDATION_DEADLINE_HOURS
       const gameStart = new Date("2025-01-15T02:00:00Z").toISOString();
       expect(isValidationClosed(gameStart)).toBe(true);
     });
 
     it("should return false for undefined gameStartTime", () => {
-      expect(isValidationClosed(undefined, 6)).toBe(false);
+      expect(isValidationClosed(undefined, DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(false);
     });
 
     it("should return false for null gameStartTime", () => {
-      expect(isValidationClosed(null, 6)).toBe(false);
+      expect(isValidationClosed(null, DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(false);
     });
 
     it("should return false for invalid date string", () => {
-      expect(isValidationClosed("not-a-date", 6)).toBe(false);
+      expect(isValidationClosed("not-a-date", DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(false);
     });
 
     it("should return false for empty string", () => {
-      expect(isValidationClosed("", 6)).toBe(false);
+      expect(isValidationClosed("", DEFAULT_VALIDATION_DEADLINE_HOURS)).toBe(false);
     });
 
     it("should handle custom deadline hours", () => {
-      // Game started 25 hours ago, deadline is 24 hours
+      // Game started 25 hours ago, deadline is EXTENDED_VALIDATION_DEADLINE_HOURS
       const gameStart = new Date("2025-01-14T11:00:00Z").toISOString();
-      expect(isValidationClosed(gameStart, 24)).toBe(true);
+      expect(isValidationClosed(gameStart, EXTENDED_VALIDATION_DEADLINE_HOURS)).toBe(true);
 
-      // Game started 23 hours ago, deadline is 24 hours
+      // Game started 23 hours ago, deadline is EXTENDED_VALIDATION_DEADLINE_HOURS
       const recentGame = new Date("2025-01-14T13:00:00Z").toISOString();
-      expect(isValidationClosed(recentGame, 24)).toBe(false);
+      expect(isValidationClosed(recentGame, EXTENDED_VALIDATION_DEADLINE_HOURS)).toBe(false);
     });
   });
 

--- a/web-app/src/utils/assignment-helpers.test.ts
+++ b/web-app/src/utils/assignment-helpers.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { getTeamNames, MODAL_CLEANUP_DELAY } from "./assignment-helpers";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getTeamNames,
+  MODAL_CLEANUP_DELAY,
+  DEFAULT_VALIDATION_DEADLINE_HOURS,
+  isValidationClosed,
+  isGamePast,
+} from "./assignment-helpers";
 import type { Assignment } from "@/api/client";
 
 describe("assignment-helpers", () => {
@@ -53,6 +59,143 @@ describe("assignment-helpers", () => {
 
       const result = getTeamNames(assignment as Assignment);
       expect(result).toEqual({ homeTeam: "TBD", awayTeam: "TBD" });
+    });
+  });
+
+  describe("DEFAULT_VALIDATION_DEADLINE_HOURS", () => {
+    it("should be defined as 6 hours", () => {
+      expect(DEFAULT_VALIDATION_DEADLINE_HOURS).toBe(6);
+    });
+  });
+
+  describe("isValidationClosed", () => {
+    const FIXED_NOW = new Date("2025-01-15T12:00:00Z");
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FIXED_NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should return true when validation deadline has passed", () => {
+      // Game started 10 hours ago, deadline is 6 hours
+      const gameStart = new Date("2025-01-15T02:00:00Z").toISOString();
+      expect(isValidationClosed(gameStart, 6)).toBe(true);
+    });
+
+    it("should return false when within validation window", () => {
+      // Game started 3 hours ago, deadline is 6 hours
+      const gameStart = new Date("2025-01-15T09:00:00Z").toISOString();
+      expect(isValidationClosed(gameStart, 6)).toBe(false);
+    });
+
+    it("should return false for future games", () => {
+      // Game starts in 2 hours
+      const gameStart = new Date("2025-01-15T14:00:00Z").toISOString();
+      expect(isValidationClosed(gameStart, 6)).toBe(false);
+    });
+
+    it("should return false exactly at the deadline boundary", () => {
+      // Game started exactly 6 hours ago - validation just closed
+      const gameStart = new Date("2025-01-15T06:00:00Z").toISOString();
+      // At exactly 6 hours, now > deadline is false (deadline = 12:00, now = 12:00)
+      expect(isValidationClosed(gameStart, 6)).toBe(false);
+    });
+
+    it("should return true just after the deadline", () => {
+      // Game started 6 hours and 1 second ago
+      const gameStart = new Date("2025-01-15T05:59:59Z").toISOString();
+      expect(isValidationClosed(gameStart, 6)).toBe(true);
+    });
+
+    it("should use default deadline when not specified", () => {
+      // Game started 10 hours ago, default deadline is 6 hours
+      const gameStart = new Date("2025-01-15T02:00:00Z").toISOString();
+      expect(isValidationClosed(gameStart)).toBe(true);
+    });
+
+    it("should return false for undefined gameStartTime", () => {
+      expect(isValidationClosed(undefined, 6)).toBe(false);
+    });
+
+    it("should return false for null gameStartTime", () => {
+      expect(isValidationClosed(null, 6)).toBe(false);
+    });
+
+    it("should return false for invalid date string", () => {
+      expect(isValidationClosed("not-a-date", 6)).toBe(false);
+    });
+
+    it("should return false for empty string", () => {
+      expect(isValidationClosed("", 6)).toBe(false);
+    });
+
+    it("should handle custom deadline hours", () => {
+      // Game started 25 hours ago, deadline is 24 hours
+      const gameStart = new Date("2025-01-14T11:00:00Z").toISOString();
+      expect(isValidationClosed(gameStart, 24)).toBe(true);
+
+      // Game started 23 hours ago, deadline is 24 hours
+      const recentGame = new Date("2025-01-14T13:00:00Z").toISOString();
+      expect(isValidationClosed(recentGame, 24)).toBe(false);
+    });
+  });
+
+  describe("isGamePast", () => {
+    const FIXED_NOW = new Date("2025-01-15T12:00:00Z");
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FIXED_NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should return true for games that have started", () => {
+      const gameStart = new Date("2025-01-15T10:00:00Z").toISOString();
+      expect(isGamePast(gameStart)).toBe(true);
+    });
+
+    it("should return false for future games", () => {
+      const gameStart = new Date("2025-01-15T14:00:00Z").toISOString();
+      expect(isGamePast(gameStart)).toBe(false);
+    });
+
+    it("should return false for games starting exactly now", () => {
+      const gameStart = new Date("2025-01-15T12:00:00Z").toISOString();
+      // now > gameStart is false when they are equal
+      expect(isGamePast(gameStart)).toBe(false);
+    });
+
+    it("should return true for games that started just 1 second ago", () => {
+      const gameStart = new Date("2025-01-15T11:59:59Z").toISOString();
+      expect(isGamePast(gameStart)).toBe(true);
+    });
+
+    it("should return false for undefined gameStartTime", () => {
+      expect(isGamePast(undefined)).toBe(false);
+    });
+
+    it("should return false for null gameStartTime", () => {
+      expect(isGamePast(null)).toBe(false);
+    });
+
+    it("should return false for invalid date string", () => {
+      expect(isGamePast("invalid-date")).toBe(false);
+    });
+
+    it("should return false for empty string", () => {
+      expect(isGamePast("")).toBe(false);
+    });
+
+    it("should return true for games from yesterday", () => {
+      const gameStart = new Date("2025-01-14T18:00:00Z").toISOString();
+      expect(isGamePast(gameStart)).toBe(true);
     });
   });
 });

--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -77,3 +77,54 @@ export function isGameReportEligible(assignment: Assignment): boolean {
     assignment.refereeGame?.game?.group?.phase?.league?.leagueCategory?.name;
   return leagueName !== undefined && GAME_REPORT_ELIGIBLE_LEAGUES.includes(leagueName);
 }
+
+/**
+ * Default validation deadline in hours after game start.
+ * Used as fallback when association settings are not available.
+ * Common values in Swiss volleyball: 6-24 hours.
+ */
+export const DEFAULT_VALIDATION_DEADLINE_HOURS = 6;
+
+/**
+ * Checks if the validation period for a game has closed.
+ *
+ * Referees have a limited window to validate game results after the game starts.
+ * This window is configured per association via `hoursAfterGameStartForRefereeToEditGameList`.
+ * Once this window passes, the validation is considered "closed".
+ *
+ * @param gameStartTime - ISO datetime string of when the game started
+ * @param deadlineHours - Hours after game start when validation closes
+ * @returns true if validation period has closed, false if still open or game hasn't started
+ */
+export function isValidationClosed(
+  gameStartTime: string | undefined | null,
+  deadlineHours: number = DEFAULT_VALIDATION_DEADLINE_HOURS,
+): boolean {
+  if (!gameStartTime) return false;
+
+  const gameStart = new Date(gameStartTime);
+  if (isNaN(gameStart.getTime())) return false;
+
+  const validationDeadline = new Date(
+    gameStart.getTime() + deadlineHours * 60 * 60 * 1000,
+  );
+
+  return new Date() > validationDeadline;
+}
+
+/**
+ * Checks if a game is in the past (has started).
+ *
+ * @param gameStartTime - ISO datetime string of when the game starts/started
+ * @returns true if game has started, false if still upcoming or invalid date
+ */
+export function isGamePast(
+  gameStartTime: string | undefined | null,
+): boolean {
+  if (!gameStartTime) return false;
+
+  const gameStart = new Date(gameStartTime);
+  if (isNaN(gameStart.getTime())) return false;
+
+  return new Date() > gameStart;
+}

--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -92,9 +92,15 @@ export const DEFAULT_VALIDATION_DEADLINE_HOURS = 6;
  * This window is configured per association via `hoursAfterGameStartForRefereeToEditGameList`.
  * Once this window passes, the validation is considered "closed".
  *
+ * Note: Uses strict "greater than" comparison (now > deadline), meaning validation
+ * is open AT the exact deadline moment and closes strictly AFTER. For example,
+ * with a 6-hour deadline: at exactly 6 hours after game start, validation is still
+ * open; at 6 hours + 1 second, it's closed.
+ *
  * @param gameStartTime - ISO datetime string of when the game started
  * @param deadlineHours - Hours after game start when validation closes
- * @returns true if validation period has closed, false if still open or game hasn't started
+ * @returns true if validation period has closed (strictly after deadline),
+ *          false if still open, game hasn't started, or invalid date
  */
 export function isValidationClosed(
   gameStartTime: string | undefined | null,


### PR DESCRIPTION
Replace the "Past" tab with "Validation Closed" on the assignments page. Games now appear in this tab when their validation period has expired, determined by the association setting `hoursAfterGameStartForRefereeToEditGameList`.

Changes:
- Add API methods for AssociationSettings and Season endpoints
- Add useAssociationSettings and useActiveSeason hooks
- Add isValidationClosed and isGamePast helper functions
- Create useValidationClosedAssignments hook that filters by season dates and validation deadline
- Update AssignmentsPage to use new hook and rename tab
- Add translations for "Validation Closed" in all 4 languages