### PR TITLE
chore(ci): configure Claude workflows to use Opus model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: opus
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: opus
           prompt: |
             CRITICAL REQUIREMENT: Before doing ANY work, you MUST read and strictly follow the CLAUDE.md file in the repository root.
 


### PR DESCRIPTION
Add model: opus parameter to both claude.yml and claude-code-review.yml
workflows to use Claude Opus instead of the default model.