### PR TITLE
test(api): add test coverage for searchPersons method

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -307,6 +307,34 @@ describe("API Client", () => {
     });
   });
 
+  describe("searchPersons", () => {
+    const mockPersonSearchResponse = { items: [], totalItemsCount: 0 };
+
+    it("uses default limit when not specified", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(mockPersonSearchResponse),
+      );
+
+      await api.searchPersons({ lastName: "müller" });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      const body = options.body as URLSearchParams;
+      expect(body.get("searchConfiguration[limit]")).toBe("50");
+    });
+
+    it("respects custom limit when provided", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(mockPersonSearchResponse),
+      );
+
+      await api.searchPersons({ lastName: "müller" }, { limit: 100 });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      const body = options.body as URLSearchParams;
+      expect(body.get("searchConfiguration[limit]")).toBe("100");
+    });
+  });
+
   describe("request headers", () => {
     it("includes Accept: application/json header", async () => {
       mockFetch.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary

- Add tests verifying default limit behavior (50) is used when not specified
- Add tests verifying custom limit is respected when provided

Closes #113

## Test plan

- [x] Run `npm run lint` - passes
- [x] Run `npm test` - all 689 tests pass (2 new tests added)
- [x] Run `npm run build` - builds successfully
- [x] Run `npm run size` - bundle size within limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)