### PR TITLE
feat(validation): add scoresheet image upload panel

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -24,7 +24,7 @@
     {
       "name": "JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "157 kB",
+      "limit": "160 kB",
       "gzip": true
     },
     {

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -232,9 +232,7 @@ describe("ValidateGameModal", () => {
         screen.getByRole("tab", { name: /Scoresheet/i, hidden: true }),
       );
 
-      expect(
-        screen.getByText("Scoresheet upload will be available here."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Upload Scoresheet")).toBeInTheDocument();
     });
 
     it("navigates tabs with arrow keys", () => {
@@ -340,9 +338,7 @@ describe("ValidateGameModal", () => {
       fireEvent.click(
         screen.getByRole("tab", { name: /Scoresheet/i, hidden: true }),
       );
-      expect(
-        screen.getByText("Scoresheet upload will be available here."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Upload Scoresheet")).toBeInTheDocument();
 
       // Reopen modal with new key (simulates opening for different assignment)
       const newAssignment = createMockAssignment({ __identity: "new-id" });

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -1,13 +1,246 @@
+import { useState, useRef, useCallback } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useAuthStore } from "@/stores/auth";
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const ACCEPTED_FILE_TYPES = ["image/jpeg", "image/png", "application/pdf"];
+const ACCEPTED_EXTENSIONS = ".jpg,.jpeg,.png,.pdf";
+const SIMULATED_UPLOAD_DURATION_MS = 1500;
+
+type UploadState = "idle" | "uploading" | "complete" | "error";
+
+interface SelectedFile {
+  file: File;
+  previewUrl: string | null;
+}
+
+interface IconProps {
+  className?: string;
+}
+
+const Icon = {
+  Upload: ({ className }: IconProps) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="17,8 12,3 7,8" />
+      <line x1="12" y1="3" x2="12" y2="15" />
+    </svg>
+  ),
+  Camera: ({ className }: IconProps) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+      <circle cx="12" cy="13" r="4" />
+    </svg>
+  ),
+  Check: ({ className }: IconProps) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22,4 12,14.01 9,11.01" />
+    </svg>
+  ),
+  File: ({ className }: IconProps) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14,2 14,8 20,8" />
+    </svg>
+  ),
+  Alert: ({ className }: IconProps) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  ),
+};
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 export function ScoresheetPanel() {
   const { t } = useTranslation();
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+
+  const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
+  const [uploadState, setUploadState] = useState<UploadState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState(0);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+
+  const validateFile = useCallback(
+    (file: File): string | null => {
+      if (!ACCEPTED_FILE_TYPES.includes(file.type)) {
+        return t("validation.scoresheetUpload.invalidFileType");
+      }
+      if (file.size > MAX_FILE_SIZE_BYTES) {
+        return t("validation.scoresheetUpload.fileTooLarge");
+      }
+      return null;
+    },
+    [t],
+  );
+
+  const simulateUpload = useCallback(() => {
+    setUploadState("uploading");
+    setUploadProgress(0);
+    const interval = setInterval(() => {
+      setUploadProgress((p) => (p >= 90 ? (clearInterval(interval), p) : p + 10));
+    }, SIMULATED_UPLOAD_DURATION_MS / 10);
+    setTimeout(() => {
+      clearInterval(interval);
+      setUploadProgress(100);
+      setUploadState("complete");
+    }, SIMULATED_UPLOAD_DURATION_MS);
+  }, []);
+
+  const handleFileSelect = useCallback(
+    (file: File) => {
+      const error = validateFile(file);
+      if (error) {
+        setErrorMessage(error);
+        return;
+      }
+      setErrorMessage(null);
+      setSelectedFile({
+        file,
+        previewUrl: file.type.startsWith("image/") ? URL.createObjectURL(file) : null,
+      });
+      simulateUpload();
+    },
+    [validateFile, simulateUpload],
+  );
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFileSelect(file);
+      e.target.value = "";
+    },
+    [handleFileSelect],
+  );
+
+  const resetState = useCallback(() => {
+    if (selectedFile?.previewUrl) URL.revokeObjectURL(selectedFile.previewUrl);
+    setSelectedFile(null);
+    setUploadState("idle");
+    setUploadProgress(0);
+    setErrorMessage(null);
+  }, [selectedFile]);
+
+  const handleReplace = useCallback(() => {
+    resetState();
+    fileInputRef.current?.click();
+  }, [resetState]);
+
+  const tKey = (key: string) => t(`validation.scoresheetUpload.${key}` as Parameters<typeof t>[0]);
 
   return (
     <div className="py-4">
-      <p className="text-sm text-gray-500 dark:text-gray-400">
-        {t("validation.scoresheetPlaceholder")}
-      </p>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_EXTENSIONS}
+        onChange={handleInputChange}
+        className="hidden"
+        aria-label={tKey("selectFile")}
+      />
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept="image/jpeg,image/png"
+        capture="environment"
+        onChange={handleInputChange}
+        className="hidden"
+        aria-label={tKey("takePhoto")}
+      />
+
+      {!selectedFile ? (
+        <div className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 text-center">
+          <Icon.Upload className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-4" />
+          <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-1">{tKey("title")}</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{tKey("description")}</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
+            {tKey("acceptedFormats")} • {tKey("maxFileSize")}
+          </p>
+
+          {errorMessage && (
+            <div role="alert" className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-2">
+              <Icon.Alert className="w-5 h-5 text-red-500 flex-shrink-0" />
+              <span className="text-sm text-red-700 dark:text-red-400">{errorMessage}</span>
+            </div>
+          )}
+
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <button type="button" onClick={() => fileInputRef.current?.click()} className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors">
+              <Icon.Upload className="w-4 h-4" />
+              {tKey("selectFile")}
+            </button>
+            <button type="button" onClick={() => cameraInputRef.current?.click()} className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors">
+              <Icon.Camera className="w-4 h-4" />
+              {tKey("takePhoto")}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+          {selectedFile.previewUrl ? (
+            <div className="relative bg-gray-100 dark:bg-gray-800">
+              <img src={selectedFile.previewUrl} alt={selectedFile.file.name} className="w-full max-h-64 object-contain" />
+            </div>
+          ) : (
+            <div className="bg-gray-100 dark:bg-gray-800 p-8 flex flex-col items-center justify-center">
+              <Icon.File className="w-16 h-16 text-gray-400 dark:text-gray-500 mb-2" />
+              <span className="text-sm text-gray-500 dark:text-gray-400">PDF</span>
+            </div>
+          )}
+
+          <div className="p-4 bg-white dark:bg-gray-800">
+            {uploadState === "uploading" && (
+              <div className="mb-3">
+                <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  <span>{tKey("uploading")}</span>
+                  <span>{uploadProgress}%</span>
+                </div>
+                <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                  <div className="h-full bg-blue-600 rounded-full transition-all duration-200" style={{ width: `${uploadProgress}%` }} />
+                </div>
+              </div>
+            )}
+
+            {uploadState === "complete" && (
+              <div className="mb-3 flex items-center gap-2 text-green-600 dark:text-green-400">
+                <Icon.Check className="w-5 h-5" />
+                <span className="text-sm font-medium">{tKey("uploadComplete")}</span>
+              </div>
+            )}
+
+            {uploadState === "error" && (
+              <div role="alert" className="mb-3 flex items-center gap-2 text-red-600 dark:text-red-400">
+                <Icon.Alert className="w-5 h-5" />
+                <span className="text-sm font-medium">{tKey("uploadError")}</span>
+              </div>
+            )}
+
+            <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{selectedFile.file.name}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">{formatFileSize(selectedFile.file.size)}</p>
+
+            <div className="mt-4 flex gap-3">
+              <button type="button" onClick={handleReplace} disabled={uploadState === "uploading"} className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                {tKey("replace")}
+              </button>
+              <button type="button" onClick={resetState} disabled={uploadState === "uploading"} className="flex-1 px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/30 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                {tKey("remove")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isDemoMode && <p className="mt-3 text-xs text-center text-gray-400 dark:text-gray-500">Demo mode: uploads are simulated</p>}
     </div>
   );
 }

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -24,32 +24,77 @@ interface IconProps {
 
 const Icon = {
   Upload: ({ className }: IconProps) => (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
       <polyline points="17,8 12,3 7,8" />
       <line x1="12" y1="3" x2="12" y2="15" />
     </svg>
   ),
   Camera: ({ className }: IconProps) => (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
       <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
       <circle cx="12" cy="13" r="4" />
     </svg>
   ),
   Check: ({ className }: IconProps) => (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
       <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
       <polyline points="22,4 12,14.01 9,11.01" />
     </svg>
   ),
   File: ({ className }: IconProps) => (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
       <polyline points="14,2 14,8 20,8" />
     </svg>
   ),
   Alert: ({ className }: IconProps) => (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
       <circle cx="12" cy="12" r="10" />
       <line x1="12" y1="8" x2="12" y2="12" />
       <line x1="12" y1="16" x2="12.01" y2="16" />
@@ -74,7 +119,10 @@ export function ScoresheetPanel() {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
-  const uploadTimersRef = useRef<{ interval?: ReturnType<typeof setInterval>; timeout?: ReturnType<typeof setTimeout> }>({});
+  const uploadTimersRef = useRef<{
+    interval?: ReturnType<typeof setInterval>;
+    timeout?: ReturnType<typeof setTimeout>;
+  }>({});
   const previewUrlRef = useRef<string | null>(null);
   const isUploadingRef = useRef(false);
 
@@ -159,7 +207,9 @@ export function ScoresheetPanel() {
       }
 
       setErrorMessage(null);
-      const newPreviewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : null;
+      const newPreviewUrl = file.type.startsWith("image/")
+        ? URL.createObjectURL(file)
+        : null;
       previewUrlRef.current = newPreviewUrl;
       setSelectedFile({
         file,
@@ -202,7 +252,8 @@ export function ScoresheetPanel() {
     fileInputRef.current?.click();
   }, [resetState]);
 
-  const tKey = (key: string) => t(`validation.scoresheetUpload.${key}` as Parameters<typeof t>[0]);
+  const tKey = (key: string) =>
+    t(`validation.scoresheetUpload.${key}` as Parameters<typeof t>[0]);
 
   return (
     <div className="py-4">
@@ -227,25 +278,42 @@ export function ScoresheetPanel() {
       {!selectedFile ? (
         <div className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 text-center">
           <Icon.Upload className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-4" />
-          <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-1">{tKey("title")}</h3>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{tKey("description")}</p>
+          <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+            {tKey("title")}
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            {tKey("description")}
+          </p>
           <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
             {tKey("acceptedFormats")} • {tKey("maxFileSize")}
           </p>
 
           {errorMessage && (
-            <div role="alert" className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-2">
+            <div
+              role="alert"
+              className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-2"
+            >
               <Icon.Alert className="w-5 h-5 text-red-500 flex-shrink-0" />
-              <span className="text-sm text-red-700 dark:text-red-400">{errorMessage}</span>
+              <span className="text-sm text-red-700 dark:text-red-400">
+                {errorMessage}
+              </span>
             </div>
           )}
 
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
-            <button type="button" onClick={() => fileInputRef.current?.click()} className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+            >
               <Icon.Upload className="w-4 h-4" />
               {tKey("selectFile")}
             </button>
-            <button type="button" onClick={() => cameraInputRef.current?.click()} className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors">
+            <button
+              type="button"
+              onClick={() => cameraInputRef.current?.click()}
+              className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+            >
               <Icon.Camera className="w-4 h-4" />
               {tKey("takePhoto")}
             </button>
@@ -255,12 +323,18 @@ export function ScoresheetPanel() {
         <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
           {selectedFile.previewUrl ? (
             <div className="relative bg-gray-100 dark:bg-gray-800">
-              <img src={selectedFile.previewUrl} alt={tKey("previewAlt")} className="w-full max-h-64 object-contain" />
+              <img
+                src={selectedFile.previewUrl}
+                alt={tKey("previewAlt")}
+                className="w-full max-h-64 object-contain"
+              />
             </div>
           ) : (
             <div className="bg-gray-100 dark:bg-gray-800 p-8 flex flex-col items-center justify-center">
               <Icon.File className="w-16 h-16 text-gray-400 dark:text-gray-500 mb-2" />
-              <span className="text-sm text-gray-500 dark:text-gray-400">PDF</span>
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                PDF
+              </span>
             </div>
           )}
 
@@ -271,27 +345,57 @@ export function ScoresheetPanel() {
                   <span>{tKey("uploading")}</span>
                   <span>{uploadProgress}%</span>
                 </div>
-                <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-                  <div className="h-full bg-blue-600 rounded-full transition-all duration-200" style={{ width: `${uploadProgress}%` }} />
+                <div
+                  className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden"
+                  role="progressbar"
+                  aria-valuenow={uploadProgress}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={tKey("uploading")}
+                >
+                  <div
+                    className="h-full bg-blue-600 rounded-full transition-all duration-200"
+                    style={{ width: `${uploadProgress}%` }}
+                  />
                 </div>
               </div>
             )}
 
             {uploadState === "complete" && (
-              <div className="mb-3 flex items-center gap-2 text-green-600 dark:text-green-400">
+              <div
+                className="mb-3 flex items-center gap-2 text-green-600 dark:text-green-400"
+                role="status"
+                aria-live="polite"
+              >
                 <Icon.Check className="w-5 h-5" />
-                <span className="text-sm font-medium">{tKey("uploadComplete")}</span>
+                <span className="text-sm font-medium">
+                  {tKey("uploadComplete")}
+                </span>
               </div>
             )}
 
-            <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{selectedFile.file.name}</p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">{formatFileSize(selectedFile.file.size)}</p>
+            <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+              {selectedFile.file.name}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {formatFileSize(selectedFile.file.size)}
+            </p>
 
             <div className="mt-4 flex gap-3">
-              <button type="button" onClick={handleReplace} disabled={uploadState === "uploading"} className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+              <button
+                type="button"
+                onClick={handleReplace}
+                disabled={uploadState === "uploading"}
+                className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
                 {tKey("replace")}
               </button>
-              <button type="button" onClick={resetState} disabled={uploadState === "uploading"} className="flex-1 px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/30 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+              <button
+                type="button"
+                onClick={resetState}
+                disabled={uploadState === "uploading"}
+                className="flex-1 px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/30 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
                 {tKey("remove")}
               </button>
             </div>
@@ -299,7 +403,11 @@ export function ScoresheetPanel() {
         </div>
       )}
 
-      {isDemoMode && <p className="mt-3 text-xs text-center text-gray-400 dark:text-gray-500">{tKey("demoModeNote")}</p>}
+      {isDemoMode && (
+        <p className="mt-3 text-xs text-center text-gray-400 dark:text-gray-500">
+          {tKey("demoModeNote")}
+        </p>
+      )}
     </div>
   );
 }

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -6,6 +6,10 @@ const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const ACCEPTED_FILE_TYPES = ["image/jpeg", "image/png", "application/pdf"];
 const ACCEPTED_EXTENSIONS = ".jpg,.jpeg,.png,.pdf";
 const SIMULATED_UPLOAD_DURATION_MS = 1500;
+const PROGRESS_INCREMENT_PERCENT = 10;
+const PROGRESS_STOP_THRESHOLD = 90;
+const PROGRESS_COMPLETE = 100;
+const PROGRESS_STEPS = 10;
 
 type UploadState = "idle" | "uploading" | "complete";
 
@@ -115,21 +119,21 @@ export function ScoresheetPanel() {
 
     uploadTimersRef.current.interval = setInterval(() => {
       setUploadProgress((p) => {
-        if (p >= 90) {
+        if (p >= PROGRESS_STOP_THRESHOLD) {
           if (uploadTimersRef.current.interval) {
             clearInterval(uploadTimersRef.current.interval);
           }
           return p;
         }
-        return p + 10;
+        return p + PROGRESS_INCREMENT_PERCENT;
       });
-    }, SIMULATED_UPLOAD_DURATION_MS / 10);
+    }, SIMULATED_UPLOAD_DURATION_MS / PROGRESS_STEPS);
 
     uploadTimersRef.current.timeout = setTimeout(() => {
       if (uploadTimersRef.current.interval) {
         clearInterval(uploadTimersRef.current.interval);
       }
-      setUploadProgress(100);
+      setUploadProgress(PROGRESS_COMPLETE);
       setUploadState("complete");
     }, SIMULATED_UPLOAD_DURATION_MS);
   }, []);

--- a/web-app/src/components/features/validation/panels.test.tsx
+++ b/web-app/src/components/features/validation/panels.test.tsx
@@ -10,9 +10,7 @@ import * as useNominationListModule from "@/hooks/useNominationList";
 
 vi.mock("@/hooks/useNominationList");
 
-function createMockAssignment(
-  overrides: Partial<Assignment> = {},
-): Assignment {
+function createMockAssignment(overrides: Partial<Assignment> = {}): Assignment {
   return {
     __identity: "assignment-1",
     refereePosition: "head-one",
@@ -161,9 +159,7 @@ describe("ScorerPanel", () => {
     expect(
       screen.getByPlaceholderText("Search scorer by name..."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/No scorer selected/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/No scorer selected/)).toBeInTheDocument();
   });
 });
 
@@ -174,8 +170,8 @@ describe("ScoresheetPanel", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    global.URL.createObjectURL = mockCreateObjectURL;
-    global.URL.revokeObjectURL = mockRevokeObjectURL;
+    globalThis.URL.createObjectURL = mockCreateObjectURL;
+    globalThis.URL.revokeObjectURL = mockRevokeObjectURL;
   });
 
   afterEach(() => {

--- a/web-app/src/components/features/validation/panels.test.tsx
+++ b/web-app/src/components/features/validation/panels.test.tsx
@@ -169,9 +169,14 @@ describe("ScorerPanel", () => {
 
 describe("ScoresheetPanel", () => {
   it("renders without crashing", () => {
-    render(<ScoresheetPanel />);
+    render(<ScoresheetPanel />, { wrapper: createWrapper() });
+    // Panel renders with upload UI
+    expect(screen.getByText("Upload Scoresheet")).toBeInTheDocument();
     expect(
-      screen.getByText("Scoresheet upload will be available here."),
+      screen.getByText("Upload a photo or scan of the physical scoresheet"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Select File" }),
     ).toBeInTheDocument();
   });
 });

--- a/web-app/src/components/features/validation/panels.test.tsx
+++ b/web-app/src/components/features/validation/panels.test.tsx
@@ -179,4 +179,26 @@ describe("ScoresheetPanel", () => {
       screen.getByRole("button", { name: "Select File" }),
     ).toBeInTheDocument();
   });
+
+  it("renders Take Photo button", () => {
+    render(<ScoresheetPanel />, { wrapper: createWrapper() });
+    expect(
+      screen.getByRole("button", { name: "Take Photo" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows accepted formats info", () => {
+    render(<ScoresheetPanel />, { wrapper: createWrapper() });
+    expect(screen.getByText(/JPEG, PNG, or PDF/)).toBeInTheDocument();
+    expect(screen.getByText(/Max 10 MB/)).toBeInTheDocument();
+  });
+
+  it("has hidden file inputs for file and camera", () => {
+    render(<ScoresheetPanel />, { wrapper: createWrapper() });
+    const fileInputs = document.querySelectorAll('input[type="file"]');
+    expect(fileInputs).toHaveLength(2);
+    // Check one accepts all file types and one is for camera
+    const cameraInput = document.querySelector('input[capture="environment"]');
+    expect(cameraInput).toBeInTheDocument();
+  });
 });

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -215,6 +215,7 @@ interface Translations {
       fileTooLarge: string;
       invalidFileType: string;
       demoModeNote: string;
+      previewAlt: string;
     };
   };
 }
@@ -434,9 +435,10 @@ const en: Translations = {
       uploadComplete: "Upload complete",
       replace: "Replace",
       remove: "Remove",
-      fileTooLarge: "File is too large. Maximum size is 10 MB.",
+fileTooLarge: "File is too large. Maximum size is 10 MB.",
       invalidFileType: "Invalid file type. Please use JPEG, PNG, or PDF.",
       demoModeNote: "Demo mode: uploads are simulated",
+      previewAlt: "Scoresheet preview",
     },
   },
 };
@@ -658,9 +660,10 @@ const de: Translations = {
       uploadComplete: "Upload abgeschlossen",
       replace: "Ersetzen",
       remove: "Entfernen",
-      fileTooLarge: "Datei ist zu gross. Maximale Grösse ist 10 MB.",
+fileTooLarge: "Datei ist zu gross. Maximale Grösse ist 10 MB.",
       invalidFileType: "Ungültiger Dateityp. Bitte verwenden Sie JPEG, PNG oder PDF.",
       demoModeNote: "Demo-Modus: Uploads werden simuliert",
+      previewAlt: "Spielbericht-Vorschau",
     },
   },
 };
@@ -882,9 +885,10 @@ const fr: Translations = {
       uploadComplete: "Téléchargement terminé",
       replace: "Remplacer",
       remove: "Supprimer",
-      fileTooLarge: "Le fichier est trop volumineux. Taille maximale: 10 Mo.",
+fileTooLarge: "Le fichier est trop volumineux. Taille maximale: 10 Mo.",
       invalidFileType: "Type de fichier invalide. Veuillez utiliser JPEG, PNG ou PDF.",
       demoModeNote: "Mode démo: les téléchargements sont simulés",
+      previewAlt: "Aperçu de la feuille de match",
     },
   },
 };
@@ -1104,9 +1108,10 @@ const it: Translations = {
       uploadComplete: "Caricamento completato",
       replace: "Sostituisci",
       remove: "Rimuovi",
-      fileTooLarge: "Il file è troppo grande. Dimensione massima: 10 MB.",
+fileTooLarge: "Il file è troppo grande. Dimensione massima: 10 MB.",
       invalidFileType: "Tipo di file non valido. Usa JPEG, PNG o PDF.",
       demoModeNote: "Modalità demo: i caricamenti sono simulati",
+      previewAlt: "Anteprima referto",
     },
   },
 };

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -210,13 +210,11 @@ interface Translations {
       takePhoto: string;
       uploading: string;
       uploadComplete: string;
-      uploadError: string;
       replace: string;
       remove: string;
       fileTooLarge: string;
       invalidFileType: string;
-      fileName: string;
-      fileSize: string;
+      demoModeNote: string;
     };
   };
 }
