### PR TITLE
Implement feature from issue 35

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -24,7 +24,7 @@
     {
       "name": "JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "150 kB",
+      "limit": "155 kB",
       "gzip": true
     },
     {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -100,6 +100,8 @@ export type RefereeGame = Schemas["RefereeGame"];
 export type PersonSummary = Schemas["PersonSummary"];
 export type AssociationSettings = Schemas["AssociationSettings"];
 export type Season = Schemas["Season"];
+export type NominationList = Schemas["NominationList"];
+export type IndoorPlayerNomination = Schemas["IndoorPlayerNomination"];
 
 // API response types
 export type AssignmentsResponse = Schemas["AssignmentsResponse"];

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -100,9 +100,6 @@ export type RefereeGame = Schemas["RefereeGame"];
 export type PersonSummary = Schemas["PersonSummary"];
 export type AssociationSettings = Schemas["AssociationSettings"];
 export type Season = Schemas["Season"];
-export type NominationList = Schemas["NominationList"];
-export type IndoorPlayerNomination = Schemas["IndoorPlayerNomination"];
-
 // API response types
 export type AssignmentsResponse = Schemas["AssignmentsResponse"];
 export type CompensationsResponse = Schemas["CompensationsResponse"];

--- a/web-app/src/components/features/validation/AwayRosterPanel.tsx
+++ b/web-app/src/components/features/validation/AwayRosterPanel.tsx
@@ -1,23 +1,16 @@
 import type { Assignment } from "@/api/client";
-import { useTranslation } from "@/hooks/useTranslation";
 import { getTeamNames } from "@/utils/assignment-helpers";
+import { RosterVerificationPanel } from "./RosterVerificationPanel";
 
 interface AwayRosterPanelProps {
   assignment: Assignment;
 }
 
 export function AwayRosterPanel({ assignment }: AwayRosterPanelProps) {
-  const { t } = useTranslation();
   const { awayTeam } = getTeamNames(assignment);
+  const gameId = assignment.refereeGame?.game?.__identity ?? "";
 
   return (
-    <div className="py-4">
-      <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
-        {awayTeam}
-      </h3>
-      <p className="text-sm text-gray-500 dark:text-gray-400">
-        {t("validation.awayRosterPlaceholder")}
-      </p>
-    </div>
+    <RosterVerificationPanel team="away" teamName={awayTeam} gameId={gameId} />
   );
 }

--- a/web-app/src/components/features/validation/HomeRosterPanel.tsx
+++ b/web-app/src/components/features/validation/HomeRosterPanel.tsx
@@ -1,23 +1,16 @@
 import type { Assignment } from "@/api/client";
-import { useTranslation } from "@/hooks/useTranslation";
 import { getTeamNames } from "@/utils/assignment-helpers";
+import { RosterVerificationPanel } from "./RosterVerificationPanel";
 
 interface HomeRosterPanelProps {
   assignment: Assignment;
 }
 
 export function HomeRosterPanel({ assignment }: HomeRosterPanelProps) {
-  const { t } = useTranslation();
   const { homeTeam } = getTeamNames(assignment);
+  const gameId = assignment.refereeGame?.game?.__identity ?? "";
 
   return (
-    <div className="py-4">
-      <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
-        {homeTeam}
-      </h3>
-      <p className="text-sm text-gray-500 dark:text-gray-400">
-        {t("validation.homeRosterPlaceholder")}
-      </p>
-    </div>
+    <RosterVerificationPanel team="home" teamName={homeTeam} gameId={gameId} />
   );
 }

--- a/web-app/src/components/features/validation/PlayerListItem.test.tsx
+++ b/web-app/src/components/features/validation/PlayerListItem.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PlayerListItem } from "./PlayerListItem";
+import type { RosterPlayer } from "@/hooks/useNominationList";
+
+function createMockPlayer(overrides: Partial<RosterPlayer> = {}): RosterPlayer {
+  return {
+    id: "player-1",
+    shirtNumber: 7,
+    displayName: "John Doe",
+    licenseCategory: "SEN",
+    isCaptain: false,
+    isLibero: false,
+    isNewlyAdded: false,
+    ...overrides,
+  };
+}
+
+describe("PlayerListItem", () => {
+  it("renders player number and name", () => {
+    const player = createMockPlayer({ shirtNumber: 12, displayName: "Max" });
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={false}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("#12")).toBeInTheDocument();
+    expect(screen.getByText("Max")).toBeInTheDocument();
+  });
+
+  it("shows license category badge when provided", () => {
+    const player = createMockPlayer({ licenseCategory: "JUN" });
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={false}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("JUN")).toBeInTheDocument();
+  });
+
+  it("shows captain indicator when isCaptain is true", () => {
+    const player = createMockPlayer({ isCaptain: true });
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={false}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("C")).toBeInTheDocument();
+  });
+
+  it("shows libero indicator when isLibero is true", () => {
+    const player = createMockPlayer({ isLibero: true });
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={false}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("L")).toBeInTheDocument();
+  });
+
+  it("shows newly added badge when isNewlyAdded is true", () => {
+    const player = createMockPlayer({ isNewlyAdded: true });
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={false}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("New")).toBeInTheDocument();
+  });
+
+  it("calls onRemove when remove button is clicked", () => {
+    const onRemove = vi.fn();
+    const player = createMockPlayer();
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={false}
+        onRemove={onRemove}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    const removeButton = screen.getByRole("button", { name: /remove/i });
+    fireEvent.click(removeButton);
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows undo button when marked for removal", () => {
+    const player = createMockPlayer();
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={true}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /undo/i })).toBeInTheDocument();
+  });
+
+  it("calls onUndoRemoval when undo button is clicked", () => {
+    const onUndoRemoval = vi.fn();
+    const player = createMockPlayer();
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={true}
+        onRemove={vi.fn()}
+        onUndoRemoval={onUndoRemoval}
+      />,
+    );
+
+    const undoButton = screen.getByRole("button", { name: /undo/i });
+    fireEvent.click(undoButton);
+
+    expect(onUndoRemoval).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies strikethrough styling when marked for removal", () => {
+    const player = createMockPlayer();
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={true}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    const nameElement = screen.getByText(player.displayName);
+    expect(nameElement).toHaveClass("line-through");
+  });
+
+  it("hides badges when marked for removal", () => {
+    const player = createMockPlayer({
+      isCaptain: true,
+      isLibero: false,
+      licenseCategory: "SEN",
+    });
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={true}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("C")).not.toBeInTheDocument();
+    expect(screen.queryByText("SEN")).not.toBeInTheDocument();
+  });
+
+  it("does not show captain indicator when not captain", () => {
+    const player = createMockPlayer({ isCaptain: false });
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={false}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("C")).not.toBeInTheDocument();
+  });
+
+  it("does not show libero indicator when not libero", () => {
+    const player = createMockPlayer({ isLibero: false });
+
+    render(
+      <PlayerListItem
+        player={player}
+        isMarkedForRemoval={false}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("L")).not.toBeInTheDocument();
+  });
+});

