### PR TITLE
docs(validation): add comment explaining isUploadingRef purpose

### DIFF
--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -58,6 +58,7 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
     timeout?: ReturnType<typeof setTimeout>;
   }>({});
   const previewUrlRef = useRef<string | null>(null);
+  // Prevent concurrent uploads (race condition prevention - not for unmount tracking)
   const isUploadingRef = useRef(false);
 
   // Cleanup preview URL and upload timers on unmount


### PR DESCRIPTION
Clarify that isUploadingRef is for race condition prevention (preventing concurrent uploads) rather than unmount tracking, which is an anti-pattern per CLAUDE.md guidelines.

Closes #131