### PR TITLE
refactor(validation): use Zod's built-in datetime validation for dateSchema

### DIFF
--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -39,12 +39,12 @@ const dateTimeSchema = z
 // - ISO datetime format: "2024-12-19T23:00:00.000000+00:00" (API returns this for paymentValueDate)
 // - Empty string: "" (API returns this for unpaid compensations)
 // - null (API returns null for unpaid compensations)
-const DATE_PREFIX_PATTERN = /^\d{4}-\d{2}-\d{2}/;
 export const dateSchema = z
-  .string()
-  .refine((val) => val === "" || DATE_PREFIX_PATTERN.test(val), {
-    message: "Invalid date format",
-  })
+  .union([
+    z.literal(""),
+    z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    z.string().datetime({ offset: true }),
+  ])
   .optional()
   .nullable();
 


### PR DESCRIPTION
## Summary

Refactored `dateSchema` to use Zod's built-in datetime validation as proposed in issue #60.

## Changes

- Replaced custom regex refine with union of:
  - Empty string literal (for unpaid compensations)
  - Exact date regex YYYY-MM-DD (stricter than prefix match)
  - Zod's datetime({ offset: true }) for ISO 8601 validation
- Removed unused `DATE_PREFIX_PATTERN` constant

## Benefits

- More consistent with `dateTimeSchema` in same file
- Leverages Zod's robust ISO 8601 validation
- Stricter validation (exact match vs prefix)

## Testing

- All 14 dateSchema tests pass
- All 481 tests pass (37 test files)
- Lint check passes
- Production build succeeds

Closes #60

---

Generated with [Claude Code](https://claude.ai/code)