### PR TITLE
feat(validation): convert ValidateGameModal to wizard-style navigation

### DIFF
--- a/web-app/src/components/ui/WizardStepIndicator.tsx
+++ b/web-app/src/components/ui/WizardStepIndicator.tsx
@@ -1,5 +1,19 @@
 import type { WizardStep } from "@/hooks/useWizardNavigation";
 
+/** Returns the appropriate style classes based on step state */
+function getStepIndicatorStyle(
+  isCurrent: boolean,
+  showCompletion: boolean,
+): string {
+  if (isCurrent) {
+    return "bg-orange-500 text-white ring-2 ring-orange-500 ring-offset-2 dark:ring-offset-gray-800";
+  }
+  if (showCompletion) {
+    return "bg-green-500 text-white";
+  }
+  return "bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400";
+}
+
 function CheckIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -102,13 +116,7 @@ export function WizardStepIndicator({
                 relative flex items-center justify-center w-8 h-8 rounded-full
                 transition-all duration-200
                 ${clickable ? "cursor-pointer hover:scale-110" : "cursor-default"}
-                ${
-                  isCurrent
-                    ? "bg-orange-500 text-white ring-2 ring-orange-500 ring-offset-2 dark:ring-offset-gray-800"
-                    : showCompletion
-                      ? "bg-green-500 text-white"
-                      : "bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400"
-                }
+                ${getStepIndicatorStyle(isCurrent, showCompletion)}
                 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800
                 aria-disabled:cursor-default aria-disabled:opacity-100
               `}

--- a/web-app/src/hooks/useWizardNavigation.ts
+++ b/web-app/src/hooks/useWizardNavigation.ts
@@ -79,10 +79,16 @@ export function useWizardNavigation<T extends WizardStep>({
   const canGoBack = !isFirstStep;
 
   // Safe access: steps.length > 0 is validated above, and currentStepIndex is clamped
-  const currentStep = useMemo(
-    () => steps[currentStepIndex] ?? steps[0],
-    [steps, currentStepIndex],
-  ) as T;
+  // to valid range [0, steps.length-1], so the element is guaranteed to exist
+  const currentStep = useMemo((): T => {
+    const step = steps[currentStepIndex];
+    if (!step) {
+      throw new Error(
+        `useWizardNavigation: step at index ${currentStepIndex} not found`,
+      );
+    }
+    return step;
+  }, [steps, currentStepIndex]);
 
   const goToStep = useCallback(
     (index: number) => {

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -245,10 +245,11 @@ const de: Translations = {
     state: {
       unsavedChangesTitle: "Ungespeicherte Änderungen",
       unsavedChangesMessage:
-        "Sie haben ungespeicherte Änderungen. Möchten Sie diese wirklich verwerfen?",
+        "Sie haben ungespeicherte Änderungen. Was möchten Sie tun?",
       continueEditing: "Weiter bearbeiten",
-      discardChanges: "Änderungen verwerfen",
+      discardChanges: "Verwerfen",
       discardAndClose: "Verwerfen und schliessen",
+      saveAndClose: "Speichern und schliessen",
       saveSuccess: "Validierung erfolgreich gespeichert",
       saveError: "Validierung konnte nicht gespeichert werden",
       markAllStepsTooltip:

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -241,10 +241,11 @@ const en: Translations = {
     state: {
       unsavedChangesTitle: "Unsaved Changes",
       unsavedChangesMessage:
-        "You have unsaved changes. Are you sure you want to discard them?",
+        "You have unsaved changes. What would you like to do?",
       continueEditing: "Continue Editing",
-      discardChanges: "Discard Changes",
+      discardChanges: "Discard",
       discardAndClose: "Discard and Close",
+      saveAndClose: "Save and Close",
       saveSuccess: "Validation saved successfully",
       saveError: "Failed to save validation",
       markAllStepsTooltip: "Mark all required steps as reviewed to finish",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -245,10 +245,11 @@ const fr: Translations = {
     state: {
       unsavedChangesTitle: "Modifications non enregistrées",
       unsavedChangesMessage:
-        "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir les abandonner?",
+        "Vous avez des modifications non enregistrées. Que voulez-vous faire?",
       continueEditing: "Continuer l'édition",
-      discardChanges: "Abandonner les modifications",
+      discardChanges: "Abandonner",
       discardAndClose: "Abandonner et fermer",
+      saveAndClose: "Enregistrer et fermer",
       saveSuccess: "Validation enregistrée avec succès",
       saveError: "Échec de l'enregistrement de la validation",
       markAllStepsTooltip:

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -240,10 +240,11 @@ const it: Translations = {
     state: {
       unsavedChangesTitle: "Modifiche non salvate",
       unsavedChangesMessage:
-        "Hai modifiche non salvate. Sei sicuro di volerle scartare?",
+        "Hai modifiche non salvate. Cosa vuoi fare?",
       continueEditing: "Continua a modificare",
-      discardChanges: "Scarta le modifiche",
+      discardChanges: "Scarta",
       discardAndClose: "Scarta e chiudi",
+      saveAndClose: "Salva e chiudi",
       saveSuccess: "Validazione salvata con successo",
       saveError: "Impossibile salvare la validazione",
       markAllStepsTooltip:

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -227,6 +227,7 @@ export interface Translations {
       continueEditing: string;
       discardChanges: string;
       discardAndClose: string;
+      saveAndClose: string;
       saveSuccess: string;
       saveError: string;
       markAllStepsTooltip: string;


### PR DESCRIPTION
Convert the ValidateGameModal from a tab-based interface to an
installation-style wizard with step-by-step navigation:

- Add useWizardNavigation hook for step state management
- Add WizardStepContainer with swipe gesture support (touch/mouse)
- Add WizardStepIndicator showing progress with completion status
- Add saveProgress() to useValidationState for auto-save on step change
- Add translation keys for wizard navigation (en, de, fr, it)
- Update tests for wizard behavior

Features:
- Single step visible at a time
- Navigate via swipe gestures OR Previous/Next buttons
- Auto-saves progress to API when changing steps or closing modal
- Step indicator shows checkmarks for completed steps
- Finish button on last step (disabled until required fields complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>