### PR TITLE
feat(ui): implement toast notification system

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -13,6 +13,7 @@ import { AppShell } from "@/components/layout/AppShell";
 import { LoadingState } from "@/components/ui/LoadingSpinner";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
 import { ReloadPrompt } from "@/components/ui/ReloadPrompt";
+import { ToastContainer } from "@/components/ui/Toast";
 import { PWAProvider } from "@/contexts/PWAContext";
 import { LoginPage } from "@/pages/LoginPage";
 import { AssignmentsPage } from "@/pages/AssignmentsPage";
@@ -250,6 +251,7 @@ export default function App() {
             </QueryErrorHandler>
           </BrowserRouter>
           <ReloadPrompt />
+          <ToastContainer />
         </QueryClientProvider>
       </PWAProvider>
     </ErrorBoundary>

--- a/web-app/src/components/ui/Toast.tsx
+++ b/web-app/src/components/ui/Toast.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef } from "react";
-import { useToastStore, type Toast as ToastType } from "@/stores/toast";
+import {
+  useToastStore,
+  DEFAULT_DURATION_MS,
+  type Toast as ToastType,
+} from "@/stores/toast";
 
-const DEFAULT_DURATION_MS = 5000;
+const TOAST_CONTAINER_Z_INDEX = "z-[100]";
 
 const TOAST_STYLES: Record<
   ToastType["type"],