--- a/web-app/src/components/features/validation/PlayerListItem.tsx
+++ b/web-app/src/components/features/validation/PlayerListItem.tsx
@@ -1,0 +1,149 @@
+import { useTranslation } from "@/hooks/useTranslation";
+import type { RosterPlayer } from "@/hooks/useNominationList";
+
+function TrashIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M3 6h18" />
+      <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+      <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+    </svg>
+  );
+}
+
+function UndoIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M3 7v6h6" />
+      <path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13" />
+    </svg>
+  );
+}
+
+interface PlayerListItemProps {
+  player: RosterPlayer;
+  isMarkedForRemoval: boolean;
+  onRemove: () => void;
+  onUndoRemoval: () => void;
+}
+
+export function PlayerListItem({
+  player,
+  isMarkedForRemoval,
+  onRemove,
+  onUndoRemoval,
+}: PlayerListItemProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={`flex items-center justify-between py-3 px-2 border-b border-gray-100 dark:border-gray-700 last:border-b-0 ${
+        isMarkedForRemoval ? "opacity-50" : ""
+      }`}
+    >
+      <div className="flex items-center gap-3 min-w-0 flex-1">
+        {/* Shirt number */}
+        <span
+          className={`font-mono text-sm font-medium w-8 text-center ${
+            isMarkedForRemoval
+              ? "text-gray-400 dark:text-gray-500"
+              : "text-gray-700 dark:text-gray-300"
+          }`}
+        >
+          #{player.shirtNumber}
+        </span>
+
+        {/* Player name */}
+        <span
+          className={`text-sm truncate ${
+            isMarkedForRemoval
+              ? "line-through text-gray-400 dark:text-gray-500"
+              : "text-gray-900 dark:text-white"
+          }`}
+        >
+          {player.displayName}
+        </span>
+
+        {/* Badges */}
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {/* License category badge */}
+          {player.licenseCategory && !isMarkedForRemoval && (
+            <span className="px-1.5 py-0.5 rounded text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">
+              {player.licenseCategory}
+            </span>
+          )}
+
+          {/* Captain badge */}
+          {player.isCaptain && !isMarkedForRemoval && (
+            <span
+              className="px-1.5 py-0.5 rounded text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200"
+              title={t("validation.roster.captain")}
+            >
+              C
+            </span>
+          )}
+
+          {/* Libero badge */}
+          {player.isLibero && !isMarkedForRemoval && (
+            <span
+              className="px-1.5 py-0.5 rounded text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200"
+              title={t("validation.roster.libero")}
+            >
+              L
+            </span>
+          )}
+
+          {/* Newly added badge */}
+          {player.isNewlyAdded && !isMarkedForRemoval && (
+            <span className="px-1.5 py-0.5 rounded text-xs bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200">
+              {t("validation.roster.newlyAdded")}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Action button */}
+      <div className="flex-shrink-0 ml-2">
+        {isMarkedForRemoval ? (
+          <button
+            type="button"
+            onClick={onUndoRemoval}
+            className="p-1.5 rounded-full text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/50 transition-colors"
+            aria-label={t("validation.roster.undoRemoval")}
+            title={t("validation.roster.undoRemoval")}
+          >
+            <UndoIcon className="w-4 h-4" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="p-1.5 rounded-full text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/50 transition-colors"
+            aria-label={t("validation.roster.removePlayer")}
+            title={t("validation.roster.removePlayer")}
+          >
+            <TrashIcon className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/components/features/validation/RosterVerificationPanel.test.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.test.tsx
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RosterVerificationPanel } from "./RosterVerificationPanel";
+import * as useNominationListModule from "@/hooks/useNominationList";
+import type { RosterPlayer } from "@/hooks/useNominationList";
+
+vi.mock("@/hooks/useNominationList");
+
+const mockPlayers: RosterPlayer[] = [
+  {
+    id: "player-1",
+    shirtNumber: 1,
+    displayName: "John Doe",
+    licenseCategory: "SEN",
+    isCaptain: true,
+    isLibero: false,
+    isNewlyAdded: false,
+  },
+  {
+    id: "player-2",
+    shirtNumber: 7,
+    displayName: "Jane Smith",
+    licenseCategory: "JUN",
+    isCaptain: false,
+    isLibero: true,
+    isNewlyAdded: false,
+  },
+  {
+    id: "player-3",
+    shirtNumber: 12,
+    displayName: "Bob Wilson",
+    licenseCategory: "SEN",
+    isCaptain: false,
+    isLibero: false,
+    isNewlyAdded: false,
+  },
+];
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("RosterVerificationPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders loading state initially", () => {
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: [],
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("Loading roster...")).toBeInTheDocument();
+  });
+
+  it("displays player list after loading", () => {
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: mockPlayers,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("Test Team")).toBeInTheDocument();
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+    expect(screen.getByText("Bob Wilson")).toBeInTheDocument();
+  });
+
+  it("shows player count", () => {
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: mockPlayers,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("3 players")).toBeInTheDocument();
+  });
+
+  it("shows captain and libero indicators", () => {
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: mockPlayers,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("C")).toBeInTheDocument();
+    expect(screen.getByText("L")).toBeInTheDocument();
+  });
+
+  it("shows error state with retry button", () => {
+    const mockRefetch = vi.fn();
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: [],
+      isLoading: false,
+      isError: true,
+      error: new Error("Network error"),
+      refetch: mockRefetch,
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("Failed to load roster")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows empty state when no players", () => {
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("No players in roster")).toBeInTheDocument();
+  });
+
+  it("shows Add Player button", () => {
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: mockPlayers,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(
+      screen.getByRole("button", { name: /add player/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks player for removal when remove button is clicked", () => {
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: mockPlayers,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    // Find the first remove button and click it
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    fireEvent.click(removeButtons[0]!);
+
+    // After removal, player count should decrease
+    expect(screen.getByText("2 players")).toBeInTheDocument();
+
+    // An undo button should appear
+    expect(screen.getByRole("button", { name: /undo/i })).toBeInTheDocument();
+  });
+
+  it("restores player when undo button is clicked", () => {
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: mockPlayers,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    // Remove a player
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    fireEvent.click(removeButtons[0]!);
+
+    expect(screen.getByText("2 players")).toBeInTheDocument();
+
+    // Undo the removal
+    const undoButton = screen.getByRole("button", { name: /undo/i });
+    fireEvent.click(undoButton);
+
+    // Player count should be restored
+    expect(screen.getByText("3 players")).toBeInTheDocument();
+  });
+
+  it("calls onModificationsChange when player is removed", () => {
+    const onModificationsChange = vi.fn();
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: mockPlayers,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+        onModificationsChange={onModificationsChange}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    fireEvent.click(removeButtons[0]!);
+
+    expect(onModificationsChange).toHaveBeenCalled();
+  });
+});

--- a/web-app/src/components/features/validation/RosterVerificationPanel.test.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RosterVerificationPanel } from "./RosterVerificationPanel";
@@ -56,6 +56,10 @@ function createWrapper() {
 describe("RosterVerificationPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("renders loading state initially", () => {

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import {
   useNominationList,
@@ -93,45 +93,28 @@ export function RosterVerificationPanel({
     new Set(),
   );
 
-  const handleRemovePlayer = useCallback(
-    (playerId: string) => {
-      setRemovedPlayerIds((prev) => {
-        const newSet = new Set(prev);
-        newSet.add(playerId);
-        return newSet;
-      });
+  // Notify parent when modifications change (fixes stale closure race condition)
+  useEffect(() => {
+    onModificationsChange?.({
+      added: addedPlayers,
+      removed: [...removedPlayerIds],
+    });
+  }, [addedPlayers, removedPlayerIds, onModificationsChange]);
 
-      // Notify parent of modifications
-      onModificationsChange?.({
-        added: addedPlayers,
-        removed: [...removedPlayerIds, playerId],
-      });
-    },
-    [addedPlayers, removedPlayerIds, onModificationsChange],
-  );
+  const handleRemovePlayer = useCallback((playerId: string) => {
+    setRemovedPlayerIds((prev) => {
+      const newSet = new Set(prev);
+      newSet.add(playerId);
+      return newSet;
+    });
+  }, []);
 
-  const handleUndoRemoval = useCallback(
-    (playerId: string) => {
-      setRemovedPlayerIds((prev) => {
-        const newSet = new Set(prev);
-        newSet.delete(playerId);
-        return newSet;
-      });
-
-      // Notify parent of modifications
-      const newRemovedIds = [...removedPlayerIds].filter(
-        (id) => id !== playerId,
-      );
-      onModificationsChange?.({
-        added: addedPlayers,
-        removed: newRemovedIds,
-      });
-    },
-    [addedPlayers, removedPlayerIds, onModificationsChange],
-  );
-
-  const handleAddPlayer = useCallback(() => {
-    // Placeholder for AddPlayerSheet integration (issue #36)
+  const handleUndoRemoval = useCallback((playerId: string) => {
+    setRemovedPlayerIds((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(playerId);
+      return newSet;
+    });
   }, []);
 
   // Combine original players with added players
@@ -212,12 +195,12 @@ export function RosterVerificationPanel({
         </div>
       )}
 
-      {/* Add Player button */}
+      {/* Add Player button - TODO(#36): Enable when AddPlayerSheet is implemented */}
       <div className="mt-4">
         <button
           type="button"
-          onClick={handleAddPlayer}
-          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-lg border border-blue-200 dark:border-blue-800 transition-colors"
+          disabled
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 cursor-not-allowed"
         >
           <UserPlusIcon className="w-4 h-4" />
           {t("validation.roster.addPlayer")}

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -1,0 +1,228 @@
+import { useState, useCallback } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+import {
+  useNominationList,
+  type RosterPlayer,
+  type RosterModifications,
+} from "@/hooks/useNominationList";
+import { PlayerListItem } from "./PlayerListItem";
+
+function UserPlusIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <line x1="19" y1="8" x2="19" y2="14" />
+      <line x1="22" y1="11" x2="16" y2="11" />
+    </svg>
+  );
+}
+
+function AlertCircleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}
+
+function RefreshIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M21 2v6h-6" />
+      <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+      <path d="M3 22v-6h6" />
+      <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+    </svg>
+  );
+}
+
+interface RosterVerificationPanelProps {
+  team: "home" | "away";
+  teamName: string;
+  gameId: string;
+  onModificationsChange?: (modifications: RosterModifications) => void;
+}
+
+export function RosterVerificationPanel({
+  team,
+  teamName,
+  gameId,
+  onModificationsChange,
+}: RosterVerificationPanelProps) {
+  const { t } = useTranslation();
+  const { players, isLoading, isError, refetch } = useNominationList({
+    gameId,
+    team,
+  });
+
+  // Track locally added players (will integrate with AddPlayerSheet in issue #36)
+  const [addedPlayers] = useState<RosterPlayer[]>([]);
+
+  // Track IDs of players marked for removal
+  const [removedPlayerIds, setRemovedPlayerIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const handleRemovePlayer = useCallback(
+    (playerId: string) => {
+      setRemovedPlayerIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.add(playerId);
+        return newSet;
+      });
+
+      // Notify parent of modifications
+      onModificationsChange?.({
+        added: addedPlayers,
+        removed: [...removedPlayerIds, playerId],
+      });
+    },
+    [addedPlayers, removedPlayerIds, onModificationsChange],
+  );
+
+  const handleUndoRemoval = useCallback(
+    (playerId: string) => {
+      setRemovedPlayerIds((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(playerId);
+        return newSet;
+      });
+
+      // Notify parent of modifications
+      const newRemovedIds = [...removedPlayerIds].filter(
+        (id) => id !== playerId,
+      );
+      onModificationsChange?.({
+        added: addedPlayers,
+        removed: newRemovedIds,
+      });
+    },
+    [addedPlayers, removedPlayerIds, onModificationsChange],
+  );
+
+  const handleAddPlayer = useCallback(() => {
+    // Placeholder for AddPlayerSheet integration (issue #36)
+  }, []);
+
+  // Combine original players with added players
+  const allPlayers = [...players, ...addedPlayers].sort(
+    (a, b) => a.shirtNumber - b.shirtNumber,
+  );
+
+  // Calculate visible player count (excluding removed)
+  const visiblePlayerCount = allPlayers.filter(
+    (p) => !removedPlayerIds.has(p.id),
+  ).length;
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="py-8 flex flex-col items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 dark:border-blue-400 mb-3" />
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {t("validation.roster.loadingRoster")}
+        </p>
+      </div>
+    );
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className="py-8 flex flex-col items-center justify-center">
+        <AlertCircleIcon className="w-10 h-10 text-red-500 mb-3" />
+        <p className="text-sm text-red-600 dark:text-red-400 mb-4">
+          {t("validation.roster.errorLoading")}
+        </p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+        >
+          <RefreshIcon className="w-4 h-4" />
+          {t("common.retry")}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-4">
+      {/* Header with team name and player count */}
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-gray-900 dark:text-white">
+          {teamName}
+        </h3>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {t("validation.roster.playerCount").replace(
+            "{count}",
+            String(visiblePlayerCount),
+          )}
+        </span>
+      </div>
+
+      {/* Player list */}
+      {allPlayers.length === 0 ? (
+        <div className="py-8 text-center">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {t("validation.roster.emptyRoster")}
+          </p>
+        </div>
+      ) : (
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+          {allPlayers.map((player) => (
+            <PlayerListItem
+              key={player.id}
+              player={player}
+              isMarkedForRemoval={removedPlayerIds.has(player.id)}
+              onRemove={() => handleRemovePlayer(player.id)}
+              onUndoRemoval={() => handleUndoRemoval(player.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Add Player button */}
+      <div className="mt-4">
+        <button
+          type="button"
+          onClick={handleAddPlayer}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-lg border border-blue-200 dark:border-blue-800 transition-colors"
+        >
+          <UserPlusIcon className="w-4 h-4" />
+          {t("validation.roster.addPlayer")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/components/features/validation/index.ts
+++ b/web-app/src/components/features/validation/index.ts
@@ -3,3 +3,5 @@ export { AwayRosterPanel } from "./AwayRosterPanel";
 export { ScorerPanel } from "./ScorerPanel";
 export { ScoresheetPanel } from "./ScoresheetPanel";
 export { AddPlayerSheet } from "./AddPlayerSheet";
+export { RosterVerificationPanel } from "./RosterVerificationPanel";
+export { PlayerListItem } from "./PlayerListItem";

--- a/web-app/src/hooks/useNominationList.test.ts
+++ b/web-app/src/hooks/useNominationList.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { useNominationList } from "./useNominationList";
+import * as authStore from "@/stores/auth";
+import * as demoStore from "@/stores/demo";
+import type { NominationList } from "@/api/client";
+
+vi.mock("@/stores/auth");
+vi.mock("@/stores/demo");
+
+const mockNominationList: NominationList = {
+  __identity: "test-nomlist-1",
+  game: { __identity: "test-game-1" },
+  team: { __identity: "test-team-1", displayName: "Test Team" },
+  closed: false,
+  isClosedForTeam: false,
+  indoorPlayerNominations: [
+    {
+      __identity: "test-nom-1",
+      shirtNumber: 1,
+      isCaptain: true,
+      isLibero: false,
+      indoorPlayer: {
+        __identity: "test-player-1",
+        person: {
+          __identity: "test-person-1",
+          firstName: "John",
+          lastName: "Doe",
+          displayName: "John Doe",
+        },
+      },
+      indoorPlayerLicenseCategory: {
+        __identity: "lic-1",
+        shortName: "SEN",
+      },
+    },
+    {
+      __identity: "test-nom-2",
+      shirtNumber: 7,
+      isCaptain: false,
+      isLibero: true,
+      indoorPlayer: {
+        __identity: "test-player-2",
+        person: {
+          __identity: "test-person-2",
+          firstName: "Jane",
+          lastName: "Smith",
+          displayName: "Jane Smith",
+        },
+      },
+      indoorPlayerLicenseCategory: {
+        __identity: "lic-2",
+        shortName: "JUN",
+      },
+    },
+  ],
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+describe("useNominationList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("demo mode", () => {
+    beforeEach(() => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+    });
+
+    it("returns demo data when in demo mode with matching game", () => {
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          nominationLists: {
+            "test-game-1": {
+              home: mockNominationList,
+              away: mockNominationList,
+            },
+          },
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(
+        () => useNominationList({ gameId: "test-game-1", team: "home" }),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.nominationList).toBe(mockNominationList);
+      expect(result.current.players).toHaveLength(2);
+    });
+
+    it("transforms nominations to players correctly", () => {
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          nominationLists: {
+            "test-game-1": {
+              home: mockNominationList,
+              away: mockNominationList,
+            },
+          },
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(
+        () => useNominationList({ gameId: "test-game-1", team: "home" }),
+        { wrapper: createWrapper() },
+      );
+
+      const players = result.current.players;
+
+      // Players should be sorted by shirt number
+      expect(players[0]).toEqual({
+        id: "test-nom-1",
+        shirtNumber: 1,
+        displayName: "John Doe",
+        licenseCategory: "SEN",
+        isCaptain: true,
+        isLibero: false,
+        isNewlyAdded: false,
+      });
+
+      expect(players[1]).toEqual({
+        id: "test-nom-2",
+        shirtNumber: 7,
+        displayName: "Jane Smith",
+        licenseCategory: "JUN",
+        isCaptain: false,
+        isLibero: true,
+        isNewlyAdded: false,
+      });
+    });
+
+    it("returns empty data when game not found in demo mode", () => {
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          nominationLists: {},
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(
+        () => useNominationList({ gameId: "nonexistent-game", team: "home" }),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.nominationList).toBeNull();
+      expect(result.current.players).toHaveLength(0);
+    });
+
+    it("returns correct team data based on team prop", () => {
+      const homeList: NominationList = {
+        ...mockNominationList,
+        __identity: "home-list",
+        team: { __identity: "home-team", displayName: "Home Team" },
+      };
+
+      const awayList: NominationList = {
+        ...mockNominationList,
+        __identity: "away-list",
+        team: { __identity: "away-team", displayName: "Away Team" },
+      };
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          nominationLists: {
+            "test-game-1": {
+              home: homeList,
+              away: awayList,
+            },
+          },
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result: homeResult } = renderHook(
+        () => useNominationList({ gameId: "test-game-1", team: "home" }),
+        { wrapper: createWrapper() },
+      );
+
+      const { result: awayResult } = renderHook(
+        () => useNominationList({ gameId: "test-game-1", team: "away" }),
+        { wrapper: createWrapper() },
+      );
+
+      expect(homeResult.current.nominationList?.__identity).toBe("home-list");
+      expect(awayResult.current.nominationList?.__identity).toBe("away-list");
+    });
+  });
+
+  describe("production mode", () => {
+    beforeEach(() => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: false } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          nominationLists: {},
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+    });
+
+    it("returns loading state initially in production mode", async () => {
+      const { result } = renderHook(
+        () => useNominationList({ gameId: "test-game-1", team: "home" }),
+        { wrapper: createWrapper() },
+      );
+
+      // The query is enabled but will return null (placeholder for real API)
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+
+    it("respects enabled option", () => {
+      const { result } = renderHook(
+        () =>
+          useNominationList({
+            gameId: "test-game-1",
+            team: "home",
+            enabled: false,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      // Query should be idle when disabled
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.nominationList).toBeNull();
+    });
+  });
+});

--- a/web-app/src/hooks/useNominationList.ts
+++ b/web-app/src/hooks/useNominationList.ts
@@ -36,14 +36,23 @@ interface UseNominationListResult {
   refetch: () => void;
 }
 
+function buildDisplayName(nomination: IndoorPlayerNomination): string {
+  const person = nomination.indoorPlayer?.person;
+  if (person?.displayName) {
+    return person.displayName;
+  }
+
+  const firstName = person?.firstName?.trim() ?? "";
+  const lastName = person?.lastName?.trim() ?? "";
+  return [firstName, lastName].filter(Boolean).join(" ");
+}
+
 function transformNominationToPlayer(
   nomination: IndoorPlayerNomination,
 ): RosterPlayer | null {
   const id = nomination.__identity;
   const shirtNumber = nomination.shirtNumber;
-  const displayName =
-    nomination.indoorPlayer?.person?.displayName ??
-    `${nomination.indoorPlayer?.person?.firstName ?? ""} ${nomination.indoorPlayer?.person?.lastName ?? ""}`.trim();
+  const displayName = buildDisplayName(nomination);
 
   if (!id || shirtNumber === undefined || !displayName) {
     return null;

--- a/web-app/src/hooks/useNominationList.ts
+++ b/web-app/src/hooks/useNominationList.ts
@@ -4,6 +4,8 @@ import type { NominationList, IndoorPlayerNomination } from "@/api/client";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 
+const NOMINATION_LIST_STALE_TIME_MS = 5 * 60 * 1000;
+
 export interface RosterPlayer {
   id: string;
   shirtNumber: number;
@@ -93,13 +95,12 @@ export function useNominationList({
 
   const query = useQuery({
     queryKey: ["nominationList", gameId, team],
+    // TODO(#37): Implement API fetch for nomination list
     queryFn: async (): Promise<NominationList | null> => {
-      // In a real implementation, this would fetch from the API
-      // For now, return null to indicate no data (demo mode handles its own data)
       return null;
     },
     enabled: enabled && !isDemoMode && !!gameId,
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: NOMINATION_LIST_STALE_TIME_MS,
   });
 
   const apiPlayers = useMemo(() => {

--- a/web-app/src/hooks/useNominationList.ts
+++ b/web-app/src/hooks/useNominationList.ts
@@ -1,0 +1,131 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { NominationList, IndoorPlayerNomination } from "@/api/client";
+import { useAuthStore } from "@/stores/auth";
+import { useDemoStore } from "@/stores/demo";
+
+export interface RosterPlayer {
+  id: string;
+  shirtNumber: number;
+  displayName: string;
+  licenseCategory?: string;
+  isCaptain?: boolean;
+  isLibero?: boolean;
+  isNewlyAdded?: boolean;
+}
+
+export interface RosterModifications {
+  added: RosterPlayer[];
+  removed: string[];
+}
+
+interface UseNominationListOptions {
+  gameId: string;
+  team: "home" | "away";
+  enabled?: boolean;
+}
+
+interface UseNominationListResult {
+  nominationList: NominationList | null;
+  players: RosterPlayer[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+function transformNominationToPlayer(
+  nomination: IndoorPlayerNomination,
+): RosterPlayer | null {
+  const id = nomination.__identity;
+  const shirtNumber = nomination.shirtNumber;
+  const displayName =
+    nomination.indoorPlayer?.person?.displayName ??
+    `${nomination.indoorPlayer?.person?.firstName ?? ""} ${nomination.indoorPlayer?.person?.lastName ?? ""}`.trim();
+
+  if (!id || shirtNumber === undefined || !displayName) {
+    return null;
+  }
+
+  return {
+    id,
+    shirtNumber,
+    displayName,
+    licenseCategory: nomination.indoorPlayerLicenseCategory?.shortName,
+    isCaptain: nomination.isCaptain ?? false,
+    isLibero: nomination.isLibero ?? false,
+    isNewlyAdded: false,
+  };
+}
+
+function transformNominationsToPlayers(
+  nominations: IndoorPlayerNomination[] | undefined,
+): RosterPlayer[] {
+  if (!nominations) return [];
+
+  return nominations
+    .map(transformNominationToPlayer)
+    .filter((player): player is RosterPlayer => player !== null)
+    .sort((a, b) => a.shirtNumber - b.shirtNumber);
+}
+
+export function useNominationList({
+  gameId,
+  team,
+  enabled = true,
+}: UseNominationListOptions): UseNominationListResult {
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const nominationLists = useDemoStore((state) => state.nominationLists);
+
+  const demoNominationList = useMemo(() => {
+    if (!isDemoMode || !gameId) return null;
+    const gameNominations = nominationLists[gameId];
+    if (!gameNominations) return null;
+    return gameNominations[team] ?? null;
+  }, [isDemoMode, gameId, team, nominationLists]);
+
+  const demoPlayers = useMemo(() => {
+    if (!demoNominationList) return [];
+    return transformNominationsToPlayers(
+      demoNominationList.indoorPlayerNominations,
+    );
+  }, [demoNominationList]);
+
+  const query = useQuery({
+    queryKey: ["nominationList", gameId, team],
+    queryFn: async (): Promise<NominationList | null> => {
+      // In a real implementation, this would fetch from the API
+      // For now, return null to indicate no data (demo mode handles its own data)
+      return null;
+    },
+    enabled: enabled && !isDemoMode && !!gameId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  const apiPlayers = useMemo(() => {
+    if (!query.data) return [];
+    return transformNominationsToPlayers(query.data.indoorPlayerNominations);
+  }, [query.data]);
+
+  if (isDemoMode) {
+    return {
+      nominationList: demoNominationList,
+      players: demoPlayers,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: () => {
+        // No-op in demo mode
+      },
+    };
+  }
+
+  return {
+    nominationList: query.data ?? null,
+    players: apiPlayers,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -176,13 +176,18 @@ interface Translations {
     awayRosterPlaceholder: string;
     scorerPlaceholder: string;
     scoresheetPlaceholder: string;
-    addPlayer: string;
-    searchPlayers: string;
-    noPlayersFound: string;
-    loadPlayersError: string;
-    playerAlreadyAdded: string;
-    jerseyNumber: string;
-    license: string;
+    roster: {
+      addPlayer: string;
+      removePlayer: string;
+      undoRemoval: string;
+      newlyAdded: string;
+      captain: string;
+      libero: string;
+      emptyRoster: string;
+      loadingRoster: string;
+      errorLoading: string;
+      playerCount: string;
+    };
   };
 }
 
@@ -365,13 +370,18 @@ const en: Translations = {
       "Away team roster verification will be available here.",
     scorerPlaceholder: "Scorer identification will be available here.",
     scoresheetPlaceholder: "Scoresheet upload will be available here.",
-    addPlayer: "Add Player",
-    searchPlayers: "Search players...",
-    noPlayersFound: "No players found",
-    loadPlayersError: "Failed to load players",
-    playerAlreadyAdded: "Already on roster",
-    jerseyNumber: "Jersey #",
-    license: "License",
+    roster: {
+      addPlayer: "Add Player",
+      removePlayer: "Remove player",
+      undoRemoval: "Undo removal",
+      newlyAdded: "New",
+      captain: "Captain",
+      libero: "Libero",
+      emptyRoster: "No players in roster",
+      loadingRoster: "Loading roster...",
+      errorLoading: "Failed to load roster",
+      playerCount: "{count} players",
+    },
   },
 };
 
@@ -556,13 +566,18 @@ const de: Translations = {
     scorerPlaceholder: "Die Schreiberidentifikation wird hier verfügbar sein.",
     scoresheetPlaceholder:
       "Der Upload des Spielberichts wird hier verfügbar sein.",
-    addPlayer: "Spieler hinzufügen",
-    searchPlayers: "Spieler suchen...",
-    noPlayersFound: "Keine Spieler gefunden",
-    loadPlayersError: "Spieler konnten nicht geladen werden",
-    playerAlreadyAdded: "Bereits im Kader",
-    jerseyNumber: "Trikot #",
-    license: "Lizenz",
+    roster: {
+      addPlayer: "Spieler hinzufügen",
+      removePlayer: "Spieler entfernen",
+      undoRemoval: "Entfernung rückgängig",
+      newlyAdded: "Neu",
+      captain: "Kapitän",
+      libero: "Libero",
+      emptyRoster: "Keine Spieler im Kader",
+      loadingRoster: "Kader wird geladen...",
+      errorLoading: "Kader konnte nicht geladen werden",
+      playerCount: "{count} Spieler",
+    },
   },
 };
 
@@ -747,13 +762,18 @@ const fr: Translations = {
     scorerPlaceholder: "L'identification du marqueur sera disponible ici.",
     scoresheetPlaceholder:
       "Le téléchargement de la feuille de match sera disponible ici.",
-    addPlayer: "Ajouter un joueur",
-    searchPlayers: "Rechercher des joueurs...",
-    noPlayersFound: "Aucun joueur trouvé",
-    loadPlayersError: "Échec du chargement des joueurs",
-    playerAlreadyAdded: "Déjà dans l'effectif",
-    jerseyNumber: "Maillot #",
-    license: "Licence",
+    roster: {
+      addPlayer: "Ajouter un joueur",
+      removePlayer: "Retirer le joueur",
+      undoRemoval: "Annuler le retrait",
+      newlyAdded: "Nouveau",
+      captain: "Capitaine",
+      libero: "Libéro",
+      emptyRoster: "Aucun joueur dans l'effectif",
+      loadingRoster: "Chargement de l'effectif...",
+      errorLoading: "Échec du chargement de l'effectif",
+      playerCount: "{count} joueurs",
+    },
   },
 };
 
@@ -936,13 +956,18 @@ const it: Translations = {
       "La verifica della rosa ospite sarà disponibile qui.",
     scorerPlaceholder: "L'identificazione del segnapunti sarà disponibile qui.",
     scoresheetPlaceholder: "Il caricamento del referto sarà disponibile qui.",
-    addPlayer: "Aggiungi giocatore",
-    searchPlayers: "Cerca giocatori...",
-    noPlayersFound: "Nessun giocatore trovato",
-    loadPlayersError: "Impossibile caricare i giocatori",
-    playerAlreadyAdded: "Già nella rosa",
-    jerseyNumber: "Maglia #",
-    license: "Licenza",
+    roster: {
+      addPlayer: "Aggiungi giocatore",
+      removePlayer: "Rimuovi giocatore",
+      undoRemoval: "Annulla rimozione",
+      newlyAdded: "Nuovo",
+      captain: "Capitano",
+      libero: "Libero",
+      emptyRoster: "Nessun giocatore nella rosa",
+      loadingRoster: "Caricamento rosa...",
+      errorLoading: "Caricamento rosa fallito",
+      playerCount: "{count} giocatori",
+    },
   },
 };
 

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -176,6 +176,13 @@ interface Translations {
     awayRosterPlaceholder: string;
     scorerPlaceholder: string;
     scoresheetPlaceholder: string;
+    addPlayer: string;
+    searchPlayers: string;
+    noPlayersFound: string;
+    loadPlayersError: string;
+    playerAlreadyAdded: string;
+    jerseyNumber: string;
+    license: string;
     roster: {
       addPlayer: string;
       removePlayer: string;
@@ -370,6 +377,13 @@ const en: Translations = {
       "Away team roster verification will be available here.",
     scorerPlaceholder: "Scorer identification will be available here.",
     scoresheetPlaceholder: "Scoresheet upload will be available here.",
+    addPlayer: "Add Player",
+    searchPlayers: "Search players...",
+    noPlayersFound: "No players found",
+    loadPlayersError: "Failed to load players",
+    playerAlreadyAdded: "Already on roster",
+    jerseyNumber: "Jersey #",
+    license: "License",
     roster: {
       addPlayer: "Add Player",
       removePlayer: "Remove player",
@@ -566,6 +580,13 @@ const de: Translations = {
     scorerPlaceholder: "Die Schreiberidentifikation wird hier verfügbar sein.",
     scoresheetPlaceholder:
       "Der Upload des Spielberichts wird hier verfügbar sein.",
+    addPlayer: "Spieler hinzufügen",
+    searchPlayers: "Spieler suchen...",
+    noPlayersFound: "Keine Spieler gefunden",
+    loadPlayersError: "Spieler konnten nicht geladen werden",
+    playerAlreadyAdded: "Bereits im Kader",
+    jerseyNumber: "Trikot #",
+    license: "Lizenz",
     roster: {
       addPlayer: "Spieler hinzufügen",
       removePlayer: "Spieler entfernen",
@@ -762,6 +783,13 @@ const fr: Translations = {
     scorerPlaceholder: "L'identification du marqueur sera disponible ici.",
     scoresheetPlaceholder:
       "Le téléchargement de la feuille de match sera disponible ici.",
+    addPlayer: "Ajouter un joueur",
+    searchPlayers: "Rechercher des joueurs...",
+    noPlayersFound: "Aucun joueur trouvé",
+    loadPlayersError: "Échec du chargement des joueurs",
+    playerAlreadyAdded: "Déjà dans l'effectif",
+    jerseyNumber: "Maillot #",
+    license: "Licence",
     roster: {
       addPlayer: "Ajouter un joueur",
       removePlayer: "Retirer le joueur",
@@ -956,6 +984,13 @@ const it: Translations = {
       "La verifica della rosa ospite sarà disponibile qui.",
     scorerPlaceholder: "L'identificazione del segnapunti sarà disponibile qui.",
     scoresheetPlaceholder: "Il caricamento del referto sarà disponibile qui.",
+    addPlayer: "Aggiungi giocatore",
+    searchPlayers: "Cerca giocatori...",
+    noPlayersFound: "Nessun giocatore trovato",
+    loadPlayersError: "Impossibile caricare i giocatori",
+    playerAlreadyAdded: "Già nella rosa",
+    jerseyNumber: "Maglia #",
+    license: "Licenza",
     roster: {
       addPlayer: "Aggiungi giocatore",
       removePlayer: "Rimuovi giocatore",

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -4,6 +4,7 @@ import type {
   CompensationRecord,
   GameExchange,
   NominationList,
+  PossibleNomination,
 } from "@/api/client";
 import { addDays, addHours, subDays } from "date-fns";
 
@@ -32,6 +33,7 @@ interface DemoState {
   compensations: CompensationRecord[];
   exchanges: GameExchange[];
   nominationLists: MockNominationLists;
+  possiblePlayers: PossibleNomination[];
 
   // Demo user's referee level for filtering exchanges
   // Level string (e.g., "N2") and gradation value (higher = more qualified)
@@ -683,10 +685,126 @@ function generateDummyData() {
     },
   ];
 
+  const dummyPossiblePlayers: PossibleNomination[] = [
+    {
+      __identity: "demo-possible-1",
+      indoorPlayer: {
+        __identity: "demo-player-1",
+        person: {
+          __identity: "demo-person-p1",
+          displayName: "Max Müller",
+          firstName: "Max",
+          lastName: "Müller",
+        },
+      },
+      licenseCategory: "SEN",
+      isAlreadyNominated: false,
+    },
+    {
+      __identity: "demo-possible-2",
+      indoorPlayer: {
+        __identity: "demo-player-2",
+        person: {
+          __identity: "demo-person-p2",
+          displayName: "Anna Schmidt",
+          firstName: "Anna",
+          lastName: "Schmidt",
+        },
+      },
+      licenseCategory: "SEN",
+      isAlreadyNominated: false,
+    },
+    {
+      __identity: "demo-possible-3",
+      indoorPlayer: {
+        __identity: "demo-player-3",
+        person: {
+          __identity: "demo-person-p3",
+          displayName: "Thomas Weber",
+          firstName: "Thomas",
+          lastName: "Weber",
+        },
+      },
+      licenseCategory: "JUN",
+      isAlreadyNominated: false,
+    },
+    {
+      __identity: "demo-possible-4",
+      indoorPlayer: {
+        __identity: "demo-player-4",
+        person: {
+          __identity: "demo-person-p4",
+          displayName: "Laura Keller",
+          firstName: "Laura",
+          lastName: "Keller",
+        },
+      },
+      licenseCategory: "SEN",
+      isAlreadyNominated: true,
+    },
+    {
+      __identity: "demo-possible-5",
+      indoorPlayer: {
+        __identity: "demo-player-5",
+        person: {
+          __identity: "demo-person-p5",
+          displayName: "Marco Rossi",
+          firstName: "Marco",
+          lastName: "Rossi",
+        },
+      },
+      licenseCategory: "JUN",
+      isAlreadyNominated: false,
+    },
+    {
+      __identity: "demo-possible-6",
+      indoorPlayer: {
+        __identity: "demo-player-6",
+        person: {
+          __identity: "demo-person-p6",
+          displayName: "Sophie Dubois",
+          firstName: "Sophie",
+          lastName: "Dubois",
+        },
+      },
+      licenseCategory: "SEN",
+      isAlreadyNominated: false,
+    },
+    {
+      __identity: "demo-possible-7",
+      indoorPlayer: {
+        __identity: "demo-player-7",
+        person: {
+          __identity: "demo-person-p7",
+          displayName: "Luca Bernasconi",
+          firstName: "Luca",
+          lastName: "Bernasconi",
+        },
+      },
+      licenseCategory: "JUN",
+      isAlreadyNominated: false,
+    },
+    {
+      __identity: "demo-possible-8",
+      indoorPlayer: {
+        __identity: "demo-player-8",
+        person: {
+          __identity: "demo-person-p8",
+          displayName: "Nina Hofmann",
+          firstName: "Nina",
+          lastName: "Hofmann",
+        },
+      },
+      licenseCategory: "SEN",
+      isAlreadyNominated: false,
+    },
+  ];
+
   return {
     assignments: dummyAssignments,
     compensations: dummyCompensations,
     exchanges: dummyExchanges,
+    possiblePlayers: dummyPossiblePlayers,
   };
 }
 
@@ -1209,6 +1327,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
   compensations: [],
   exchanges: [],
   nominationLists: {},
+  possiblePlayers: [],
   userRefereeLevel: null,
   userRefereeLevelGradationValue: null,
 
@@ -1219,6 +1338,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
       compensations: data.compensations,
       exchanges: data.exchanges,
       nominationLists: generateMockNominationLists(),
+      possiblePlayers: data.possiblePlayers,
       userRefereeLevel: DEMO_USER_REFEREE_LEVEL,
       userRefereeLevelGradationValue: DEMO_USER_REFEREE_LEVEL_GRADATION_VALUE,
     });
@@ -1230,6 +1350,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
       compensations: [],
       exchanges: [],
       nominationLists: {},
+      possiblePlayers: [],
       userRefereeLevel: null,
       userRefereeLevelGradationValue: null,
     }),
@@ -1242,6 +1363,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
         compensations: newData.compensations,
         exchanges: newData.exchanges,
         nominationLists: generateMockNominationLists(),
+        possiblePlayers: newData.possiblePlayers,
       };
     }),
 

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -3,16 +3,35 @@ import type {
   Assignment,
   CompensationRecord,
   GameExchange,
-  PossibleNomination,
+  NominationList,
 } from "@/api/client";
 import { addDays, addHours, subDays } from "date-fns";
+
+// Mock player for roster display
+export interface MockRosterPlayer {
+  id: string;
+  shirtNumber: number;
+  displayName: string;
+  licenseCategory?: string;
+  isCaptain?: boolean;
+  isLibero?: boolean;
+}
+
+// Mock nomination lists keyed by game ID, then by team type
+export type MockNominationLists = Record<
+  string,
+  {
+    home: NominationList;
+    away: NominationList;
+  }
+>;
 
 interface DemoState {
   // Data arrays - populated when demo mode is enabled via useAuthStore
   assignments: Assignment[];
   compensations: CompensationRecord[];
   exchanges: GameExchange[];
-  possiblePlayers: PossibleNomination[];
+  nominationLists: MockNominationLists;
 
   // Demo user's referee level for filtering exchanges
   // Level string (e.g., "N2") and gradation value (higher = more qualified)
@@ -664,127 +683,518 @@ function generateDummyData() {
     },
   ];
 
-  const dummyPossiblePlayers: PossibleNomination[] = [
-    {
-      __identity: "demo-possible-1",
-      indoorPlayer: {
-        __identity: "demo-player-1",
-        person: {
-          __identity: "demo-person-p1",
-          displayName: "Max Müller",
-          firstName: "Max",
-          lastName: "Müller",
-        },
-      },
-      licenseCategory: "SEN",
-      isAlreadyNominated: false,
-    },
-    {
-      __identity: "demo-possible-2",
-      indoorPlayer: {
-        __identity: "demo-player-2",
-        person: {
-          __identity: "demo-person-p2",
-          displayName: "Anna Schmidt",
-          firstName: "Anna",
-          lastName: "Schmidt",
-        },
-      },
-      licenseCategory: "SEN",
-      isAlreadyNominated: false,
-    },
-    {
-      __identity: "demo-possible-3",
-      indoorPlayer: {
-        __identity: "demo-player-3",
-        person: {
-          __identity: "demo-person-p3",
-          displayName: "Thomas Weber",
-          firstName: "Thomas",
-          lastName: "Weber",
-        },
-      },
-      licenseCategory: "JUN",
-      isAlreadyNominated: false,
-    },
-    {
-      __identity: "demo-possible-4",
-      indoorPlayer: {
-        __identity: "demo-player-4",
-        person: {
-          __identity: "demo-person-p4",
-          displayName: "Laura Keller",
-          firstName: "Laura",
-          lastName: "Keller",
-        },
-      },
-      licenseCategory: "SEN",
-      isAlreadyNominated: true,
-    },
-    {
-      __identity: "demo-possible-5",
-      indoorPlayer: {
-        __identity: "demo-player-5",
-        person: {
-          __identity: "demo-person-p5",
-          displayName: "Marco Rossi",
-          firstName: "Marco",
-          lastName: "Rossi",
-        },
-      },
-      licenseCategory: "JUN",
-      isAlreadyNominated: false,
-    },
-    {
-      __identity: "demo-possible-6",
-      indoorPlayer: {
-        __identity: "demo-player-6",
-        person: {
-          __identity: "demo-person-p6",
-          displayName: "Sophie Dubois",
-          firstName: "Sophie",
-          lastName: "Dubois",
-        },
-      },
-      licenseCategory: "SEN",
-      isAlreadyNominated: false,
-    },
-    {
-      __identity: "demo-possible-7",
-      indoorPlayer: {
-        __identity: "demo-player-7",
-        person: {
-          __identity: "demo-person-p7",
-          displayName: "Luca Bernasconi",
-          firstName: "Luca",
-          lastName: "Bernasconi",
-        },
-      },
-      licenseCategory: "JUN",
-      isAlreadyNominated: false,
-    },
-    {
-      __identity: "demo-possible-8",
-      indoorPlayer: {
-        __identity: "demo-player-8",
-        person: {
-          __identity: "demo-person-p8",
-          displayName: "Nina Hofmann",
-          firstName: "Nina",
-          lastName: "Hofmann",
-        },
-      },
-      licenseCategory: "SEN",
-      isAlreadyNominated: false,
-    },
-  ];
-
   return {
     assignments: dummyAssignments,
     compensations: dummyCompensations,
     exchanges: dummyExchanges,
-    possiblePlayers: dummyPossiblePlayers,
   };
+}
+
+function generateMockNominationLists(): MockNominationLists {
+  // Generate mock nomination lists for the first 3 demo games
+  // These correspond to demo-g-1, demo-g-2, demo-g-3 from the assignments
+
+  const nominationLists: MockNominationLists = {
+    "demo-g-1": {
+      home: {
+        __identity: "demo-nomlist-home-1",
+        game: { __identity: "demo-g-1" },
+        team: { __identity: "team-1", displayName: "VBC Zürich Lions" },
+        closed: false,
+        isClosedForTeam: false,
+        indoorPlayerNominations: [
+          {
+            __identity: "demo-nom-1-1",
+            shirtNumber: 1,
+            isCaptain: true,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-1-1",
+              person: {
+                __identity: "demo-person-1-1",
+                firstName: "Marco",
+                lastName: "Meier",
+                displayName: "Marco Meier",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-1-2",
+            shirtNumber: 7,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-1-2",
+              person: {
+                __identity: "demo-person-1-2",
+                firstName: "Lukas",
+                lastName: "Schneider",
+                displayName: "Lukas Schneider",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-1-3",
+            shirtNumber: 12,
+            isCaptain: false,
+            isLibero: true,
+            indoorPlayer: {
+              __identity: "demo-player-1-3",
+              person: {
+                __identity: "demo-person-1-3",
+                firstName: "Noah",
+                lastName: "Weber",
+                displayName: "Noah Weber",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-jun",
+              shortName: "JUN",
+            },
+          },
+          {
+            __identity: "demo-nom-1-4",
+            shirtNumber: 5,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-1-4",
+              person: {
+                __identity: "demo-person-1-4",
+                firstName: "Felix",
+                lastName: "Keller",
+                displayName: "Felix Keller",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-1-5",
+            shirtNumber: 9,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-1-5",
+              person: {
+                __identity: "demo-person-1-5",
+                firstName: "Tim",
+                lastName: "Fischer",
+                displayName: "Tim Fischer",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-1-6",
+            shirtNumber: 14,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-1-6",
+              person: {
+                __identity: "demo-person-1-6",
+                firstName: "Jan",
+                lastName: "Brunner",
+                displayName: "Jan Brunner",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+        ],
+      },
+      away: {
+        __identity: "demo-nomlist-away-1",
+        game: { __identity: "demo-g-1" },
+        team: { __identity: "team-2", displayName: "Volley Luzern" },
+        closed: false,
+        isClosedForTeam: false,
+        indoorPlayerNominations: [
+          {
+            __identity: "demo-nom-2-1",
+            shirtNumber: 3,
+            isCaptain: true,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-2-1",
+              person: {
+                __identity: "demo-person-2-1",
+                firstName: "David",
+                lastName: "Steiner",
+                displayName: "David Steiner",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-2-2",
+            shirtNumber: 8,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-2-2",
+              person: {
+                __identity: "demo-person-2-2",
+                firstName: "Simon",
+                lastName: "Frei",
+                displayName: "Simon Frei",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-2-3",
+            shirtNumber: 11,
+            isCaptain: false,
+            isLibero: true,
+            indoorPlayer: {
+              __identity: "demo-player-2-3",
+              person: {
+                __identity: "demo-person-2-3",
+                firstName: "Luca",
+                lastName: "Gerber",
+                displayName: "Luca Gerber",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-jun",
+              shortName: "JUN",
+            },
+          },
+          {
+            __identity: "demo-nom-2-4",
+            shirtNumber: 6,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-2-4",
+              person: {
+                __identity: "demo-person-2-4",
+                firstName: "Yannick",
+                lastName: "Hofer",
+                displayName: "Yannick Hofer",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-2-5",
+            shirtNumber: 10,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-2-5",
+              person: {
+                __identity: "demo-person-2-5",
+                firstName: "Nico",
+                lastName: "Baumann",
+                displayName: "Nico Baumann",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+        ],
+      },
+    },
+    "demo-g-2": {
+      home: {
+        __identity: "demo-nomlist-home-2",
+        game: { __identity: "demo-g-2" },
+        team: { __identity: "team-3", displayName: "Schönenwerd Smash" },
+        closed: false,
+        isClosedForTeam: false,
+        indoorPlayerNominations: [
+          {
+            __identity: "demo-nom-3-1",
+            shirtNumber: 2,
+            isCaptain: true,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-3-1",
+              person: {
+                __identity: "demo-person-3-1",
+                firstName: "Raphael",
+                lastName: "Widmer",
+                displayName: "Raphael Widmer",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-3-2",
+            shirtNumber: 15,
+            isCaptain: false,
+            isLibero: true,
+            indoorPlayer: {
+              __identity: "demo-player-3-2",
+              person: {
+                __identity: "demo-person-3-2",
+                firstName: "Kevin",
+                lastName: "Bieri",
+                displayName: "Kevin Bieri",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-3-3",
+            shirtNumber: 4,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-3-3",
+              person: {
+                __identity: "demo-person-3-3",
+                firstName: "Patrick",
+                lastName: "Moser",
+                displayName: "Patrick Moser",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+        ],
+      },
+      away: {
+        __identity: "demo-nomlist-away-2",
+        game: { __identity: "demo-g-2" },
+        team: { __identity: "team-4", displayName: "Traktor Basel" },
+        closed: false,
+        isClosedForTeam: false,
+        indoorPlayerNominations: [
+          {
+            __identity: "demo-nom-4-1",
+            shirtNumber: 1,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-4-1",
+              person: {
+                __identity: "demo-person-4-1",
+                firstName: "Benjamin",
+                lastName: "Koch",
+                displayName: "Benjamin Koch",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-4-2",
+            shirtNumber: 13,
+            isCaptain: true,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-4-2",
+              person: {
+                __identity: "demo-person-4-2",
+                firstName: "Michael",
+                lastName: "Lang",
+                displayName: "Michael Lang",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-4-3",
+            shirtNumber: 17,
+            isCaptain: false,
+            isLibero: true,
+            indoorPlayer: {
+              __identity: "demo-player-4-3",
+              person: {
+                __identity: "demo-person-4-3",
+                firstName: "Julian",
+                lastName: "Roth",
+                displayName: "Julian Roth",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-jun",
+              shortName: "JUN",
+            },
+          },
+        ],
+      },
+    },
+    "demo-g-3": {
+      home: {
+        __identity: "demo-nomlist-home-3",
+        game: { __identity: "demo-g-3" },
+        team: { __identity: "team-5", displayName: "Volley Näfels" },
+        closed: false,
+        isClosedForTeam: false,
+        indoorPlayerNominations: [
+          {
+            __identity: "demo-nom-5-1",
+            shirtNumber: 6,
+            isCaptain: true,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-5-1",
+              person: {
+                __identity: "demo-person-5-1",
+                firstName: "Anna",
+                lastName: "Huber",
+                displayName: "Anna Huber",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-5-2",
+            shirtNumber: 10,
+            isCaptain: false,
+            isLibero: true,
+            indoorPlayer: {
+              __identity: "demo-player-5-2",
+              person: {
+                __identity: "demo-person-5-2",
+                firstName: "Lisa",
+                lastName: "Meyer",
+                displayName: "Lisa Meyer",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-5-3",
+            shirtNumber: 8,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-5-3",
+              person: {
+                __identity: "demo-person-5-3",
+                firstName: "Sara",
+                lastName: "Schmid",
+                displayName: "Sara Schmid",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-jun",
+              shortName: "JUN",
+            },
+          },
+        ],
+      },
+      away: {
+        __identity: "demo-nomlist-away-3",
+        game: { __identity: "demo-g-3" },
+        team: { __identity: "team-6", displayName: "Volero Zürich" },
+        closed: false,
+        isClosedForTeam: false,
+        indoorPlayerNominations: [
+          {
+            __identity: "demo-nom-6-1",
+            shirtNumber: 4,
+            isCaptain: true,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-6-1",
+              person: {
+                __identity: "demo-person-6-1",
+                firstName: "Elena",
+                lastName: "Keller",
+                displayName: "Elena Keller",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-6-2",
+            shirtNumber: 7,
+            isCaptain: false,
+            isLibero: false,
+            indoorPlayer: {
+              __identity: "demo-player-6-2",
+              person: {
+                __identity: "demo-person-6-2",
+                firstName: "Julia",
+                lastName: "Lehmann",
+                displayName: "Julia Lehmann",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+          {
+            __identity: "demo-nom-6-3",
+            shirtNumber: 12,
+            isCaptain: false,
+            isLibero: true,
+            indoorPlayer: {
+              __identity: "demo-player-6-3",
+              person: {
+                __identity: "demo-person-6-3",
+                firstName: "Nina",
+                lastName: "Zimmermann",
+                displayName: "Nina Zimmermann",
+              },
+            },
+            indoorPlayerLicenseCategory: {
+              __identity: "lic-sen",
+              shortName: "SEN",
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  return nominationLists;
 }
 
 // Demo user referee level configuration
@@ -798,7 +1208,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
   assignments: [],
   compensations: [],
   exchanges: [],
-  possiblePlayers: [],
+  nominationLists: {},
   userRefereeLevel: null,
   userRefereeLevelGradationValue: null,
 
@@ -808,7 +1218,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
       assignments: data.assignments,
       compensations: data.compensations,
       exchanges: data.exchanges,
-      possiblePlayers: data.possiblePlayers,
+      nominationLists: generateMockNominationLists(),
       userRefereeLevel: DEMO_USER_REFEREE_LEVEL,
       userRefereeLevelGradationValue: DEMO_USER_REFEREE_LEVEL_GRADATION_VALUE,
     });
@@ -819,7 +1229,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
       assignments: [],
       compensations: [],
       exchanges: [],
-      possiblePlayers: [],
+      nominationLists: {},
       userRefereeLevel: null,
       userRefereeLevelGradationValue: null,
     }),
@@ -831,7 +1241,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
         assignments: newData.assignments,
         compensations: newData.compensations,
         exchanges: newData.exchanges,
-        possiblePlayers: newData.possiblePlayers,
+        nominationLists: generateMockNominationLists(),
       };
     }),
 


### PR DESCRIPTION
… display

This PR implements the RosterVerificationPanel component that displays and manages the player nomination list for home and away teams during game validation.

Key changes:
- Add RosterVerificationPanel component with player list, removal, and add button
- Add PlayerListItem component for individual player display with badges
- Add useNominationList hook for fetching nomination data
- Add mock nomination data to demo store for testing
- Add roster-related translation keys (EN, DE, FR, IT)
- Update HomeRosterPanel and AwayRosterPanel to use RosterVerificationPanel
- Export new types (NominationList, IndoorPlayerNomination) from API client

Closes #35