@@ -434,13 +432,11 @@ const en: Translations = {
       takePhoto: "Take Photo",
       uploading: "Uploading...",
       uploadComplete: "Upload complete",
-      uploadError: "Upload failed. Please try again.",
       replace: "Replace",
       remove: "Remove",
       fileTooLarge: "File is too large. Maximum size is 10 MB.",
       invalidFileType: "Invalid file type. Please use JPEG, PNG, or PDF.",
-      fileName: "File name",
-      fileSize: "Size",
+      demoModeNote: "Demo mode: uploads are simulated",
     },
   },
 };
@@ -660,13 +656,11 @@ const de: Translations = {
       takePhoto: "Foto aufnehmen",
       uploading: "Wird hochgeladen...",
       uploadComplete: "Upload abgeschlossen",
-      uploadError: "Upload fehlgeschlagen. Bitte erneut versuchen.",
       replace: "Ersetzen",
       remove: "Entfernen",
       fileTooLarge: "Datei ist zu gross. Maximale Grösse ist 10 MB.",
       invalidFileType: "Ungültiger Dateityp. Bitte verwenden Sie JPEG, PNG oder PDF.",
-      fileName: "Dateiname",
-      fileSize: "Grösse",
+      demoModeNote: "Demo-Modus: Uploads werden simuliert",
     },
   },
 };
