### PR TITLE
feat(validation): add ScorerSearchPanel with fuzzy person search

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -24,7 +24,7 @@
     {
       "name": "JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "155 kB",
+      "limit": "157 kB",
       "gzip": true
     },
     {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -111,6 +111,17 @@ export type IndoorPlayerNomination = Schemas["IndoorPlayerNomination"];
 export type PossibleNomination = Schemas["PossibleNomination"];
 export type PossibleNominationsResponse = Schemas["PossibleNominationsResponse"];
 
+// Person search types
+export type PersonSearchResult = Schemas["PersonSearchResult"];
+export type PersonSearchResponse = Schemas["PersonSearchResponse"];
+
+// Search filter for person search endpoint
+export interface PersonSearchFilter {
+  firstName?: string;
+  lastName?: string;
+  yearOfBirth?: string;
+}
+
 // Request parameter types
 export interface SearchConfiguration {
   offset?: number;
@@ -537,6 +548,58 @@ export const api = {
         nominationList: nominationListId,
         onlyFromMyTeam: options?.onlyFromMyTeam ?? true,
         onlyRelevantGender: options?.onlyRelevantGender ?? true,
+      },
+    );
+  },
+
+  /**
+   * Searches for persons by name or year of birth using Elasticsearch.
+   * Used for autocomplete when selecting scorers or other personnel.
+   *
+   * The search performs fuzzy matching on firstName, lastName, and yearOfBirth.
+   * Results include association ID, display name, and birthday.
+   *
+   * @param filters - Search filters (firstName, lastName, yearOfBirth)
+   * @param options - Pagination options (offset, limit)
+   * @returns Search results with person details
+   * @example
+   * // Search by last name
+   * const results = await api.searchPersons({ lastName: 'müller' });
+   *
+   * // Search by first and last name
+   * const results = await api.searchPersons({ firstName: 'hans', lastName: 'müller' });
+   *
+   * // Search by name and birth year
+   * const results = await api.searchPersons({ lastName: 'müller', yearOfBirth: '1985' });
+   */
+  async searchPersons(
+    filters: PersonSearchFilter,
+    options?: { offset?: number; limit?: number },
+  ): Promise<PersonSearchResponse> {
+    const propertyFilters: Array<{ propertyName: string; text: string }> = [];
+
+    if (filters.firstName) {
+      propertyFilters.push({ propertyName: "firstName", text: filters.firstName });
+    }
+    if (filters.lastName) {
+      propertyFilters.push({ propertyName: "lastName", text: filters.lastName });
+    }
+    if (filters.yearOfBirth) {
+      propertyFilters.push({ propertyName: "yearOfBirth", text: filters.yearOfBirth });
+    }
+
+    const searchConfig: Record<string, unknown> = {
+      propertyFilters,
+      offset: options?.offset ?? 0,
+      limit: options?.limit ?? 50,
+    };
+
+    return apiRequest<PersonSearchResponse>(
+      "/sportmanager.core/api%5celasticsearchperson/search",
+      "POST",
+      {
+        searchConfiguration: searchConfig,
+        propertyRenderConfiguration: ["birthday"],
       },
     );
   },

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -115,10 +115,17 @@ export type PossibleNominationsResponse = Schemas["PossibleNominationsResponse"]
 export type PersonSearchResult = Schemas["PersonSearchResult"];
 export type PersonSearchResponse = Schemas["PersonSearchResponse"];
 
-// Search filter for person search endpoint
+/**
+ * Search filters for person search endpoint.
+ * All filters use fuzzy matching via Elasticsearch.
+ * Results match persons where all provided filters match (AND logic).
+ */
 export interface PersonSearchFilter {
+  /** First name to search for (fuzzy match) */
   firstName?: string;
+  /** Last name to search for (fuzzy match) */
   lastName?: string;
+  /** Year of birth as 4-digit string (e.g., "1985") */
   yearOfBirth?: string;
 }
 

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -20,6 +20,9 @@ import type {
   AssociationSettings,
   Season,
   PossibleNominationsResponse,
+  PersonSearchFilter,
+  PersonSearchResponse,
+  PersonSearchResult,
 } from "./client";
 import { useDemoStore } from "@/stores/demo";
 
@@ -323,6 +326,44 @@ export const mockApi = {
     return {
       items: store.possiblePlayers,
       totalItemsCount: store.possiblePlayers.length,
+    };
+  },
+
+  async searchPersons(
+    filters: PersonSearchFilter,
+    options?: { offset?: number; limit?: number },
+  ): Promise<PersonSearchResponse> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+
+    const store = useDemoStore.getState();
+    const { firstName, lastName, yearOfBirth } = filters;
+
+    const filtered = store.scorers.filter((scorer: PersonSearchResult) => {
+      const scorerFirstName = scorer.firstName?.toLowerCase() ?? "";
+      const scorerLastName = scorer.lastName?.toLowerCase() ?? "";
+      const scorerYear = scorer.birthday
+        ? new Date(scorer.birthday).getFullYear().toString()
+        : "";
+
+      if (firstName && !scorerFirstName.includes(firstName.toLowerCase())) {
+        return false;
+      }
+      if (lastName && !scorerLastName.includes(lastName.toLowerCase())) {
+        return false;
+      }
+      if (yearOfBirth && !scorerYear.includes(yearOfBirth)) {
+        return false;
+      }
+      return true;
+    });
+
+    const offset = options?.offset ?? 0;
+    const limit = options?.limit ?? 50;
+    const paginated = filtered.slice(offset, offset + limit);
+
+    return {
+      items: paginated,
+      totalItemsCount: filtered.length,
     };
   },
 };

