### PR TITLE
fix(api): change scorer search from POST to GET method

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -330,6 +330,24 @@ describe("API Client", () => {
       expect(options.body).toBeUndefined();
     });
 
+    it("does not include CSRF token in GET request URL", async () => {
+      // CSRF tokens in URLs can leak through browser history, server logs,
+      // referer headers, and proxy logs - only include for state-changing methods
+      setCsrfToken("test-csrf-token");
+
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(mockPersonSearchResponse),
+      );
+
+      await api.searchPersons({ lastName: "müller" });
+
+      const params = getQueryParams();
+      expect(params.get("__csrfToken")).toBeNull();
+
+      // Clean up
+      setCsrfToken(null);
+    });
+
     it("uses default limit when not specified", async () => {
       mockFetch.mockResolvedValueOnce(
         createMockResponse(mockPersonSearchResponse),

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -246,11 +246,17 @@ async function apiRequest<T>(
   method: "GET" | "POST" | "PUT" | "DELETE" = "GET",
   body?: Record<string, unknown>,
 ): Promise<T> {
-  const url = `${API_BASE}${endpoint}`;
+  let url = `${API_BASE}${endpoint}`;
 
   const headers: HeadersInit = {
     Accept: "application/json",
   };
+
+  // For GET requests, append parameters as query string
+  if (method === "GET" && body) {
+    const params = buildFormData(body);
+    url = `${url}?${params.toString()}`;
+  }
 
   if (method !== "GET" && body) {
     headers["Content-Type"] = "application/x-www-form-urlencoded";
@@ -643,7 +649,7 @@ export const api = {
 
     return apiRequest<PersonSearchResponse>(
       "/sportmanager.core/api%5celasticsearchperson/search",
-      "POST",
+      "GET",
       {
         searchConfiguration: searchConfig,
         propertyRenderConfiguration: [

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -184,7 +184,16 @@ export function clearSession() {
 // e.g., searchConfiguration[offset] = 0, searchConfiguration[limit] = 10
 const MAX_DEPTH = 10;
 
-function buildFormData(data: Record<string, unknown>): URLSearchParams {
+interface BuildFormDataOptions {
+  /** Include CSRF token in params. Default true. Set false for GET requests. */
+  includeCsrfToken?: boolean;
+}
+
+function buildFormData(
+  data: Record<string, unknown>,
+  options: BuildFormDataOptions = {},
+): URLSearchParams {
+  const { includeCsrfToken = true } = options;
   const params = new URLSearchParams();
   // Track objects in current path to detect true circular references
   // Using Set<object> and removing after recursion allows shared references
@@ -233,7 +242,10 @@ function buildFormData(data: Record<string, unknown>): URLSearchParams {
     flatten(value, key, 0);
   });
 
-  if (csrfToken) {
+  // Only include CSRF token for state-changing requests (POST/PUT/DELETE).
+  // GET requests should not include CSRF tokens in URLs as they can leak
+  // through browser history, server logs, referer headers, and proxy logs.
+  if (includeCsrfToken && csrfToken) {
     params.append("__csrfToken", csrfToken);
   }
 
@@ -252,9 +264,9 @@ async function apiRequest<T>(
     Accept: "application/json",
   };
 
-  // For GET requests, append parameters as query string
+  // For GET requests, append parameters as query string (without CSRF token)
   if (method === "GET" && body) {
-    const params = buildFormData(body);
+    const params = buildFormData(body, { includeCsrfToken: false });
     url = `${url}?${params.toString()}`;
   }
 


### PR DESCRIPTION
The Elasticsearch person search endpoint expects GET requests with query
parameters, not POST with form body. The OpenAPI schema correctly
specifies this (get: operations["searchPersons"]), but the client was
using POST which caused the API to return empty results.

Changes:
- Update apiRequest to support query params for GET requests
- Change searchPersons from POST to GET method
- Update tests to verify GET with query string parameters