### PR TITLE
test(validation): add test for Enter key without highlight in ScorerSearchPanel

### DIFF
--- a/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
@@ -404,6 +404,29 @@ describe("ScorerSearchPanel - Keyboard Navigation", () => {
     expect(onScorerSelect).toHaveBeenCalledWith(mockScorers[0]);
   });
 
+  it("does not call onScorerSelect when Enter is pressed without highlight", async () => {
+    const onScorerSelect = vi.fn();
+    render(
+      <ScorerSearchPanel
+        selectedScorer={null}
+        onScorerSelect={onScorerSelect}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search scorer by name...");
+    fireEvent.change(searchInput, { target: { value: "Müller" } });
+
+    act(() => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+
+    // Press Enter without navigating to any item
+    fireEvent.keyDown(searchInput, { key: "Enter" });
+
+    expect(onScorerSelect).not.toHaveBeenCalled();
+  });
+
   it("clears highlight with Escape key", async () => {
     render(
       <ScorerSearchPanel selectedScorer={null} onScorerSelect={vi.fn()} />,


### PR DESCRIPTION
## Summary

- Add explicit test to verify pressing Enter without highlighting an item doesn't trigger `onScorerSelect`
- Covers edge case that was already handled correctly in implementation but lacked test coverage

## Test plan

- [x] Test passes locally (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)