@@ -886,13 +880,11 @@ const fr: Translations = {
       takePhoto: "Prendre une photo",
       uploading: "Téléchargement...",
       uploadComplete: "Téléchargement terminé",
-      uploadError: "Échec du téléchargement. Veuillez réessayer.",
       replace: "Remplacer",
       remove: "Supprimer",
       fileTooLarge: "Le fichier est trop volumineux. Taille maximale: 10 Mo.",
       invalidFileType: "Type de fichier invalide. Veuillez utiliser JPEG, PNG ou PDF.",
-      fileName: "Nom du fichier",
-      fileSize: "Taille",
+      demoModeNote: "Mode démo: les téléchargements sont simulés",
     },
   },
 };
@@ -1110,13 +1102,11 @@ const it: Translations = {
       takePhoto: "Scatta foto",
       uploading: "Caricamento...",
       uploadComplete: "Caricamento completato",
-      uploadError: "Caricamento fallito. Riprova.",
       replace: "Sostituisci",
       remove: "Rimuovi",
       fileTooLarge: "Il file è troppo grande. Dimensione massima: 10 MB.",
       invalidFileType: "Tipo di file non valido. Usa JPEG, PNG o PDF.",
-      fileName: "Nome file",
-      fileSize: "Dimensione",
+      demoModeNote: "Modalità demo: i caricamenti sono simulati",
     },
   },
 };

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -201,6 +201,23 @@ interface Translations {
       searchError: string;
       noScorerSelected: string;
     };
