### PR TITLE
refactor(compensations): use single data fetch hook with dynamic filter

### DIFF
--- a/web-app/src/pages/CompensationsPage.test.tsx
+++ b/web-app/src/pages/CompensationsPage.test.tsx
@@ -66,14 +66,8 @@ describe("CompensationsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Default mocks
+    // Default mocks - single useCompensations hook with dynamic filter
     vi.mocked(useConvocations.useCompensations).mockReturnValue(
-      createMockQueryResult([]),
-    );
-    vi.mocked(useConvocations.usePaidCompensations).mockReturnValue(
-      createMockQueryResult([]),
-    );
-    vi.mocked(useConvocations.useUnpaidCompensations).mockReturnValue(
       createMockQueryResult([]),
     );
     vi.mocked(useConvocations.useCompensationTotals).mockReturnValue({
@@ -199,6 +193,30 @@ describe("CompensationsPage", () => {
 
       expect(screen.getByText("CHF 150.00")).toBeInTheDocument();
       expect(screen.getByText("CHF 250.50")).toBeInTheDocument();
+    });
+  });
+
+  describe("Data Fetching", () => {
+    it("should call useCompensations with undefined for All tab", () => {
+      render(<CompensationsPage />);
+
+      expect(useConvocations.useCompensations).toHaveBeenCalledWith(undefined);
+    });
+
+    it("should call useCompensations with false for Pending tab", () => {
+      render(<CompensationsPage />);
+
+      fireEvent.click(screen.getByRole("tab", { name: /pending/i }));
+
+      expect(useConvocations.useCompensations).toHaveBeenCalledWith(false);
+    });
+
+    it("should call useCompensations with true for Paid tab", () => {
+      render(<CompensationsPage />);
+
+      fireEvent.click(screen.getByRole("tab", { name: /^paid$/i }));
+
+      expect(useConvocations.useCompensations).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -1,10 +1,5 @@
-import { useState, useCallback } from "react";
-import {
-  useCompensations,
-  usePaidCompensations,
-  useUnpaidCompensations,
-  useCompensationTotals,
-} from "@/hooks/useConvocations";
+import { useState, useCallback, useMemo } from "react";
+import { useCompensations, useCompensationTotals } from "@/hooks/useConvocations";
 import { CompensationCard } from "@/components/features/CompensationCard";
 import { EditCompensationModal } from "@/components/features/EditCompensationModal";
 import { SwipeableCard } from "@/components/ui/SwipeableCard";
@@ -22,49 +17,28 @@ import { useTranslation } from "@/hooks/useTranslation";
 
 type FilterType = "all" | "paid" | "unpaid";
 
+// Convert tab filter to useCompensations parameter
+function filterToPaidFilter(filter: FilterType): boolean | undefined {
+  switch (filter) {
+    case "paid":
+      return true;
+    case "unpaid":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
 export function CompensationsPage() {
   const [filter, setFilter] = useState<FilterType>("all");
   const { t } = useTranslation();
   const { editCompensationModal, handleGeneratePDF } = useCompensationActions();
 
-  const {
-    data: allData,
-    isLoading: allLoading,
-    error: allError,
-    refetch: refetchAll,
-  } = useCompensations();
-  const {
-    data: paidData,
-    isLoading: paidLoading,
-    error: paidError,
-    refetch: refetchPaid,
-  } = usePaidCompensations();
-  const {
-    data: unpaidData,
-    isLoading: unpaidLoading,
-    error: unpaidError,
-    refetch: refetchUnpaid,
-  } = useUnpaidCompensations();
+  // Single data fetch based on current filter (like ExchangePage pattern)
+  const paidFilter = useMemo(() => filterToPaidFilter(filter), [filter]);
+  const { data, isLoading, error, refetch } = useCompensations(paidFilter);
 
   const totals = useCompensationTotals();
-
-  const dataMap = { all: allData, paid: paidData, unpaid: unpaidData };
-  const loadingMap = {
-    all: allLoading,
-    paid: paidLoading,
-    unpaid: unpaidLoading,
-  };
-  const errorMap = { all: allError, paid: paidError, unpaid: unpaidError };
-  const refetchMap = {
-    all: refetchAll,
-    paid: refetchPaid,
-    unpaid: refetchUnpaid,
-  };
-
-  const data = dataMap[filter];
-  const isLoading = loadingMap[filter];
-  const error = errorMap[filter];
-  const refetch = refetchMap[filter];
 
   const tabs = [
     { id: "all" as const, label: t("compensations.all") },


### PR DESCRIPTION
## Summary
- Replaces 3 separate data fetch hooks (`useCompensations`, `usePaidCompensations`, `useUnpaidCompensations`) with single `useCompensations(paidFilter)` call
- Adds `filterToPaidFilter` helper function to convert tab filter to API parameter:
  - `"all"` → `undefined` (fetch all)
  - `"paid"` → `true`
  - `"unpaid"` → `false`
- Uses `useMemo` to derive `paidFilter` from current filter state
- Follows the same pattern used in ExchangePage for consistency
- Removes unnecessary imports and intermediate data/loading/error maps

## Test plan
- [ ] Verify all three tabs (all, paid, unpaid) show correct data
- [ ] Verify switching tabs triggers new data fetch
- [ ] Verify loading and error states work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)