### PR TITLE
docs(api): add new fields from HAR analysis for eScoresheet

### DIFF
--- a/docs/api/captures/escoresheet_endpoints.md
+++ b/docs/api/captures/escoresheet_endpoints.md
@@ -292,12 +292,29 @@ GET /api/sportmanager.indoorvolleyball/api\game/showWithNestedObjects
 | scoresheet.file.persistentResource | Attached PDF file info |
 | scoresheet.file.publicResourceUri | Public URL to the PDF |
 | scoresheet.closedAt | When scoresheet was finalized |
+| scoresheet.game.startingDateTime | Game start time |
 | scoresheet.scoresheetValidation.scoresheetValidationIssues.*.validationIssueConfiguration.hideForUserContexts | Which contexts hide this issue |
-| nominationListOfTeamHome.* | Home team nomination list |
-| nominationListOfTeamAway.\* | Away team nomination list |
-| nominationListOfTeamHome.indoorPlayerNominations.*.indoorPlayer.person.birthday | Player birthdates |
-| nominationListOfTeamHome.indoorPlayerNominations.*.indoorPlayerLicenseCategory.shortName | License categories |
+| scoresheet.notFoundButNominatedPersons.*.birthday | Birthdates of unmatched persons |
+| scoresheet.notFoundButNominatedPersons.*.relatedPerson | Potentially matching persons |
+| scoresheet.emergencySubstituteReferees.*.person.birthday | Emergency referee birthdates |
+| nominationListOfTeamHome/Away.\* | Team nomination lists |
+| nominationListOfTeamHome/Away.game.startingDateTime | Game start time |
+| nominationListOfTeamHome/Away.game.encounter.teamHomeDisplayName | Team display names |
+| nominationListOfTeamHome/Away.game.group.isTournamentGroup | Whether tournament group |
+| nominationListOfTeamHome/Away.team | Team reference |
+| nominationListOfTeamHome/Away.closedAt | When nomination list was closed |
+| nominationListOfTeamHome/Away.coachPerson.\* | Head coach details |
+| nominationListOfTeamHome/Away.firstAssistantCoachPerson.\* | First assistant coach details |
+| nominationListOfTeamHome/Away.secondAssistantCoachPerson.\* | Second assistant coach details |
+| nominationListOfTeamHome/Away.indoorPlayerNominations.*.indoorPlayer.person.birthday | Player birthdates |
+| nominationListOfTeamHome/Away.indoorPlayerNominations.*.indoorPlayerLicenseCategory.shortName | License categories |
+| nominationListOfTeamHome/Away.indoorPlayerNominations.*.indoorPlayerNominationValidation.indoorPlayerNominationValidationIssues.*.validationIssueConfiguration.hideForUserContexts | Validation issue visibility |
+| nominationListOfTeamHome/Away.indoorPlayerNominations.*.indoorPlayerNominationValidation.gameOfOtherNominationOnSameDay | Other game on same day |
+| nominationListOfTeamHome/Away.nominationListValidation.nominationListValidationIssues.*.validationIssueConfiguration.hideForUserContexts | List validation visibility |
+| nominationListOfTeamHome/Away.notFoundButNominatedPersons.*.birthday | Unmatched person birthdates |
+| nominationListOfTeamHome/Away.notFoundButNominatedPersons.*.relatedPerson | Potentially matching persons |
 | group.phase.league.leagueCategory.writersCanUseSimpleScoresheetForThisLeagueCategory | Whether simple scoresheet allowed |
+| group.phase.league.leagueCategory.managingAssociation | Managing association |
 
 ______________________________________________________________________
 

--- a/docs/api/captures/game_details_endpoints.md
+++ b/docs/api/captures/game_details_endpoints.md
@@ -203,9 +203,60 @@ The dialog displays:
 
 ______________________________________________________________________
 
