### PR TITLE
fix(api): request all required fields in scorer search

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -422,6 +422,32 @@ describe("API Client", () => {
       expect(body.get("searchConfiguration[propertyFilters][2][propertyName]")).toBe("yearOfBirth");
       expect(body.get("searchConfiguration[propertyFilters][2][text]")).toBe("1985");
     });
+
+    it("requests all required properties for displaying search results", async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(mockPersonSearchResponse),
+      );
+
+      await api.searchPersons({ lastName: "test" });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      const body = options.body as URLSearchParams;
+
+      // These properties are required for ScorerResultsList to display results properly.
+      // Missing properties will cause search results to appear empty.
+      const requiredProperties = [
+        "displayName",
+        "firstName",
+        "lastName",
+        "associationId",
+        "birthday",
+        "gender",
+      ];
+
+      requiredProperties.forEach((prop, index) => {
+        expect(body.get(`propertyRenderConfiguration[${index}]`)).toBe(prop);
+      });
+    });
   });
 
   describe("request headers", () => {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -646,7 +646,14 @@ export const api = {
       "POST",
       {
         searchConfiguration: searchConfig,
-        propertyRenderConfiguration: ["birthday"],
+        propertyRenderConfiguration: [
+          "displayName",
+          "firstName",
+          "lastName",
+          "associationId",
+          "birthday",
+          "gender",
+        ],
       },
     );
   },


### PR DESCRIPTION
The searchPersons API was only requesting the "birthday" field in
propertyRenderConfiguration, causing the API to not return other
fields needed for display (displayName, firstName, lastName,
associationId, gender). This made search results appear empty.

Add a regression test to ensure all required properties are always
requested.