### PR TITLE
refactor(validation): remove outdated isMountedRef pattern from ScoresheetPanel

### DIFF
--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -73,8 +73,6 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
       if (timers.timeout) {
         clearTimeout(timers.timeout);
       }
-      // Signal that upload was cancelled to prevent callbacks from firing
-      isUploadingRef.current = false;
     };
   }, []);
 
@@ -119,9 +117,6 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
     }, SIMULATED_UPLOAD_DURATION_MS / PROGRESS_STEPS);
 
     uploadTimersRef.current.timeout = setTimeout(() => {
-      // Guard against callbacks firing after unmount
-      if (!isUploadingRef.current) return;
-
       if (uploadTimersRef.current.interval) {
         clearInterval(uploadTimersRef.current.interval);
       }


### PR DESCRIPTION
## Summary

- Remove unnecessary unmount guard in `setTimeout` callback that followed the deprecated `isMountedRef` pattern
- React 18+ no longer warns about state updates on unmounted components
- Timers are already cleaned up in the `useEffect` cleanup function, making the guard redundant
- Retain `isUploadingRef` for its valid use case: preventing concurrent uploads (race condition prevention)

## Background

This was identified during code review of #121 as tech debt that should be addressed. The pattern is explicitly called out in CLAUDE.md (lines 206-240) as an anti-pattern for React 18+.

## Test plan

- [x] All existing tests pass (715 tests)
- [x] ESLint passes with no warnings
- [x] Production build succeeds
- [x] Verified `isUploadingRef` is still used for race condition prevention in `handleFileSelect`

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)