### PR TITLE
fix(a11y): add aria-describedby to link search input to hint text

### DIFF
--- a/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
@@ -554,6 +554,22 @@ describe("ScorerSearchPanel - ARIA Attributes", () => {
     expect(searchInput).toBeInTheDocument();
   });
 
+  it("links search input to hint text via aria-describedby", () => {
+    render(
+      <ScorerSearchPanel selectedScorer={null} onScorerSelect={vi.fn()} />,
+      { wrapper: createWrapper() },
+    );
+
+    const searchInput = screen.getByRole("combobox");
+    const hintText = screen.getByText(/Enter name.*or add birth year/i);
+
+    expect(hintText).toHaveAttribute("id");
+    expect(searchInput).toHaveAttribute(
+      "aria-describedby",
+      hintText.getAttribute("id"),
+    );
+  });
+
   it("has listbox role on results list", async () => {
     render(
       <ScorerSearchPanel selectedScorer={null} onScorerSelect={vi.fn()} />,

--- a/web-app/src/components/features/validation/ScorerSearchPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.tsx
@@ -25,6 +25,9 @@ const FOCUS_DELAY_MS = 100;
 /** Unique ID for the scorer search listbox element, used for ARIA relationships. */
 const SCORER_LISTBOX_ID = "scorer-search-listbox";
 
+/** Unique ID for the search hint text, used for aria-describedby relationship. */
+const SCORER_SEARCH_HINT_ID = "scorer-search-hint";
+
 interface ScorerSearchPanelProps {
   selectedScorer?: ValidatedPersonSearchResult | null;
   onScorerSelect: (scorer: ValidatedPersonSearchResult | null) => void;
@@ -158,6 +161,7 @@ export function ScorerSearchPanel({
                   : undefined
               }
               aria-autocomplete="list"
+              aria-describedby={SCORER_SEARCH_HINT_ID}
               className="
                 w-full px-4 py-2 rounded-lg
                 bg-gray-100 dark:bg-gray-700
@@ -168,7 +172,10 @@ export function ScorerSearchPanel({
                 outline-none transition-colors
               "
             />
-            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            <p
+              id={SCORER_SEARCH_HINT_ID}
+              className="mt-2 text-xs text-gray-500 dark:text-gray-400"
+            >
               {t("validation.scorerSearch.searchHint")}
             </p>
           </div>


### PR DESCRIPTION
## Summary

- Add `aria-describedby` attribute to the scorer search input to programmatically associate it with the hint text
- This improves accessibility for screen reader users by announcing the search format hint when the input is focused

## Changes

- Add `SCORER_SEARCH_HINT_ID` constant for the hint element ID (per CLAUDE.md magic string guidelines)
- Add `id` attribute to the hint paragraph element
- Add `aria-describedby` attribute to the search input
- Add test verifying the `aria-describedby` relationship

## Test plan

- [x] Verify all existing tests pass
- [x] Verify new accessibility test passes
- [ ] Test with a screen reader (e.g., VoiceOver, NVDA) to confirm hint text is announced when focusing the search input

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)