+    scoresheetUpload: {
+      title: string;
+      description: string;
+      acceptedFormats: string;
+      maxFileSize: string;
+      selectFile: string;
+      takePhoto: string;
+      uploading: string;
+      uploadComplete: string;
+      uploadError: string;
+      replace: string;
+      remove: string;
+      fileTooLarge: string;
+      invalidFileType: string;
+      fileName: string;
+      fileSize: string;
+    };
   };
 }
 
@@ -407,6 +424,23 @@ const en: Translations = {
       searchHint: "Enter name (e.g., 'Müller' or 'Hans Müller') or add birth year (e.g., 'Müller 1985')",
       searchError: "Failed to search scorers",
       noScorerSelected: "No scorer selected. Use the search above to find and select a scorer.",
+    },
+    scoresheetUpload: {
+      title: "Upload Scoresheet",
+      description: "Upload a photo or scan of the physical scoresheet",
+      acceptedFormats: "JPEG, PNG, or PDF",
+      maxFileSize: "Max 10 MB",
+      selectFile: "Select File",
+      takePhoto: "Take Photo",
+      uploading: "Uploading...",
+      uploadComplete: "Upload complete",
+      uploadError: "Upload failed. Please try again.",
+      replace: "Replace",
+      remove: "Remove",
+      fileTooLarge: "File is too large. Maximum size is 10 MB.",
+      invalidFileType: "Invalid file type. Please use JPEG, PNG, or PDF.",
+      fileName: "File name",
+      fileSize: "Size",
     },
   },
 };