+## Game Object Fields
+
+When retrieving full game details via `showWithNestedObjects`, the following fields are available:
+
+### Core Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| \_\_identity | UUID | Game identifier |
+| number | integer | Match number |
+| status | string | Game status (e.g., "approved", "scheduled", "completed") |
+| startingDateTime | datetime | Game start date/time |
+| playingWeekday | string | Day of week |
+| gameDayIndex | integer | Match day number in the season |
+| displayName | string | Full formatted display name |
+| shortDisplayName | string | Short display name |
+
+### Nomination List Flags
+
+| Field | Type | Description |
+|-------|------|-------------|
+| hasNominationListToReviewByReferee | boolean | Whether referee needs to review nomination lists |
+| hasNominationListOfTeamHomeOfActiveParty | boolean | Whether active party has home team access |
+| hasNominationListOfTeamAwayOfActiveParty | boolean | Whether active party has away team access |
+| hasNominationListOfTeamOfActiveParty | boolean | Whether active party has any team access |
+
+### Game Result Flags
+
+| Field | Type | Description |
+|-------|------|-------------|
+| isForfeitGame | boolean | Whether the game was forfeited |
+| forfeitDecisionDateTime | datetime/null | When forfeit decision was made |
+| hasGameResultReportFromHomeTeam | boolean | Home team submitted result |
+| hasGameResultReportFromAwayTeam | boolean | Away team submitted result |
+| hasGameResultReportFromReferee | boolean | Referee submitted result |
+| hasGameResultReportFromChampionshipOwner | boolean | Owner submitted result |
+| homeTeamGameResultReportDeadlineExceeded | boolean | Home team deadline exceeded |
+| awayTeamGameResultReportDeadlineExceeded | boolean | Away team deadline exceeded |
+| refereeGameResultReportDeadlineExceeded | boolean | Referee deadline exceeded |
+
+### Group Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| group.isTournamentGroup | boolean | Whether this is a tournament group |
+| group.hasNoScoresheet | boolean | Whether games require no scoresheet |
+| group.managingAssociationShortName | string | Managing association (e.g., "SVRZ") |
+
+______________________________________________________________________
+
 ## Notes
 
 - The game UUID comes from the `refereeGame.game.__identity` field in the exchange/assignment response
 - All 3 endpoints are called in parallel when opening the dialog
 - The Plus code is linked to Google Maps: `https://maps.google.com/?q=[Plus Code]&hl=fr`
 - Contact info includes email (mailto: links) and phone (tel: links)
+- The `isTournamentGroup` flag affects nomination list requirements for subsequent games

--- a/docs/api/captures/nomination_list_endpoints.md
+++ b/docs/api/captures/nomination_list_endpoints.md
@@ -298,8 +298,26 @@ Each player nomination contains:
 | shirtNumber | integer | Jersey number for the game |
 | isCaptain | boolean | Team captain designation |
 | isLibero | boolean | Libero player designation |
+| isEligible | boolean | Whether the player is eligible to play |
+| doubleLicenseTeam | object/null | Team reference if player has a double license |
 | indoorPlayerLicenseCategory | object | License category (SEN, JUN, etc.) |
 | indoorPlayerNominationValidation | object | Validation issues for this player |
+
+### Indoor Player Fields
+
+The `indoorPlayer` object contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| \_\_identity | UUID | Player record ID |
+| person | object | Person details (name, birthday, etc.) |
+| hasAcceptedDopingDeclaration | boolean | Whether player accepted doping declaration |
+| hasActivatedIndoorLicense | boolean | Whether indoor license is activated |
+| hasValidatedIndoorLicense | boolean | Whether indoor license is validated |
+| hasPlayerPicture | boolean | Whether player has a profile picture |
+| isClassifiedAsLocallyEducated | boolean | Locally educated classification (foreigner rules) |
+| isForeignerRegardingGamePlay | boolean | Counts as foreigner for game play rules |
+| totalLicensesCount | integer | Total licenses held by the player |
 
 ### License Categories
 