@@ -50,7 +54,7 @@ function ToastItem({ toast }: ToastItemProps) {
 
   useEffect(() => {
     const duration = toast.duration ?? DEFAULT_DURATION_MS;
-    timerRef.current = window.setTimeout(() => {
+    timerRef.current = setTimeout(() => {
       removeToast(toast.id);
     }, duration);
 
@@ -112,7 +116,7 @@ export function ToastContainer() {
 
   return (
     <div
-      className="fixed top-4 right-4 z-[100] flex flex-col gap-2 max-w-sm w-full pointer-events-none"
+      className={`fixed top-4 right-4 ${TOAST_CONTAINER_Z_INDEX} flex flex-col gap-2 max-w-sm w-full pointer-events-none`}
       aria-label="Notifications"
     >
       {toasts.map((toast) => (

--- a/web-app/src/components/ui/Toast.tsx
+++ b/web-app/src/components/ui/Toast.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef } from "react";
+import { useToastStore, type Toast as ToastType } from "@/stores/toast";
+
+const DEFAULT_DURATION_MS = 5000;
+
+const TOAST_STYLES: Record<
+  ToastType["type"],
+  { bg: string; border: string; text: string; icon: string }
+> = {
+  success: {
+    bg: "bg-green-50 dark:bg-green-900/30",
+    border: "border-green-200 dark:border-green-800",
+    text: "text-green-800 dark:text-green-200",
+    icon: "text-green-500 dark:text-green-400",
+  },
+  error: {
+    bg: "bg-red-50 dark:bg-red-900/30",
+    border: "border-red-200 dark:border-red-800",
+    text: "text-red-800 dark:text-red-200",
+    icon: "text-red-500 dark:text-red-400",
+  },
+  warning: {
+    bg: "bg-amber-50 dark:bg-amber-900/30",
+    border: "border-amber-200 dark:border-amber-800",
+    text: "text-amber-800 dark:text-amber-200",
+    icon: "text-amber-500 dark:text-amber-400",
+  },
+  info: {
+    bg: "bg-blue-50 dark:bg-blue-900/30",
+    border: "border-blue-200 dark:border-blue-800",
+    text: "text-blue-800 dark:text-blue-200",
+    icon: "text-blue-500 dark:text-blue-400",
+  },
+};
+
+const TOAST_ICONS: Record<ToastType["type"], string> = {
+  success: "M5 13l4 4L19 7",
+  error: "M6 18L18 6M6 6l12 12",
+  warning: "M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z",
+  info: "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+};
+
+interface ToastItemProps {
+  toast: ToastType;
+}
+
+function ToastItem({ toast }: ToastItemProps) {
+  const removeToast = useToastStore((state) => state.removeToast);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const duration = toast.duration ?? DEFAULT_DURATION_MS;
+    timerRef.current = window.setTimeout(() => {
+      removeToast(toast.id);
+    }, duration);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [toast.id, toast.duration, removeToast]);
+
+  const styles = TOAST_STYLES[toast.type];
+  const iconPath = TOAST_ICONS[toast.type];
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className={`flex items-start gap-3 p-4 rounded-lg border shadow-lg ${styles.bg} ${styles.border} animate-in slide-in-from-top-2 fade-in duration-200`}
+    >
+      <svg
+        className={`w-5 h-5 flex-shrink-0 mt-0.5 ${styles.icon}`}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+        aria-hidden="true"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d={iconPath} />
+      </svg>
+      <p className={`flex-1 text-sm font-medium ${styles.text}`}>
+        {toast.message}
+      </p>
+      <button
+        onClick={() => removeToast(toast.id)}
+        className={`flex-shrink-0 p-1 -m-1 rounded hover:bg-black/5 dark:hover:bg-white/10 transition-colors ${styles.text}`}
+        aria-label="Dismiss notification"
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export function ToastContainer() {
+  const toasts = useToastStore((state) => state.toasts);
+
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed top-4 right-4 z-[100] flex flex-col gap-2 max-w-sm w-full pointer-events-none"
+      aria-label="Notifications"
+    >
+      {toasts.map((toast) => (
+        <div key={toast.id} className="pointer-events-auto">
+          <ToastItem toast={toast} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web-app/src/hooks/useAssignmentActions.ts
+++ b/web-app/src/hooks/useAssignmentActions.ts
@@ -10,6 +10,7 @@ import {
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { useSettingsStore } from "@/stores/settings";
+import { toast } from "@/stores/toast";
 import { useTranslation } from "@/hooks/useTranslation";
 
 interface UseAssignmentActionsResult {
@@ -84,7 +85,7 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
         logger.debug(
           "[useAssignmentActions] Safe mode: game validation blocked",
         );
-        alert(t("settings.safeModeBlocked"));
+        toast.warning(t("settings.safeModeBlocked"));
         return;
       }
 
@@ -111,14 +112,13 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
         logger.debug(
           "[useAssignmentActions] Game report not available for this league",
         );
-        alert(t("assignments.gameReportNotAvailable"));
+        toast.info(t("assignments.gameReportNotAvailable"));
         return;
       }
 
       if (isDemoMode) {
         logger.debug("[useAssignmentActions] Demo mode: PDF download disabled");
-        // TODO(#77): Replace alert with toast notification when notification system is implemented
-        alert("PDF downloads are not available in demo mode");
+        toast.info(t("compensations.pdfNotAvailableDemo"));
         return;
       }
 
@@ -157,7 +157,7 @@ This is a mock PDF report.`;
         logger.debug(
           "[useAssignmentActions] Safe mode: adding to exchange blocked",
         );
-        alert(t("settings.safeModeBlocked"));
+        toast.warning(t("settings.safeModeBlocked"));
         return;
       }
 
@@ -167,10 +167,7 @@ This is a mock PDF report.`;
           "[useAssignmentActions] Demo mode: added assignment to exchange:",
           assignment.__identity,
         );
-        // TODO(#77): Replace alert with toast notification when notification system is implemented
-        alert(
-          `Assignment "${homeTeam} vs ${awayTeam}" added to exchange list. Check the Exchange tab!`,
-        );
+        toast.success(t("exchange.addedToExchangeSuccess"));
         return;
       }
 
@@ -179,10 +176,7 @@ This is a mock PDF report.`;
         game: `${homeTeam} vs ${awayTeam}`,
       });
 
-      // TODO(#77): Replace alert with toast notification when notification system is implemented
-      alert(
-        `Assignment "${homeTeam} vs ${awayTeam}" added to exchange list (mocked)`,
-      );
+      toast.success(t("exchange.addedToExchangeSuccess"));
     },
     [isDemoMode, isSafeModeEnabled, addAssignmentToExchange, t],
   );

--- a/web-app/src/hooks/useCompensationActions.ts
+++ b/web-app/src/hooks/useCompensationActions.ts
@@ -5,6 +5,7 @@ import { logger } from "@/utils/logger";
 import { MODAL_CLEANUP_DELAY } from "@/utils/assignment-helpers";
 import { useAuthStore } from "@/stores/auth";
 import { useSettingsStore } from "@/stores/settings";
+import { toast } from "@/stores/toast";
 import { useTranslation } from "@/hooks/useTranslation";
 
 interface UseCompensationActionsResult {
@@ -44,7 +45,7 @@ export function useCompensationActions(): UseCompensationActionsResult {
         logger.debug(
           "[useCompensationActions] Safe mode: editing compensation blocked",
         );
-        alert(t("settings.safeModeBlocked"));
+        toast.warning(t("settings.safeModeBlocked"));
         return;
       }
 
@@ -71,8 +72,7 @@ export function useCompensationActions(): UseCompensationActionsResult {
         logger.debug(
           "[useCompensationActions] Demo mode: PDF download disabled",
         );
-        // TODO(#77): Replace alert with toast notification when notification system is implemented
-        alert(t("compensations.pdfNotAvailableDemo"));
+        toast.info(t("compensations.pdfNotAvailableDemo"));
         return;
       }
 
@@ -96,8 +96,7 @@ export function useCompensationActions(): UseCompensationActionsResult {
         );
       } catch (error) {
         logger.error("[useCompensationActions] Failed to generate PDF:", error);
-        // TODO(#77): Replace alert with toast notification when notification system is implemented
-        alert(t("compensations.pdfDownloadFailed"));
+        toast.error(t("compensations.pdfDownloadFailed"));
       } finally {
         isDownloadingRef.current = false;
       }

--- a/web-app/src/hooks/useExchangeActions.test.ts
+++ b/web-app/src/hooks/useExchangeActions.test.ts
@@ -7,10 +7,25 @@ import type { UseMutationResult } from "@tanstack/react-query";
 import * as useConvocations from "./useConvocations";
 import * as authStore from "@/stores/auth";
 import * as settingsStore from "@/stores/settings";
+import { toast } from "@/stores/toast";
 
 vi.mock("./useConvocations");
 vi.mock("@/stores/auth");
 vi.mock("@/stores/settings");
+vi.mock("@/stores/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    language: "en",
+  }),
+}));
 
 function createMockExchange(): GameExchange {
   return {
@@ -42,7 +57,6 @@ describe("useExchangeActions", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
-    vi.spyOn(window, "alert").mockImplementation(() => {});
 
     // Default: not in demo mode, safe mode disabled
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
@@ -200,9 +214,7 @@ describe("useExchangeActions", () => {
     });
 
     expect(mockApplyMutate).toHaveBeenCalledWith(mockExchange.__identity);
-    expect(window.alert).toHaveBeenCalledWith(
-      "Successfully applied for exchange",
-    );
+    expect(toast.success).toHaveBeenCalledWith("exchange.applySuccess");
   });
 
   it("should handle take over action failure", async () => {
@@ -216,9 +228,7 @@ describe("useExchangeActions", () => {
     });
 
     expect(mockApplyMutate).toHaveBeenCalledWith(mockExchange.__identity);
-    expect(window.alert).toHaveBeenCalledWith(
-      "Failed to apply for exchange. Please try again.",
-    );
+    expect(toast.error).toHaveBeenCalledWith("exchange.applyError");
   });
 
   it("should handle remove from exchange action successfully", async () => {
@@ -232,9 +242,7 @@ describe("useExchangeActions", () => {
     });
 
     expect(mockWithdrawMutate).toHaveBeenCalledWith(mockExchange.__identity);
-    expect(window.alert).toHaveBeenCalledWith(
-      "Successfully removed from exchange",
-    );
+    expect(toast.success).toHaveBeenCalledWith("exchange.withdrawSuccess");
   });
 
   it("should handle remove from exchange action failure", async () => {
@@ -248,9 +256,7 @@ describe("useExchangeActions", () => {
     });
 
     expect(mockWithdrawMutate).toHaveBeenCalledWith(mockExchange.__identity);
-    expect(window.alert).toHaveBeenCalledWith(
-      "Failed to remove from exchange. Please try again.",
-    );
+    expect(toast.error).toHaveBeenCalledWith("exchange.withdrawError");
   });
 
   it("should prevent duplicate take over actions", async () => {
@@ -425,9 +431,7 @@ describe("useExchangeActions", () => {
       });
 
       expect(mockApplyMutate).not.toHaveBeenCalled();
-      expect(window.alert).toHaveBeenCalledWith(
-        "This operation is blocked in safe mode. Disable safe mode in Settings to proceed.",
-      );
+      expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
     });
 
     it("should block remove from exchange when safe mode is enabled", async () => {
@@ -438,9 +442,7 @@ describe("useExchangeActions", () => {
       });
 
       expect(mockWithdrawMutate).not.toHaveBeenCalled();
-      expect(window.alert).toHaveBeenCalledWith(
-        "This operation is blocked in safe mode. Disable safe mode in Settings to proceed.",
-      );
+      expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
     });
 
     it("should not block operations in demo mode even with safe mode enabled", async () => {

--- a/web-app/src/hooks/useExchangeActions.ts
+++ b/web-app/src/hooks/useExchangeActions.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from "@/utils/logger";
 import { MODAL_CLEANUP_DELAY } from "@/utils/assignment-helpers";
 import { useAuthStore } from "@/stores/auth";
+import { toast } from "@/stores/toast";
 import { useSettingsStore } from "@/stores/settings";
 import { useTranslation } from "@/hooks/useTranslation";
 
@@ -104,7 +105,7 @@ export function useExchangeActions(): UseExchangeActionsResult {
         logger.debug(
           "[useExchangeActions] Safe mode: taking exchange blocked",
         );
-        alert(t("settings.safeModeBlocked"));
+        toast.warning(t("settings.safeModeBlocked"));
         return;
       }
 
@@ -120,9 +121,8 @@ export function useExchangeActions(): UseExchangeActionsResult {
           exchange.__identity,
         );
 
-        // TODO(#110): Replace alert with toast notification when notification system is implemented
         if (!isDemoMode) {
-          alert("Successfully applied for exchange");
+          toast.success(t("exchange.applySuccess"));
         }
       } catch (error) {
         logger.error(
@@ -130,8 +130,7 @@ export function useExchangeActions(): UseExchangeActionsResult {
           error,
         );
 
-        // TODO(#110): Replace alert with toast notification when notification system is implemented
-        alert("Failed to apply for exchange. Please try again.");
+        toast.error(t("exchange.applyError"));
       } finally {
         isTakingOverRef.current = false;
       }
@@ -146,7 +145,7 @@ export function useExchangeActions(): UseExchangeActionsResult {
         logger.debug(
           "[useExchangeActions] Safe mode: withdrawing from exchange blocked",
         );
-        alert(t("settings.safeModeBlocked"));
+        toast.warning(t("settings.safeModeBlocked"));
         return;
       }
 
@@ -162,9 +161,8 @@ export function useExchangeActions(): UseExchangeActionsResult {
           exchange.__identity,
         );
 
-        // TODO(#110): Replace alert with toast notification when notification system is implemented
         if (!isDemoMode) {
-          alert("Successfully removed from exchange");
+          toast.success(t("exchange.withdrawSuccess"));
         }
       } catch (error) {
         logger.error(
@@ -172,8 +170,7 @@ export function useExchangeActions(): UseExchangeActionsResult {
           error,
         );
 
-        // TODO(#110): Replace alert with toast notification when notification system is implemented
-        alert("Failed to remove from exchange. Please try again.");
+        toast.error(t("exchange.withdrawError"));
       } finally {
         isRemovingRef.current = false;
       }

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -119,6 +119,13 @@ const de: Translations = {
     noApplicationsTitle: "Keine Bewerbungen",
     noApplicationsDescription:
       "Sie haben sich noch für keine Tauschangebote beworben.",
+    applySuccess: "Erfolgreich für Tausch beworben",
+    applyError: "Bewerbung für Tausch fehlgeschlagen. Bitte erneut versuchen.",
+    withdrawSuccess: "Erfolgreich vom Tausch zurückgezogen",
+    withdrawError:
+      "Rückzug vom Tausch fehlgeschlagen. Bitte erneut versuchen.",
+    addedToExchangeSuccess: "Einsatz zur Tauschbörse hinzugefügt",
+    addedToExchangeError: "Einsatz konnte nicht zur Tauschbörse hinzugefügt werden",
   },
   positions: {
     "head-one": "1. Schiedsrichter",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -118,6 +118,12 @@ const en: Translations = {
       "There are currently no referee positions available for exchange.",
     noApplicationsTitle: "No applications",
     noApplicationsDescription: "You haven't applied for any exchanges yet.",
+    applySuccess: "Successfully applied for exchange",
+    applyError: "Failed to apply for exchange. Please try again.",
+    withdrawSuccess: "Successfully removed from exchange",
+    withdrawError: "Failed to remove from exchange. Please try again.",
+    addedToExchangeSuccess: "Assignment added to exchange list",
+    addedToExchangeError: "Failed to add assignment to exchange",
   },
   positions: {
     "head-one": "1st Referee",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -119,6 +119,12 @@ const fr: Translations = {
     noApplicationsTitle: "Aucune candidature",
     noApplicationsDescription:
       "Vous n'avez pas encore postulé pour des échanges.",
+    applySuccess: "Candidature à l'échange réussie",
+    applyError: "Échec de la candidature. Veuillez réessayer.",
+    withdrawSuccess: "Retrait de l'échange réussi",
+    withdrawError: "Échec du retrait de l'échange. Veuillez réessayer.",
+    addedToExchangeSuccess: "Désignation ajoutée à la bourse aux échanges",
+    addedToExchangeError: "Impossible d'ajouter la désignation à la bourse",
   },
   positions: {
     "head-one": "1er Arbitre",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -117,6 +117,12 @@ const it: Translations = {
     noApplicationsTitle: "Nessuna candidatura",
     noApplicationsDescription:
       "Non hai ancora fatto domanda per nessuno scambio.",
+    applySuccess: "Candidatura allo scambio riuscita",
+    applyError: "Candidatura fallita. Riprova.",
+    withdrawSuccess: "Ritiro dallo scambio riuscito",
+    withdrawError: "Ritiro dallo scambio fallito. Riprova.",
+    addedToExchangeSuccess: "Designazione aggiunta alla borsa scambi",
+    addedToExchangeError: "Impossibile aggiungere la designazione alla borsa",
   },
   positions: {
     "head-one": "1° Arbitro",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -114,6 +114,12 @@ export interface Translations {
     noOpenExchangesDescription: string;
     noApplicationsTitle: string;
     noApplicationsDescription: string;
+    applySuccess: string;
+    applyError: string;
+    withdrawSuccess: string;
+    withdrawError: string;
+    addedToExchangeSuccess: string;
+    addedToExchangeError: string;
   };
   positions: {
     "head-one": string;

--- a/web-app/src/stores/toast.ts
+++ b/web-app/src/stores/toast.ts
@@ -1,0 +1,63 @@
+import { create } from "zustand";
+
+export type ToastType = "success" | "error" | "info" | "warning";
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+  duration?: number;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (toast: Omit<Toast, "id">) => string;
+  removeToast: (id: string) => void;
+  clearToasts: () => void;
+}
+
+const DEFAULT_DURATION_MS = 5000;
+
+function generateId(): string {
+  return `toast-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export const useToastStore = create<ToastState>()((set) => ({
+  toasts: [],
+
+  addToast: (toast) => {
+    const id = generateId();
+    set((state) => ({
+      toasts: [...state.toasts, { ...toast, id }],
+    }));
+    return id;
+  },
+
+  removeToast: (id) => {
+    set((state) => ({
+      toasts: state.toasts.filter((t) => t.id !== id),
+    }));
+  },
+
+  clearToasts: () => {
+    set({ toasts: [] });
+  },
+}));
+
+/**
+ * Convenience functions for showing toasts.
+ * These can be used outside of React components.
+ */
+export const toast = {
+  success: (message: string, duration = DEFAULT_DURATION_MS): string =>
+    useToastStore.getState().addToast({ message, type: "success", duration }),
+
+  error: (message: string, duration = DEFAULT_DURATION_MS): string =>
+    useToastStore.getState().addToast({ message, type: "error", duration }),
+
+  info: (message: string, duration = DEFAULT_DURATION_MS): string =>
+    useToastStore.getState().addToast({ message, type: "info", duration }),
+
+  warning: (message: string, duration = DEFAULT_DURATION_MS): string =>
+    useToastStore.getState().addToast({ message, type: "warning", duration }),
+};

--- a/web-app/src/stores/toast.ts
+++ b/web-app/src/stores/toast.ts
@@ -16,20 +16,21 @@ interface ToastState {
   clearToasts: () => void;
 }
 
-const DEFAULT_DURATION_MS = 5000;
-
-function generateId(): string {
-  return `toast-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-}
+export const DEFAULT_DURATION_MS = 5000;
+const MAX_TOASTS = 5;
 
 export const useToastStore = create<ToastState>()((set) => ({
   toasts: [],
 
   addToast: (toast) => {
-    const id = generateId();
-    set((state) => ({
-      toasts: [...state.toasts, { ...toast, id }],
-    }));
+    const id = crypto.randomUUID();
+    set((state) => {
+      const newToasts = [...state.toasts, { ...toast, id }];
+      if (newToasts.length > MAX_TOASTS) {
+        return { toasts: newToasts.slice(-MAX_TOASTS) };
+      }
+      return { toasts: newToasts };
+    });
     return id;
   },
 


### PR DESCRIPTION
Replace browser alerts with a toast notification system for a better UX.

- Add toast store using Zustand for global toast state management
- Create Toast and ToastContainer components with styled notifications
- Support success, error, warning, and info toast types
- Add auto-dismiss with configurable duration
- Replace all alert() calls in useExchangeActions, useAssignmentActions,
  and useCompensationActions with appropriate toast notifications
- Add translations for toast messages in all supported languages (en, de, fr, it)
- Update tests to mock toast store instead of window.alert

This addresses TODO(#77) and TODO(#110) to replace alerts with toast notifications.