### PR TITLE
feat(ci): add MCP GitHub tools to Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,7 @@ jobs:
             actions: read
           # Allow Claude to use npm commands for running tests, builds, and linting
           # Allow gh CLI for issue management (create, edit, list, comment)
+          # Allow MCP GitHub tools for issue management
           allowed_tools: |
             Bash(npm:*)
             Bash(gh issue create:*)
@@ -44,3 +45,9 @@ jobs:
             Bash(gh issue list:*)
             Bash(gh issue comment:*)
             Bash(gh issue view:*)
+            mcp__github__issue_read
+            mcp__github__issue_write
+            mcp__github__add_issue_comment
+            mcp__github__pull_request_read
+            mcp__github__pull_request_review_write
+            mcp__github__add_comment_to_pending_review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,15 +36,19 @@ jobs:
           additional_permissions: |
             actions: read
           # Allow Claude to use npm commands for running tests, builds, and linting
-          # Allow gh CLI for issue management (create, edit, list, comment)
-          # Allow MCP GitHub tools for issue management
           allowed_tools: |
             Bash(npm:*)
+            # gh CLI for basic issue/PR operations (view, list, comment)
             Bash(gh issue create:*)
             Bash(gh issue edit:*)
             Bash(gh issue list:*)
             Bash(gh issue comment:*)
             Bash(gh issue view:*)
+            Bash(gh pr view:*)
+            Bash(gh pr diff:*)
+            Bash(gh pr comment:*)
+            Bash(gh pr list:*)
+            # MCP GitHub tools for advanced operations (create/update, PR reviews, line-level comments)
             mcp__github__issue_read
             mcp__github__issue_write
             mcp__github__add_issue_comment


### PR DESCRIPTION
## Summary

- Enable Claude to use MCP GitHub tools when triggered by `@claude` mentions in issues and PRs
- Added issue management tools: read, write, and comment on issues
- Added PR management tools: read PR details/status, create reviews, and add line-level comments

## Tools Added

**Issue management:**
- `mcp__github__issue_read` - Read issue details, comments, labels
- `mcp__github__issue_write` - Create and update issues
- `mcp__github__add_issue_comment` - Add comments to issues and PRs

**Pull request management:**
- `mcp__github__pull_request_read` - Read PR details, comments, status
- `mcp__github__pull_request_review_write` - Create and submit PR reviews
- `mcp__github__add_comment_to_pending_review` - Add line-level review comments

## Test plan

- [ ] Trigger Claude with `@claude` in an issue comment and ask it to create a new issue
- [ ] Trigger Claude with `@claude` in a PR and ask it to check CI status

🤖 Generated with [Claude Code](https://claude.com/claude-code)