### PR TITLE
fix(validation): reset search state when AddPlayerSheet closes

### DIFF
--- a/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
@@ -222,6 +222,23 @@ describe("AddPlayerSheet", () => {
     expect(screen.getByText("No players found")).toBeInTheDocument();
   });
 
+  it("clears search query when close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<AddPlayerSheet {...defaultProps} onClose={onClose} />, {
+      wrapper: createWrapper(),
+    });
+
+    const searchInput = screen.getByPlaceholderText("Search players...");
+    fireEvent.change(searchInput, { target: { value: "Anna" } });
+    expect(searchInput).toHaveValue("Anna");
+
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    fireEvent.click(closeButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(searchInput).toHaveValue("");
+  });
+
   it("calls onAddPlayer when a player is selected", () => {
     const onAddPlayer = vi.fn();
     render(<AddPlayerSheet {...defaultProps} onAddPlayer={onAddPlayer} />, {

--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import type { PossibleNomination } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
@@ -57,6 +57,11 @@ export function AddPlayerSheet({
     });
   }, [players, debouncedQuery, excludePlayerIds]);
 
+  const handleClose = useCallback(() => {
+    setSearchQuery("");
+    onClose();
+  }, [onClose]);
+
   // Focus search input when opened
   useEffect(() => {
     if (isOpen && searchInputRef.current) {
@@ -68,7 +73,7 @@ export function AddPlayerSheet({
   }, [isOpen]);
 
   return (
-    <ResponsiveSheet isOpen={isOpen} onClose={onClose} titleId="add-player-title">
+    <ResponsiveSheet isOpen={isOpen} onClose={handleClose} titleId="add-player-title">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
           <h2
@@ -78,7 +83,7 @@ export function AddPlayerSheet({
             {t("validation.addPlayer")}
           </h2>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             aria-label={t("common.close")}
             className="
               p-2 -mr-2 rounded-lg


### PR DESCRIPTION
Wrap the onClose callback with handleClose that clears the search query
before calling the parent's onClose. This ensures users see a fresh
search input when reopening the modal.

Closes #82