### PR TITLE
Recreate PR 68 on latest main branch

### DIFF
--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -432,7 +432,10 @@ export function useValidationClosedAssignments(): UseQueryResult<
   const demoFilteredData = useMemo(() => {
     if (!isDemoMode) return [];
 
-    const inDateRange = demoAssignments.filter((assignment) => {
+    // Defensive fallback: store initializes assignments as [], but during SSR/hydration
+    // or in test environments, the store state may not be fully initialized yet.
+    const assignments = demoAssignments ?? [];
+    const inDateRange = assignments.filter((assignment) => {
       const gameDate = assignment.refereeGame?.game?.startingDateTime;
       if (!gameDate) return false;
 

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -97,13 +97,10 @@ export function ExchangePage() {
     [takeOverModal.open, removeFromExchangeModal.open],
   );
 
-  const tabs = useMemo(
-    () => [
-      { id: "open" as const, label: t("exchange.open") },
-      { id: "applied" as const, label: t("exchange.myApplications") },
-    ],
-    [t],
-  );
+  const tabs = [
+    { id: "open" as const, label: t("exchange.open") },
+    { id: "applied" as const, label: t("exchange.myApplications") },
+  ];
 
   const handleTabChange = useCallback((tabId: string) => {
     setStatusFilter(tabId as ExchangeStatus);


### PR DESCRIPTION
Remove unnecessary useMemo wrapping from tabs array in ExchangePage to align with the pattern used in CompensationsPage.

The `t` function from useTranslation is stable, and creating a 2-item array requires minimal computation, making memoization overhead unnecessary.

Closes #58