### PR TITLE
test(hooks): extract time format regex to named constant

### DIFF
--- a/web-app/src/hooks/useDateFormat.test.ts
+++ b/web-app/src/hooks/useDateFormat.test.ts
@@ -4,6 +4,8 @@ import { useDateFormat, getDateLocale, safeParseISO } from "./useDateFormat";
 import { useLanguageStore } from "@/stores/language";
 import { enUS } from "date-fns/locale/en-US";
 
+const TIME_FORMAT_PATTERN = /^\d{2}:\d{2}$/; // HH:mm format
+
 describe("useDateFormat", () => {
   beforeEach(() => {
     act(() => {
@@ -19,7 +21,7 @@ describe("useDateFormat", () => {
 
       expect(result.current.date).toBeInstanceOf(Date);
       // Time is formatted in local timezone, so just check format pattern
-      expect(result.current.timeLabel).toMatch(/^\d{2}:\d{2}$/);
+      expect(result.current.timeLabel).toMatch(TIME_FORMAT_PATTERN);
       expect(result.current.dateLabel).toBeDefined();
     });
 
@@ -89,7 +91,7 @@ describe("useDateFormat", () => {
       // Date should still be valid and formatted
       expect(result.current.date).toBeInstanceOf(Date);
       // Time is formatted in local timezone, so just check format pattern
-      expect(result.current.timeLabel).toMatch(/^\d{2}:\d{2}$/);
+      expect(result.current.timeLabel).toMatch(TIME_FORMAT_PATTERN);
     });
   });
 

--- a/web-app/src/hooks/useDateFormat.test.ts
+++ b/web-app/src/hooks/useDateFormat.test.ts
@@ -4,7 +4,8 @@ import { useDateFormat, getDateLocale, safeParseISO } from "./useDateFormat";
 import { useLanguageStore } from "@/stores/language";
 import { enUS } from "date-fns/locale/en-US";
 
-const TIME_FORMAT_PATTERN = /^\d{2}:\d{2}$/; // HH:mm format
+// Pattern for validating HH:mm time format (e.g., "14:30", "09:15")
+const TIME_FORMAT_PATTERN = /^\d{2}:\d{2}$/;
 
 describe("useDateFormat", () => {
   beforeEach(() => {


### PR DESCRIPTION
Extracted the magic number regex pattern `/^\d{2}:\d{2}$/` to a named
constant `TIME_FORMAT_PATTERN` in `useDateFormat.test.ts`. This improves
code readability by making the pattern reusable and clearly documented.

Fixes #146

🤖 Generated with [Claude Code](https://claude.ai/code)