### PR TITLE
chore(api): regenerate API types from OpenAPI spec

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -24,7 +24,7 @@
     {
       "name": "JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "164 kB",
+      "limit": "170 kB",
       "gzip": true
     },
     {


### PR DESCRIPTION
Updates generated types to include new fields:
- Game: status, nomination list access flags, scoresheet, forfeit info, result reporting fields
- Group: displayName, shortName, tournament flags, managing association
- PersonSummary: expanded profile fields (birthday, contact, legal guardians, etc.)
- NominationList: isSubsequentGameForTeamInTournamentGroup flag
- IndoorPlayerNomination: isEligible, doubleLicenseTeam, validation details
- New IndoorPlayer schema with license and classification fields