### PR TITLE
feat(validation): add backdrop click to close AddPlayerSheet

### DIFF
--- a/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
@@ -127,7 +127,7 @@ describe("AddPlayerSheet", () => {
     expect(screen.getByText("Anna Schmidt")).toBeInTheDocument();
   });
 
-  it("does not close when backdrop is clicked (accessibility)", () => {
+  it("calls onClose when backdrop is clicked", () => {
     const onClose = vi.fn();
     render(<AddPlayerSheet {...defaultProps} onClose={onClose} />, {
       wrapper: createWrapper(),
@@ -136,7 +136,7 @@ describe("AddPlayerSheet", () => {
     const backdrop = document.querySelector('[aria-hidden="true"]');
     fireEvent.click(backdrop!);
 
-    expect(onClose).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("calls onClose when close button is clicked", () => {

--- a/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
@@ -139,6 +139,18 @@ describe("AddPlayerSheet", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("does not close when dialog content is clicked", () => {
+    const onClose = vi.fn();
+    render(<AddPlayerSheet {...defaultProps} onClose={onClose} />, {
+      wrapper: createWrapper(),
+    });
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(dialog);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("calls onClose when close button is clicked", () => {
     const onClose = vi.fn();
     render(<AddPlayerSheet {...defaultProps} onClose={onClose} />, {

--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -79,10 +79,11 @@ export function AddPlayerSheet({
 
   return (
     <div className="fixed inset-0 z-50">
-      {/* Backdrop - non-interactive, Escape key handles closing */}
+      {/* Backdrop - click to close */}
       <div
         className="absolute inset-0 bg-black/50 transition-opacity"
         aria-hidden="true"
+        onClick={onClose}
       />
 
       {/* Sheet Container - bottom drawer on mobile, centered modal on desktop */}

--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import type { PossibleNomination } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { usePossiblePlayerNominations } from "@/hooks/usePlayerNominations";
@@ -75,6 +75,15 @@ export function AddPlayerSheet({
     }
   }, [isOpen]);
 
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
   if (!isOpen) return null;
 
   return (
@@ -83,7 +92,7 @@ export function AddPlayerSheet({
       <div
         className="absolute inset-0 bg-black/50 transition-opacity"
         aria-hidden="true"
-        onClick={onClose}
+        onClick={handleBackdropClick}
       />
 
       {/* Sheet Container - bottom drawer on mobile, centered modal on desktop */}


### PR DESCRIPTION
Add onClick handler to the backdrop div so users can close the sheet
by clicking outside it, improving UX consistency with other modals.

Closes #86