### PR TITLE
feat(validation): debounce search input in AddPlayerSheet

### DIFF
--- a/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { AddPlayerSheet } from "./AddPlayerSheet";
@@ -80,6 +80,9 @@ function createWrapper() {
   };
 }
 
+// Debounce delay used in AddPlayerSheet component
+const SEARCH_DEBOUNCE_MS = 200;
+
 describe("AddPlayerSheet", () => {
   const defaultProps = {
     isOpen: true,
@@ -91,6 +94,11 @@ describe("AddPlayerSheet", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders when isOpen is true", () => {
@@ -180,6 +188,10 @@ describe("AddPlayerSheet", () => {
     const searchInput = screen.getByPlaceholderText("Search players...");
     fireEvent.change(searchInput, { target: { value: "Anna" } });
 
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+
     expect(screen.getByText("Anna Schmidt")).toBeInTheDocument();
     expect(screen.queryByText("Max Müller")).not.toBeInTheDocument();
   });
@@ -190,6 +202,10 @@ describe("AddPlayerSheet", () => {
     const searchInput = screen.getByPlaceholderText("Search players...");
     fireEvent.change(searchInput, { target: { value: "ANNA" } });
 
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+
     expect(screen.getByText("Anna Schmidt")).toBeInTheDocument();
   });
 
@@ -198,6 +214,10 @@ describe("AddPlayerSheet", () => {
 
     const searchInput = screen.getByPlaceholderText("Search players...");
     fireEvent.change(searchInput, { target: { value: "XYZ NonExistent" } });
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
 
     expect(screen.getByText("No players found")).toBeInTheDocument();
   });

--- a/web-app/src/hooks/useDebouncedValue.test.ts
+++ b/web-app/src/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+describe("useDebouncedValue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns initial value immediately", () => {
+    const { result } = renderHook(() => useDebouncedValue("initial", 200));
+
+    expect(result.current).toBe("initial");
+  });
+
+  it("updates value after delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 200),
+      { initialProps: { value: "initial" } },
+    );
+
+    expect(result.current).toBe("initial");
+
+    rerender({ value: "updated" });
+    expect(result.current).toBe("initial");
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe("updated");
+  });
+
+  it("only updates once for multiple rapid changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "ab" });
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    rerender({ value: "abc" });
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    rerender({ value: "abcd" });
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe("abcd");
+  });
+
+  it("resets timer when value changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 200),
+      { initialProps: { value: "first" } },
+    );
+
+    rerender({ value: "second" });
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current).toBe("first");
+
+    rerender({ value: "third" });
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current).toBe("first");
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current).toBe("third");
+  });
+
+  it("works with different types", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 100),
+      { initialProps: { value: 42 } },
+    );
+
+    expect(result.current).toBe(42);
+
+    rerender({ value: 100 });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe(100);
+  });
+
+  it("handles delay changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebouncedValue(value, delay),
+      { initialProps: { value: "test", delay: 200 } },
+    );
+
+    rerender({ value: "updated", delay: 500 });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe("test");
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe("updated");
+  });
+});

--- a/web-app/src/hooks/useDebouncedValue.ts
+++ b/web-app/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Returns a debounced version of the provided value that only updates
+ * after the specified delay has passed without any new changes.
+ *
+ * @param value - The value to debounce
+ * @param delay - The debounce delay in milliseconds
+ * @returns The debounced value
+ */
+export function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(timeoutId);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
Add 200ms debounce to search filtering in AddPlayerSheet to improve
performance when handling large player datasets. This prevents
unnecessary re-filtering on every keystroke.

- Add useDebouncedValue hook with comprehensive tests
- Apply debounce to search query in AddPlayerSheet
- Update tests to account for debounce timing

Closes #84