### PR TITLE
chore(ci): enforce strict CLAUDE.md compliance for GitHub Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,10 +34,26 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+            EVENT TYPE: ${{ github.event.action }}
 
             CRITICAL: You MUST read the CLAUDE.md file FIRST and strictly enforce all guidelines during this review.
 
-            Review this PR against the CLAUDE.md requirements. Flag violations of:
+            ## CONSISTENCY REQUIREMENTS
+
+            BEFORE reviewing, check for previous review comments on this PR:
+            1. Run `gh pr view ${{ github.event.pull_request.number }} --comments` to see all previous comments
+            2. Identify any previous Claude Code Review comments (they follow the format below)
+            3. Track which issues were previously raised
+
+            When re-reviewing (EVENT TYPE is "synchronize"):
+            - DO NOT repeat issues that are still present - only reference them briefly
+            - DO acknowledge issues that have been FIXED with "✅ Fixed: [issue]"
+            - DO flag any NEW issues introduced in the latest commits
+            - Focus your detailed comments on changes since the last review
+
+            ## REVIEW CHECKLIST (CLAUDE.md requirements)
+
+            Flag violations of:
             - Naming conventions (PascalCase components, camelCase hooks/variables, SCREAMING_SNAKE_CASE constants)
             - Magic numbers (must use named constants)
             - Array index as React key (must use unique identifiers)
@@ -52,6 +68,26 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage for business logic
+
+            ## OUTPUT FORMAT (use this exact structure for consistency)
+
+            ```
+            ## Claude Code Review
+
+            **Review type:** [Initial review | Re-review after changes]
+
+            ### Summary
+            [1-2 sentence overview]
+
+            ### Issues Found
+            [List issues with file:line references, or "No issues found"]
+
+            ### Fixed Since Last Review (re-reviews only)
+            [List resolved issues, or omit section for initial reviews]
+
+            ### Recommendations
+            [Optional suggestions for improvement]
+            ```
 
             Be constructive but firm - violations of CLAUDE.md guidelines should be explicitly called out.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,17 +35,25 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            IMPORTANT: First, read the CLAUDE.md file to understand project conventions.
-            Pay special attention to the "Common Anti-patterns to Avoid" and "Accessibility" sections.
+            CRITICAL: You MUST read the CLAUDE.md file FIRST and strictly enforce all guidelines during this review.
 
-            Then review this pull request and provide feedback on:
-            - Code quality and best practices
+            Review this PR against the CLAUDE.md requirements. Flag violations of:
+            - Naming conventions (PascalCase components, camelCase hooks/variables, SCREAMING_SNAKE_CASE constants)
+            - Magic numbers (must use named constants)
+            - Array index as React key (must use unique identifiers)
+            - Memory leaks (intervals/timeouts/subscriptions not cleaned up)
+            - Outdated patterns (isMountedRef instead of AbortController)
+            - Missing accessibility (ARIA attributes, keyboard navigation)
+            - Functions over 20-30 lines or with more than 3-4 parameters
+            - Unnecessary comments (code should be self-documenting)
+
+            Also review for:
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
-            - Test coverage
+            - Test coverage for business logic
 
-            Be constructive and helpful in your feedback.
+            Be constructive but firm - violations of CLAUDE.md guidelines should be explicitly called out.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,30 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            CRITICAL REQUIREMENT: Before doing ANY work, you MUST read and strictly follow the CLAUDE.md file in the repository root.
+
+            The CLAUDE.md file contains mandatory project guidelines including:
+            - Code philosophy and naming conventions
+            - React best practices (React 19 patterns, no outdated isMountedRef, etc.)
+            - Common anti-patterns to avoid (magic numbers, index keys, memory leaks, race conditions)
+            - Testing requirements
+            - API integration patterns
+            - Accessibility requirements
+            - CI validation commands that MUST pass
+            - Definition of Done criteria
+
+            VERIFICATION CHECKLIST - Before completing any task:
+            1. ✅ Read CLAUDE.md first
+            2. ✅ Follow all naming conventions (PascalCase components, camelCase hooks, etc.)
+            3. ✅ No magic numbers - use named constants
+            4. ✅ No array index as React keys
+            5. ✅ Clean up all intervals/timeouts/subscriptions
+            6. ✅ Use modern React 18+ patterns (no isMountedRef)
+            7. ✅ Run full CI validation: npm run generate:api && npm run lint && npm test && npm run build
+            8. ✅ Ensure accessibility (ARIA attributes, keyboard navigation)
+
+            If your changes don't meet these guidelines, fix them before completing the task.
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Add custom prompts to both Claude workflows requiring strict adherence
to CLAUDE.md guidelines:
- claude.yml: Added verification checklist for @claude mentions
- claude-code-review.yml: Strengthened review criteria to flag violations