### PR TITLE
fix: follow CLAUDE.md modal pattern for SwipeableCard Escape handling

### DIFF
--- a/web-app/src/components/ui/SwipeableCard.test.tsx
+++ b/web-app/src/components/ui/SwipeableCard.test.tsx
@@ -101,6 +101,35 @@ describe("SwipeableCard", () => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
+    it("hides action buttons on Escape key when focus is on action button", () => {
+      const { container } = render(
+        <SwipeableCard
+          onSwipeLeft={() => {}}
+          onSwipeRight={() => {}}
+          leftActionLabel="Left"
+          rightActionLabel="Right"
+        >
+          <div>Content</div>
+        </SwipeableCard>,
+      );
+
+      const wrapper = container.firstChild as HTMLElement;
+
+      // Show actions
+      fireEvent.keyDown(wrapper, { key: "Enter" });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      // Get the action button and verify it has focus
+      const rightButton = screen.getByText("Right");
+      expect(rightButton).toHaveFocus();
+
+      // Press Escape while button has focus
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      // Dialog should be dismissed
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
     it("calls onSwipeLeft when left action button is clicked", () => {
       const onSwipeLeft = vi.fn();
       const { container } = render(

--- a/web-app/src/components/ui/SwipeableCard.tsx
+++ b/web-app/src/components/ui/SwipeableCard.tsx
@@ -545,40 +545,45 @@ export function SwipeableCard({
       </div>
 
       {showActions && hasAnyAction && (
-        // Dialog overlay with action buttons - backdrop dismisses on click
+        // Modal overlay with action buttons - backdrop dismisses on click
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
         <div
-          role="dialog"
-          aria-label="Card actions"
-          aria-modal="true"
-          className="absolute inset-0 z-20 bg-black/50 rounded-xl flex items-center justify-center gap-2 p-4"
           onClick={() => setShowActions(false)}
+          className="absolute inset-0 z-20 bg-black/50 rounded-xl flex items-center justify-center gap-2 p-4"
         >
-          {rightActions?.[0] && (
-            <button
-              ref={(el) => el?.focus()}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleRightAction();
-              }}
-              className={`${rightActions[0].color} text-white px-4 py-2 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white`}
-            >
-              {rightActions[0].label}
-            </button>
-          )}
-          {leftActions?.[0] && (
-            <button
-              ref={(el) => {
-                if (!rightActions?.[0]) el?.focus();
-              }}
-              onClick={(e) => {
-                e.stopPropagation();
-                handleLeftAction();
-              }}
-              className={`${leftActions[0].color} text-white px-4 py-2 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white ml-2`}
-            >
-              {leftActions[0].label}
-            </button>
-          )}
+          <div
+            role="dialog"
+            aria-label="Card actions"
+            aria-modal="true"
+            className="flex items-center justify-center gap-2"
+          >
+            {rightActions?.[0] && (
+              <button
+                ref={(el) => el?.focus()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRightAction();
+                }}
+                className={`${rightActions[0].color} text-white px-4 py-2 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white`}
+              >
+                {rightActions[0].label}
+              </button>
+            )}
+            {leftActions?.[0] && (
+              <button
+                ref={(el) => {
+                  if (!rightActions?.[0]) el?.focus();
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleLeftAction();
+                }}
+                className={`${leftActions[0].color} text-white px-4 py-2 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white ml-2`}
+              >
+                {leftActions[0].label}
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/web-app/src/components/ui/SwipeableCard.tsx
+++ b/web-app/src/components/ui/SwipeableCard.tsx
@@ -174,6 +174,20 @@ export function SwipeableCard({
     };
   }, []);
 
+  useEffect(() => {
+    if (!showActions) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setShowActions(false);
+        closeDrawer();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [showActions, closeDrawer]);
+
   const handleDragStart = useCallback(
     (clientX: number, clientY: number) => {
       startXRef.current = clientX;
@@ -367,18 +381,12 @@ export function SwipeableCard({
     [isDrawerOpen],
   );
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        setShowActions((prev) => !prev);
-      } else if (e.key === "Escape") {
-        setShowActions(false);
-        closeDrawer();
-      }
-    },
-    [closeDrawer],
-  );
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setShowActions((prev) => !prev);
+    }
+  }, []);
 
   const handleLeftAction = useCallback(() => {
     setShowActions(false);
@@ -538,16 +546,12 @@ export function SwipeableCard({
 
       {showActions && hasAnyAction && (
         // Dialog overlay with action buttons - backdrop dismisses on click
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- Dialog backdrop needs click handler to dismiss
         <div
           role="dialog"
           aria-label="Card actions"
           aria-modal="true"
           className="absolute inset-0 z-20 bg-black/50 rounded-xl flex items-center justify-center gap-2 p-4"
           onClick={() => setShowActions(false)}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") setShowActions(false);
-          }}
         >
           {rightActions?.[0] && (
             <button


### PR DESCRIPTION
## Summary
Implements the CLAUDE.md modal pattern for SwipeableCard dialog's Escape key handling, ensuring it works regardless of which element has focus.

## Changes
- Removed Escape key handling from handleKeyDown callback
- Removed onKeyDown handler from dialog element
- Added useEffect with document-level keydown listener for Escape
- Added test to verify Escape works when focus is on action button

## Testing
- All 458 tests pass
- Lint check passes
- Production build successful

Fixes #50

🤖 Generated with [Claude Code](https://claude.ai/code)) | [Branch](https://github.com/Takishima/volleykit/tree/claude/issue-50-20251213-2341) | [View job run](https://github.com/Takishima/volleykit/actions/runs/20199552913