### PR TITLE
feat(validation): add panel scrolling and replace Next with Validate button

### DIFF
--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -160,7 +160,7 @@ describe("ValidateGameModal", () => {
       ).toBeInTheDocument();
     });
 
-    it("shows Next button on first step", () => {
+    it("shows Validate button on first step", () => {
       render(
         <ValidateGameModal
           assignment={createMockAssignment()}
@@ -170,11 +170,11 @@ describe("ValidateGameModal", () => {
         { wrapper: createWrapper() },
       );
       expect(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       ).toBeInTheDocument();
     });
 
-    it("advances to Away Roster panel when Next is clicked", async () => {
+    it("advances to Away Roster panel when Validate is clicked", async () => {
       render(
         <ValidateGameModal
           assignment={createMockAssignment()}
@@ -185,7 +185,7 @@ describe("ValidateGameModal", () => {
       );
 
       fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       );
 
       await waitFor(() => {
@@ -206,7 +206,7 @@ describe("ValidateGameModal", () => {
 
       // Go to step 2
       fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       );
 
       await waitFor(() => {
@@ -228,7 +228,7 @@ describe("ValidateGameModal", () => {
 
       // Go to step 2
       fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       );
 
       await waitFor(() => {
@@ -258,14 +258,14 @@ describe("ValidateGameModal", () => {
 
       // Navigate to step 3
       fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       );
       await waitFor(() =>
         expect(screen.getByText("Step 2 of 4")).toBeInTheDocument(),
       );
 
       fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       );
       await waitFor(() =>
         expect(screen.getByText("Step 3 of 4")).toBeInTheDocument(),
@@ -288,24 +288,13 @@ describe("ValidateGameModal", () => {
         { wrapper: createWrapper() },
       );
 
-      // Navigate to step 4
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
-      await waitFor(() =>
-        expect(screen.getByText("Step 2 of 4")).toBeInTheDocument(),
-      );
+      // Navigate to step 4 using step indicator (since Validate on step 3 is disabled without scorer)
+      const scoresheetStep = screen.getByRole("button", {
+        name: /Scoresheet/i,
+        hidden: true,
+      });
+      fireEvent.click(scoresheetStep);
 
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
-      await waitFor(() =>
-        expect(screen.getByText("Step 3 of 4")).toBeInTheDocument(),
-      );
-
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
       await waitFor(() =>
         expect(screen.getByText("Step 4 of 4")).toBeInTheDocument(),
       );
@@ -329,14 +318,14 @@ describe("ValidateGameModal", () => {
       expect(screen.getByText("Step 1 of 4")).toBeInTheDocument();
 
       fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       );
       await waitFor(() => {
         expect(screen.getByText("Step 2 of 4")).toBeInTheDocument();
       });
 
       fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       );
       await waitFor(() => {
         expect(screen.getByText("Step 3 of 4")).toBeInTheDocument();
@@ -431,24 +420,13 @@ describe("ValidateGameModal", () => {
         </Wrapper>,
       );
 
-      // Navigate to step 4
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
-      await waitFor(() =>
-        expect(screen.getByText("Step 2 of 4")).toBeInTheDocument(),
-      );
+      // Navigate to step 4 using step indicator
+      const scoresheetStep = screen.getByRole("button", {
+        name: /Scoresheet/i,
+        hidden: true,
+      });
+      fireEvent.click(scoresheetStep);
 
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
-      await waitFor(() =>
-        expect(screen.getByText("Step 3 of 4")).toBeInTheDocument(),
-      );
-
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
       await waitFor(() =>
         expect(screen.getByText("Step 4 of 4")).toBeInTheDocument(),
       );
@@ -486,24 +464,13 @@ describe("ValidateGameModal", () => {
         { wrapper: createWrapper() },
       );
 
-      // Navigate to last step
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
-      await waitFor(() =>
-        expect(screen.getByText("Step 2 of 4")).toBeInTheDocument(),
-      );
+      // Navigate to last step using step indicator
+      const scoresheetStep = screen.getByRole("button", {
+        name: /Scoresheet/i,
+        hidden: true,
+      });
+      fireEvent.click(scoresheetStep);
 
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
-      await waitFor(() =>
-        expect(screen.getByText("Step 3 of 4")).toBeInTheDocument(),
-      );
-
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
       await waitFor(() =>
         expect(screen.getByText("Step 4 of 4")).toBeInTheDocument(),
       );
@@ -513,7 +480,7 @@ describe("ValidateGameModal", () => {
       ).toBeInTheDocument();
     });
 
-    it("disables Finish button when required panels are incomplete", async () => {
+    it("disables Finish button when previous panels are not validated", async () => {
       render(
         <ValidateGameModal
           assignment={createMockAssignment()}
@@ -523,24 +490,14 @@ describe("ValidateGameModal", () => {
         { wrapper: createWrapper() },
       );
 
-      // Navigate to last step
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
-      await waitFor(() =>
-        expect(screen.getByText("Step 2 of 4")).toBeInTheDocument(),
-      );
+      // Navigate to last step using step indicator (not Validate button)
+      // This allows us to reach the last step without validating previous steps
+      const scoresheetStep = screen.getByRole("button", {
+        name: /Scoresheet/i,
+        hidden: true,
+      });
+      fireEvent.click(scoresheetStep);
 
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
-      await waitFor(() =>
-        expect(screen.getByText("Step 3 of 4")).toBeInTheDocument(),
-      );
-
-      fireEvent.click(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
-      );
       await waitFor(() =>
         expect(screen.getByText("Step 4 of 4")).toBeInTheDocument(),
       );
@@ -552,7 +509,40 @@ describe("ValidateGameModal", () => {
       expect(finishButton).toBeDisabled();
     });
 
-    it("renders both Cancel and Next buttons on first step", () => {
+    it("disables Validate button on scorer panel when no scorer is selected", async () => {
+      render(
+        <ValidateGameModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+        { wrapper: createWrapper() },
+      );
+
+      // Validate first two panels to reach step 3
+      fireEvent.click(
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
+      );
+      await waitFor(() =>
+        expect(screen.getByText("Step 2 of 4")).toBeInTheDocument(),
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
+      );
+      await waitFor(() =>
+        expect(screen.getByText("Step 3 of 4")).toBeInTheDocument(),
+      );
+
+      // Validate button should be disabled because no scorer is selected
+      const validateButton = screen.getByRole("button", {
+        name: /Validate/i,
+        hidden: true,
+      });
+      expect(validateButton).toBeDisabled();
+    });
+
+    it("renders both Cancel and Validate buttons on first step", () => {
       render(
         <ValidateGameModal
           assignment={createMockAssignment()}
@@ -566,7 +556,7 @@ describe("ValidateGameModal", () => {
         screen.getByRole("button", { name: /Cancel/i, hidden: true }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: /Next/i, hidden: true }),
+        screen.getByRole("button", { name: /Validate/i, hidden: true }),
       ).toBeInTheDocument();
     });
   });

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -258,6 +258,7 @@ const de: Translations = {
     wizard: {
       previous: "Zurück",
       next: "Weiter",
+      validate: "Validieren",
       finish: "Abschliessen",
       stepOf: "Schritt {current} von {total}",
       saving: "Speichern...",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -253,6 +253,7 @@ const en: Translations = {
     wizard: {
       previous: "Previous",
       next: "Next",
+      validate: "Validate",
       finish: "Finish",
       stepOf: "Step {current} of {total}",
       saving: "Saving...",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -258,6 +258,7 @@ const fr: Translations = {
     wizard: {
       previous: "Précédent",
       next: "Suivant",
+      validate: "Valider",
       finish: "Terminer",
       stepOf: "Étape {current} sur {total}",
       saving: "Enregistrement...",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -253,6 +253,7 @@ const it: Translations = {
     wizard: {
       previous: "Precedente",
       next: "Avanti",
+      validate: "Valida",
       finish: "Termina",
       stepOf: "Passo {current} di {total}",
       saving: "Salvataggio...",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -235,6 +235,7 @@ export interface Translations {
     wizard: {
       previous: string;
       next: string;
+      validate: string;
       finish: string;
       stepOf: string;
       saving: string;


### PR DESCRIPTION
- Add scrollable container (max-h-80) to validation panel content
- Replace "Next" button with "Validate" button on all non-last panels
- Validate button marks current step as done and advances to next
- Remove checkbox from all panels (validation now happens via buttons)
- Make Finish button validate last panel (if not optional) before finalizing
- Add 'validate' translation key in all locales (en, de, fr, it)
- Update tests to use new Validate button and navigation patterns