### PR TITLE
refactor(compensations): standardize code patterns with ExchangePage

### DIFF
--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -50,20 +50,23 @@ export function CompensationsPage() {
     setFilter(tabId as FilterType);
   }, []);
 
-  const getSwipeConfig = (compensation: CompensationRecord): SwipeConfig => {
-    const actions = createCompensationActions(compensation, {
-      onEditCompensation: editCompensationModal.open,
-      onGeneratePDF: handleGeneratePDF,
-    });
+  const getSwipeConfig = useCallback(
+    (compensation: CompensationRecord): SwipeConfig => {
+      const actions = createCompensationActions(compensation, {
+        onEditCompensation: editCompensationModal.open,
+        onGeneratePDF: handleGeneratePDF,
+      });
 
-    const isPaid = compensation.convocationCompensation?.paymentDone;
+      const isPaid = compensation.convocationCompensation?.paymentDone;
 
-    return {
-      left: isPaid
-        ? [actions.generatePDF]
-        : [actions.editCompensation, actions.generatePDF],
-    };
-  };
+      return {
+        left: isPaid
+          ? [actions.generatePDF]
+          : [actions.editCompensation, actions.generatePDF],
+      };
+    },
+    [editCompensationModal.open, handleGeneratePDF],
+  );
 
   const renderContent = () => {
     if (isLoading) {
@@ -155,8 +158,8 @@ export function CompensationsPage() {
         {renderContent()}
       </TabPanel>
 
-      {/* Edit Compensation Modal */}
-      {editCompensationModal.isOpen && editCompensationModal.compensation && (
+      {/* Edit Compensation Modal - compensation is guaranteed non-null by conditional render */}
+      {editCompensationModal.compensation && (
         <EditCompensationModal
           isOpen={editCompensationModal.isOpen}
           onClose={editCompensationModal.close}

--- a/web-app/src/utils/compensation-actions.ts
+++ b/web-app/src/utils/compensation-actions.ts
@@ -1,6 +1,10 @@
 import type { CompensationRecord } from "@/api/client";
 import type { SwipeAction } from "@/types/swipe";
 
+// Swipe action icons
+const ICON_EDIT = "💰";
+const ICON_PDF = "📄";
+
 export interface CompensationActionConfig {
   editCompensation: SwipeAction;
   generatePDF: SwipeAction;
@@ -21,7 +25,7 @@ export function createCompensationActions(
       label: "Edit Compensation",
       shortLabel: "Edit",
       color: "bg-blue-500",
-      icon: "💰",
+      icon: ICON_EDIT,
       onAction: () => handlers.onEditCompensation(compensation),
     },
     generatePDF: {
@@ -29,7 +33,7 @@ export function createCompensationActions(
       label: "Generate PDF",
       shortLabel: "PDF",
       color: "bg-orange-500",
-      icon: "📄",
+      icon: ICON_PDF,
       onAction: () => handlers.onGeneratePDF(compensation),
     },
   };


### PR DESCRIPTION
## Summary
- Wraps `getSwipeConfig` in `useCallback` with proper dependencies for consistent memoization
- Extracts icon constants (`ICON_EDIT`, `ICON_PDF`) in `compensation-actions.ts` to match exchange-actions pattern
- Simplifies modal render condition: checks `editCompensationModal.compensation` directly (non-null guarantees modal can render)

## Test plan
- [ ] Verify swipe actions still work correctly on compensation cards
- [ ] Verify modal opens and closes properly
- [ ] No visual or behavioral changes expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)