### PR TITLE
fix(i18n): add missing translations to CompensationsPage

### DIFF
--- a/web-app/src/hooks/useCompensationActions.test.ts
+++ b/web-app/src/hooks/useCompensationActions.test.ts
@@ -9,6 +9,12 @@ import { MODAL_CLEANUP_DELAY } from "@/utils/assignment-helpers";
 
 vi.mock("@/stores/auth");
 vi.mock("@/stores/settings");
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    language: "en",
+  }),
+}));
 
 function createMockCompensation(): CompensationRecord {
   return {
@@ -174,9 +180,7 @@ describe("useCompensationActions", () => {
       await result.current.handleGeneratePDF(mockCompensation);
     });
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      "Failed to download compensation PDF. Please try again later.",
-    );
+    expect(alertSpy).toHaveBeenCalledWith("compensations.pdfDownloadFailed");
 
     alertSpy.mockRestore();
   });
@@ -235,7 +239,7 @@ describe("useCompensationActions", () => {
 
       expect(downloadSpy).not.toHaveBeenCalled();
       expect(alertSpy).toHaveBeenCalledWith(
-        "PDF downloads are not available in demo mode",
+        "compensations.pdfNotAvailableDemo",
       );
 
       alertSpy.mockRestore();

--- a/web-app/src/hooks/useCompensationActions.ts
+++ b/web-app/src/hooks/useCompensationActions.ts
@@ -72,7 +72,7 @@ export function useCompensationActions(): UseCompensationActionsResult {
           "[useCompensationActions] Demo mode: PDF download disabled",
         );
         // TODO(#77): Replace alert with toast notification when notification system is implemented
-        alert("PDF downloads are not available in demo mode");
+        alert(t("compensations.pdfNotAvailableDemo"));
         return;
       }
 
@@ -97,12 +97,12 @@ export function useCompensationActions(): UseCompensationActionsResult {
       } catch (error) {
         logger.error("[useCompensationActions] Failed to generate PDF:", error);
         // TODO(#77): Replace alert with toast notification when notification system is implemented
-        alert("Failed to download compensation PDF. Please try again later.");
+        alert(t("compensations.pdfDownloadFailed"));
       } finally {
         isDownloadingRef.current = false;
       }
     },
