### PR TITLE
fix(validation): sort newly added players to end of roster list

### DIFF
--- a/web-app/src/components/features/validation/RosterVerificationPanel.test.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.test.tsx
@@ -316,4 +316,55 @@ describe("RosterVerificationPanel", () => {
 
     expect(onModificationsChange).toHaveBeenCalled();
   });
+
+  it("sorts newly added players to end of list", () => {
+    const playersWithNewlyAdded: RosterPlayer[] = [
+      {
+        id: "player-existing-high",
+        shirtNumber: 15,
+        displayName: "High Number",
+        isNewlyAdded: false,
+      },
+      {
+        id: "player-new",
+        shirtNumber: 0,
+        displayName: "Newly Added Player",
+        isNewlyAdded: true,
+      },
+      {
+        id: "player-existing-low",
+        shirtNumber: 3,
+        displayName: "Low Number",
+        isNewlyAdded: false,
+      },
+    ];
+
+    vi.mocked(useNominationListModule.useNominationList).mockReturnValue({
+      nominationList: null,
+      players: playersWithNewlyAdded,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <RosterVerificationPanel
+        team="home"
+        teamName="Test Team"
+        gameId="game-1"
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const playerNames = screen
+      .getAllByText(/Low Number|High Number|Newly Added Player/)
+      .map((el) => el.textContent);
+
+    expect(playerNames).toEqual([
+      "Low Number",
+      "High Number",
+      "Newly Added Player",
+    ]);
+  });
 });

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -147,10 +147,11 @@ export function RosterVerificationPanel({
     setIsAddPlayerSheetOpen(false);
   }, []);
 
-  // Combine original players with added players
-  const allPlayers = [...players, ...addedPlayers].sort(
-    (a, b) => a.shirtNumber - b.shirtNumber,
-  );
+  const allPlayers = [...players, ...addedPlayers].sort((a, b) => {
+    if (a.isNewlyAdded && !b.isNewlyAdded) return 1;
+    if (!a.isNewlyAdded && b.isNewlyAdded) return -1;
+    return a.shirtNumber - b.shirtNumber;
+  });
 
   // Calculate visible player count (excluding removed)
   const visiblePlayerCount = allPlayers.filter(


### PR DESCRIPTION
Players added via AddPlayerSheet now appear at the bottom of the
roster instead of the top. This improves UX as newly added players
(with shirtNumber: 0) would previously sort to the top.

Closes #87