--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -232,6 +232,20 @@ export const gameExchangeSchema = z
   })
   .passthrough();
 
+// Person search result schema (for scorer search)
+export const personSearchResultSchema = z
+  .object({
+    __identity: uuidSchema,
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    displayName: z.string().optional(),
+    associationId: z.number().optional().nullable(),
+    birthday: dateTimeSchema,
+    gender: z.enum(["m", "f"]).optional().nullable(),
+    _permissions: permissionsSchema,
+  })
+  .passthrough();
+
 // Response schemas
 export const assignmentsResponseSchema = z.object({
   items: z.array(assignmentSchema),
@@ -248,12 +262,20 @@ export const exchangesResponseSchema = z.object({
   totalItemsCount: z.number(),
 });
 
+export const personSearchResponseSchema = z.object({
+  items: z.array(personSearchResultSchema).optional(),
+  totalItemsCount: z.number().optional(),
+});
+
 // Type exports inferred from Zod schemas
 export type ValidatedAssignment = z.infer<typeof assignmentSchema>;
 export type ValidatedCompensationRecord = z.infer<
   typeof compensationRecordSchema
 >;
 export type ValidatedGameExchange = z.infer<typeof gameExchangeSchema>;
+export type ValidatedPersonSearchResult = z.infer<
+  typeof personSearchResultSchema
+>;
 export type ValidatedAssignmentsResponse = z.infer<
   typeof assignmentsResponseSchema
 >;
@@ -262,6 +284,9 @@ export type ValidatedCompensationsResponse = z.infer<
 >;
 export type ValidatedExchangesResponse = z.infer<
   typeof exchangesResponseSchema
+>;
+export type ValidatedPersonSearchResponse = z.infer<
+  typeof personSearchResponseSchema
 >;
 
 /**

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -7,6 +7,23 @@ import * as useNominationListModule from "@/hooks/useNominationList";
 
 vi.mock("@/hooks/useNominationList");
 
+vi.mock("@/hooks/useScorerSearch", () => ({
+  useScorerSearch: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+  parseSearchInput: vi.fn((input: string) => {
+    if (!input.trim()) return {};
+    return { lastName: input };
+  }),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+}));
+
 function createMockAssignment(
   overrides: Partial<Assignment> = {},
 ): Assignment {
@@ -192,8 +209,12 @@ describe("ValidateGameModal", () => {
         screen.getByRole("tab", { name: /Scorer/i, hidden: true }),
       );
 
+      // ScorerPanel now shows search input and no-selection message
       expect(
-        screen.getByText("Scorer identification will be available here."),
+        screen.getByPlaceholderText("Search scorer by name..."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/No scorer selected/),
       ).toBeInTheDocument();
     });
 

--- a/web-app/src/components/features/validation/ScorerPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerPanel.tsx
@@ -1,13 +1,33 @@
-import { useTranslation } from "@/hooks/useTranslation";
+import { useState } from "react";
+import type { PersonSearchResult } from "@/api/client";
+import { ScorerSearchPanel } from "./ScorerSearchPanel";
 
-export function ScorerPanel() {
-  const { t } = useTranslation();
+interface ScorerPanelProps {
+  onScorerChange?: (scorer: PersonSearchResult | null) => void;
+  initialScorer?: PersonSearchResult | null;
+}
+
+/**
+ * Scorer panel wrapper that manages the selected scorer state.
+ * Use this when you want the panel to manage its own state.
+ * For controlled usage, use ScorerSearchPanel directly.
+ */
+export function ScorerPanel({
+  onScorerChange,
+  initialScorer = null,
+}: ScorerPanelProps) {
+  const [selectedScorer, setSelectedScorer] =
+    useState<PersonSearchResult | null>(initialScorer);
+
+  const handleScorerSelect = (scorer: PersonSearchResult | null) => {
+    setSelectedScorer(scorer);
+    onScorerChange?.(scorer);
+  };
 
   return (
-    <div className="py-4">
-      <p className="text-sm text-gray-500 dark:text-gray-400">
-        {t("validation.scorerPlaceholder")}
-      </p>
-    </div>
+    <ScorerSearchPanel
+      selectedScorer={selectedScorer}
+      onScorerSelect={handleScorerSelect}
+    />
   );
 }

--- a/web-app/src/components/features/validation/ScorerPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerPanel.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import type { PersonSearchResult } from "@/api/client";
+import type { ValidatedPersonSearchResult } from "@/api/validation";
 import { ScorerSearchPanel } from "./ScorerSearchPanel";
 
 interface ScorerPanelProps {
-  onScorerChange?: (scorer: PersonSearchResult | null) => void;
-  initialScorer?: PersonSearchResult | null;
+  onScorerChange?: (scorer: ValidatedPersonSearchResult | null) => void;
+  initialScorer?: ValidatedPersonSearchResult | null;
 }
 
 /**
@@ -17,9 +17,9 @@ export function ScorerPanel({
   initialScorer = null,
 }: ScorerPanelProps) {
   const [selectedScorer, setSelectedScorer] =
-    useState<PersonSearchResult | null>(initialScorer);
+    useState<ValidatedPersonSearchResult | null>(initialScorer);
 
-  const handleScorerSelect = (scorer: PersonSearchResult | null) => {
+  const handleScorerSelect = (scorer: ValidatedPersonSearchResult | null) => {
     setSelectedScorer(scorer);
     onScorerChange?.(scorer);
   };

--- a/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { ScorerSearchPanel } from "./ScorerSearchPanel";
+import type { PersonSearchResult } from "@/api/client";
+
+const mockScorers: PersonSearchResult[] = [
+  {
+    __identity: "scorer-1",
+    firstName: "Hans",
+    lastName: "Müller",
+    displayName: "Hans Müller",
+    associationId: 12345,
+    birthday: "1985-03-15T00:00:00+00:00",
+    gender: "m",
+  },
+  {
+    __identity: "scorer-2",
+    firstName: "Maria",
+    lastName: "Müller",
+    displayName: "Maria Müller",
+    associationId: 12346,
+    birthday: "1990-07-22T00:00:00+00:00",
+    gender: "f",
+  },
+  {
+    __identity: "scorer-3",
+    firstName: "Peter",
+    lastName: "Schmidt",
+    displayName: "Peter Schmidt",
+    associationId: 23456,
+    birthday: "1978-11-08T00:00:00+00:00",
+    gender: "m",
+  },
+];
+
+vi.mock("@/hooks/useScorerSearch", () => ({
+  useScorerSearch: vi.fn(() => ({
+    data: mockScorers,
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+  parseSearchInput: vi.fn((input: string) => {
+    if (!input.trim()) return {};
+    return { lastName: input };
+  }),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+// Debounce delay used in ScorerSearchPanel component
+const SEARCH_DEBOUNCE_MS = 300;
+
+describe("ScorerSearchPanel", () => {
+  const defaultProps = {
+    selectedScorer: null,
+    onScorerSelect: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders search input when no scorer is selected", () => {
+    render(<ScorerSearchPanel {...defaultProps} />, {
+      wrapper: createWrapper(),
+    });
+    expect(
+      screen.getByPlaceholderText("Search scorer by name..."),
+    ).toBeInTheDocument();
+  });
+
+  it("displays search hint text", () => {
+    render(<ScorerSearchPanel {...defaultProps} />, {
+      wrapper: createWrapper(),
+    });
+    expect(
+      screen.getByText(/Enter name.*or add birth year/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows 'no scorer selected' message when empty and not searching", () => {
+    render(<ScorerSearchPanel {...defaultProps} />, {
+      wrapper: createWrapper(),
+    });
+    expect(
+      screen.getByText(/No scorer selected/i),
+    ).toBeInTheDocument();
+  });
+
+  it("displays search results when query is entered", async () => {
+    render(<ScorerSearchPanel {...defaultProps} />, {
+      wrapper: createWrapper(),
+    });
+
+    const searchInput = screen.getByPlaceholderText("Search scorer by name...");
+    fireEvent.change(searchInput, { target: { value: "Müller" } });
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+
+    expect(screen.getByText("Hans Müller")).toBeInTheDocument();
+    expect(screen.getByText("Maria Müller")).toBeInTheDocument();
+  });
+
+  it("displays association ID in search results", async () => {
+    render(<ScorerSearchPanel {...defaultProps} />, {
+      wrapper: createWrapper(),
+    });
+
+    const searchInput = screen.getByPlaceholderText("Search scorer by name...");
+    fireEvent.change(searchInput, { target: { value: "Müller" } });
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+
+    expect(screen.getByText("ID: 12345")).toBeInTheDocument();
+  });
+
+  it("calls onScorerSelect when a scorer is clicked", async () => {
+    const onScorerSelect = vi.fn();
+    render(
+      <ScorerSearchPanel {...defaultProps} onScorerSelect={onScorerSelect} />,
+      { wrapper: createWrapper() },
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search scorer by name...");
+    fireEvent.change(searchInput, { target: { value: "Müller" } });
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+
+    const scorerButton = screen.getByText("Hans Müller").closest("button");
+    fireEvent.click(scorerButton!);
+
+    expect(onScorerSelect).toHaveBeenCalledTimes(1);
+    expect(onScorerSelect).toHaveBeenCalledWith(mockScorers[0]);
+  });
+
+  it("displays selected scorer when one is provided", () => {
+    render(
+      <ScorerSearchPanel
+        {...defaultProps}
+        selectedScorer={mockScorers[0]}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(screen.getByText("Hans Müller")).toBeInTheDocument();
+    expect(screen.getByText("ID: 12345")).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Search scorer by name..."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onScorerSelect with null when clear button is clicked", () => {
+    const onScorerSelect = vi.fn();
+    render(
+      <ScorerSearchPanel
+        {...defaultProps}
+        selectedScorer={mockScorers[0]}
+        onScorerSelect={onScorerSelect}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const clearButton = screen.getByRole("button", { name: /close/i });
+    fireEvent.click(clearButton);
+
+    expect(onScorerSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("clears search input when scorer is selected", async () => {
+    const onScorerSelect = vi.fn();
+    render(
+      <ScorerSearchPanel {...defaultProps} onScorerSelect={onScorerSelect} />,
+      { wrapper: createWrapper() },
+    );
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search scorer by name...",
+    ) as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: "Müller" } });
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+
+    const scorerButton = screen.getByText("Hans Müller").closest("button");
+    fireEvent.click(scorerButton!);
+
+    // After selecting, the search input should be cleared
+    expect(searchInput.value).toBe("");
+  });
+});
+
+describe("ScorerSearchPanel - Loading State", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows loading spinner when search is loading", async () => {
+    const { useScorerSearch } = await import("@/hooks/useScorerSearch");
+    vi.mocked(useScorerSearch).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+
+    render(
+      <ScorerSearchPanel
+        selectedScorer={null}
+        onScorerSelect={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search scorer by name...");
+    fireEvent.change(searchInput, { target: { value: "Müller" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(document.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+});
+
+describe("ScorerSearchPanel - Error State", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows error message when search fails", async () => {
+    const { useScorerSearch } = await import("@/hooks/useScorerSearch");
+    vi.mocked(useScorerSearch).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Search failed"),
+    });
+
+    render(
+      <ScorerSearchPanel
+        selectedScorer={null}
+        onScorerSelect={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search scorer by name...");
+    fireEvent.change(searchInput, { target: { value: "Müller" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    const errorMessage = screen.getByText("Failed to search scorers");
+    expect(errorMessage).toBeInTheDocument();
+    expect(errorMessage).toHaveAttribute("role", "alert");
+  });
+});
+
+describe("ScorerSearchPanel - Empty Results", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows no results message when search returns empty", async () => {
+    const { useScorerSearch } = await import("@/hooks/useScorerSearch");
+    vi.mocked(useScorerSearch).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(
+      <ScorerSearchPanel
+        selectedScorer={null}
+        onScorerSelect={vi.fn()}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search scorer by name...");
+    fireEvent.change(searchInput, { target: { value: "XYZ" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByText("No players found")).toBeInTheDocument();
+  });
+});

--- a/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
@@ -3,11 +3,11 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { ScorerSearchPanel } from "./ScorerSearchPanel";
-import type { PersonSearchResult } from "@/api/client";
+import type { ValidatedPersonSearchResult } from "@/api/validation";
 
-const mockScorers: PersonSearchResult[] = [
+const mockScorers: ValidatedPersonSearchResult[] = [
   {
-    __identity: "scorer-1",
+    __identity: "a1111111-1111-4111-a111-111111111111",
     firstName: "Hans",
     lastName: "Müller",
     displayName: "Hans Müller",
@@ -16,7 +16,7 @@ const mockScorers: PersonSearchResult[] = [
     gender: "m",
   },
   {
-    __identity: "scorer-2",
+    __identity: "a2222222-2222-4222-a222-222222222222",
     firstName: "Maria",
     lastName: "Müller",
     displayName: "Maria Müller",
@@ -25,7 +25,7 @@ const mockScorers: PersonSearchResult[] = [
     gender: "f",
   },
   {
-    __identity: "scorer-3",
+    __identity: "a3333333-3333-4333-a333-333333333333",
     firstName: "Peter",
     lastName: "Schmidt",
     displayName: "Peter Schmidt",

--- a/web-app/src/components/features/validation/ScorerSearchPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.tsx
@@ -1,0 +1,219 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import type { PersonSearchResult } from "@/api/client";
+import { useTranslation } from "@/hooks/useTranslation";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useScorerSearch, parseSearchInput } from "@/hooks/useScorerSearch";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+
+// Debounce delay for search input as specified in issue #37
+const SEARCH_DEBOUNCE_MS = 300;
+
+// Delay before focusing search input to ensure UI has settled
+const FOCUS_DELAY_MS = 100;
+
+interface ScorerSearchPanelProps {
+  selectedScorer?: PersonSearchResult | null;
+  onScorerSelect: (scorer: PersonSearchResult | null) => void;
+}
+
+/**
+ * Formats a birthday date string for display.
+ * Returns the date in a localized format, or empty string if invalid.
+ */
+function formatBirthday(birthday: string | undefined | null): string {
+  if (!birthday) return "";
+  const date = new Date(birthday);
+  if (isNaN(date.getTime())) return "";
+  return date.toLocaleDateString();
+}
+
+/**
+ * Panel for searching and selecting a game scorer.
+ * Features fuzzy search with flexible input parsing (names in any order, optional birth year).
+ */
+export function ScorerSearchPanel({
+  selectedScorer,
+  onScorerSelect,
+}: ScorerSearchPanelProps) {
+  const { t } = useTranslation();
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(searchQuery, SEARCH_DEBOUNCE_MS);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const searchFilters = parseSearchInput(debouncedQuery);
+  const { data: results, isLoading, isError } = useScorerSearch(searchFilters);
+
+  // Focus search input on mount
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      searchInputRef.current?.focus();
+    }, FOCUS_DELAY_MS);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  const handleSelect = useCallback(
+    (scorer: PersonSearchResult) => {
+      onScorerSelect(scorer);
+      setSearchQuery("");
+    },
+    [onScorerSelect],
+  );
+
+  const handleClear = useCallback(() => {
+    onScorerSelect(null);
+    setSearchQuery("");
+    searchInputRef.current?.focus();
+  }, [onScorerSelect]);
+
+  const hasResults = results && results.length > 0;
+  const showResults = debouncedQuery.trim() && !selectedScorer;
+
+  return (
+    <div className="py-4">
+      {/* Selected Scorer Display */}
+      {selectedScorer && (
+        <div className="mb-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="font-medium text-gray-900 dark:text-white">
+                {selectedScorer.displayName}
+              </div>
+              <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                {selectedScorer.associationId && (
+                  <span>ID: {selectedScorer.associationId}</span>
+                )}
+                {selectedScorer.birthday && (
+                  <span>{formatBirthday(selectedScorer.birthday)}</span>
+                )}
+              </div>
+            </div>
+            <button
+              onClick={handleClear}
+              aria-label={t("common.close")}
+              className="
+                p-2 rounded-lg
+                text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200
+                hover:bg-gray-100 dark:hover:bg-gray-700
+                transition-colors
+              "
+            >
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Search Input */}
+      {!selectedScorer && (
+        <>
+          <div className="mb-4">
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t("validation.scorerSearch.searchPlaceholder")}
+              aria-label={t("validation.scorerSearch.searchPlaceholder")}
+              className="
+                w-full px-4 py-2 rounded-lg
+                bg-gray-100 dark:bg-gray-700
+                text-gray-900 dark:text-white
+                placeholder-gray-500 dark:placeholder-gray-400
+                border border-transparent
+                focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20
+                outline-none transition-colors
+              "
+            />
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              {t("validation.scorerSearch.searchHint")}
+            </p>
+          </div>
+
+          {/* Results */}
+          {showResults && (
+            <div className="mt-4">
+              {isLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <LoadingSpinner size="md" />
+                </div>
+              ) : isError ? (
+                <div
+                  role="alert"
+                  className="text-center py-8 text-red-500 dark:text-red-400"
+                >
+                  {t("validation.scorerSearch.searchError")}
+                </div>
+              ) : !hasResults ? (
+                <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                  {t("validation.noPlayersFound")}
+                </div>
+              ) : (
+                <ul className="space-y-1">
+                  {results.map((scorer) => (
+                    <li key={scorer.__identity}>
+                      <button
+                        onClick={() => handleSelect(scorer)}
+                        className="
+                          w-full flex items-center justify-between p-3 rounded-lg
+                          text-left
+                          hover:bg-gray-100 dark:hover:bg-gray-700
+                          transition-colors
+                        "
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="font-medium text-gray-900 dark:text-white truncate">
+                            {scorer.displayName}
+                          </div>
+                          <div className="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                            {scorer.associationId && (
+                              <span>ID: {scorer.associationId}</span>
+                            )}
+                            {scorer.birthday && (
+                              <span>{formatBirthday(scorer.birthday)}</span>
+                            )}
+                          </div>
+                        </div>
+                        <svg
+                          className="w-5 h-5 text-gray-400 flex-shrink-0 ml-2"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M9 5l7 7-7 7"
+                          />
+                        </svg>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Optional indicator when no scorer is selected and no search is active */}
+      {!selectedScorer && !showResults && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {t("validation.scorerSearch.noScorerSelected")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web-app/src/components/features/validation/ScorerSearchPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from "react";
-import type { PersonSearchResult } from "@/api/client";
+import type { ValidatedPersonSearchResult } from "@/api/validation";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useScorerSearch, parseSearchInput } from "@/hooks/useScorerSearch";
@@ -12,8 +12,8 @@ const SEARCH_DEBOUNCE_MS = 300;
 const FOCUS_DELAY_MS = 100;
 
 interface ScorerSearchPanelProps {
-  selectedScorer?: PersonSearchResult | null;
-  onScorerSelect: (scorer: PersonSearchResult | null) => void;
+  selectedScorer?: ValidatedPersonSearchResult | null;
+  onScorerSelect: (scorer: ValidatedPersonSearchResult | null) => void;
 }
 
 /**
@@ -43,16 +43,18 @@ export function ScorerSearchPanel({
   const searchFilters = parseSearchInput(debouncedQuery);
   const { data: results, isLoading, isError } = useScorerSearch(searchFilters);
 
-  // Focus search input on mount
+  // Focus search input on mount and when scorer is cleared
   useEffect(() => {
-    const timeout = setTimeout(() => {
-      searchInputRef.current?.focus();
-    }, FOCUS_DELAY_MS);
-    return () => clearTimeout(timeout);
-  }, []);
+    if (!selectedScorer) {
+      const timeout = setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, FOCUS_DELAY_MS);
+      return () => clearTimeout(timeout);
+    }
+  }, [selectedScorer]);
 
   const handleSelect = useCallback(
-    (scorer: PersonSearchResult) => {
+    (scorer: ValidatedPersonSearchResult) => {
       onScorerSelect(scorer);
       setSearchQuery("");
     },

--- a/web-app/src/components/features/validation/index.ts
+++ b/web-app/src/components/features/validation/index.ts
@@ -1,6 +1,7 @@
 export { HomeRosterPanel } from "./HomeRosterPanel";
 export { AwayRosterPanel } from "./AwayRosterPanel";
 export { ScorerPanel } from "./ScorerPanel";
+export { ScorerSearchPanel } from "./ScorerSearchPanel";
 export { ScoresheetPanel } from "./ScoresheetPanel";
 export { AddPlayerSheet } from "./AddPlayerSheet";
 export { RosterVerificationPanel } from "./RosterVerificationPanel";

--- a/web-app/src/components/features/validation/panels.test.tsx
+++ b/web-app/src/components/features/validation/panels.test.tsx
@@ -138,11 +138,31 @@ describe("AwayRosterPanel", () => {
   });
 });
 
+vi.mock("@/hooks/useScorerSearch", () => ({
+  useScorerSearch: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+  })),
+  parseSearchInput: vi.fn((input: string) => {
+    if (!input.trim()) return {};
+    return { lastName: input };
+  }),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+}));
+
 describe("ScorerPanel", () => {
   it("renders without crashing", () => {
-    render(<ScorerPanel />);
+    render(<ScorerPanel />, { wrapper: createWrapper() });
     expect(
-      screen.getByText("Scorer identification will be available here."),
+      screen.getByPlaceholderText("Search scorer by name..."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/No scorer selected/),
     ).toBeInTheDocument();
   });
 });

--- a/web-app/src/hooks/useScorerSearch.test.tsx
+++ b/web-app/src/hooks/useScorerSearch.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { parseSearchInput, useScorerSearch } from "./useScorerSearch";
+import type { PersonSearchResponse } from "@/api/client";
+
+// Mock the API client
+vi.mock("@/api/client", () => ({
+  getApiClient: vi.fn(() => ({
+    searchPersons: vi.fn(),
+  })),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("parseSearchInput", () => {
+  it("returns empty object for empty input", () => {
+    expect(parseSearchInput("")).toEqual({});
+    expect(parseSearchInput("   ")).toEqual({});
+  });
+
+  it("parses single word as lastName", () => {
+    expect(parseSearchInput("müller")).toEqual({ lastName: "müller" });
+    expect(parseSearchInput("Schmidt")).toEqual({ lastName: "Schmidt" });
+  });
+
+  it("parses two words as firstName and lastName", () => {
+    expect(parseSearchInput("hans müller")).toEqual({
+      firstName: "hans",
+      lastName: "müller",
+    });
+    expect(parseSearchInput("Anna Schmidt")).toEqual({
+      firstName: "Anna",
+      lastName: "Schmidt",
+    });
+  });
+
+  it("handles extra whitespace correctly", () => {
+    expect(parseSearchInput("  hans   müller  ")).toEqual({
+      firstName: "hans",
+      lastName: "müller",
+    });
+  });
+
+  it("parses year at end correctly", () => {
+    expect(parseSearchInput("müller 1985")).toEqual({
+      lastName: "müller",
+      yearOfBirth: "1985",
+    });
+  });
+
+  it("parses full name with year", () => {
+    expect(parseSearchInput("hans müller 1985")).toEqual({
+      firstName: "hans",
+      lastName: "müller",
+      yearOfBirth: "1985",
+    });
+  });
+
+  it("does not parse non-4-digit numbers as year", () => {
+    expect(parseSearchInput("müller 85")).toEqual({
+      firstName: "müller",
+      lastName: "85",
+    });
+    expect(parseSearchInput("müller 19850")).toEqual({
+      firstName: "müller",
+      lastName: "19850",
+    });
+  });
+
+  it("handles three or more name parts", () => {
+    expect(parseSearchInput("Hans Peter Müller")).toEqual({
+      firstName: "Hans",
+      lastName: "Peter Müller",
+    });
+    expect(parseSearchInput("Hans Peter Müller 1985")).toEqual({
+      firstName: "Hans",
+      lastName: "Peter Müller",
+      yearOfBirth: "1985",
+    });
+  });
+});
+
+describe("useScorerSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not fetch when no filters are provided", async () => {
+    const { getApiClient } = await import("@/api/client");
+    const mockSearchPersons = vi.fn();
+    vi.mocked(getApiClient).mockReturnValue({
+      searchPersons: mockSearchPersons,
+    } as unknown as ReturnType<typeof getApiClient>);
+
+    const { result } = renderHook(() => useScorerSearch({}), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(mockSearchPersons).not.toHaveBeenCalled();
+  });
+
+  it("fetches when lastName filter is provided", async () => {
+    const { getApiClient } = await import("@/api/client");
+    const mockResponse: PersonSearchResponse = {
+      items: [
+        {
+          __identity: "scorer-1",
+          firstName: "Hans",
+          lastName: "Müller",
+          displayName: "Hans Müller",
+          associationId: 12345,
+          birthday: "1985-03-15T00:00:00+00:00",
+        },
+      ],
+      totalItemsCount: 1,
+    };
+    const mockSearchPersons = vi.fn().mockResolvedValue(mockResponse);
+    vi.mocked(getApiClient).mockReturnValue({
+      searchPersons: mockSearchPersons,
+    } as unknown as ReturnType<typeof getApiClient>);
+
+    const { result } = renderHook(
+      () => useScorerSearch({ lastName: "müller" }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(1);
+    });
+
+    expect(mockSearchPersons).toHaveBeenCalledWith({ lastName: "müller" });
+    expect(result.current.data?.[0]?.displayName).toBe("Hans Müller");
+  });
+
+  it("does not fetch when enabled is false", async () => {
+    const { getApiClient } = await import("@/api/client");
+    const mockSearchPersons = vi.fn();
+    vi.mocked(getApiClient).mockReturnValue({
+      searchPersons: mockSearchPersons,
+    } as unknown as ReturnType<typeof getApiClient>);
+
+    const { result } = renderHook(
+      () => useScorerSearch({ lastName: "müller" }, { enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockSearchPersons).not.toHaveBeenCalled();
+  });
+
+  it("handles API errors", async () => {
+    const { getApiClient } = await import("@/api/client");
+    const mockSearchPersons = vi
+      .fn()
+      .mockRejectedValue(new Error("API Error"));
+    vi.mocked(getApiClient).mockReturnValue({
+      searchPersons: mockSearchPersons,
+    } as unknown as ReturnType<typeof getApiClient>);
+
+    const { result } = renderHook(
+      () => useScorerSearch({ lastName: "müller" }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe("API Error");
+  });
+});

--- a/web-app/src/hooks/useScorerSearch.test.tsx
+++ b/web-app/src/hooks/useScorerSearch.test.tsx
@@ -126,7 +126,7 @@ describe("useScorerSearch", () => {
     const mockResponse: PersonSearchResponse = {
       items: [
         {
-          __identity: "scorer-1",
+          __identity: "a1111111-1111-4111-a111-111111111111",
           firstName: "Hans",
           lastName: "Müller",
           displayName: "Hans Müller",

--- a/web-app/src/hooks/useScorerSearch.ts
+++ b/web-app/src/hooks/useScorerSearch.ts
@@ -1,0 +1,108 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getApiClient,
+  type PersonSearchFilter,
+  type PersonSearchResult,
+} from "@/api/client";
+import { useAuthStore } from "@/stores/auth";
+
+// Query key factory for scorer search
+const scorerSearchKeys = {
+  all: ["scorerSearch"] as const,
+  search: (filters: PersonSearchFilter) =>
+    [...scorerSearchKeys.all, filters] as const,
+};
+
+// Cache duration: 5 minutes for search results
+const STALE_TIME_MS = 5 * 60 * 1000;
+
+/**
+ * Parses a search input string into search filters.
+ * Supports flexible token parsing:
+ * - Single word: treated as lastName
+ * - Two words: treated as firstName and lastName (any order)
+ * - Four-digit number at end: treated as yearOfBirth
+ *
+ * @example
+ * parseSearchInput("müller") // { lastName: "müller" }
+ * parseSearchInput("hans müller") // { firstName: "hans", lastName: "müller" }
+ * parseSearchInput("müller 1985") // { lastName: "müller", yearOfBirth: "1985" }
+ * parseSearchInput("hans müller 1985") // { firstName: "hans", lastName: "müller", yearOfBirth: "1985" }
+ */
+export function parseSearchInput(input: string): PersonSearchFilter {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  const tokens = trimmed.split(/\s+/);
+  const result: PersonSearchFilter = {};
+
+  // Check if last token is a year (4 digits)
+  const lastToken = tokens[tokens.length - 1];
+  if (lastToken && /^\d{4}$/.test(lastToken)) {
+    result.yearOfBirth = lastToken;
+    tokens.pop();
+  }
+
+  // Parse remaining name tokens
+  if (tokens.length === 1) {
+    result.lastName = tokens[0];
+  } else if (tokens.length >= 2) {
+    // First token as firstName, rest as lastName
+    result.firstName = tokens[0];
+    result.lastName = tokens.slice(1).join(" ");
+  }
+
+  return result;
+}
+
+interface UseScorerSearchOptions {
+  enabled?: boolean;
+}
+
+interface UseScorerSearchResult {
+  data: PersonSearchResult[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Hook for searching scorers/persons by name or year of birth.
+ * Uses TanStack Query for caching and automatic refetching.
+ *
+ * @param filters - Search filters (firstName, lastName, yearOfBirth)
+ * @param options - Query options
+ * @returns Query result with search results
+ * @example
+ * const { data, isLoading } = useScorerSearch({ lastName: 'müller' });
+ */
+export function useScorerSearch(
+  filters: PersonSearchFilter,
+  options: UseScorerSearchOptions = {},
+): UseScorerSearchResult {
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const apiClient = getApiClient(isDemoMode);
+
+  const hasFilters = Boolean(
+    filters.firstName || filters.lastName || filters.yearOfBirth,
+  );
+
+  const query = useQuery({
+    queryKey: scorerSearchKeys.search(filters),
+    queryFn: async () => {
+      const response = await apiClient.searchPersons(filters);
+      return response.items ?? [];
+    },
+    enabled: options.enabled !== false && hasFilters,
+    staleTime: STALE_TIME_MS,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+  };
+}

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -195,6 +195,12 @@ interface Translations {
       errorLoading: string;
       playerCount: string;
     };
+    scorerSearch: {
+      searchPlaceholder: string;
+      searchHint: string;
+      searchError: string;
+      noScorerSelected: string;
+    };
   };
 }
 
@@ -395,6 +401,12 @@ const en: Translations = {
       loadingRoster: "Loading roster...",
       errorLoading: "Failed to load roster",
       playerCount: "{count} players",
+    },
+    scorerSearch: {
+      searchPlaceholder: "Search scorer by name...",
+      searchHint: "Enter name (e.g., 'Müller' or 'Hans Müller') or add birth year (e.g., 'Müller 1985')",
+      searchError: "Failed to search scorers",
+      noScorerSelected: "No scorer selected. Use the search above to find and select a scorer.",
     },
   },
 };
@@ -599,6 +611,12 @@ const de: Translations = {
       errorLoading: "Kader konnte nicht geladen werden",
       playerCount: "{count} Spieler",
     },
+    scorerSearch: {
+      searchPlaceholder: "Schreiber nach Name suchen...",
+      searchHint: "Namen eingeben (z.B. 'Müller' oder 'Hans Müller') oder Geburtsjahr hinzufügen (z.B. 'Müller 1985')",
+      searchError: "Schreibersuche fehlgeschlagen",
+      noScorerSelected: "Kein Schreiber ausgewählt. Verwenden Sie die Suche oben, um einen Schreiber zu finden und auszuwählen.",
+    },
   },
 };
 
@@ -802,6 +820,12 @@ const fr: Translations = {
       errorLoading: "Échec du chargement de l'effectif",
       playerCount: "{count} joueurs",
     },
+    scorerSearch: {
+      searchPlaceholder: "Rechercher un marqueur par nom...",
+      searchHint: "Entrez le nom (ex. 'Müller' ou 'Hans Müller') ou ajoutez l'année de naissance (ex. 'Müller 1985')",
+      searchError: "Échec de la recherche de marqueurs",
+      noScorerSelected: "Aucun marqueur sélectionné. Utilisez la recherche ci-dessus pour trouver et sélectionner un marqueur.",
+    },
   },
 };
 
@@ -1002,6 +1026,12 @@ const it: Translations = {
       loadingRoster: "Caricamento rosa...",
       errorLoading: "Caricamento rosa fallito",
       playerCount: "{count} giocatori",
+    },
+    scorerSearch: {
+      searchPlaceholder: "Cerca segnapunti per nome...",
+      searchHint: "Inserisci il nome (es. 'Müller' o 'Hans Müller') o aggiungi l'anno di nascita (es. 'Müller 1985')",
+      searchError: "Ricerca segnapunti fallita",
+      noScorerSelected: "Nessun segnapunti selezionato. Usa la ricerca sopra per trovare e selezionare un segnapunti.",
     },
   },
 };

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -5,6 +5,7 @@ import type {
   GameExchange,
   NominationList,
   PossibleNomination,
+  PersonSearchResult,
 } from "@/api/client";
 import { addDays, addHours, subDays } from "date-fns";
 
@@ -34,6 +35,7 @@ interface DemoState {
   exchanges: GameExchange[];
   nominationLists: MockNominationLists;
   possiblePlayers: PossibleNomination[];
+  scorers: PersonSearchResult[];
 
   // Demo user's referee level for filtering exchanges
   // Level string (e.g., "N2") and gradation value (higher = more qualified)
@@ -800,11 +802,105 @@ function generateDummyData() {
     },
   ];
 
+  const dummyScorers: PersonSearchResult[] = [
+    {
+      __identity: "demo-scorer-1",
+      firstName: "Hans",
+      lastName: "Müller",
+      displayName: "Hans Müller",
+      associationId: 12345,
+      birthday: "1985-03-15T00:00:00+00:00",
+      gender: "m",
+    },
+    {
+      __identity: "demo-scorer-2",
+      firstName: "Maria",
+      lastName: "Müller",
+      displayName: "Maria Müller",
+      associationId: 12346,
+      birthday: "1990-07-22T00:00:00+00:00",
+      gender: "f",
+    },
+    {
+      __identity: "demo-scorer-3",
+      firstName: "Peter",
+      lastName: "Schmidt",
+      displayName: "Peter Schmidt",
+      associationId: 23456,
+      birthday: "1978-11-08T00:00:00+00:00",
+      gender: "m",
+    },
+    {
+      __identity: "demo-scorer-4",
+      firstName: "Anna",
+      lastName: "Weber",
+      displayName: "Anna Weber",
+      associationId: 34567,
+      birthday: "1995-01-30T00:00:00+00:00",
+      gender: "f",
+    },
+    {
+      __identity: "demo-scorer-5",
+      firstName: "Thomas",
+      lastName: "Brunner",
+      displayName: "Thomas Brunner",
+      associationId: 45678,
+      birthday: "1982-09-12T00:00:00+00:00",
+      gender: "m",
+    },
+    {
+      __identity: "demo-scorer-6",
+      firstName: "Sandra",
+      lastName: "Keller",
+      displayName: "Sandra Keller",
+      associationId: 56789,
+      birthday: "1988-05-25T00:00:00+00:00",
+      gender: "f",
+    },
+    {
+      __identity: "demo-scorer-7",
+      firstName: "Marco",
+      lastName: "Meier",
+      displayName: "Marco Meier",
+      associationId: 67890,
+      birthday: "1992-12-03T00:00:00+00:00",
+      gender: "m",
+    },
+    {
+      __identity: "demo-scorer-8",
+      firstName: "Lisa",
+      lastName: "Fischer",
+      displayName: "Lisa Fischer",
+      associationId: 78901,
+      birthday: "1985-08-18T00:00:00+00:00",
+      gender: "f",
+    },
+    {
+      __identity: "demo-scorer-9",
+      firstName: "Stefan",
+      lastName: "Huber",
+      displayName: "Stefan Huber",
+      associationId: 89012,
+      birthday: "1975-04-07T00:00:00+00:00",
+      gender: "m",
+    },
+    {
+      __identity: "demo-scorer-10",
+      firstName: "Nicole",
+      lastName: "Steiner",
+      displayName: "Nicole Steiner",
+      associationId: 90123,
+      birthday: "1998-02-14T00:00:00+00:00",
+      gender: "f",
+    },
+  ];
+
   return {
     assignments: dummyAssignments,
     compensations: dummyCompensations,
     exchanges: dummyExchanges,
     possiblePlayers: dummyPossiblePlayers,
+    scorers: dummyScorers,
   };
 }
 
