### PR TITLE
feat(demo): add region-specific mock data for different associations

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -84,12 +84,14 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const [verifyError, setVerifyError] = useState<string | null>(null);
 
   // Regenerate demo data on page load if demo mode is enabled but data is empty
-  // Uses the stored association code or defaults to SV (Swiss Volley national)
+  // This only runs once when data needs initialization, not on association changes
+  // (association changes are handled by AppShell when user switches occupation)
   useEffect(() => {
     if (isDemoMode && assignments.length === 0) {
       initializeDemoData(activeAssociationCode ?? "SV");
     }
-  }, [isDemoMode, assignments.length, activeAssociationCode, initializeDemoData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run when data is empty, not on association changes
+  }, [isDemoMode, assignments.length, initializeDemoData]);
 
   // Verify persisted session is still valid on mount
   useEffect(() => {

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -77,17 +77,19 @@ const queryClient = new QueryClient({
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { status, checkSession, isDemoMode } = useAuthStore();
-  const { assignments, initializeDemoData } = useDemoStore();
+  const { assignments, activeAssociationCode, initializeDemoData } =
+    useDemoStore();
   const shouldVerifySession = status === "authenticated" && !isDemoMode;
   const [isVerifying, setIsVerifying] = useState(() => shouldVerifySession);
   const [verifyError, setVerifyError] = useState<string | null>(null);
 
   // Regenerate demo data on page load if demo mode is enabled but data is empty
+  // Uses the stored association code or defaults to SV (Swiss Volley national)
   useEffect(() => {
     if (isDemoMode && assignments.length === 0) {
-      initializeDemoData();
+      initializeDemoData(activeAssociationCode ?? "SV");
     }
-  }, [isDemoMode, assignments.length, initializeDemoData]);
+  }, [isDemoMode, assignments.length, activeAssociationCode, initializeDemoData]);
 
   // Verify persisted session is still valid on mount
   useEffect(() => {

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Outlet, NavLink, useLocation } from "react-router-dom";
 import { useAuthStore, type Occupation } from "@/stores/auth";
+import { useDemoStore, type DemoAssociationCode } from "@/stores/demo";
 import { useTranslation } from "@/hooks/useTranslation";
 import { getOccupationLabelKey } from "@/utils/occupation-labels";
 
@@ -17,6 +18,13 @@ const navItems = [
   { path: "/settings", labelKey: "nav.settings" as const, icon: "⚙️" },
 ];
 
+// Valid association codes that can be used for demo mode data generation
+const DEMO_ASSOCIATION_CODES = new Set<DemoAssociationCode>(["SV", "SVRBA", "SVRZ"]);
+
+function isDemoAssociationCode(code: string | undefined): code is DemoAssociationCode {
+  return code !== undefined && DEMO_ASSOCIATION_CODES.has(code as DemoAssociationCode);
+}
+
 export function AppShell() {
   const location = useLocation();
   const { t } = useTranslation();
@@ -28,6 +36,7 @@ export function AppShell() {
     setActiveOccupation,
     isDemoMode,
   } = useAuthStore();
+  const { setActiveAssociation } = useDemoStore();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const getOccupationLabel = useCallback(
@@ -68,6 +77,17 @@ export function AppShell() {
   const handleOccupationSelect = (id: string) => {
     setActiveOccupation(id);
     setIsDropdownOpen(false);
+
+    // In demo mode, regenerate data based on the selected occupation's association
+    if (isDemoMode) {
+      const selectedOccupation = user?.occupations?.find((o) => o.id === id);
+      if (
+        selectedOccupation &&
+        isDemoAssociationCode(selectedOccupation.associationCode)
+      ) {
+        setActiveAssociation(selectedOccupation.associationCode);
+      }
+    }
   };
 
   return (

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -28,7 +28,9 @@ export function LoginPage() {
   const isLoading = status === "loading";
 
   const handleDemoLogin = useCallback(() => {
-    initializeDemoData();
+    // Initialize with SV (Swiss Volley national) association as default
+    // User can switch to other associations via the occupation dropdown
+    initializeDemoData("SV");
     setDemoAuthenticated();
     navigate("/");
   }, [initializeDemoData, setDemoAuthenticated, navigate]);
@@ -37,7 +39,7 @@ export function LoginPage() {
   // This runs once on mount - the functions are stable store actions
   useEffect(() => {
     if (DEMO_MODE_ONLY) {
-      initializeDemoData();
+      initializeDemoData("SV");
       setDemoAuthenticated();
       navigate("/");
     }

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -438,11 +438,15 @@ export const useAuthStore = create<AuthState>()(
       },
 
       setDemoAuthenticated: () => {
-        // Only include referee occupations - this app is designed for referee management
-        // Multiple occupations for referees who work across different associations
+        // Demo occupations with different regions:
+        // - SV (Swiss Volley): National level, handles NLA/NLB games, can edit compensation
+        // - SVRBA (Regional Basel): Regional level, handles up to 1L games, no compensation editing
+        // - SVRZ (Regional Zurich): Regional level, handles up to 1L games, no compensation editing
         const demoOccupations: Occupation[] = [
-          { id: "demo-referee-vd", type: "referee", associationCode: "AVL-VD" },
-          { id: "demo-referee-ge", type: "referee", associationCode: "AVL-GE" },
+          { id: "demo-referee-sv", type: "referee", associationCode: "SV" },
+          { id: "demo-referee-svrba", type: "referee", associationCode: "SVRBA" },
+          { id: "demo-referee-svrz", type: "referee", associationCode: "SVRZ" },
+          { id: "demo-player", type: "player", clubName: "VBC Demo" },
         ];
         set({
           status: "authenticated",

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -6,6 +6,7 @@ import type {
   NominationList,
   PossibleNomination,
   PersonSearchResult,
+  RefereeGame,
 } from "@/api/client";
 import { addDays, addHours, subDays } from "date-fns";
 
@@ -436,7 +437,7 @@ function createRefereeGame({
   isGameInFuture,
   associationCode,
   idPrefix,
-}: RefereeGameParams) {
+}: RefereeGameParams): RefereeGame {
   const venues = getVenuesForAssociation(associationCode);
   const leagues = getLeaguesForAssociation(associationCode);
   const venue = venues[venueIndex % venues.length]!;

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -1019,511 +1019,173 @@ function generateDummyData(associationCode: DemoAssociationCode = "SV") {
   };
 }
 
-function generateMockNominationLists(): MockNominationLists {
-  // Generate mock nomination lists for the first 3 demo games
-  // These correspond to demo-g-1, demo-g-2, demo-g-3 from the assignments
+// Player nomination configuration for nomination lists
+interface PlayerNominationConfig {
+  index: number;
+  shirtNumber: number;
+  firstName: string;
+  lastName: string;
+  licenseCategory: "SEN" | "JUN";
+  isCaptain?: boolean;
+  isLibero?: boolean;
+}
 
-  const nominationLists: MockNominationLists = {
-    "demo-g-1": {
-      home: {
-        __identity: "demo-nomlist-home-1",
-        game: { __identity: "demo-g-1" },
-        team: { __identity: "team-1", displayName: "VBC Zürich Lions" },
-        closed: false,
-        isClosedForTeam: false,
-        indoorPlayerNominations: [
-          {
-            __identity: "demo-nom-1-1",
-            shirtNumber: 1,
-            isCaptain: true,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-1-1",
-              person: {
-                __identity: "demo-person-1-1",
-                firstName: "Marco",
-                lastName: "Meier",
-                displayName: "Marco Meier",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-1-2",
-            shirtNumber: 7,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-1-2",
-              person: {
-                __identity: "demo-person-1-2",
-                firstName: "Lukas",
-                lastName: "Schneider",
-                displayName: "Lukas Schneider",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-1-3",
-            shirtNumber: 12,
-            isCaptain: false,
-            isLibero: true,
-            indoorPlayer: {
-              __identity: "demo-player-1-3",
-              person: {
-                __identity: "demo-person-1-3",
-                firstName: "Noah",
-                lastName: "Weber",
-                displayName: "Noah Weber",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-jun",
-              shortName: "JUN",
-            },
-          },
-          {
-            __identity: "demo-nom-1-4",
-            shirtNumber: 5,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-1-4",
-              person: {
-                __identity: "demo-person-1-4",
-                firstName: "Felix",
-                lastName: "Keller",
-                displayName: "Felix Keller",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-1-5",
-            shirtNumber: 9,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-1-5",
-              person: {
-                __identity: "demo-person-1-5",
-                firstName: "Tim",
-                lastName: "Fischer",
-                displayName: "Tim Fischer",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-1-6",
-            shirtNumber: 14,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-1-6",
-              person: {
-                __identity: "demo-person-1-6",
-                firstName: "Jan",
-                lastName: "Brunner",
-                displayName: "Jan Brunner",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-        ],
-      },
-      away: {
-        __identity: "demo-nomlist-away-1",
-        game: { __identity: "demo-g-1" },
-        team: { __identity: "team-2", displayName: "Volley Luzern" },
-        closed: false,
-        isClosedForTeam: false,
-        indoorPlayerNominations: [
-          {
-            __identity: "demo-nom-2-1",
-            shirtNumber: 3,
-            isCaptain: true,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-2-1",
-              person: {
-                __identity: "demo-person-2-1",
-                firstName: "David",
-                lastName: "Steiner",
-                displayName: "David Steiner",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-2-2",
-            shirtNumber: 8,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-2-2",
-              person: {
-                __identity: "demo-person-2-2",
-                firstName: "Simon",
-                lastName: "Frei",
-                displayName: "Simon Frei",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-2-3",
-            shirtNumber: 11,
-            isCaptain: false,
-            isLibero: true,
-            indoorPlayer: {
-              __identity: "demo-player-2-3",
-              person: {
-                __identity: "demo-person-2-3",
-                firstName: "Luca",
-                lastName: "Gerber",
-                displayName: "Luca Gerber",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-jun",
-              shortName: "JUN",
-            },
-          },
-          {
-            __identity: "demo-nom-2-4",
-            shirtNumber: 6,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-2-4",
-              person: {
-                __identity: "demo-person-2-4",
-                firstName: "Yannick",
-                lastName: "Hofer",
-                displayName: "Yannick Hofer",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-2-5",
-            shirtNumber: 10,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-2-5",
-              person: {
-                __identity: "demo-person-2-5",
-                firstName: "Nico",
-                lastName: "Baumann",
-                displayName: "Nico Baumann",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-        ],
+function createPlayerNomination(
+  config: PlayerNominationConfig,
+  gameIndex: number,
+  teamIndex: number,
+) {
+  const identity = `demo-nom-${gameIndex}-${teamIndex}-${config.index}`;
+  const displayName = `${config.firstName} ${config.lastName}`;
+  return {
+    __identity: identity,
+    shirtNumber: config.shirtNumber,
+    isCaptain: config.isCaptain ?? false,
+    isLibero: config.isLibero ?? false,
+    indoorPlayer: {
+      __identity: `demo-player-${gameIndex}-${teamIndex}-${config.index}`,
+      person: {
+        __identity: `demo-person-${gameIndex}-${teamIndex}-${config.index}`,
+        firstName: config.firstName,
+        lastName: config.lastName,
+        displayName,
       },
     },
-    "demo-g-2": {
-      home: {
-        __identity: "demo-nomlist-home-2",
-        game: { __identity: "demo-g-2" },
-        team: { __identity: "team-3", displayName: "Schönenwerd Smash" },
-        closed: false,
-        isClosedForTeam: false,
-        indoorPlayerNominations: [
-          {
-            __identity: "demo-nom-3-1",
-            shirtNumber: 2,
-            isCaptain: true,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-3-1",
-              person: {
-                __identity: "demo-person-3-1",
-                firstName: "Raphael",
-                lastName: "Widmer",
-                displayName: "Raphael Widmer",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-3-2",
-            shirtNumber: 15,
-            isCaptain: false,
-            isLibero: true,
-            indoorPlayer: {
-              __identity: "demo-player-3-2",
-              person: {
-                __identity: "demo-person-3-2",
-                firstName: "Kevin",
-                lastName: "Bieri",
-                displayName: "Kevin Bieri",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-3-3",
-            shirtNumber: 4,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-3-3",
-              person: {
-                __identity: "demo-person-3-3",
-                firstName: "Patrick",
-                lastName: "Moser",
-                displayName: "Patrick Moser",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-        ],
-      },
-      away: {
-        __identity: "demo-nomlist-away-2",
-        game: { __identity: "demo-g-2" },
-        team: { __identity: "team-4", displayName: "Traktor Basel" },
-        closed: false,
-        isClosedForTeam: false,
-        indoorPlayerNominations: [
-          {
-            __identity: "demo-nom-4-1",
-            shirtNumber: 1,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-4-1",
-              person: {
-                __identity: "demo-person-4-1",
-                firstName: "Benjamin",
-                lastName: "Koch",
-                displayName: "Benjamin Koch",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-4-2",
-            shirtNumber: 13,
-            isCaptain: true,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-4-2",
-              person: {
-                __identity: "demo-person-4-2",
-                firstName: "Michael",
-                lastName: "Lang",
-                displayName: "Michael Lang",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-4-3",
-            shirtNumber: 17,
-            isCaptain: false,
-            isLibero: true,
-            indoorPlayer: {
-              __identity: "demo-player-4-3",
-              person: {
-                __identity: "demo-person-4-3",
-                firstName: "Julian",
-                lastName: "Roth",
-                displayName: "Julian Roth",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-jun",
-              shortName: "JUN",
-            },
-          },
-        ],
-      },
-    },
-    "demo-g-3": {
-      home: {
-        __identity: "demo-nomlist-home-3",
-        game: { __identity: "demo-g-3" },
-        team: { __identity: "team-5", displayName: "Volley Näfels" },
-        closed: false,
-        isClosedForTeam: false,
-        indoorPlayerNominations: [
-          {
-            __identity: "demo-nom-5-1",
-            shirtNumber: 6,
-            isCaptain: true,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-5-1",
-              person: {
-                __identity: "demo-person-5-1",
-                firstName: "Anna",
-                lastName: "Huber",
-                displayName: "Anna Huber",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-5-2",
-            shirtNumber: 10,
-            isCaptain: false,
-            isLibero: true,
-            indoorPlayer: {
-              __identity: "demo-player-5-2",
-              person: {
-                __identity: "demo-person-5-2",
-                firstName: "Lisa",
-                lastName: "Meyer",
-                displayName: "Lisa Meyer",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-5-3",
-            shirtNumber: 8,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-5-3",
-              person: {
-                __identity: "demo-person-5-3",
-                firstName: "Sara",
-                lastName: "Schmid",
-                displayName: "Sara Schmid",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-jun",
-              shortName: "JUN",
-            },
-          },
-        ],
-      },
-      away: {
-        __identity: "demo-nomlist-away-3",
-        game: { __identity: "demo-g-3" },
-        team: { __identity: "team-6", displayName: "Volero Zürich" },
-        closed: false,
-        isClosedForTeam: false,
-        indoorPlayerNominations: [
-          {
-            __identity: "demo-nom-6-1",
-            shirtNumber: 4,
-            isCaptain: true,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-6-1",
-              person: {
-                __identity: "demo-person-6-1",
-                firstName: "Elena",
-                lastName: "Keller",
-                displayName: "Elena Keller",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-6-2",
-            shirtNumber: 7,
-            isCaptain: false,
-            isLibero: false,
-            indoorPlayer: {
-              __identity: "demo-player-6-2",
-              person: {
-                __identity: "demo-person-6-2",
-                firstName: "Julia",
-                lastName: "Lehmann",
-                displayName: "Julia Lehmann",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-          {
-            __identity: "demo-nom-6-3",
-            shirtNumber: 12,
-            isCaptain: false,
-            isLibero: true,
-            indoorPlayer: {
-              __identity: "demo-player-6-3",
-              person: {
-                __identity: "demo-person-6-3",
-                firstName: "Nina",
-                lastName: "Zimmermann",
-                displayName: "Nina Zimmermann",
-              },
-            },
-            indoorPlayerLicenseCategory: {
-              __identity: "lic-sen",
-              shortName: "SEN",
-            },
-          },
-        ],
-      },
+    indoorPlayerLicenseCategory: {
+      __identity: `lic-${config.licenseCategory.toLowerCase()}`,
+      shortName: config.licenseCategory,
     },
   };
+}
 
-  return nominationLists;
+// Nomination list configuration for a team in a game
+interface NominationListConfig {
+  gameId: string;
+  teamId: string;
+  teamDisplayName: string;
+  side: "home" | "away";
+  players: PlayerNominationConfig[];
+}
+
+function createNominationList(
+  config: NominationListConfig,
+  gameIndex: number,
+  teamIndex: number,
+): NominationList {
+  return {
+    __identity: `demo-nomlist-${config.side}-${gameIndex}`,
+    game: { __identity: config.gameId },
+    team: { __identity: config.teamId, displayName: config.teamDisplayName },
+    closed: false,
+    isClosedForTeam: false,
+    indoorPlayerNominations: config.players.map((player) =>
+      createPlayerNomination(player, gameIndex, teamIndex),
+    ),
+  };
+}
+
+// Game nomination configuration pairs (home and away teams)
+interface GameNominationConfig {
+  gameIndex: number;
+  gameId: string;
+  home: Omit<NominationListConfig, "gameId" | "side">;
+  away: Omit<NominationListConfig, "gameId" | "side">;
+}
+
+// Configuration data for mock nomination lists (3 games with home/away teams)
+const NOMINATION_LIST_CONFIGS: GameNominationConfig[] = [
+  {
+    gameIndex: 1,
+    gameId: "demo-g-1",
+    home: {
+      teamId: "team-1",
+      teamDisplayName: "VBC Zürich Lions",
+      players: [
+        { index: 1, shirtNumber: 1, firstName: "Marco", lastName: "Meier", licenseCategory: "SEN", isCaptain: true },
+        { index: 2, shirtNumber: 7, firstName: "Lukas", lastName: "Schneider", licenseCategory: "SEN" },
+        { index: 3, shirtNumber: 12, firstName: "Noah", lastName: "Weber", licenseCategory: "JUN", isLibero: true },
+        { index: 4, shirtNumber: 5, firstName: "Felix", lastName: "Keller", licenseCategory: "SEN" },
+        { index: 5, shirtNumber: 9, firstName: "Tim", lastName: "Fischer", licenseCategory: "SEN" },
+        { index: 6, shirtNumber: 14, firstName: "Jan", lastName: "Brunner", licenseCategory: "SEN" },
+      ],
+    },
+    away: {
+      teamId: "team-2",
+      teamDisplayName: "Volley Luzern",
+      players: [
+        { index: 1, shirtNumber: 3, firstName: "David", lastName: "Steiner", licenseCategory: "SEN", isCaptain: true },
+        { index: 2, shirtNumber: 8, firstName: "Simon", lastName: "Frei", licenseCategory: "SEN" },
+        { index: 3, shirtNumber: 11, firstName: "Luca", lastName: "Gerber", licenseCategory: "JUN", isLibero: true },
+        { index: 4, shirtNumber: 6, firstName: "Yannick", lastName: "Hofer", licenseCategory: "SEN" },
+        { index: 5, shirtNumber: 10, firstName: "Nico", lastName: "Baumann", licenseCategory: "SEN" },
+      ],
+    },
+  },
+  {
+    gameIndex: 2,
+    gameId: "demo-g-2",
+    home: {
+      teamId: "team-3",
+      teamDisplayName: "Schönenwerd Smash",
+      players: [
+        { index: 1, shirtNumber: 2, firstName: "Raphael", lastName: "Widmer", licenseCategory: "SEN", isCaptain: true },
+        { index: 2, shirtNumber: 15, firstName: "Kevin", lastName: "Bieri", licenseCategory: "SEN", isLibero: true },
+        { index: 3, shirtNumber: 4, firstName: "Patrick", lastName: "Moser", licenseCategory: "SEN" },
+      ],
+    },
+    away: {
+      teamId: "team-4",
+      teamDisplayName: "Traktor Basel",
+      players: [
+        { index: 1, shirtNumber: 1, firstName: "Benjamin", lastName: "Koch", licenseCategory: "SEN" },
+        { index: 2, shirtNumber: 13, firstName: "Michael", lastName: "Lang", licenseCategory: "SEN", isCaptain: true },
+        { index: 3, shirtNumber: 17, firstName: "Julian", lastName: "Roth", licenseCategory: "JUN", isLibero: true },
+      ],
+    },
+  },
+  {
+    gameIndex: 3,
+    gameId: "demo-g-3",
+    home: {
+      teamId: "team-5",
+      teamDisplayName: "Volley Näfels",
+      players: [
+        { index: 1, shirtNumber: 6, firstName: "Anna", lastName: "Huber", licenseCategory: "SEN", isCaptain: true },
+        { index: 2, shirtNumber: 10, firstName: "Lisa", lastName: "Meyer", licenseCategory: "SEN", isLibero: true },
+        { index: 3, shirtNumber: 8, firstName: "Sara", lastName: "Schmid", licenseCategory: "JUN" },
+      ],
+    },
+    away: {
+      teamId: "team-6",
+      teamDisplayName: "Volero Zürich",
+      players: [
+        { index: 1, shirtNumber: 4, firstName: "Elena", lastName: "Keller", licenseCategory: "SEN", isCaptain: true },
+        { index: 2, shirtNumber: 7, firstName: "Julia", lastName: "Lehmann", licenseCategory: "SEN" },
+        { index: 3, shirtNumber: 12, firstName: "Nina", lastName: "Zimmermann", licenseCategory: "SEN", isLibero: true },
+      ],
+    },
+  },
+];
+
+function generateMockNominationLists(): MockNominationLists {
+  const result: MockNominationLists = {};
+
+  for (const config of NOMINATION_LIST_CONFIGS) {
+    result[config.gameId] = {
+      home: createNominationList(
+        { ...config.home, gameId: config.gameId, side: "home" },
+        config.gameIndex,
+        1,
+      ),
+      away: createNominationList(
+        { ...config.away, gameId: config.gameId, side: "away" },
+        config.gameIndex,
+        2,
+      ),
+    };
+  }
+
+  return result;
 }
 
 // Demo user referee level configuration

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -98,6 +98,13 @@ const SAMPLE_DISTANCES = {
 // Starting team identifier for auto-incrementing IDs
 const BASE_TEAM_IDENTIFIER = 59591;
 
+// Demo game numbers for assignments, compensations, and exchanges
+const DEMO_GAME_NUMBERS = {
+  ASSIGNMENTS: [382417, 382418, 382419, 382420, 382421] as const,
+  COMPENSATIONS: [382500, 382501, 382502, 382503, 382504] as const,
+  EXCHANGES: [382600, 382601, 382602, 382603, 382604] as const,
+} as const;
+
 function calculateTravelExpenses(distanceInMetres: number): number {
   const distanceInKm = distanceInMetres / 1000;
   return Math.round(distanceInKm * TRAVEL_EXPENSE_RATE_PER_KM * 100) / 100;
@@ -481,118 +488,120 @@ function createRefereeGame({
   };
 }
 
+interface AssignmentConfig {
+  index: number;
+  status: "active" | "cancelled" | "archived";
+  position: RefereePosition;
+  confirmationStatus: "confirmed" | "pending";
+  confirmationDaysAgo: number | null;
+  gameDate: Date;
+  venueIndex: number;
+  leagueIndex: number;
+  gender: "m" | "f";
+  isGameInFuture: boolean;
+  isOpenInExchange?: boolean;
+  hasMessage?: boolean;
+  linkedDouble?: string;
+}
+
+function createAssignment(
+  config: AssignmentConfig,
+  associationCode: DemoAssociationCode,
+  now: Date,
+): Assignment {
+  return {
+    __identity: `demo-assignment-${config.index}`,
+    refereeConvocationStatus: config.status,
+    refereePosition: config.position,
+    confirmationStatus: config.confirmationStatus,
+    confirmationDate:
+      config.confirmationDaysAgo !== null
+        ? subDays(now, config.confirmationDaysAgo).toISOString()
+        : null,
+    isOpenEntryInRefereeGameExchange: config.isOpenInExchange ?? false,
+    hasLastMessageToReferee: config.hasMessage ?? false,
+    hasLinkedDoubleConvocation: !!config.linkedDouble,
+    ...(config.linkedDouble && {
+      linkedDoubleConvocationGameNumberAndRefereePosition: config.linkedDouble,
+    }),
+    refereeGame: createRefereeGame({
+      gameId: String(config.index),
+      gameNumber: DEMO_GAME_NUMBERS.ASSIGNMENTS[config.index - 1]!,
+      gameDate: config.gameDate,
+      venueIndex: config.venueIndex,
+      leagueIndex: config.leagueIndex,
+      gender: config.gender,
+      isGameInFuture: config.isGameInFuture,
+      associationCode,
+      idPrefix: "demo",
+    }),
+  };
+}
+
 function generateAssignments(
   associationCode: DemoAssociationCode,
   now: Date,
 ): Assignment[] {
-  return [
-    {
-      __identity: "demo-assignment-1",
-      refereeConvocationStatus: "active",
-      refereePosition: "head-one",
-      confirmationStatus: "confirmed",
-      confirmationDate: subDays(now, 5).toISOString(),
-      isOpenEntryInRefereeGameExchange: false,
-      hasLastMessageToReferee: false,
-      hasLinkedDoubleConvocation: false,
-      refereeGame: createRefereeGame({
-        gameId: "1",
-        gameNumber: 382417,
-        gameDate: addDays(now, 2),
-        venueIndex: 0,
-        leagueIndex: 0,
-        gender: "m",
-        isGameInFuture: true,
-        associationCode,
-        idPrefix: "demo",
-      }),
-    },
-    {
-      __identity: "demo-assignment-2",
-      refereeConvocationStatus: "active",
-      refereePosition: "linesman-one",
-      confirmationStatus: "confirmed",
-      confirmationDate: subDays(now, 3).toISOString(),
-      isOpenEntryInRefereeGameExchange: false,
-      hasLastMessageToReferee: true,
-      hasLinkedDoubleConvocation: false,
-      refereeGame: createRefereeGame({
-        gameId: "2",
-        gameNumber: 382418,
-        gameDate: addHours(addDays(now, 0), 3),
-        venueIndex: 1,
-        leagueIndex: 1,
-        gender: "m",
-        isGameInFuture: true,
-        associationCode,
-        idPrefix: "demo",
-      }),
-    },
-    {
-      __identity: "demo-assignment-3",
-      refereeConvocationStatus: "active",
-      refereePosition: "head-two",
-      confirmationStatus: "pending",
-      confirmationDate: null,
-      isOpenEntryInRefereeGameExchange: false,
-      hasLastMessageToReferee: false,
-      hasLinkedDoubleConvocation: true,
-      linkedDoubleConvocationGameNumberAndRefereePosition: "382420 / ARB 1",
-      refereeGame: createRefereeGame({
-        gameId: "3",
-        gameNumber: 382419,
-        gameDate: addDays(now, 5),
-        venueIndex: 2,
-        leagueIndex: 0,
-        gender: "f",
-        isGameInFuture: true,
-        associationCode,
-        idPrefix: "demo",
-      }),
-    },
-    {
-      __identity: "demo-assignment-4",
-      refereeConvocationStatus: "cancelled",
-      refereePosition: "head-one",
-      confirmationStatus: "confirmed",
-      confirmationDate: subDays(now, 10).toISOString(),
-      isOpenEntryInRefereeGameExchange: true,
-      hasLastMessageToReferee: false,
-      hasLinkedDoubleConvocation: false,
-      refereeGame: createRefereeGame({
-        gameId: "4",
-        gameNumber: 382420,
-        gameDate: addDays(now, 7),
-        venueIndex: 3,
-        leagueIndex: 1,
-        gender: "f",
-        isGameInFuture: true,
-        associationCode,
-        idPrefix: "demo",
-      }),
-    },
-    {
-      __identity: "demo-assignment-5",
-      refereeConvocationStatus: "archived",
-      refereePosition: "linesman-two",
-      confirmationStatus: "confirmed",
-      confirmationDate: subDays(now, 14).toISOString(),
-      isOpenEntryInRefereeGameExchange: false,
-      hasLastMessageToReferee: false,
-      hasLinkedDoubleConvocation: false,
-      refereeGame: createRefereeGame({
-        gameId: "5",
-        gameNumber: 382421,
-        gameDate: subDays(now, 3),
-        venueIndex: 4,
-        leagueIndex: associationCode === "SV" ? 1 : 2,
-        gender: "m",
-        isGameInFuture: false,
-        associationCode,
-        idPrefix: "demo",
-      }),
-    },
+  const configs: AssignmentConfig[] = [
+    { index: 1, status: "active", position: "head-one", confirmationStatus: "confirmed", confirmationDaysAgo: 5, gameDate: addDays(now, 2), venueIndex: 0, leagueIndex: 0, gender: "m", isGameInFuture: true },
+    { index: 2, status: "active", position: "linesman-one", confirmationStatus: "confirmed", confirmationDaysAgo: 3, gameDate: addHours(now, 3), venueIndex: 1, leagueIndex: 1, gender: "m", isGameInFuture: true, hasMessage: true },
+    { index: 3, status: "active", position: "head-two", confirmationStatus: "pending", confirmationDaysAgo: null, gameDate: addDays(now, 5), venueIndex: 2, leagueIndex: 0, gender: "f", isGameInFuture: true, linkedDouble: "382420 / ARB 1" },
+    { index: 4, status: "cancelled", position: "head-one", confirmationStatus: "confirmed", confirmationDaysAgo: 10, gameDate: addDays(now, 7), venueIndex: 3, leagueIndex: 1, gender: "f", isGameInFuture: true, isOpenInExchange: true },
+    { index: 5, status: "archived", position: "linesman-two", confirmationStatus: "confirmed", confirmationDaysAgo: 14, gameDate: subDays(now, 3), venueIndex: 4, leagueIndex: associationCode === "SV" ? 1 : 2, gender: "m", isGameInFuture: false },
   ];
+
+  return configs.map((config) => createAssignment(config, associationCode, now));
+}
+
+interface CompensationConfig {
+  index: number;
+  position: RefereePosition;
+  daysAgo: number;
+  venueIndex: number;
+  leagueIndex: number;
+  gender: "m" | "f";
+  distance: keyof typeof SAMPLE_DISTANCES;
+  paymentDone: boolean;
+  paymentDaysAgo?: number;
+  transportationMode?: "car" | "train";
+}
+
+function createCompensationRecord(
+  config: CompensationConfig,
+  associationCode: DemoAssociationCode,
+  now: Date,
+  isSV: boolean,
+): CompensationRecord {
+  return {
+    __identity: `demo-comp-${config.index}`,
+    refereeConvocationStatus: "active",
+    refereePosition: config.position,
+    compensationDate: subDays(now, config.daysAgo).toISOString(),
+    refereeGame: createRefereeGame({
+      gameId: String(config.index),
+      gameNumber: DEMO_GAME_NUMBERS.COMPENSATIONS[config.index - 1]!,
+      gameDate: subDays(now, config.daysAgo),
+      venueIndex: config.venueIndex,
+      leagueIndex: config.leagueIndex,
+      gender: config.gender,
+      isGameInFuture: false,
+      associationCode,
+      idPrefix: "comp",
+    }),
+    convocationCompensation: {
+      __identity: `demo-cc-${config.index}`,
+      ...createCompensationData({
+        position: config.position,
+        distanceInMetres: SAMPLE_DISTANCES[config.distance],
+        isSV,
+        paymentDone: config.paymentDone,
+        ...(config.paymentDaysAgo !== undefined && {
+          paymentValueDate: toDateString(subDays(now, config.paymentDaysAgo)),
+        }),
+        transportationMode: config.transportationMode,
+      }),
+    },
+  };
 }
 
 function generateCompensations(
@@ -601,142 +610,15 @@ function generateCompensations(
 ): CompensationRecord[] {
   const isSV = associationCode === "SV";
 
-  return [
-    {
-      __identity: "demo-comp-1",
-      refereeConvocationStatus: "active",
-      refereePosition: "head-one",
-      compensationDate: subDays(now, 7).toISOString(),
-      refereeGame: createRefereeGame({
-        gameId: "1",
-        gameNumber: 382500,
-        gameDate: subDays(now, 7),
-        venueIndex: 0,
-        leagueIndex: 0,
-        gender: "m",
-        isGameInFuture: false,
-        associationCode,
-        idPrefix: "comp",
-      }),
-      convocationCompensation: {
-        __identity: "demo-cc-1",
-        ...createCompensationData({
-          position: "head-one",
-          distanceInMetres: SAMPLE_DISTANCES.MEDIUM_LONG,
-          isSV,
-          paymentDone: true,
-          paymentValueDate: toDateString(subDays(now, 2)),
-        }),
-      },
-    },
-    {
-      __identity: "demo-comp-2",
-      refereeConvocationStatus: "active",
-      refereePosition: "linesman-one",
-      compensationDate: subDays(now, 14).toISOString(),
-      refereeGame: createRefereeGame({
-        gameId: "2",
-        gameNumber: 382501,
-        gameDate: subDays(now, 14),
-        venueIndex: 1,
-        leagueIndex: 1,
-        gender: "m",
-        isGameInFuture: false,
-        associationCode,
-        idPrefix: "comp",
-      }),
-      convocationCompensation: {
-        __identity: "demo-cc-2",
-        ...createCompensationData({
-          position: "linesman-one",
-          distanceInMetres: SAMPLE_DISTANCES.MEDIUM,
-          isSV,
-          paymentDone: false,
-        }),
-      },
-    },
-    {
-      __identity: "demo-comp-3",
-      refereeConvocationStatus: "active",
-      refereePosition: "head-two",
-      compensationDate: subDays(now, 21).toISOString(),
-      refereeGame: createRefereeGame({
-        gameId: "3",
-        gameNumber: 382502,
-        gameDate: subDays(now, 21),
-        venueIndex: 2,
-        leagueIndex: 0,
-        gender: "f",
-        isGameInFuture: false,
-        associationCode,
-        idPrefix: "comp",
-      }),
-      convocationCompensation: {
-        __identity: "demo-cc-3",
-        ...createCompensationData({
-          position: "head-two",
-          distanceInMetres: SAMPLE_DISTANCES.LONG,
-          isSV,
-          paymentDone: true,
-          paymentValueDate: toDateString(subDays(now, 14)),
-        }),
-      },
-    },
-    {
-      __identity: "demo-comp-4",
-      refereeConvocationStatus: "active",
-      refereePosition: "head-one",
-      compensationDate: subDays(now, 5).toISOString(),
-      refereeGame: createRefereeGame({
-        gameId: "4",
-        gameNumber: 382503,
-        gameDate: subDays(now, 5),
-        venueIndex: 3,
-        leagueIndex: 1,
-        gender: "f",
-        isGameInFuture: false,
-        associationCode,
-        idPrefix: "comp",
-      }),
-      convocationCompensation: {
-        __identity: "demo-cc-4",
-        ...createCompensationData({
-          position: "head-one",
-          distanceInMetres: SAMPLE_DISTANCES.VERY_LONG,
-          isSV,
-          paymentDone: false,
-        }),
-      },
-    },
-    {
-      __identity: "demo-comp-5",
-      refereeConvocationStatus: "active",
-      refereePosition: "linesman-two",
-      compensationDate: subDays(now, 28).toISOString(),
-      refereeGame: createRefereeGame({
-        gameId: "5",
-        gameNumber: 382504,
-        gameDate: subDays(now, 28),
-        venueIndex: 4,
-        leagueIndex: associationCode === "SV" ? 1 : 2,
-        gender: "m",
-        isGameInFuture: false,
-        associationCode,
-        idPrefix: "comp",
-      }),
-      convocationCompensation: {
-        __identity: "demo-cc-5",
-        ...createCompensationData({
-          position: "linesman-two",
-          distanceInMetres: SAMPLE_DISTANCES.SHORT,
-          isSV,
-          paymentDone: true,
-          paymentValueDate: toDateString(subDays(now, 21)),
-          transportationMode: "train",
-        }),
-      },
-    },
+  const configs: CompensationConfig[] = [
+    { index: 1, position: "head-one", daysAgo: 7, venueIndex: 0, leagueIndex: 0, gender: "m", distance: "MEDIUM_LONG", paymentDone: true, paymentDaysAgo: 2 },
+    { index: 2, position: "linesman-one", daysAgo: 14, venueIndex: 1, leagueIndex: 1, gender: "m", distance: "MEDIUM", paymentDone: false },
+    { index: 3, position: "head-two", daysAgo: 21, venueIndex: 2, leagueIndex: 0, gender: "f", distance: "LONG", paymentDone: true, paymentDaysAgo: 14 },
+    { index: 4, position: "head-one", daysAgo: 5, venueIndex: 3, leagueIndex: 1, gender: "f", distance: "VERY_LONG", paymentDone: false },
+    { index: 5, position: "linesman-two", daysAgo: 28, venueIndex: 4, leagueIndex: associationCode === "SV" ? 1 : 2, gender: "m", distance: "SHORT", paymentDone: true, paymentDaysAgo: 21, transportationMode: "train" },
   ];
+
+  return configs.map((config) => createCompensationRecord(config, associationCode, now, isSV));
 }
 
 function generateExchanges(


### PR DESCRIPTION
- Add multiple referee occupations with association codes (SV, SVRBA, SVRZ)
- SV (Swiss Volley national) gets NLA/NLB games with flexible compensation editing
- Regional associations (SVRBA Basel, SVRZ Zurich) get 1L/2L/3L games without compensation editing
- Regenerate mock data when user switches occupation in demo mode
- Add managingAssociationShortName to all game groups for proper filtering
- Update data initialization to accept association code parameter