### PR TITLE
fix(a11y): remove interactive onClick from aria-hidden backdrop

### DIFF
--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -268,7 +268,7 @@ describe("ValidateGameModal", () => {
       expect(mockOnClose).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onClose when backdrop is clicked", () => {
+    it("does not close when clicking backdrop (accessibility fix: only Escape/button closes)", () => {
       render(
         <ValidateGameModal
           assignment={createMockAssignment()}
@@ -278,11 +278,12 @@ describe("ValidateGameModal", () => {
         { wrapper: createWrapper() },
       );
 
+      // Click on backdrop (parent of dialog)
       const backdrop = screen.getByRole("dialog", {
         hidden: true,
       }).parentElement;
       fireEvent.click(backdrop!);
-      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockOnClose).not.toHaveBeenCalled();
     });
 
     it("does not close when clicking inside the modal", () => {

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -42,15 +42,6 @@ export function ValidateGameModal({
     onClose();
   }, [onClose]);
 
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) {
-        handleClose();
-      }
-    },
-    [handleClose],
-  );
-
   // Handle Escape key to close modal
   useEffect(() => {
     if (!isOpen) return;
@@ -76,7 +67,6 @@ export function ValidateGameModal({
   return (
     <div
       className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-      onClick={handleBackdropClick}
       aria-hidden="true"
     >
       <div


### PR DESCRIPTION
Remove onClick handler from ValidateGameModal backdrop that was marked
with aria-hidden="true", fixing WCAG accessibility violation. Interactive
elements should never be hidden from assistive technology.

Modal can still be dismissed via Escape key (existing handler) or the
Close button.

Closes #80