### PR TITLE
feat(i18n): preload locales at app startup for instant language switching

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -26,6 +26,7 @@ import {
   isAuthError,
   RETRY_CONFIG,
 } from "@/utils/query-error-utils";
+import { usePreloadLocales } from "@/hooks/usePreloadLocales";
 
 /**
  * Global error handler for React Query mutations.
@@ -206,6 +207,8 @@ function QueryErrorHandler({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  usePreloadLocales();
+
   return (
     <ErrorBoundary>
       <PWAProvider>

--- a/web-app/src/hooks/usePreloadLocales.test.ts
+++ b/web-app/src/hooks/usePreloadLocales.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { usePreloadLocales } from "./usePreloadLocales";
+import * as i18n from "@/i18n";
+import * as useDateFormat from "@/hooks/useDateFormat";
+
+// Extend Window interface for requestIdleCallback
+declare global {
+  interface Window {
+    requestIdleCallback: (
+      callback: IdleRequestCallback,
+      options?: IdleRequestOptions,
+    ) => number;
+    cancelIdleCallback: (id: number) => void;
+  }
+}
+
+vi.mock("@/i18n", () => ({
+  preloadTranslations: vi.fn(),
+}));
+
+vi.mock("@/hooks/useDateFormat", () => ({
+  preloadDateLocales: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+describe("usePreloadLocales", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("requestIdleCallback behavior", () => {
+    it("preloads locales when browser is idle", () => {
+      const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
+      const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
+
+      mockPreloadTranslations.mockResolvedValue();
+      mockPreloadDateLocales.mockResolvedValue();
+
+      const mockRequestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+        callback({} as IdleDeadline);
+        return 1;
+      });
+      const mockCancelIdleCallback = vi.fn();
+
+      window.requestIdleCallback = mockRequestIdleCallback;
+      window.cancelIdleCallback = mockCancelIdleCallback;
+
+      renderHook(() => usePreloadLocales());
+
+      expect(mockRequestIdleCallback).toHaveBeenCalledWith(
+        expect.any(Function),
+        { timeout: 1000 },
+      );
+      expect(mockPreloadTranslations).toHaveBeenCalledTimes(1);
+      expect(mockPreloadDateLocales).toHaveBeenCalledTimes(1);
+    });
+
+    it("cleans up idle callback on unmount", () => {
+      const mockRequestIdleCallback = vi.fn(() => 42);
+      const mockCancelIdleCallback = vi.fn();
+
+      window.requestIdleCallback = mockRequestIdleCallback;
+      window.cancelIdleCallback = mockCancelIdleCallback;
+
+      const { unmount } = renderHook(() => usePreloadLocales());
+
+      expect(mockRequestIdleCallback).toHaveBeenCalled();
+
+      unmount();
+
+      expect(mockCancelIdleCallback).toHaveBeenCalledWith(42);
+    });
+  });
+
+  describe("setTimeout fallback", () => {
+    it("falls back to setTimeout when requestIdleCallback unavailable", () => {
+      const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
+      const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
+
+      mockPreloadTranslations.mockResolvedValue();
+      mockPreloadDateLocales.mockResolvedValue();
+
+      // Remove requestIdleCallback
+      const originalRequestIdleCallback = window.requestIdleCallback;
+      // @ts-expect-error - Intentionally deleting for test
+      delete window.requestIdleCallback;
+
+      renderHook(() => usePreloadLocales());
+
+      expect(mockPreloadTranslations).not.toHaveBeenCalled();
+      expect(mockPreloadDateLocales).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(mockPreloadTranslations).toHaveBeenCalledTimes(1);
+      expect(mockPreloadDateLocales).toHaveBeenCalledTimes(1);
+
+      // Restore
+      window.requestIdleCallback = originalRequestIdleCallback;
+    });
+
+    it("cleans up timeout on unmount when using fallback", () => {
+      const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
+      const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
+
+      mockPreloadTranslations.mockResolvedValue();
+      mockPreloadDateLocales.mockResolvedValue();
+
+      // Remove requestIdleCallback
+      const originalRequestIdleCallback = window.requestIdleCallback;
+      // @ts-expect-error - Intentionally deleting for test
+      delete window.requestIdleCallback;
+
+      const { unmount } = renderHook(() => usePreloadLocales());
+
+      unmount();
+
+      vi.advanceTimersByTime(1000);
+
+      // Should not have been called since we unmounted before timeout
+      expect(mockPreloadTranslations).not.toHaveBeenCalled();
+      expect(mockPreloadDateLocales).not.toHaveBeenCalled();
+
+      // Restore
+      window.requestIdleCallback = originalRequestIdleCallback;
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles preloadTranslations errors gracefully", async () => {
+      const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
+      const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
+      const { logger } = await import("@/utils/logger");
+
+      const testError = new Error("Translation load failed");
+      mockPreloadTranslations.mockRejectedValue(testError);
+      mockPreloadDateLocales.mockResolvedValue();
+
+      const mockRequestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+        callback({} as IdleDeadline);
+        return 1;
+      });
+
+      window.requestIdleCallback = mockRequestIdleCallback;
+
+      renderHook(() => usePreloadLocales());
+
+      await vi.waitFor(() => {
+        expect(logger.error).toHaveBeenCalledWith(
+          "[usePreloadLocales] Failed to preload locales:",
+          testError,
+        );
+      });
+    });
+
+    it("handles preloadDateLocales errors gracefully", async () => {
+      const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
+      const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
+      const { logger } = await import("@/utils/logger");
+
+      const testError = new Error("Date locale load failed");
+      mockPreloadTranslations.mockResolvedValue();
+      mockPreloadDateLocales.mockRejectedValue(testError);
+
+      const mockRequestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+        callback({} as IdleDeadline);
+        return 1;
+      });
+
+      window.requestIdleCallback = mockRequestIdleCallback;
+
+      renderHook(() => usePreloadLocales());
+
+      await vi.waitFor(() => {
+        expect(logger.error).toHaveBeenCalledWith(
+          "[usePreloadLocales] Failed to preload locales:",
+          testError,
+        );
+      });
+    });
+
+    it("handles both preload functions failing", async () => {
+      const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
+      const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
+      const { logger } = await import("@/utils/logger");
+
+      const testError = new Error("All preloads failed");
+      mockPreloadTranslations.mockRejectedValue(testError);
+      mockPreloadDateLocales.mockRejectedValue(testError);
+
+      const mockRequestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+        callback({} as IdleDeadline);
+        return 1;
+      });
+
+      window.requestIdleCallback = mockRequestIdleCallback;
+
+      renderHook(() => usePreloadLocales());
+
+      await vi.waitFor(() => {
+        expect(logger.error).toHaveBeenCalledWith(
+          "[usePreloadLocales] Failed to preload locales:",
+          testError,
+        );
+      });
+    });
+  });
+
+  describe("timing behavior", () => {
+    it("uses 1000ms timeout for requestIdleCallback", () => {
+      const mockRequestIdleCallback = vi.fn(() => 1);
+      window.requestIdleCallback = mockRequestIdleCallback;
+
+      renderHook(() => usePreloadLocales());
+
+      expect(mockRequestIdleCallback).toHaveBeenCalledWith(
+        expect.any(Function),
+        { timeout: 1000 },
+      );
+    });
+
+    it("uses 1000ms delay for setTimeout fallback", () => {
+      const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
+      const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
+
+      mockPreloadTranslations.mockResolvedValue();
+      mockPreloadDateLocales.mockResolvedValue();
+
+      // Remove requestIdleCallback
+      const originalRequestIdleCallback = window.requestIdleCallback;
+      // @ts-expect-error - Intentionally deleting for test
+      delete window.requestIdleCallback;
+
+      renderHook(() => usePreloadLocales());
+
+      // Not called before timeout
+      vi.advanceTimersByTime(999);
+      expect(mockPreloadTranslations).not.toHaveBeenCalled();
+
+      // Called at timeout
+      vi.advanceTimersByTime(1);
+      expect(mockPreloadTranslations).toHaveBeenCalledTimes(1);
+      expect(mockPreloadDateLocales).toHaveBeenCalledTimes(1);
+
+      // Restore
+      window.requestIdleCallback = originalRequestIdleCallback;
+    });
+  });
+});

--- a/web-app/src/hooks/usePreloadLocales.ts
+++ b/web-app/src/hooks/usePreloadLocales.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { preloadTranslations } from "@/i18n";
+import { preloadDateLocales } from "@/hooks/useDateFormat";
+import { logger } from "@/utils/logger";
+
+const PRELOAD_IDLE_TIMEOUT_MS = 1000;
+
+/**
+ * Preloads all translation and date locales when the browser is idle.
+ * This makes subsequent language switches instant while not blocking initial render.
+ * Uses requestIdleCallback to defer preloading until the browser has spare time.
+ */
+export function usePreloadLocales(): void {
+  useEffect(() => {
+    const handlePreload = () => {
+      Promise.all([preloadTranslations(), preloadDateLocales()]).catch(
+        (error) => {
+          logger.error("[usePreloadLocales] Failed to preload locales:", error);
+        },
+      );
+    };
+
+    if ("requestIdleCallback" in window) {
+      const idleCallbackId = requestIdleCallback(handlePreload, {
+        timeout: PRELOAD_IDLE_TIMEOUT_MS,
+      });
+      return () => cancelIdleCallback(idleCallbackId);
+    }
+
+    const timeoutId = setTimeout(handlePreload, PRELOAD_IDLE_TIMEOUT_MS);
+    return () => clearTimeout(timeoutId);
+  }, []);
+}


### PR DESCRIPTION
Implements locale preloading using requestIdleCallback to improve UX when users switch languages. This makes subsequent language changes instant while not blocking initial app render.

## Changes

- Create usePreloadLocales hook that preloads all translations and date locales
- Use requestIdleCallback to defer preloading until browser is idle (1s timeout)
- Integrate hook in main App component
- Includes proper cleanup to cancel callbacks on unmount

Closes #147

Generated with [Claude Code](https://claude.ai/code)