### PR TITLE
feat(validation): add debounced search to AddPlayerSheet

### DIFF
--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import type { PossibleNomination } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { usePossiblePlayerNominations } from "@/hooks/usePlayerNominations";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
 // Delay before focusing search input to ensure the sheet animation has started
@@ -24,6 +25,7 @@ export function AddPlayerSheet({
 }: AddPlayerSheetProps) {
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const { data: players, isLoading, isError } = usePossiblePlayerNominations({
@@ -34,7 +36,7 @@ export function AddPlayerSheet({
   const filteredPlayers = useMemo(() => {
     if (!players) return [];
 
-    const query = searchQuery.toLowerCase();
+    const query = debouncedSearchQuery.toLowerCase();
     return players.filter((player) => {
       const playerId = player.indoorPlayer?.__identity ?? "";
       if (excludePlayerIds.includes(playerId)) {
@@ -49,7 +51,7 @@ export function AddPlayerSheet({
         player.indoorPlayer?.person?.displayName?.toLowerCase() ?? "";
       return name.includes(query);
     });
-  }, [players, searchQuery, excludePlayerIds]);
+  }, [players, debouncedSearchQuery, excludePlayerIds]);
 
   // Handle Escape key
   useEffect(() => {

--- a/web-app/src/hooks/useDebouncedValue.test.ts
+++ b/web-app/src/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+describe("useDebouncedValue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the initial value immediately", () => {
+    const { result } = renderHook(() => useDebouncedValue("initial"));
+    expect(result.current).toBe("initial");
+  });
+
+  it("does not update value before delay has passed", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value),
+      { initialProps: { value: "initial" } },
+    );
+
+    rerender({ value: "updated" });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe("initial");
+  });
+
+  it("updates value after default delay (200ms)", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value),
+      { initialProps: { value: "initial" } },
+    );
+
+    rerender({ value: "updated" });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe("updated");
+  });
+
+  it("respects custom delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebouncedValue(value, delay),
+      { initialProps: { value: "initial", delay: 500 } },
+    );
+
+    rerender({ value: "updated", delay: 500 });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe("initial");
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe("updated");
+  });
+
+  it("resets timer on rapid changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value),
+      { initialProps: { value: "initial" } },
+    );
+
+    rerender({ value: "first" });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    rerender({ value: "second" });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    rerender({ value: "third" });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe("initial");
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe("third");
+  });
+
+  it("works with different value types", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value),
+      { initialProps: { value: 42 } },
+    );
+
+    expect(result.current).toBe(42);
+
+    rerender({ value: 100 });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe(100);
+  });
+
+  it("handles object values", () => {
+    const initialObj = { name: "test" };
+    const updatedObj = { name: "updated" };
+
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value),
+      { initialProps: { value: initialObj } },
+    );
+
+    expect(result.current).toBe(initialObj);
+
+    rerender({ value: updatedObj });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe(updatedObj);
+  });
+});

--- a/web-app/src/hooks/useDebouncedValue.ts
+++ b/web-app/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react";
+
+const DEFAULT_DELAY_MS = 200;
+
+/**
+ * Hook that debounces a value, only updating after the specified delay
+ * has passed without new changes.
+ */
+export function useDebouncedValue<T>(value: T, delayMs = DEFAULT_DELAY_MS): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => clearTimeout(timeoutId);
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
Implement search input debouncing with 200ms delay to reduce unnecessary
filter operations during rapid typing. This addresses performance concerns
for large player datasets.

Changes:
- Create reusable useDebouncedValue hook with configurable delay
- Add comprehensive tests for the hook behavior
- Update AddPlayerSheet to use debounced search query
- Update AddPlayerSheet tests to handle debouncing with fake timers

Closes #84