-    [isDemoMode],
+    [isDemoMode, t],
   );
 
   return {

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -98,6 +98,7 @@ interface Translations {
     noPaidDescription: string;
     noUnpaidTitle: string;
     noUnpaidDescription: string;
+    errorLoading: string;
     pdfNotAvailableDemo: string;
     pdfDownloadFailed: string;
   };
@@ -284,9 +285,11 @@ const en: Translations = {
     loading: "Loading assignments...",
     noAssignments: "No assignments found",
     noUpcomingTitle: "No upcoming assignments",
-    noUpcomingDescription: "You have no upcoming referee assignments scheduled.",
+    noUpcomingDescription:
+      "You have no upcoming referee assignments scheduled.",
     noClosedTitle: "No closed assignments",
-    noClosedDescription: "No assignments with closed validation in this season.",
+    noClosedDescription:
+      "No assignments with closed validation in this season.",
     confirmed: "Confirmed",
     pending: "Pending",
     cancelled: "Cancelled",
@@ -317,6 +320,7 @@ const en: Translations = {
     noPaidDescription: "No paid compensations found.",
     noUnpaidTitle: "No pending compensations",
     noUnpaidDescription: "No pending compensations. All caught up!",
+    errorLoading: "Failed to load compensations",
     pdfNotAvailableDemo: "PDF downloads are not available in demo mode",
     pdfDownloadFailed:
       "Failed to download compensation PDF. Please try again later.",
@@ -517,9 +521,11 @@ const de: Translations = {
     loading: "Einsätze werden geladen...",
     noAssignments: "Keine Einsätze gefunden",
     noUpcomingTitle: "Keine bevorstehenden Einsätze",
-    noUpcomingDescription: "Sie haben keine bevorstehenden Schiedsrichtereinsätze geplant.",
+    noUpcomingDescription:
+      "Sie haben keine bevorstehenden Schiedsrichtereinsätze geplant.",
     noClosedTitle: "Keine abgeschlossenen Einsätze",
-    noClosedDescription: "Keine Einsätze mit abgeschlossener Validierung in dieser Saison.",
+    noClosedDescription:
+      "Keine Einsätze mit abgeschlossener Validierung in dieser Saison.",
     confirmed: "Bestätigt",
     pending: "Ausstehend",
     cancelled: "Abgesagt",
@@ -550,8 +556,8 @@ const de: Translations = {
     noPaidDescription: "Keine bezahlten Entschädigungen gefunden.",
     noUnpaidTitle: "Keine ausstehenden Entschädigungen",
     noUnpaidDescription: "Keine ausstehenden Entschädigungen. Alles erledigt!",
-    pdfNotAvailableDemo:
-      "PDF-Downloads sind im Demo-Modus nicht verfügbar",
+    errorLoading: "Entschädigungen konnten nicht geladen werden",
+    pdfNotAvailableDemo: "PDF-Downloads sind im Demo-Modus nicht verfügbar",
     pdfDownloadFailed:
       "PDF konnte nicht heruntergeladen werden. Bitte versuchen Sie es später erneut.",
   },
@@ -755,7 +761,8 @@ const fr: Translations = {
     noUpcomingTitle: "Aucune désignation à venir",
     noUpcomingDescription: "Vous n'avez aucune désignation d'arbitre prévue.",
     noClosedTitle: "Aucune désignation clôturée",
-    noClosedDescription: "Aucune désignation avec validation fermée cette saison.",
+    noClosedDescription:
+      "Aucune désignation avec validation fermée cette saison.",
     confirmed: "Confirmé",
     pending: "En attente",
     cancelled: "Annulé",
@@ -786,6 +793,7 @@ const fr: Translations = {
     noPaidDescription: "Aucune indemnité payée trouvée.",
     noUnpaidTitle: "Aucune indemnité en attente",
     noUnpaidDescription: "Aucune indemnité en attente. Tout est à jour!",
+    errorLoading: "Échec du chargement des indemnités",
     pdfNotAvailableDemo:
       "Les téléchargements PDF ne sont pas disponibles en mode démo",
     pdfDownloadFailed:
@@ -991,7 +999,8 @@ const it: Translations = {
     noUpcomingTitle: "Nessuna designazione in programma",
     noUpcomingDescription: "Non hai designazioni arbitrali in programma.",
     noClosedTitle: "Nessuna designazione chiusa",
-    noClosedDescription: "Nessuna designazione con validazione chiusa in questa stagione.",
+    noClosedDescription:
+      "Nessuna designazione con validazione chiusa in questa stagione.",
     confirmed: "Confermato",
     pending: "In attesa",
     cancelled: "Annullato",
@@ -1022,10 +1031,9 @@ const it: Translations = {
     noPaidDescription: "Nessun compenso pagato trovato.",
     noUnpaidTitle: "Nessun compenso in attesa",
     noUnpaidDescription: "Nessun compenso in attesa. Tutto aggiornato!",
-    pdfNotAvailableDemo:
-      "I download PDF non sono disponibili in modalità demo",
-    pdfDownloadFailed:
-      "Impossibile scaricare il PDF. Riprova più tardi.",
+    errorLoading: "Impossibile caricare i compensi",
+    pdfNotAvailableDemo: "I download PDF non sono disponibili in modalità demo",
+    pdfDownloadFailed: "Impossibile scaricare il PDF. Riprova più tardi.",
   },
   exchange: {
     title: "Borsa scambi",
@@ -1050,7 +1058,8 @@ const it: Translations = {
     noOpenExchangesDescription:
       "Al momento non ci sono posizioni arbitrali disponibili per lo scambio.",
     noApplicationsTitle: "Nessuna candidatura",
-    noApplicationsDescription: "Non hai ancora fatto domanda per nessuno scambio.",
+    noApplicationsDescription:
+      "Non hai ancora fatto domanda per nessuno scambio.",
   },
   positions: {
     "head-one": "1° Arbitro",

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -91,6 +91,15 @@ interface Translations {
     total: string;
     all: string;
     received: string;
+    loading: string;
+    noCompensationsTitle: string;
+    noCompensationsDescription: string;
+    noPaidTitle: string;
+    noPaidDescription: string;
+    noUnpaidTitle: string;
+    noUnpaidDescription: string;
+    pdfNotAvailableDemo: string;
+    pdfDownloadFailed: string;
   };
   exchange: {
     title: string;
@@ -301,6 +310,16 @@ const en: Translations = {
     total: "Total",
     all: "All",
     received: "Received",
+    loading: "Loading compensations...",
+    noCompensationsTitle: "No compensations",
+    noCompensationsDescription: "You have no compensation records yet.",
+    noPaidTitle: "No paid compensations",
+    noPaidDescription: "No paid compensations found.",
+    noUnpaidTitle: "No pending compensations",
+    noUnpaidDescription: "No pending compensations. All caught up!",
+    pdfNotAvailableDemo: "PDF downloads are not available in demo mode",
+    pdfDownloadFailed:
+      "Failed to download compensation PDF. Please try again later.",
   },
   exchange: {
     title: "Exchange",
@@ -524,6 +543,17 @@ const de: Translations = {
     total: "Total",
     all: "Alle",
     received: "Erhalten",
+    loading: "Entschädigungen werden geladen...",
+    noCompensationsTitle: "Keine Entschädigungen",
+    noCompensationsDescription: "Sie haben noch keine Entschädigungseinträge.",
+    noPaidTitle: "Keine bezahlten Entschädigungen",
+    noPaidDescription: "Keine bezahlten Entschädigungen gefunden.",
+    noUnpaidTitle: "Keine ausstehenden Entschädigungen",
+    noUnpaidDescription: "Keine ausstehenden Entschädigungen. Alles erledigt!",
+    pdfNotAvailableDemo:
+      "PDF-Downloads sind im Demo-Modus nicht verfügbar",
+    pdfDownloadFailed:
+      "PDF konnte nicht heruntergeladen werden. Bitte versuchen Sie es später erneut.",
   },
   exchange: {
     title: "Tauschbörse",
@@ -749,6 +779,17 @@ const fr: Translations = {
     total: "Total",
     all: "Toutes",
     received: "Reçu",
+    loading: "Chargement des indemnités...",
+    noCompensationsTitle: "Aucune indemnité",
+    noCompensationsDescription: "Vous n'avez pas encore d'entrées d'indemnité.",
+    noPaidTitle: "Aucune indemnité payée",
+    noPaidDescription: "Aucune indemnité payée trouvée.",
+    noUnpaidTitle: "Aucune indemnité en attente",
+    noUnpaidDescription: "Aucune indemnité en attente. Tout est à jour!",
+    pdfNotAvailableDemo:
+      "Les téléchargements PDF ne sont pas disponibles en mode démo",
+    pdfDownloadFailed:
+      "Échec du téléchargement du PDF. Veuillez réessayer plus tard.",
   },
   exchange: {
     title: "Bourse aux échanges",
@@ -974,6 +1015,17 @@ const it: Translations = {
     total: "Totale",
     all: "Tutti",
     received: "Ricevuto",
+    loading: "Caricamento compensi...",
+    noCompensationsTitle: "Nessun compenso",
+    noCompensationsDescription: "Non hai ancora voci di compenso.",
+    noPaidTitle: "Nessun compenso pagato",
+    noPaidDescription: "Nessun compenso pagato trovato.",
+    noUnpaidTitle: "Nessun compenso in attesa",
+    noUnpaidDescription: "Nessun compenso in attesa. Tutto aggiornato!",
+    pdfNotAvailableDemo:
+      "I download PDF non sono disponibili in modalità demo",
+    pdfDownloadFailed:
+      "Impossibile scaricare il PDF. Riprova più tardi.",
   },
   exchange: {
     title: "Borsa scambi",

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -96,7 +96,7 @@ export function CompensationsPage() {
           message={
             error instanceof Error
               ? error.message
-              : t("compensations.noCompensations")
+              : t("compensations.errorLoading")
           }
           onRetry={() => refetch()}
         />

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -65,9 +65,29 @@ export function CompensationsPage() {
     };
   };
 
+  const getEmptyStateContent = () => {
+    switch (filter) {
+      case "paid":
+        return {
+          title: t("compensations.noPaidTitle"),
+          description: t("compensations.noPaidDescription"),
+        };
+      case "unpaid":
+        return {
+          title: t("compensations.noUnpaidTitle"),
+          description: t("compensations.noUnpaidDescription"),
+        };
+      default:
+        return {
+          title: t("compensations.noCompensationsTitle"),
+          description: t("compensations.noCompensationsDescription"),
+        };
+    }
+  };
+
   const renderContent = () => {
     if (isLoading) {
-      return <LoadingState message="Loading compensations..." />;
+      return <LoadingState message={t("compensations.loading")} />;
     }
 
     if (error) {
@@ -76,7 +96,7 @@ export function CompensationsPage() {
           message={
             error instanceof Error
               ? error.message
-              : "Failed to load compensations"
+              : t("compensations.noCompensations")
           }
           onRetry={() => refetch()}
         />
@@ -84,19 +104,8 @@ export function CompensationsPage() {
     }
 
     if (!data || data.length === 0) {
-      return (
-        <EmptyState
-          icon="💰"
-          title="No compensations"
-          description={
-            filter === "all"
-              ? "You have no compensation records yet."
-              : filter === "paid"
-                ? "No paid compensations found."
-                : "No pending compensations. All caught up!"
-          }
-        />
-      );
+      const { title, description } = getEmptyStateContent();
+      return <EmptyState icon="💰" title={title} description={description} />;
     }
 
     return (


### PR DESCRIPTION
## Summary
- Adds 9 new translation keys for compensations in all 4 languages (en, de, fr, it):
  - `loading` - Loading message
  - `noCompensationsTitle` / `noCompensationsDescription` - Empty state for "all" tab
  - `noPaidTitle` / `noPaidDescription` - Empty state for "paid" tab
  - `noUnpaidTitle` / `noUnpaidDescription` - Empty state for "unpaid" tab
  - `pdfNotAvailableDemo` / `pdfDownloadFailed` - Alert messages
- Replaces hardcoded empty state messages with translated strings via `getEmptyStateContent()` helper
- Replaces hardcoded alert messages in `useCompensationActions` with translated strings

## Test plan
- [ ] Verify empty states show translated text for each filter tab (all, paid, unpaid)
- [ ] Verify alert messages for demo mode and PDF errors are translated
- [ ] Test with different language settings to confirm translations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)