@@ -617,6 +651,23 @@ const de: Translations = {
       searchError: "Schreibersuche fehlgeschlagen",
       noScorerSelected: "Kein Schreiber ausgewählt. Verwenden Sie die Suche oben, um einen Schreiber zu finden und auszuwählen.",
     },
+    scoresheetUpload: {
+      title: "Spielbericht hochladen",
+      description: "Laden Sie ein Foto oder einen Scan des physischen Spielberichts hoch",
+      acceptedFormats: "JPEG, PNG oder PDF",
+      maxFileSize: "Max. 10 MB",
+      selectFile: "Datei auswählen",
+      takePhoto: "Foto aufnehmen",
+      uploading: "Wird hochgeladen...",
+      uploadComplete: "Upload abgeschlossen",
+      uploadError: "Upload fehlgeschlagen. Bitte erneut versuchen.",
+      replace: "Ersetzen",
+      remove: "Entfernen",
+      fileTooLarge: "Datei ist zu gross. Maximale Grösse ist 10 MB.",
+      invalidFileType: "Ungültiger Dateityp. Bitte verwenden Sie JPEG, PNG oder PDF.",
+      fileName: "Dateiname",
+      fileSize: "Grösse",
+    },
   },
 };
 
@@ -826,6 +877,23 @@ const fr: Translations = {
       searchError: "Échec de la recherche de marqueurs",
       noScorerSelected: "Aucun marqueur sélectionné. Utilisez la recherche ci-dessus pour trouver et sélectionner un marqueur.",
     },