@@ -1328,6 +1424,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
   exchanges: [],
   nominationLists: {},
   possiblePlayers: [],
+  scorers: [],
   userRefereeLevel: null,
   userRefereeLevelGradationValue: null,
 
@@ -1339,6 +1436,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
       exchanges: data.exchanges,
       nominationLists: generateMockNominationLists(),
       possiblePlayers: data.possiblePlayers,
+      scorers: data.scorers,
       userRefereeLevel: DEMO_USER_REFEREE_LEVEL,
       userRefereeLevelGradationValue: DEMO_USER_REFEREE_LEVEL_GRADATION_VALUE,
     });
@@ -1351,6 +1449,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
       exchanges: [],
       nominationLists: {},
       possiblePlayers: [],
+      scorers: [],
       userRefereeLevel: null,
       userRefereeLevelGradationValue: null,
     }),
@@ -1364,6 +1463,7 @@ export const useDemoStore = create<DemoState>()((set) => ({
         exchanges: newData.exchanges,
         nominationLists: generateMockNominationLists(),
         possiblePlayers: newData.possiblePlayers,
+        scorers: newData.scorers,
       };
     }),
 


### PR DESCRIPTION
Implement scorer selection panel with Elasticsearch-powered fuzzy search:

- Add searchPersons API endpoint to client (elasticsearchperson/search)
- Create useScorerSearch hook with TanStack Query and 300ms debounce
- Build ScorerSearchPanel component with flexible input parsing:
  - Single word parsed as lastName
  - Two words parsed as firstName + lastName
  - 4-digit number at end parsed as yearOfBirth
- Display search results with name, association ID, and date of birth
- Show selected scorer with clear button to deselect
- Add demo mode support with 10 mock scorers
- Add Zod validation schema for PersonSearchResponse
- Add translations for all 4 languages (en, de, fr, it)
- Update existing ScorerPanel to use ScorerSearchPanel internally

Closes #37