### PR TITLE
chore(build): add total bundle size budget to size-limit config

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -43,6 +43,12 @@
       "path": "dist/assets/*.css",
       "limit": "10 kB",
       "gzip": true
+    },
+    {
+      "name": "Total JS Bundle",
+      "path": "dist/assets/*.js",
+      "limit": "180 kB",
+      "gzip": true
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Add a fourth size-limit entry that monitors all JavaScript assets
collectively with a 180 kB cap. This prevents situations where
individual chunks remain under their limits while the combined
total exceeds acceptable thresholds.

Closes #148