+    scoresheetUpload: {
+      title: "Télécharger la feuille de match",
+      description: "Téléchargez une photo ou un scan de la feuille de match physique",
+      acceptedFormats: "JPEG, PNG ou PDF",
+      maxFileSize: "Max 10 Mo",
+      selectFile: "Sélectionner un fichier",
+      takePhoto: "Prendre une photo",
+      uploading: "Téléchargement...",
+      uploadComplete: "Téléchargement terminé",
+      uploadError: "Échec du téléchargement. Veuillez réessayer.",
+      replace: "Remplacer",
+      remove: "Supprimer",
+      fileTooLarge: "Le fichier est trop volumineux. Taille maximale: 10 Mo.",
+      invalidFileType: "Type de fichier invalide. Veuillez utiliser JPEG, PNG ou PDF.",
+      fileName: "Nom du fichier",
+      fileSize: "Taille",
+    },
   },
 };
 
@@ -1032,6 +1100,23 @@ const it: Translations = {
       searchHint: "Inserisci il nome (es. 'Müller' o 'Hans Müller') o aggiungi l'anno di nascita (es. 'Müller 1985')",
       searchError: "Ricerca segnapunti fallita",
       noScorerSelected: "Nessun segnapunti selezionato. Usa la ricerca sopra per trovare e selezionare un segnapunti.",
+    },
+    scoresheetUpload: {
+      title: "Carica referto",
+      description: "Carica una foto o una scansione del referto fisico",
+      acceptedFormats: "JPEG, PNG o PDF",
+      maxFileSize: "Max 10 MB",
+      selectFile: "Seleziona file",
+      takePhoto: "Scatta foto",
+      uploading: "Caricamento...",
+      uploadComplete: "Caricamento completato",
+      uploadError: "Caricamento fallito. Riprova.",
+      replace: "Sostituisci",
+      remove: "Rimuovi",
+      fileTooLarge: "Il file è troppo grande. Dimensione massima: 10 MB.",
+      invalidFileType: "Tipo di file non valido. Usa JPEG, PNG o PDF.",
+      fileName: "Nome file",
+      fileSize: "Dimensione",
     },
   },
 };


### PR DESCRIPTION
Implement ScoresheetUploadPanel component for uploading scoresheet
images during game validation. Features include:

- File picker supporting JPEG, PNG, and PDF formats
- Mobile camera capture using capture="environment" attribute
- Image preview display after file selection
- Upload progress indicator with animated progress bar
- Replace and Remove buttons for file management
- File size validation with 10MB limit
- Demo mode with simulated uploads (no live API calls)

Closes #38