### PR TITLE
docs: add inline comments for magic numbers in query-error-utils

### DIFF
--- a/web-app/src/utils/query-error-utils.ts
+++ b/web-app/src/utils/query-error-utils.ts
@@ -54,10 +54,10 @@ export function isRetryableError(error: unknown): boolean {
  * Exported as a single config object for easier testing and modification.
  */
 export const RETRY_CONFIG = {
-  MAX_RETRY_DELAY_MS: 30000,
-  BASE_RETRY_DELAY_MS: 1000,
-  JITTER_FACTOR: 0.25,
-  MAX_QUERY_RETRIES: 3,
+  MAX_RETRY_DELAY_MS: 30000, // 30 seconds maximum delay between retries
+  BASE_RETRY_DELAY_MS: 1000, // Start with 1 second delay
+  JITTER_FACTOR: 0.25, // Add up to 25% random jitter to prevent thundering herd
+  MAX_QUERY_RETRIES: 3, // Maximum number of retry attempts
 } as const;
 
 /**


### PR DESCRIPTION
Add inline comments to RETRY_CONFIG constants explaining:
- Human-readable durations (30 seconds, 1 second)
- Purpose of jitter (prevent thundering herd)
- Maximum retry attempts

Closes #53

Generated with [Claude Code](https://claude.ai/code)