### PR TITLE
refactor(ui): extract inline SVG icons to shared UI components

### DIFF
--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -1,6 +1,13 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useAuthStore } from "@/stores/auth";
+import {
+  UploadIcon,
+  CameraIcon,
+  CheckIcon,
+  FileIcon,
+  AlertIcon,
+} from "@/components/ui/icons";
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const ACCEPTED_FILE_TYPES = ["image/jpeg", "image/png", "application/pdf"];
@@ -17,90 +24,6 @@ interface SelectedFile {
   file: File;
   previewUrl: string | null;
 }
-
-interface IconProps {
-  className?: string;
-}
-
-const Icon = {
-  Upload: ({ className }: IconProps) => (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-      <polyline points="17,8 12,3 7,8" />
-      <line x1="12" y1="3" x2="12" y2="15" />
-    </svg>
-  ),
-  Camera: ({ className }: IconProps) => (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
-      <circle cx="12" cy="13" r="4" />
-    </svg>
-  ),
-  Check: ({ className }: IconProps) => (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-      <polyline points="22,4 12,14.01 9,11.01" />
-    </svg>
-  ),
-  File: ({ className }: IconProps) => (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-      <polyline points="14,2 14,8 20,8" />
-    </svg>
-  ),
-  Alert: ({ className }: IconProps) => (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <circle cx="12" cy="12" r="10" />
-      <line x1="12" y1="8" x2="12" y2="12" />
-      <line x1="12" y1="16" x2="12.01" y2="16" />
-    </svg>
-  ),
-};
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -277,7 +200,7 @@ export function ScoresheetPanel() {
 
       {!selectedFile ? (
         <div className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 text-center">
-          <Icon.Upload className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-4" />
+          <UploadIcon className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-4" />
           <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-1">
             {tKey("title")}
           </h3>
@@ -293,7 +216,7 @@ export function ScoresheetPanel() {
               role="alert"
               className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-2"
             >
-              <Icon.Alert className="w-5 h-5 text-red-500 flex-shrink-0" />
+              <AlertIcon className="w-5 h-5 text-red-500 flex-shrink-0" />
               <span className="text-sm text-red-700 dark:text-red-400">
                 {errorMessage}
               </span>
@@ -306,7 +229,7 @@ export function ScoresheetPanel() {
               onClick={() => fileInputRef.current?.click()}
               className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
             >
-              <Icon.Upload className="w-4 h-4" />
+              <UploadIcon className="w-4 h-4" />
               {tKey("selectFile")}
             </button>
             <button
@@ -314,7 +237,7 @@ export function ScoresheetPanel() {
               onClick={() => cameraInputRef.current?.click()}
               className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
             >
-              <Icon.Camera className="w-4 h-4" />
+              <CameraIcon className="w-4 h-4" />
               {tKey("takePhoto")}
             </button>
           </div>
@@ -331,7 +254,7 @@ export function ScoresheetPanel() {
             </div>
           ) : (
             <div className="bg-gray-100 dark:bg-gray-800 p-8 flex flex-col items-center justify-center">
-              <Icon.File className="w-16 h-16 text-gray-400 dark:text-gray-500 mb-2" />
+              <FileIcon className="w-16 h-16 text-gray-400 dark:text-gray-500 mb-2" />
               <span className="text-sm text-gray-500 dark:text-gray-400">
                 PDF
               </span>
@@ -367,7 +290,7 @@ export function ScoresheetPanel() {
                 role="status"
                 aria-live="polite"
               >
-                <Icon.Check className="w-5 h-5" />
+                <CheckIcon className="w-5 h-5" />
                 <span className="text-sm font-medium">
                   {tKey("uploadComplete")}
                 </span>

--- a/web-app/src/components/ui/icons.test.tsx
+++ b/web-app/src/components/ui/icons.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  UploadIcon,
+  CameraIcon,
+  CheckIcon,
+  FileIcon,
+  AlertIcon,
+} from "./icons";
+
+const icons = [
+  { name: "UploadIcon", Component: UploadIcon },
+  { name: "CameraIcon", Component: CameraIcon },
+  { name: "CheckIcon", Component: CheckIcon },
+  { name: "FileIcon", Component: FileIcon },
+  { name: "AlertIcon", Component: AlertIcon },
+];
+
+describe("Icon components", () => {
+  describe.each(icons)("$name", ({ Component }) => {
+    it("renders an SVG element", () => {
+      const { container } = render(<Component />);
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+
+    it("applies aria-hidden for accessibility", () => {
+      const { container } = render(<Component />);
+      expect(container.querySelector("svg")).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+    });
+
+    it("applies custom className", () => {
+      const { container } = render(<Component className="custom-class" />);
+      expect(container.querySelector("svg")).toHaveClass("custom-class");
+    });
+  });
+});

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -1,0 +1,95 @@
+export interface IconProps {
+  className?: string;
+}
+
+export function UploadIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="17,8 12,3 7,8" />
+      <line x1="12" y1="3" x2="12" y2="15" />
+    </svg>
+  );
+}
+
+export function CameraIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+      <circle cx="12" cy="13" r="4" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22,4 12,14.01 9,11.01" />
+    </svg>
+  );
+}
+
+export function FileIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14,2 14,8 20,8" />
+    </svg>
+  );
+}
+
+export function AlertIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -1,3 +1,9 @@
+/**
+ * Shared icon components for the VolleyKit application.
+ * Each icon is exported individually to support tree-shaking.
+ * All icons accept an optional className prop for styling.
+ */
+
 export interface IconProps {
   className?: string;
 }


### PR DESCRIPTION
## Summary

- Created new `src/components/ui/icons.tsx` with 5 shared icon components (`UploadIcon`, `CameraIcon`, `CheckIcon`, `FileIcon`, `AlertIcon`)
- Updated `ScoresheetPanel.tsx` to import icons from the shared location
- Each icon is exported individually for tree-shaking support

## Benefits

- **Reusability**: Icons can now be used across the application
- **Maintainability**: Single source of truth for icon definitions
- **Bundle size**: Tree-shaking support via individual exports
- **Consistency**: Ensures consistent icon styling across the app

Closes #109

## Test plan

- [x] Linting passes with no warnings
- [x] All 658 tests pass
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)