### PR TITLE
feat(tabs): add Home/End keyboard navigation to Tabs component

### DIFF
--- a/web-app/src/hooks/useTabNavigation.test.ts
+++ b/web-app/src/hooks/useTabNavigation.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useTabNavigation } from "./useTabNavigation";
+
+describe("useTabNavigation", () => {
+  const tabs = ["tab1", "tab2", "tab3"] as const;
+
+  describe("getTabProps", () => {
+    it("returns correct props for active tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab1",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab1", 0);
+
+      expect(props.role).toBe("tab");
+      expect(props.id).toBe("tab-tab1");
+      expect(props["aria-selected"]).toBe(true);
+      expect(props["aria-controls"]).toBe("tabpanel-tab1");
+      expect(props.tabIndex).toBe(0);
+    });
+
+    it("returns correct props for inactive tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab1",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab2", 1);
+
+      expect(props["aria-selected"]).toBe(false);
+      expect(props.tabIndex).toBe(-1);
+    });
+  });
+
+  describe("keyboard navigation", () => {
+    it("handles ArrowRight to move to next tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab1",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab1", 0);
+      const event = {
+        key: "ArrowRight",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onTabChange).toHaveBeenCalledWith("tab2");
+    });
+
+    it("handles ArrowLeft to move to previous tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab2",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab2", 1);
+      const event = {
+        key: "ArrowLeft",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onTabChange).toHaveBeenCalledWith("tab1");
+    });
+
+    it("wraps around when pressing ArrowRight on last tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab3",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab3", 2);
+      const event = {
+        key: "ArrowRight",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onTabChange).toHaveBeenCalledWith("tab1");
+    });
+
+    it("wraps around when pressing ArrowLeft on first tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab1",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab1", 0);
+      const event = {
+        key: "ArrowLeft",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onTabChange).toHaveBeenCalledWith("tab3");
+    });
+
+    it("handles Home key to jump to first tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab3",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab3", 2);
+      const event = {
+        key: "Home",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onTabChange).toHaveBeenCalledWith("tab1");
+    });
+
+    it("handles End key to jump to last tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab1",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab1", 0);
+      const event = {
+        key: "End",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onTabChange).toHaveBeenCalledWith("tab3");
+    });
+
+    it("does nothing when Home is pressed on first tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab1",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab1", 0);
+      const event = {
+        key: "Home",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onTabChange).toHaveBeenCalledWith("tab1");
+    });
+
+    it("does nothing when End is pressed on last tab", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab3",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab3", 2);
+      const event = {
+        key: "End",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(onTabChange).toHaveBeenCalledWith("tab3");
+    });
+
+    it("ignores other keys", () => {
+      const onTabChange = vi.fn();
+      const { result } = renderHook(() =>
+        useTabNavigation({
+          tabs,
+          activeTab: "tab1",
+          onTabChange,
+        }),
+      );
+
+      const props = result.current.getTabProps("tab1", 0);
+      const event = {
+        key: "Enter",
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLButtonElement>;
+
+      props.onKeyDown(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(onTabChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web-app/src/hooks/useTabNavigation.ts
+++ b/web-app/src/hooks/useTabNavigation.ts
@@ -27,6 +27,12 @@ export function useTabNavigation<T extends string>({
       } else if (e.key === "ArrowLeft") {
         e.preventDefault();
         nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        nextIndex = 0;
+      } else if (e.key === "End") {
+        e.preventDefault();
+        nextIndex = tabs.length - 1;
       }
 
       if (nextIndex !== null) {


### PR DESCRIPTION
Implements Home/End key support in useTabNavigation hook following WAI-ARIA tab pattern guidelines.

## Changes
- Added Home/End key handlers in `useTabNavigation.ts`
- Created comprehensive test suite with 11 tests
- Users can now press Home to jump to first tab
- Users can now press End to jump to last tab

Closes #57

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/Takishima/volleykit/tree/claude/issue-57-20251213-2352) | [View job run](https://github.com/Takishima/volleykit/actions/runs/20199660535