### PR TITLE
refactor: extract magic numbers to named constants

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -21,6 +21,13 @@ if (!import.meta.env.DEV && !API_BASE) {
   );
 }
 
+/**
+ * Default limit for search results when not explicitly specified.
+ * 50 balances comprehensive results with reasonable response times
+ * for typical Elasticsearch person searches.
+ */
+const DEFAULT_SEARCH_RESULTS_LIMIT = 50;
+
 // Backend error response schema
 const backendErrorSchema = z
   .object({
@@ -109,7 +116,8 @@ export type ExchangesResponse = Schemas["ExchangesResponse"];
 export type NominationList = Schemas["NominationList"];
 export type IndoorPlayerNomination = Schemas["IndoorPlayerNomination"];
 export type PossibleNomination = Schemas["PossibleNomination"];
-export type PossibleNominationsResponse = Schemas["PossibleNominationsResponse"];
+export type PossibleNominationsResponse =
+  Schemas["PossibleNominationsResponse"];
 
 // Person search types
 export type PersonSearchResult = Schemas["PersonSearchResult"];
@@ -588,19 +596,28 @@ export const api = {
     const propertyFilters: Array<{ propertyName: string; text: string }> = [];
 
     if (filters.firstName) {
-      propertyFilters.push({ propertyName: "firstName", text: filters.firstName });
+      propertyFilters.push({
+        propertyName: "firstName",
+        text: filters.firstName,
+      });
     }
     if (filters.lastName) {
-      propertyFilters.push({ propertyName: "lastName", text: filters.lastName });
+      propertyFilters.push({
+        propertyName: "lastName",
+        text: filters.lastName,
+      });
     }
     if (filters.yearOfBirth) {
-      propertyFilters.push({ propertyName: "yearOfBirth", text: filters.yearOfBirth });
+      propertyFilters.push({
+        propertyName: "yearOfBirth",
+        text: filters.yearOfBirth,
+      });
     }
 
     const searchConfig: Record<string, unknown> = {
       propertyFilters,
       offset: options?.offset ?? 0,
-      limit: options?.limit ?? 50,
+      limit: options?.limit ?? DEFAULT_SEARCH_RESULTS_LIMIT,
     };
 
     return apiRequest<PersonSearchResponse>(

--- a/web-app/src/components/features/validation/ScorerSearchPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.tsx
@@ -5,10 +5,20 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useScorerSearch, parseSearchInput } from "@/hooks/useScorerSearch";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
-// Debounce delay for search input as specified in issue #37
+/**
+ * Debounce delay for search input.
+ * 300ms balances responsiveness with avoiding excessive API calls:
+ * - Short enough that users don't perceive lag after typing
+ * - Long enough to batch rapid keystrokes into single requests
+ * Research suggests 200-400ms is optimal for search-as-you-type UX.
+ */
 const SEARCH_DEBOUNCE_MS = 300;
 
-// Delay before focusing search input to ensure UI has settled
+/**
+ * Delay before focusing search input after mount or state changes.
+ * 100ms allows React to complete rendering and DOM updates before
+ * attempting to focus, preventing focus failures on unmounted elements.
+ */
 const FOCUS_DELAY_MS = 100;
 
 interface ScorerSearchPanelProps {

--- a/web-app/src/hooks/useScorerSearch.ts
+++ b/web-app/src/hooks/useScorerSearch.ts
@@ -14,7 +14,13 @@ const scorerSearchKeys = {
     [...scorerSearchKeys.all, filters] as const,
 };
 
-// Cache duration: 5 minutes for search results
+/**
+ * Cache duration for search results.
+ * 5 minutes balances data freshness with reducing unnecessary requests:
+ * - Person data changes infrequently (names, IDs are stable)
+ * - Users often search for the same person multiple times in a session
+ * - Reduces load on the Elasticsearch backend
+ */
 const STALE_TIME_MS = 5 * 60 * 1000;
 
 /**


### PR DESCRIPTION
## Summary
- Extract `50` to `DEFAULT_SEARCH_RESULTS_LIMIT` in `client.ts` with JSDoc
- Add JSDoc explaining `SEARCH_DEBOUNCE_MS` (300ms) - balances responsiveness with avoiding excessive API calls
- Add JSDoc explaining `FOCUS_DELAY_MS` (100ms) - allows React rendering to complete before focus
- Add JSDoc explaining `STALE_TIME_MS` (5 min) - balances data freshness with reducing requests

Closes #101

## Test plan
- [x] Lint passes
- [x] All tests pass (621)
- [x] Build succeeds
- [x] Bundle size within limits (158.87 kB < 160 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)