@@ -322,6 +340,10 @@ Player nominations can have validation issues:
 {
   "indoorPlayerNominationValidation": {
     "__identity": "<validation-uuid>",
+    "hasValidationIssues": true,
+    "hasUnresolvedValidationIssues": true,
+    "hasValidationIssuesForAssociationUserContext": true,
+    "hasValidationIssuesForClubUserContext": false,
     "indoorPlayerNominationValidationIssues": [
       {
         "__identity": "<issue-uuid>",
@@ -356,3 +378,4 @@ ______________________________________________________________________
 - Referees control the final nomination at the venue
 - The `isClosedForTeam` flag prevents team modifications while allowing referee edits
 - `notFoundButNominatedPersons` handles cases where a person isn't in the system
+- `isSubsequentGameForTeamInTournamentGroup` is true for second/third games in a tournament group, which may have different nomination requirements

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -1837,20 +1837,84 @@ components:
           type: string
           enum: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]
           example: "Mon"
+        status:
+          type: string
+          description: Game status (e.g., "approved", "scheduled", "completed")
+          example: "approved"
         encounter:
           $ref: '#/components/schemas/Encounter'
         group:
           $ref: '#/components/schemas/Group'
         hall:
           $ref: '#/components/schemas/Hall'
+        # Nomination list flags
         hasNominationListToReviewByReferee:
           type: boolean
+        hasNominationListOfTeamHomeOfActiveParty:
+          type: boolean
+          description: Whether active party has home team nomination list access
+        hasNominationListOfTeamAwayOfActiveParty:
+          type: boolean
+          description: Whether active party has away team nomination list access
+        hasNominationListOfTeamOfActiveParty:
+          type: boolean
+          description: Whether active party has any team nomination list access
+        # Nomination lists (for showWithNestedObjects)
+        nominationListOfTeamHome:
+          $ref: '#/components/schemas/NominationList'
+        nominationListOfTeamAway:
+          $ref: '#/components/schemas/NominationList'
+        scoresheet:
+          $ref: '#/components/schemas/Scoresheet'
+        # Game result flags
         isVolleyCupGameWithoutNationalAssociationLeagueCategoryTeams:
+          type: boolean
+        isForfeitGame:
+          type: boolean
+          description: Whether the game was forfeited
+        forfeitDecisionDateTime:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the forfeit decision was made
+        result:
+          type: object
+          nullable: true
+          description: Game result (null if not yet played)
+        bestOfSeriesResult:
+          type: object
+          nullable: true
+        pointSystem:
+          type: object
+          nullable: true
+        # Game result reports
+        hasGameResultReportFromHomeTeam:
+          type: boolean
+        hasGameResultReportFromAwayTeam:
+          type: boolean
+        hasGameResultReportFromReferee:
+          type: boolean
+        hasGameResultReportFromChampionshipOwner:
+          type: boolean
+        homeTeamGameResultReportDeadlineExceeded:
+          type: boolean
+        awayTeamGameResultReportDeadlineExceeded:
+          type: boolean
+        refereeGameResultReportDeadlineExceeded:
           type: boolean
         displayName:
           type: string
           description: Full formatted display name for the game
           example: "#382417 | 08.12.2025 20:30 | #3926 | Volley Uster H2 — #85 | VC Tornado Adliswil H1 (3L, ♂, Hin- und Rückrunde, Herren 3. Liga Gruppe B)"
+        shortDisplayName:
+          type: string
+        shortDisplayNameWithoutStartingDate:
+          type: string
+        gameDayIndex:
+          type: integer
+          description: Match day number in the season
+        onAWeekday:
+          type: boolean
         lastPostponement:
           type: object
           nullable: true
@@ -2105,6 +2169,32 @@ components:
         name:
           type: string
           example: "Herren 3. Liga Gruppe B"
+        displayName:
+          type: string
+          example: "#27106 | Herren 2. Liga"
+        shortName:
+          type: string
+        identifier:
+          type: string
+        isTournamentGroup:
+          type: boolean
+          description: Whether this is a tournament group (affects nomination workflow)
+        hasNoScoresheet:
+          type: boolean
+          description: Whether games in this group require no scoresheet
+        bestOfSeriesState:
+          type: string
+          nullable: true
+        considerForTopScorerRanking:
+          type: boolean
+        playingInterval:
+          type: string
+          nullable: true
+        playingModeType:
+          type: string
+        managingAssociationShortName:
+          type: string
+          description: Short name of the managing association (e.g., "SVRZ")
         phase:
           $ref: '#/components/schemas/Phase'
     Phase:
@@ -2567,6 +2657,7 @@ components:
                   $ref: '#/components/schemas/PersonSummary'
     PersonSummary:
       type: object
+      description: Basic person information (minimal fields)
       properties:
         __identity:
           type: string
@@ -2580,6 +2671,75 @@ components:
         displayName:
           type: string
           example: "Nick Leo Kunz"
+        fullName:
+          type: string
+          description: Full formatted name
+        birthday:
+          type: string
+          format: date-time
+          nullable: true
+        formattedAndTimezoneIndependentBirthday:
+          type: string
+          description: Birthday formatted without timezone issues
+        age:
+          type: integer
+          description: Calculated age
+        yearOfBirth:
+          type: integer
+        gender:
+          type: string
+          enum: [m, f]
+        associationId:
+          type: integer
+          description: Swiss Volley association ID
+        # Contact info (when expanded)
+        primaryPhoneNumber:
+          type: string
+          nullable: true
+        mobilePhoneNumber:
+          type: string
+          nullable: true
+        # For minors
+        firstLegalGuardian:
+          type: object
+          nullable: true
+          description: First legal guardian (for junior players)
+        secondLegalGuardian:
+          type: object
+          nullable: true
+          description: Second legal guardian (for junior players)
+        # Account status
+        hasAccount:
+          type: boolean
+        accountActive:
+          type: boolean
+        username:
+          type: string
+          nullable: true
+        # Profile
+        hasProfilePicture:
+          type: boolean
+        profilePicture:
+          type: object
+          nullable: true
+        bodyHeight:
+          type: integer
+          nullable: true
+          description: Height in centimeters
+        # Language
+        language:
+          type: string
+        correspondenceLanguage:
+          type: string
+        localeIdentifier:
+          type: string
+        # GDPR
+        isAnonymized:
+          type: boolean
+        anonymizedAt:
+          type: string
+          format: date-time
+          nullable: true
     RefereePosition:
       type: string
       description: |
@@ -5312,6 +5472,9 @@ components:
         isClosedForTeam:
           type: boolean
           description: Whether the team can no longer modify the list
+        isSubsequentGameForTeamInTournamentGroup:
+          type: boolean
+          description: Whether this is a subsequent game for the team in a tournament group (affects nomination requirements)
         nominationListValidation:
           $ref: '#/components/schemas/NominationListValidation'
         notFoundButNominatedPersons:
@@ -5431,13 +5594,7 @@ components:
           type: string
           format: uuid
         indoorPlayer:
-          type: object
-          properties:
-            __identity:
-              type: string
-              format: uuid
-            person:
-              $ref: '#/components/schemas/PersonSummary'
+          $ref: '#/components/schemas/IndoorPlayer'
         shirtNumber:
           type: integer
           description: Player's shirt number for the game
@@ -5445,6 +5602,19 @@ components:
           type: boolean
         isLibero:
           type: boolean
+        isEligible:
+          type: boolean
+          description: Whether the player is eligible to play in this game
+        doubleLicenseTeam:
+          type: object
+          nullable: true
+          description: Team reference if player has a double license
+          properties:
+            __identity:
+              type: string
+              format: uuid
+            displayName:
+              type: string
         indoorPlayerLicenseCategory:
           type: object
           properties:
@@ -5460,6 +5630,15 @@ components:
             __identity:
               type: string
               format: uuid
+            hasValidationIssues:
+              type: boolean
+            hasUnresolvedValidationIssues:
+              type: boolean
+              description: Whether there are unresolved validation issues
+            hasValidationIssuesForAssociationUserContext:
+              type: boolean
+            hasValidationIssuesForClubUserContext:
+              type: boolean
             indoorPlayerNominationValidationIssues:
               type: array
               items:
@@ -5468,6 +5647,41 @@ components:
               type: object
               nullable: true
               description: If player is nominated for another game on the same day
+    IndoorPlayer:
+      type: object
+      description: An indoor volleyball player
+      properties:
+        __identity:
+          type: string
+          format: uuid
+        person:
+          $ref: '#/components/schemas/PersonSummary'
+        hasAcceptedDopingDeclaration:
+          type: boolean
+          description: Whether the player has accepted the doping declaration
+        hasActivatedIndoorLicense:
+          type: boolean
+          description: Whether the indoor license is activated
+        hasValidatedIndoorLicense:
+          type: boolean
+          description: Whether the indoor license is validated
+        hasPlayerPicture:
+          type: boolean
+        playerPicture:
+          type: object
+          nullable: true
+        isClassifiedAsLocallyEducated:
+          type: boolean
+          description: Whether player is classified as locally educated (relevant for foreigner rules)
+        isClassifiedAsLocallyEducatedManuallySet:
+          type: boolean
+          description: Whether the locally educated classification was manually set
+        isForeignerRegardingGamePlay:
+          type: boolean
+          description: Whether player counts as a foreigner for game play rules
+        totalLicensesCount:
+          type: integer
+          description: Total number of licenses held by the player
     PossibleNominationsResponse:
       type: object
       description: Response containing possible player nominations


### PR DESCRIPTION
## Summary

- Add newly discovered API fields from HAR file analysis to OpenAPI spec and capture documentation
- Document IndoorPlayer schema with license/foreigner flags
- Expand Game, Group, NominationList, and PersonSummary schemas with new fields
- Update eScoresheet, nomination list, and game details documentation

## Changes

**OpenAPI spec (`volleymanager-openapi.yaml`):**
- New `IndoorPlayer` schema with `hasAcceptedDopingDeclaration`, `hasValidatedIndoorLicense`, `isForeignerRegardingGamePlay`, etc.
- Added `isEligible` and `doubleLicenseTeam` to `IndoorPlayerNomination`
- Added `hasUnresolvedValidationIssues` to validation schemas
- Expanded `Game` schema with nomination list flags and game result fields
- Added `isTournamentGroup`, `hasNoScoresheet`, `managingAssociationShortName` to `Group`
- Expanded `PersonSummary` with contact info, legal guardians, profile fields
- Added `isSubsequentGameForTeamInTournamentGroup` to `NominationList`

**Capture documentation:**
- `nomination_list_endpoints.md`: Document indoor player fields table
- `escoresheet_endpoints.md`: Add new propertyRenderConfiguration parameters
- `game_details_endpoints.md`: Add game object field documentation tables

## Test plan

- [ ] Verify OpenAPI spec is valid YAML
- [ ] Review field descriptions match observed API behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)