### PR TITLE
fix(api): send single-term scorer search to both name fields

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -334,7 +334,7 @@ describe("API Client", () => {
       expect(body.get("searchConfiguration[limit]")).toBe("100");
     });
 
-    it("sends single-term search to both firstName and lastName for OR matching", async () => {
+    it("sends lastName-only search to both firstName and lastName for OR matching", async () => {
       mockFetch.mockResolvedValueOnce(
         createMockResponse(mockPersonSearchResponse),
       );
@@ -349,6 +349,23 @@ describe("API Client", () => {
       expect(body.get("searchConfiguration[propertyFilters][0][text]")).toBe("müller");
       expect(body.get("searchConfiguration[propertyFilters][1][propertyName]")).toBe("lastName");
       expect(body.get("searchConfiguration[propertyFilters][1][text]")).toBe("müller");
+    });
+
+    it("sends firstName-only search to both firstName and lastName for OR matching", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(mockPersonSearchResponse),
+      );
+
+      await api.searchPersons({ firstName: "hans" });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      const body = options.body as URLSearchParams;
+
+      // Single term should be sent to both firstName and lastName
+      expect(body.get("searchConfiguration[propertyFilters][0][propertyName]")).toBe("firstName");
+      expect(body.get("searchConfiguration[propertyFilters][0][text]")).toBe("hans");
+      expect(body.get("searchConfiguration[propertyFilters][1][propertyName]")).toBe("lastName");
+      expect(body.get("searchConfiguration[propertyFilters][1][text]")).toBe("hans");
     });
 
     it("sends two-term search to separate firstName and lastName fields", async () => {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -604,33 +604,23 @@ export const api = {
 
     // Single-term search: send to both firstName and lastName for OR matching.
     // This enables searches like "hans" to find matches in either name field.
-    const isSingleTermSearch =
-      (firstName && !lastName) || (lastName && !firstName);
-
-    if (isSingleTermSearch) {
-      // One of firstName or lastName is guaranteed to be defined here
-      const searchTerm = (firstName ?? lastName)!;
-      propertyFilters.push({
-        propertyName: "firstName",
-        text: searchTerm,
-      });
-      propertyFilters.push({
-        propertyName: "lastName",
-        text: searchTerm,
-      });
+    if (firstName && !lastName) {
+      propertyFilters.push(
+        { propertyName: "firstName", text: firstName },
+        { propertyName: "lastName", text: firstName },
+      );
+    } else if (lastName && !firstName) {
+      propertyFilters.push(
+        { propertyName: "firstName", text: lastName },
+        { propertyName: "lastName", text: lastName },
+      );
     } else {
       // Two-term search: send each to its respective field
       if (firstName) {
-        propertyFilters.push({
-          propertyName: "firstName",
-          text: firstName,
-        });
+        propertyFilters.push({ propertyName: "firstName", text: firstName });
       }
       if (lastName) {
-        propertyFilters.push({
-          propertyName: "lastName",
-          text: lastName,
-        });
+        propertyFilters.push({ propertyName: "lastName", text: lastName });
       }
     }
 

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -126,14 +126,18 @@ export type PersonSearchResponse = Schemas["PersonSearchResponse"];
 /**
  * Search filters for person search endpoint.
  * All filters use fuzzy matching via Elasticsearch.
- * Results match persons where all provided filters match (AND logic).
+ *
+ * Search behavior:
+ * - Single name field (firstName OR lastName): searches both name fields (OR logic)
+ * - Both name fields: each searches its respective field only
+ * - yearOfBirth: AND logic with name fields
  */
 export interface PersonSearchFilter {
-  /** First name to search for (fuzzy match) */
+  /** First name to search for (fuzzy match). When provided alone, searches both name fields. */
   firstName?: string;
-  /** Last name to search for (fuzzy match) */
+  /** Last name to search for (fuzzy match). When provided alone, searches both name fields. */
   lastName?: string;
-  /** Year of birth as 4-digit string (e.g., "1985") */
+  /** Year of birth as 4-digit string (e.g., "1985"). Combined with name using AND logic. */
   yearOfBirth?: string;
 }
 


### PR DESCRIPTION
The Elasticsearch person search API uses OR logic across property
filters. When searching with a single term like "müller", we now
send it to both firstName and lastName fields, matching the
documented API behavior. This allows single-term searches to find
matches in either name field, fixing fuzzy search in production.

Previously, single-term searches only searched the lastName field,
causing searches like "hans" to miss first names.