### PR TITLE
feat(ui): extract bottom sheet pattern as ResponsiveSheet component

### DIFF
--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -1,8 +1,9 @@
-import { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import type { PossibleNomination } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { usePossiblePlayerNominations } from "@/hooks/usePlayerNominations";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { ResponsiveSheet } from "@/components/ui/ResponsiveSheet";
 
 // Delay before focusing search input to ensure the sheet animation has started
 const FOCUS_DELAY_MS = 100;
@@ -51,20 +52,6 @@ export function AddPlayerSheet({
     });
   }, [players, searchQuery, excludePlayerIds]);
 
-  // Handle Escape key
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isOpen, onClose]);
-
   // Focus search input when opened
   useEffect(() => {
     if (isOpen && searchInputRef.current) {
@@ -75,41 +62,8 @@ export function AddPlayerSheet({
     }
   }, [isOpen]);
 
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50">
-      {/* Backdrop - click to close */}
-      <div
-        className="absolute inset-0 bg-black/50 transition-opacity"
-        aria-hidden="true"
-        onClick={handleBackdropClick}
-      />
-
-      {/* Sheet Container - bottom drawer on mobile, centered modal on desktop */}
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="add-player-title"
-        className="
-          fixed inset-x-0 bottom-0
-          md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2
-          max-h-[80vh] md:max-h-[70vh] md:max-w-lg md:w-full
-          bg-white dark:bg-gray-800 rounded-t-xl md:rounded-lg
-          shadow-xl flex flex-col
-          animate-in slide-in-from-bottom md:slide-in-from-bottom-0 md:fade-in
-          duration-200
-        "
-      >
+    <ResponsiveSheet isOpen={isOpen} onClose={onClose} titleId="add-player-title">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
           <h2
@@ -226,7 +180,6 @@ export function AddPlayerSheet({
             </ul>
           )}
         </div>
-      </div>
-    </div>
+    </ResponsiveSheet>
   );
 }

--- a/web-app/src/components/ui/ResponsiveSheet.test.tsx
+++ b/web-app/src/components/ui/ResponsiveSheet.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ResponsiveSheet } from "./ResponsiveSheet";
+
+describe("ResponsiveSheet", () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    titleId: "test-title",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders when isOpen is true", () => {
+    render(
+      <ResponsiveSheet {...defaultProps}>
+        <h2 id="test-title">Test Title</h2>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+
+  it("does not render when isOpen is false", () => {
+    render(
+      <ResponsiveSheet {...defaultProps} isOpen={false}>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByText("Content")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <ResponsiveSheet {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    const backdrop = document.querySelector('[aria-hidden="true"]');
+    fireEvent.click(backdrop!);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close when dialog content is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <ResponsiveSheet {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(dialog);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <ResponsiveSheet {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose for other keys", () => {
+    const onClose = vi.fn();
+    render(
+      <ResponsiveSheet {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    fireEvent.keyDown(document, { key: "Enter" });
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("has proper accessibility attributes", () => {
+    render(
+      <ResponsiveSheet {...defaultProps}>
+        <h2 id="test-title">Test Title</h2>
+      </ResponsiveSheet>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "test-title");
+  });
+
+  it("has aria-hidden backdrop", () => {
+    render(
+      <ResponsiveSheet {...defaultProps}>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    const backdrop = document.querySelector('[aria-hidden="true"]');
+    expect(backdrop).toBeInTheDocument();
+    expect(backdrop).toHaveClass("bg-black/50");
+  });
+
+  it("removes escape listener when closed", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <ResponsiveSheet {...defaultProps} onClose={onClose}>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    rerender(
+      <ResponsiveSheet {...defaultProps} isOpen={false} onClose={onClose}>
+        <p>Content</p>
+      </ResponsiveSheet>,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/web-app/src/components/ui/ResponsiveSheet.tsx
+++ b/web-app/src/components/ui/ResponsiveSheet.tsx
@@ -1,0 +1,66 @@
+import { useCallback, useEffect } from "react";
+
+interface ResponsiveSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  titleId: string;
+  children: React.ReactNode;
+}
+
+export function ResponsiveSheet({
+  isOpen,
+  onClose,
+  titleId,
+  children,
+}: ResponsiveSheetProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen, onClose]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0 bg-black/50 transition-opacity"
+        aria-hidden="true"
+        onClick={handleBackdropClick}
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="
+          fixed inset-x-0 bottom-0
+          md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2
+          max-h-[80vh] md:max-h-[70vh] md:max-w-lg md:w-full
+          bg-white dark:bg-gray-800 rounded-t-xl md:rounded-lg
+          shadow-xl flex flex-col
+          animate-in slide-in-from-bottom md:slide-in-from-bottom-0 md:fade-in
+          duration-200
+        "
+      >
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Extract the responsive bottom sheet pattern from AddPlayerSheet into a
reusable ResponsiveSheet component. The component handles:
- Mobile: bottom drawer with slide-in animation, rounded top corners
- Desktop: centered modal with fade-in animation, fully rounded corners
- Escape key handling
- Backdrop click to close
- Proper accessibility attributes (role, aria-modal, aria-labelledby)

Resolves #85