### PR TITLE
fix(demo): remove player occupation from demo mode

### DIFF
--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -438,7 +438,7 @@ export const useAuthStore = create<AuthState>()(
       },
 
       setDemoAuthenticated: () => {
-        // Demo occupations with different regions:
+        // Demo occupations with different regions (referee-only for this referee-focused app):
         // - SV (Swiss Volley): National level, handles NLA/NLB games, can edit compensation
         // - SVRBA (Regional Basel): Regional level, handles up to 1L games, no compensation editing
         // - SVRZ (Regional Zurich): Regional level, handles up to 1L games, no compensation editing
@@ -446,7 +446,6 @@ export const useAuthStore = create<AuthState>()(
           { id: "demo-referee-sv", type: "referee", associationCode: "SV" },
           { id: "demo-referee-svrba", type: "referee", associationCode: "SVRBA" },
           { id: "demo-referee-svrz", type: "referee", associationCode: "SVRZ" },
-          { id: "demo-player", type: "player", clubName: "VBC Demo" },
         ];
         set({
           status: "authenticated",

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { setCsrfToken, clearSession } from "@/api/client";
+import { filterRefereeOccupations } from "@/utils/parseOccupations";
 
 export type AuthStatus = "idle" | "loading" | "authenticated" | "error";
 
@@ -438,15 +439,23 @@ export const useAuthStore = create<AuthState>()(
       },
 
       setDemoAuthenticated: () => {
-        // Demo occupations with different regions (referee-only for this referee-focused app):
+        // Raw demo occupations simulating what the API would return.
+        // This includes non-referee roles (player) that should be filtered out.
         // - SV (Swiss Volley): National level, handles NLA/NLB games, can edit compensation
         // - SVRBA (Regional Basel): Regional level, handles up to 1L games, no compensation editing
         // - SVRZ (Regional Zurich): Regional level, handles up to 1L games, no compensation editing
-        const demoOccupations: Occupation[] = [
+        // - Player: Non-referee role that gets filtered out by filterRefereeOccupations()
+        const rawDemoOccupations: Occupation[] = [
           { id: "demo-referee-sv", type: "referee", associationCode: "SV" },
           { id: "demo-referee-svrba", type: "referee", associationCode: "SVRBA" },
           { id: "demo-referee-svrz", type: "referee", associationCode: "SVRZ" },
+          { id: "demo-player", type: "player", clubName: "VBC Demo" },
         ];
+
+        // Filter to referee-only (this app is referee-focused).
+        // This same filtering will be applied when real API profile loading is implemented.
+        const demoOccupations = filterRefereeOccupations(rawDemoOccupations);
+
         set({
           status: "authenticated",
           isDemoMode: true,

--- a/web-app/src/utils/parseOccupations.test.ts
+++ b/web-app/src/utils/parseOccupations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseOccupation, parseOccupations } from "./parseOccupations";
+import { parseOccupation, parseOccupations, filterRefereeOccupations } from "./parseOccupations";
 
 describe("parseOccupations", () => {
   describe("parseOccupation", () => {
@@ -167,6 +167,63 @@ describe("parseOccupations", () => {
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual({ id: "ref-1", type: "referee" });
       expect(result[1]).toEqual({ id: "player-1", type: "player" });
+    });
+  });
+
+  describe("filterRefereeOccupations", () => {
+    it("should keep only referee occupations", () => {
+      const occupations = [
+        { id: "ref-1", type: "referee" as const, associationCode: "SV" },
+        { id: "player-1", type: "player" as const, clubName: "VBC Demo" },
+        { id: "ref-2", type: "referee" as const, associationCode: "SVRBA" },
+      ];
+
+      const result = filterRefereeOccupations(occupations);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ id: "ref-1", type: "referee", associationCode: "SV" });
+      expect(result[1]).toEqual({ id: "ref-2", type: "referee", associationCode: "SVRBA" });
+    });
+
+    it("should filter out all non-referee roles", () => {
+      const occupations = [
+        { id: "ref-1", type: "referee" as const, associationCode: "SV" },
+        { id: "player-1", type: "player" as const, clubName: "VBC Demo" },
+        { id: "club-1", type: "clubAdmin" as const, clubName: "VBC Admin" },
+        { id: "assoc-1", type: "associationAdmin" as const, associationCode: "SV" },
+      ];
+
+      const result = filterRefereeOccupations(occupations);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ id: "ref-1", type: "referee", associationCode: "SV" });
+    });
+
+    it("should return empty array when no referee occupations", () => {
+      const occupations = [
+        { id: "player-1", type: "player" as const, clubName: "VBC Demo" },
+      ];
+
+      const result = filterRefereeOccupations(occupations);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array for empty input", () => {
+      const result = filterRefereeOccupations([]);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should preserve all occupation properties", () => {
+      const occupations = [
+        { id: "ref-1", type: "referee" as const, associationCode: "SV", clubName: undefined },
+      ];
+
+      const result = filterRefereeOccupations(occupations);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ id: "ref-1", type: "referee", associationCode: "SV", clubName: undefined });
     });
   });
 });

--- a/web-app/src/utils/parseOccupations.ts
+++ b/web-app/src/utils/parseOccupations.ts
@@ -88,3 +88,26 @@ export function parseOccupations(
     .map((attr) => parseOccupation(attr, refereeOnly))
     .filter((occ): occ is Occupation => occ !== null);
 }
+
+/**
+ * Filters an array of Occupation objects to only include referee roles.
+ *
+ * This is used to filter occupations that are already in the Occupation format
+ * (e.g., from demo mode or cached data), as opposed to parseOccupations() which
+ * parses raw API AttributeValue objects.
+ *
+ * @param occupations - Array of Occupation objects to filter
+ * @returns Only occupations with type "referee"
+ *
+ * @example
+ * // Filter demo occupations to referee-only
+ * const allOccupations = [
+ *   { id: "1", type: "referee", associationCode: "SV" },
+ *   { id: "2", type: "player", clubName: "VBC Demo" },
+ * ];
+ * const refereeOnly = filterRefereeOccupations(allOccupations);
+ * // Returns: [{ id: "1", type: "referee", associationCode: "SV" }]
+ */
+export function filterRefereeOccupations(occupations: Occupation[]): Occupation[] {
+  return occupations.filter((occ) => occ.type === "referee");
+}


### PR DESCRIPTION
The referee-focused app should only show referee occupations. Remove
the player occupation from demo mode to align with the app's purpose.

After this fix, demo mode shows only 3 referee occupations:
- Referee (SV) - National level
- Referee (SVRBA) - Regional Basel
- Referee (SVRZ) - Regional Zurich