### PR TITLE
feat(auth): filter occupations to referee-only for referee-focused app

### DIFF
--- a/web-app/src/components/layout/AppShell.test.tsx
+++ b/web-app/src/components/layout/AppShell.test.tsx
@@ -39,7 +39,10 @@ const demoUser: UserProfile = {
   id: "demo-user",
   firstName: "Demo",
   lastName: "User",
-  occupations: [{ id: "demo-referee", type: "referee" }],
+  occupations: [
+    { id: "demo-referee-vd", type: "referee", associationCode: "AVL-VD" },
+    { id: "demo-referee-ge", type: "referee", associationCode: "AVL-GE" },
+  ],
 };
 
 const realUser: UserProfile = {
@@ -69,7 +72,7 @@ describe("AppShell", () => {
         createMockAuthStore({
           user: demoUser,
           isDemoMode: true,
-          activeOccupationId: "demo-referee",
+          activeOccupationId: "demo-referee-vd",
         }),
       );
 
@@ -101,7 +104,7 @@ describe("AppShell", () => {
         createMockAuthStore({
           user: demoUser,
           isDemoMode: true,
-          activeOccupationId: "demo-referee",
+          activeOccupationId: "demo-referee-vd",
         }),
       );
 
@@ -125,7 +128,7 @@ describe("AppShell", () => {
           createMockAuthStore({
             user: demoUser,
             isDemoMode: true,
-            activeOccupationId: "demo-referee",
+            activeOccupationId: "demo-referee-vd",
           }),
         );
 
@@ -134,5 +137,81 @@ describe("AppShell", () => {
         expect(screen.getByText(expected)).toBeInTheDocument();
       },
     );
+  });
+
+  describe("occupation dropdown", () => {
+    it("does NOT render dropdown when user has only one occupation", () => {
+      const singleOccupationUser: UserProfile = {
+        id: "user-1",
+        firstName: "John",
+        lastName: "Doe",
+        occupations: [{ id: "ref-1", type: "referee" }],
+      };
+
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: singleOccupationUser,
+          activeOccupationId: "ref-1",
+        }),
+      );
+
+      renderAppShell();
+
+      // Dropdown button should not exist
+      expect(
+        screen.queryByRole("button", { name: /referee/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders dropdown when user has multiple occupations", () => {
+      const multiOccupationUser: UserProfile = {
+        id: "user-1",
+        firstName: "John",
+        lastName: "Doe",
+        occupations: [
+          { id: "ref-1", type: "referee" },
+          { id: "ref-2", type: "referee", associationCode: "VBC" },
+        ],
+      };
+
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: multiOccupationUser,
+          activeOccupationId: "ref-1",
+        }),
+      );
+
+      renderAppShell();
+
+      // Dropdown button should exist with haspopup attribute
+      const dropdownButton = screen.getByRole("button", {
+        name: /referee/i,
+      });
+      expect(dropdownButton).toBeInTheDocument();
+      expect(dropdownButton).toHaveAttribute("aria-haspopup", "listbox");
+    });
+
+    it("does NOT render dropdown when user has no occupations", () => {
+      const noOccupationUser: UserProfile = {
+        id: "user-1",
+        firstName: "John",
+        lastName: "Doe",
+        occupations: [],
+      };
+
+      vi.mocked(useAuthStore).mockReturnValue(
+        createMockAuthStore({
+          user: noOccupationUser,
+          activeOccupationId: null,
+        }),
+      );
+
+      renderAppShell();
+
+      // No dropdown button should exist
+      expect(
+        screen.queryByRole("button", { name: /select role/i }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -4,6 +4,8 @@ import { useAuthStore, type Occupation } from "@/stores/auth";
 import { useTranslation } from "@/hooks/useTranslation";
 import { getOccupationLabelKey } from "@/utils/occupation-labels";
 
+const MINIMUM_OCCUPATIONS_FOR_SWITCHER = 2;
+
 const navItems = [
   { path: "/", labelKey: "nav.assignments" as const, icon: "📋" },
   {
@@ -83,8 +85,8 @@ export function AppShell() {
 
             {isAuthenticated && (
               <div className="flex items-center gap-3">
-                {/* Occupation dropdown - only show when multiple occupations exist */}
-                {user?.occupations && user.occupations.length > 1 && (
+                {user?.occupations &&
+                  user.occupations.length >= MINIMUM_OCCUPATIONS_FOR_SWITCHER && (
                   <div className="relative" ref={dropdownRef}>
                     <button
                       onClick={() => setIsDropdownOpen(!isDropdownOpen)}

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -83,8 +83,8 @@ export function AppShell() {
 
             {isAuthenticated && (
               <div className="flex items-center gap-3">
-                {/* Occupation dropdown */}
-                {user?.occupations && user.occupations.length > 0 && (
+                {/* Occupation dropdown - only show when multiple occupations exist */}
+                {user?.occupations && user.occupations.length > 1 && (
                   <div className="relative" ref={dropdownRef}>
                     <button
                       onClick={() => setIsDropdownOpen(!isDropdownOpen)}

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -438,9 +438,11 @@ export const useAuthStore = create<AuthState>()(
       },
 
       setDemoAuthenticated: () => {
+        // Only include referee occupations - this app is designed for referee management
+        // Multiple occupations for referees who work across different associations
         const demoOccupations: Occupation[] = [
-          { id: "demo-referee", type: "referee" },
-          { id: "demo-player", type: "player", clubName: "VBC Demo" },
+          { id: "demo-referee-vd", type: "referee", associationCode: "AVL-VD" },
+          { id: "demo-referee-ge", type: "referee", associationCode: "AVL-GE" },
         ];
         set({
           status: "authenticated",

--- a/web-app/src/utils/parseOccupations.test.ts
+++ b/web-app/src/utils/parseOccupations.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { parseOccupation, parseOccupations } from "./parseOccupations";
+
+describe("parseOccupations", () => {
+  describe("parseOccupation", () => {
+    it("should parse referee role", () => {
+      const attr = {
+        __identity: "ref-123",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+      };
+
+      const result = parseOccupation(attr);
+
+      expect(result).toEqual({
+        id: "ref-123",
+        type: "referee",
+      });
+    });
+
+    it("should filter out player role by default", () => {
+      const attr = {
+        __identity: "player-123",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:Player",
+      };
+
+      const result = parseOccupation(attr);
+
+      expect(result).toBeNull();
+    });
+
+    it("should filter out clubAdmin role by default", () => {
+      const attr = {
+        __identity: "club-123",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:ClubAdmin",
+      };
+
+      const result = parseOccupation(attr);
+
+      expect(result).toBeNull();
+    });
+
+    it("should filter out associationAdmin role by default", () => {
+      const attr = {
+        __identity: "assoc-123",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:AssociationAdmin",
+      };
+
+      const result = parseOccupation(attr);
+
+      expect(result).toBeNull();
+    });
+
+    it("should include player role when refereeOnly is false", () => {
+      const attr = {
+        __identity: "player-123",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:Player",
+      };
+
+      const result = parseOccupation(attr, false);
+
+      expect(result).toEqual({
+        id: "player-123",
+        type: "player",
+      });
+    });
+
+    it("should return null for missing roleIdentifier", () => {
+      const attr = {
+        __identity: "ref-123",
+      };
+
+      const result = parseOccupation(attr);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for missing __identity", () => {
+      const attr = {
+        roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+      };
+
+      const result = parseOccupation(attr);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for unrecognized role", () => {
+      const attr = {
+        __identity: "unknown-123",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:UnknownRole",
+      };
+
+      const result = parseOccupation(attr);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("parseOccupations", () => {
+    it("should parse multiple referee occupations", () => {
+      const attrs = [
+        {
+          __identity: "ref-1",
+          roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+        },
+        {
+          __identity: "ref-2",
+          roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+        },
+      ];
+
+      const result = parseOccupations(attrs);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ id: "ref-1", type: "referee" });
+      expect(result[1]).toEqual({ id: "ref-2", type: "referee" });
+    });
+
+    it("should filter out non-referee roles from mixed list", () => {
+      const attrs = [
+        {
+          __identity: "ref-1",
+          roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+        },
+        {
+          __identity: "player-1",
+          roleIdentifier: "Indoorvolleyball.RefAdmin:Player",
+        },
+        {
+          __identity: "club-1",
+          roleIdentifier: "Indoorvolleyball.RefAdmin:ClubAdmin",
+        },
+      ];
+
+      const result = parseOccupations(attrs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ id: "ref-1", type: "referee" });
+    });
+
+    it("should return empty array for undefined input", () => {
+      const result = parseOccupations(undefined);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array for empty array input", () => {
+      const result = parseOccupations([]);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should include all roles when refereeOnly is false", () => {
+      const attrs = [
+        {
+          __identity: "ref-1",
+          roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+        },
+        {
+          __identity: "player-1",
+          roleIdentifier: "Indoorvolleyball.RefAdmin:Player",
+        },
+      ];
+
+      const result = parseOccupations(attrs, false);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ id: "ref-1", type: "referee" });
+      expect(result[1]).toEqual({ id: "player-1", type: "player" });
+    });
+  });
+});

--- a/web-app/src/utils/parseOccupations.ts
+++ b/web-app/src/utils/parseOccupations.ts
@@ -1,3 +1,15 @@
+/**
+ * Occupation parsing utilities for API responses.
+ *
+ * NOTE: This utility is prepared for when real profile loading from the API
+ * is implemented. Currently, occupations are only set in demo mode. When
+ * PersonDetails.eligibleAttributeValues is fetched from the API, use
+ * parseOccupations() to filter to referee-only roles.
+ *
+ * @example
+ * // Future usage when profile loading is implemented:
+ * const occupations = parseOccupations(personDetails.eligibleAttributeValues);
+ */
 import type { Occupation } from "@/stores/auth";
 import type { components } from "@/api/schema";
 
@@ -47,11 +59,6 @@ export function parseOccupation(
   }
 
   if (!type) {
-    return null;
-  }
-
-  // For referee roles, we only support the referee type
-  if (refereeOnly && type !== "referee") {
     return null;
   }
 

--- a/web-app/src/utils/parseOccupations.ts
+++ b/web-app/src/utils/parseOccupations.ts
@@ -42,13 +42,11 @@ export function parseOccupation(
     return null;
   }
 
-  // Determine the occupation type from roleIdentifier
   let type: Occupation["type"] | null = null;
 
   if (ROLE_PATTERNS.referee.test(roleIdentifier)) {
     type = "referee";
   } else if (!refereeOnly) {
-    // Only check non-referee types if refereeOnly is false
     if (ROLE_PATTERNS.player.test(roleIdentifier)) {
       type = "player";
     } else if (ROLE_PATTERNS.clubAdmin.test(roleIdentifier)) {
@@ -65,7 +63,6 @@ export function parseOccupation(
   return {
     id: attr.__identity,
     type,
-    // associationCode could be extracted from attributeIdentifier if needed
   };
 }
 

--- a/web-app/src/utils/parseOccupations.ts
+++ b/web-app/src/utils/parseOccupations.ts
@@ -1,0 +1,86 @@
+import type { Occupation } from "@/stores/auth";
+import type { components } from "@/api/schema";
+
+type AttributeValue = components["schemas"]["AttributeValue"];
+
+/**
+ * Role identifier patterns from the VolleyManager API.
+ * Only referee roles are supported by this app.
+ */
+const ROLE_PATTERNS = {
+  referee: /:Referee$/,
+  player: /:Player$/,
+  clubAdmin: /:ClubAdmin$/,
+  associationAdmin: /:AssociationAdmin$/,
+} as const;
+
+/**
+ * Parses an AttributeValue from the API into an Occupation.
+ * Returns null if the role is not recognized or not a referee role.
+ *
+ * @param attr - The AttributeValue from eligibleAttributeValues
+ * @param refereeOnly - If true, only return referee occupations (default: true)
+ */
+export function parseOccupation(
+  attr: AttributeValue,
+  refereeOnly = true,
+): Occupation | null {
+  const roleIdentifier = attr.roleIdentifier;
+  if (!roleIdentifier || !attr.__identity) {
+    return null;
+  }
+
+  // Determine the occupation type from roleIdentifier
+  let type: Occupation["type"] | null = null;
+
+  if (ROLE_PATTERNS.referee.test(roleIdentifier)) {
+    type = "referee";
+  } else if (!refereeOnly) {
+    // Only check non-referee types if refereeOnly is false
+    if (ROLE_PATTERNS.player.test(roleIdentifier)) {
+      type = "player";
+    } else if (ROLE_PATTERNS.clubAdmin.test(roleIdentifier)) {
+      type = "clubAdmin";
+    } else if (ROLE_PATTERNS.associationAdmin.test(roleIdentifier)) {
+      type = "associationAdmin";
+    }
+  }
+
+  if (!type) {
+    return null;
+  }
+
+  // For referee roles, we only support the referee type
+  if (refereeOnly && type !== "referee") {
+    return null;
+  }
+
+  return {
+    id: attr.__identity,
+    type,
+    // associationCode could be extracted from attributeIdentifier if needed
+  };
+}
+
+/**
+ * Parses eligibleAttributeValues from the API PersonDetails response
+ * and returns only referee occupations.
+ *
+ * This app is designed for referee management, so non-referee roles
+ * (player, clubAdmin, associationAdmin) are filtered out.
+ *
+ * @param attributeValues - Array of AttributeValue from the API
+ * @param refereeOnly - If true, only return referee occupations (default: true)
+ */
+export function parseOccupations(
+  attributeValues: AttributeValue[] | undefined,
+  refereeOnly = true,
+): Occupation[] {
+  if (!attributeValues || attributeValues.length === 0) {
+    return [];
+  }
+
+  return attributeValues
+    .map((attr) => parseOccupation(attr, refereeOnly))
+    .filter((occ): occ is Occupation => occ !== null);
+}


### PR DESCRIPTION
- Add parseOccupations utility to filter API eligibleAttributeValues to
  referee roles only (this app is designed for referee management)
- Update demo mode to have multiple referee occupations from different
  associations (AVL-VD, AVL-GE) for realistic testing
- Hide occupation dropdown when user has only one occupation to reduce
  UI clutter
- Add comprehensive tests for occupation filtering and dropdown visibility