### PR TITLE
refactor(ui): unify icon system with Lucide Icons

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-query": "^5.90.12",
         "date-fns": "^4.1.0",
+        "lucide-react": "^0.562.0",
         "openapi-typescript-fetch": "^2.2.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
@@ -8409,6 +8410,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.562.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
+      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -55,6 +55,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query": "^5.90.12",
     "date-fns": "^4.1.0",
+    "lucide-react": "^0.562.0",
     "openapi-typescript-fetch": "^2.2.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -2,6 +2,7 @@ import { format, parseISO } from "date-fns";
 import { Card, CardContent } from "@/components/ui/Card";
 import { ExpandArrow } from "@/components/ui/ExpandArrow";
 import { Badge } from "@/components/ui/Badge";
+import { Check, Circle } from "@/components/ui/icons";
 import type { CompensationRecord } from "@/api/client";
 import { useExpandable } from "@/hooks/useExpandable";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -69,7 +70,11 @@ export function CompensationCard({
                 {total.toFixed(0)}
               </div>
               <Badge variant={isPaid ? "success" : "warning"}>
-                {isPaid ? "✓" : "○"}
+                {isPaid ? (
+                  <Check className="w-3 h-3" aria-hidden="true" />
+                ) : (
+                  <Circle className="w-3 h-3" aria-hidden="true" />
+                )}
               </Badge>
               {!disableExpansion && <ExpandArrow isExpanded={isExpanded} />}
             </div>

--- a/web-app/src/components/features/validation/PlayerListItem.tsx
+++ b/web-app/src/components/features/validation/PlayerListItem.tsx
@@ -1,43 +1,7 @@
 import { useTranslation } from "@/hooks/useTranslation";
 import { Badge } from "@/components/ui/Badge";
 import type { RosterPlayer } from "@/hooks/useNominationList";
-
-function TrashIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M3 6h18" />
-      <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-      <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-    </svg>
-  );
-}
-
-function UndoIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M3 7v6h6" />
-      <path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13" />
-    </svg>
-  );
-}
+import { Trash2, Undo2 } from "@/components/ui/icons";
 
 interface PlayerListItemProps {
   player: RosterPlayer;
@@ -123,7 +87,7 @@ export function PlayerListItem({
             aria-label={t("validation.roster.undoRemoval")}
             title={t("validation.roster.undoRemoval")}
           >
-            <UndoIcon className="w-4 h-4" />
+            <Undo2 className="w-4 h-4" aria-hidden="true" />
           </button>
         ) : (
           <button
@@ -133,7 +97,7 @@ export function PlayerListItem({
             aria-label={t("validation.roster.removePlayer")}
             title={t("validation.roster.removePlayer")}
           >
-            <TrashIcon className="w-4 h-4" />
+            <Trash2 className="w-4 h-4" aria-hidden="true" />
           </button>
         )}
       </div>

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -8,65 +8,7 @@ import {
 } from "@/hooks/useNominationList";
 import { PlayerListItem } from "./PlayerListItem";
 import { AddPlayerSheet } from "./AddPlayerSheet";
-
-function UserPlusIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-      <circle cx="9" cy="7" r="4" />
-      <line x1="19" y1="8" x2="19" y2="14" />
-      <line x1="22" y1="11" x2="16" y2="11" />
-    </svg>
-  );
-}
-
-function AlertCircleIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <circle cx="12" cy="12" r="10" />
-      <line x1="12" y1="8" x2="12" y2="12" />
-      <line x1="12" y1="16" x2="12.01" y2="16" />
-    </svg>
-  );
-}
-
-function RefreshIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M21 2v6h-6" />
-      <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
-      <path d="M3 22v-6h6" />
-      <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
-    </svg>
-  );
-}
+import { UserPlus, AlertCircle, RefreshCw } from "@/components/ui/icons";
 
 interface RosterVerificationPanelProps {
   team: "home" | "away";
@@ -174,7 +116,7 @@ export function RosterVerificationPanel({
   if (isError) {
     return (
       <div className="py-8 flex flex-col items-center justify-center">
-        <AlertCircleIcon className="w-10 h-10 text-danger-500 mb-3" />
+        <AlertCircle className="w-10 h-10 text-danger-500 mb-3" aria-hidden="true" />
         <p className="text-sm text-danger-600 dark:text-danger-400 mb-4">
           {t("validation.roster.errorLoading")}
         </p>
@@ -183,7 +125,7 @@ export function RosterVerificationPanel({
           onClick={() => refetch()}
           className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
         >
-          <RefreshIcon className="w-4 h-4" />
+          <RefreshCw className="w-4 h-4" aria-hidden="true" />
           {t("common.retry")}
         </button>
       </div>
@@ -233,7 +175,7 @@ export function RosterVerificationPanel({
           onClick={() => setIsAddPlayerSheetOpen(true)}
           className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 hover:bg-primary-100 dark:hover:bg-primary-900/50 rounded-lg border border-primary-200 dark:border-primary-800 transition-colors"
         >
-          <UserPlusIcon className="w-4 h-4" />
+          <UserPlus className="w-4 h-4" aria-hidden="true" />
           {t("validation.roster.addPlayer")}
         </button>
       </div>

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -2,11 +2,11 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useAuthStore } from "@/stores/auth";
 import {
-  UploadIcon,
-  CameraIcon,
-  CheckIcon,
-  FileIcon,
-  AlertIcon,
+  Upload,
+  Camera,
+  CheckCircle,
+  FileText,
+  AlertCircle,
 } from "@/components/ui/icons";
 
 interface ScoresheetPanelProps {
@@ -218,7 +218,7 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
 
       {!selectedFile ? (
         <div className="border-2 border-dashed border-border-strong dark:border-border-strong-dark rounded-lg p-6 text-center">
-          <UploadIcon className="w-12 h-12 mx-auto text-text-subtle dark:text-text-subtle-dark mb-4" />
+          <Upload className="w-12 h-12 mx-auto text-text-subtle dark:text-text-subtle-dark mb-4" aria-hidden="true" />
           <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-1">
             {tKey("title")}
           </h3>
@@ -234,7 +234,7 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
               role="alert"
               className="mb-4 p-3 bg-danger-50 dark:bg-danger-900/20 border border-danger-200 dark:border-danger-800 rounded-lg flex items-center gap-2"
             >
-              <AlertIcon className="w-5 h-5 text-danger-500 flex-shrink-0" />
+              <AlertCircle className="w-5 h-5 text-danger-500 flex-shrink-0" aria-hidden="true" />
               <span className="text-sm text-danger-700 dark:text-danger-400">
                 {errorMessage}
               </span>
@@ -247,7 +247,7 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
               onClick={() => fileInputRef.current?.click()}
               className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
             >
-              <UploadIcon className="w-4 h-4" />
+              <Upload className="w-4 h-4" aria-hidden="true" />
               {tKey("selectFile")}
             </button>
             <button
@@ -255,7 +255,7 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
               onClick={() => cameraInputRef.current?.click()}
               className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark rounded-lg transition-colors"
             >
-              <CameraIcon className="w-4 h-4" />
+              <Camera className="w-4 h-4" aria-hidden="true" />
               {tKey("takePhoto")}
             </button>
           </div>
@@ -272,7 +272,7 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
             </div>
           ) : (
             <div className="bg-surface-subtle dark:bg-surface-card-dark p-8 flex flex-col items-center justify-center">
-              <FileIcon className="w-16 h-16 text-text-subtle dark:text-text-subtle-dark mb-2" />
+              <FileText className="w-16 h-16 text-text-subtle dark:text-text-subtle-dark mb-2" aria-hidden="true" />
               <span className="text-sm text-text-muted dark:text-text-muted-dark">
                 PDF
               </span>
@@ -308,7 +308,7 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
                 role="status"
                 aria-live="polite"
               >
-                <CheckIcon className="w-5 h-5" />
+                <CheckCircle className="w-5 h-5" aria-hidden="true" />
                 <span className="text-sm font-medium">
                   {tKey("uploadComplete")}
                 </span>

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -4,18 +4,29 @@ import { useAuthStore, type Occupation } from "@/stores/auth";
 import { useDemoStore, type DemoAssociationCode } from "@/stores/demo";
 import { useTranslation } from "@/hooks/useTranslation";
 import { getOccupationLabelKey } from "@/utils/occupation-labels";
+import {
+  Volleyball,
+  ClipboardList,
+  Wallet,
+  ArrowLeftRight,
+  Settings,
+  ChevronDown,
+} from "@/components/ui/icons";
+import type { LucideIcon } from "lucide-react";
 
 const MINIMUM_OCCUPATIONS_FOR_SWITCHER = 2;
 
-const navItems = [
-  { path: "/", labelKey: "nav.assignments" as const, icon: "📋" },
-  {
-    path: "/compensations",
-    labelKey: "nav.compensations" as const,
-    icon: "💰",
-  },
-  { path: "/exchange", labelKey: "nav.exchange" as const, icon: "🔄" },
-  { path: "/settings", labelKey: "nav.settings" as const, icon: "⚙️" },
+interface NavItem {
+  path: string;
+  labelKey: "nav.assignments" | "nav.compensations" | "nav.exchange" | "nav.settings";
+  icon: LucideIcon;
+}
+
+const navItems: NavItem[] = [
+  { path: "/", labelKey: "nav.assignments", icon: ClipboardList },
+  { path: "/compensations", labelKey: "nav.compensations", icon: Wallet },
+  { path: "/exchange", labelKey: "nav.exchange", icon: ArrowLeftRight },
+  { path: "/settings", labelKey: "nav.settings", icon: Settings },
 ];
 
 // Valid association codes that can be used for demo mode data generation
@@ -97,7 +108,7 @@ export function AppShell() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-14">
             <div className="flex items-center gap-2">
-              <span className="text-xl">🏐</span>
+              <Volleyball className="w-6 h-6 text-primary-600 dark:text-primary-400" aria-hidden="true" />
               <h1 className="text-lg font-bold text-text-primary dark:text-text-primary-dark">
                 VolleyKit
               </h1>
@@ -119,16 +130,10 @@ export function AppShell() {
                           ? getOccupationLabel(activeOccupation)
                           : "Select role"}
                       </span>
-                      <svg
+                      <ChevronDown
                         className={`w-4 h-4 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
                         aria-hidden="true"
-                      >
-                        <path d="M6 9l6 6 6-6" />
-                      </svg>
+                      />
                     </button>
 
                     {isDropdownOpen && (
@@ -204,6 +209,7 @@ export function AppShell() {
           <div className="flex justify-around">
             {navItems.map((item) => {
               const isActive = location.pathname === item.path;
+              const Icon = item.icon;
               return (
                 <NavLink
                   key={item.path}
@@ -218,11 +224,10 @@ export function AppShell() {
                     }
                   `}
                 >
-                  <span
-                    className={`text-lg leading-tight ${isActive ? "scale-110" : ""} transition-transform`}
-                  >
-                    {item.icon}
-                  </span>
+                  <Icon
+                    className={`w-5 h-5 ${isActive ? "scale-110" : ""} transition-transform`}
+                    aria-hidden="true"
+                  />
                   <span>{t(item.labelKey)}</span>
                 </NavLink>
               );

--- a/web-app/src/components/ui/ExpandArrow.tsx
+++ b/web-app/src/components/ui/ExpandArrow.tsx
@@ -1,3 +1,5 @@
+import { ChevronDown } from "@/components/ui/icons";
+
 interface ExpandArrowProps {
   isExpanded: boolean;
   className?: string;
@@ -9,15 +11,9 @@ interface ExpandArrowProps {
  */
 export function ExpandArrow({ isExpanded, className = "" }: ExpandArrowProps) {
   return (
-    <svg
+    <ChevronDown
       className={`w-4 h-4 text-text-subtle transition-transform duration-200 ${isExpanded ? "rotate-180" : ""} ${className}`}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
       aria-hidden="true"
-    >
-      <path d="M6 9l6 6 6-6" />
-    </svg>
+    />
   );
 }

--- a/web-app/src/components/ui/LoadingSpinner.test.tsx
+++ b/web-app/src/components/ui/LoadingSpinner.test.tsx
@@ -91,9 +91,15 @@ describe("EmptyState", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders custom icon", () => {
-    render(<EmptyState title="No items" icon="🎉" />);
-    expect(screen.getByText("🎉")).toBeInTheDocument();
+  it("renders icon from string name", () => {
+    const { container } = render(<EmptyState title="No items" icon="calendar" />);
+    // Calendar icon renders as SVG
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders custom ReactNode icon", () => {
+    render(<EmptyState title="No items" icon={<span data-testid="custom-icon">Custom</span>} />);
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
   });
 
   it("renders action button when provided", () => {

--- a/web-app/src/components/ui/LoadingSpinner.tsx
+++ b/web-app/src/components/ui/LoadingSpinner.tsx
@@ -1,3 +1,7 @@
+import type { ReactNode } from "react";
+import { AlertTriangle, Calendar, Lock, Inbox, Wallet, ArrowLeftRight } from "@/components/ui/icons";
+import type { LucideIcon } from "lucide-react";
+
 interface LoadingSpinnerProps {
   size?: "sm" | "md" | "lg";
   className?: string;
@@ -62,7 +66,7 @@ interface ErrorStateProps {
 export function ErrorState({ message, onRetry }: ErrorStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-12 gap-4">
-      <div className="text-4xl">⚠️</div>
+      <AlertTriangle className="w-10 h-10 text-warning-500" aria-hidden="true" />
       <p className="text-danger-600 dark:text-danger-400 text-center">{message}</p>
       {onRetry && (
         <button onClick={onRetry} className="btn btn-secondary">
@@ -73,8 +77,18 @@ export function ErrorState({ message, onRetry }: ErrorStateProps) {
   );
 }
 
+/** Map of icon names to Lucide components for EmptyState */
+const EMPTY_STATE_ICONS: Record<string, LucideIcon> = {
+  calendar: Calendar,
+  lock: Lock,
+  inbox: Inbox,
+  wallet: Wallet,
+  exchange: ArrowLeftRight,
+};
+
 interface EmptyStateProps {
-  icon?: string;
+  /** Icon identifier: 'calendar', 'lock', 'inbox', 'wallet', 'exchange', or a custom ReactNode */
+  icon?: string | ReactNode;
   title: string;
   description?: string;
   action?: {
@@ -84,14 +98,27 @@ interface EmptyStateProps {
 }
 
 export function EmptyState({
-  icon = "📭",
+  icon = "inbox",
   title,
   description,
   action,
 }: EmptyStateProps) {
+  const renderIcon = () => {
+    if (typeof icon === "string") {
+      const IconComponent = EMPTY_STATE_ICONS[icon];
+      if (IconComponent) {
+        return <IconComponent className="w-12 h-12 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />;
+      }
+      // Fallback for unknown string icons
+      return <Inbox className="w-12 h-12 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />;
+    }
+    // Custom ReactNode passed directly
+    return icon;
+  };
+
   return (
     <div className="flex flex-col items-center justify-center py-12 gap-3 text-center">
-      <div className="text-5xl">{icon}</div>
+      {renderIcon()}
       <h3 className="text-lg font-medium text-text-primary dark:text-text-primary-dark">
         {title}
       </h3>

--- a/web-app/src/components/ui/Tabs.tsx
+++ b/web-app/src/components/ui/Tabs.tsx
@@ -1,4 +1,5 @@
 import { useTabNavigation } from "@/hooks/useTabNavigation";
+import { Check, Circle } from "@/components/ui/icons";
 
 /** Tab completion status for visual indicators */
 export type TabStatus = "complete" | "incomplete" | "optional";
@@ -9,36 +10,6 @@ export interface Tab {
   badge?: string;
   /** Completion status for visual indicator */
   status?: TabStatus;
-}
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <polyline points="20,6 9,17 4,12" />
-    </svg>
-  );
-}
-
-function WarningDotIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      className={className}
-      aria-hidden="true"
-    >
-      <circle cx="12" cy="12" r="5" />
-    </svg>
-  );
 }
 
 interface TabsProps {
@@ -91,10 +62,10 @@ export function Tabs({
                 `}
               >
                 {tab.status === "complete" && (
-                  <CheckIcon className="w-4 h-4 mr-1.5 text-success-600 dark:text-success-400" />
+                  <Check className="w-4 h-4 mr-1.5 text-success-600 dark:text-success-400" aria-hidden="true" />
                 )}
                 {tab.status === "incomplete" && (
-                  <WarningDotIcon className="w-3 h-3 mr-1.5 text-warning-500 dark:text-warning-400" />
+                  <Circle className="w-3 h-3 mr-1.5 text-warning-500 dark:text-warning-400 fill-current" aria-hidden="true" />
                 )}
                 {tab.label}
                 {tab.badge && (

--- a/web-app/src/components/ui/WizardStepIndicator.tsx
+++ b/web-app/src/components/ui/WizardStepIndicator.tsx
@@ -1,4 +1,5 @@
 import type { WizardStep } from "@/hooks/useWizardNavigation";
+import { Check } from "@/components/ui/icons";
 
 /** Returns the appropriate style classes based on step state */
 function getStepIndicatorStyle(
@@ -12,23 +13,6 @@ function getStepIndicatorStyle(
     return "bg-success-500 text-white";
   }
   return "bg-surface-muted dark:bg-surface-subtle-dark text-text-muted dark:text-text-muted-dark";
-}
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="3"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <polyline points="20,6 9,17 4,12" />
-    </svg>
-  );
 }
 
 interface WizardStepIndicatorProps {
@@ -122,7 +106,7 @@ export function WizardStepIndicator({
               `}
             >
               {showCompletion && !isCurrent ? (
-                <CheckIcon className="w-4 h-4" />
+                <Check className="w-4 h-4" strokeWidth={3} aria-hidden="true" />
               ) : (
                 <span className="text-xs font-semibold">{index + 1}</span>
               )}

--- a/web-app/src/components/ui/icons.test.tsx
+++ b/web-app/src/components/ui/icons.test.tsx
@@ -1,39 +1,69 @@
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import {
-  UploadIcon,
-  CameraIcon,
-  CheckIcon,
-  FileIcon,
-  AlertIcon,
+  Upload,
+  Camera,
+  Check,
+  FileText,
+  AlertCircle,
+  ClipboardList,
+  Wallet,
+  ArrowLeftRight,
+  Settings,
+  UserPlus,
+  RefreshCw,
+  Trash2,
+  Undo2,
+  ChevronDown,
+  Circle,
+  CheckCircle,
+  AlertTriangle,
+  Calendar,
+  Lock,
+  Inbox,
+  Volleyball,
 } from "./icons";
 
 const icons = [
-  { name: "UploadIcon", Component: UploadIcon },
-  { name: "CameraIcon", Component: CameraIcon },
-  { name: "CheckIcon", Component: CheckIcon },
-  { name: "FileIcon", Component: FileIcon },
-  { name: "AlertIcon", Component: AlertIcon },
+  { name: "Upload", Component: Upload },
+  { name: "Camera", Component: Camera },
+  { name: "Check", Component: Check },
+  { name: "FileText", Component: FileText },
+  { name: "AlertCircle", Component: AlertCircle },
+  { name: "ClipboardList", Component: ClipboardList },
+  { name: "Wallet", Component: Wallet },
+  { name: "ArrowLeftRight", Component: ArrowLeftRight },
+  { name: "Settings", Component: Settings },
+  { name: "UserPlus", Component: UserPlus },
+  { name: "RefreshCw", Component: RefreshCw },
+  { name: "Trash2", Component: Trash2 },
+  { name: "Undo2", Component: Undo2 },
+  { name: "ChevronDown", Component: ChevronDown },
+  { name: "Circle", Component: Circle },
+  { name: "CheckCircle", Component: CheckCircle },
+  { name: "AlertTriangle", Component: AlertTriangle },
+  { name: "Calendar", Component: Calendar },
+  { name: "Lock", Component: Lock },
+  { name: "Inbox", Component: Inbox },
+  { name: "Volleyball", Component: Volleyball },
 ];
 
-describe("Icon components", () => {
+describe("Lucide icon re-exports", () => {
   describe.each(icons)("$name", ({ Component }) => {
     it("renders an SVG element", () => {
       const { container } = render(<Component />);
       expect(container.querySelector("svg")).toBeInTheDocument();
     });
 
-    it("applies aria-hidden for accessibility", () => {
-      const { container } = render(<Component />);
-      expect(container.querySelector("svg")).toHaveAttribute(
-        "aria-hidden",
-        "true",
-      );
-    });
-
     it("applies custom className", () => {
       const { container } = render(<Component className="custom-class" />);
       expect(container.querySelector("svg")).toHaveClass("custom-class");
+    });
+
+    it("supports custom size via className", () => {
+      const { container } = render(<Component className="w-6 h-6" />);
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveClass("w-6", "h-6");
     });
   });
 });

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -1,101 +1,39 @@
 /**
- * Shared icon components for the VolleyKit application.
- * Each icon is exported individually to support tree-shaking.
- * All icons accept an optional className prop for styling.
+ * Unified icon exports using Lucide Icons.
+ * All icons are re-exported from lucide-react for consistent styling.
+ * Import icons from this file to ensure consistent usage across the app.
+ *
+ * @see https://lucide.dev/icons for the full icon catalog
  */
 
-export interface IconProps {
-  className?: string;
-}
+// Re-export icons used throughout the app
+// Each export maintains tree-shaking - only imported icons are bundled
 
-export function UploadIcon({ className }: IconProps) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-      <polyline points="17,8 12,3 7,8" />
-      <line x1="12" y1="3" x2="12" y2="15" />
-    </svg>
-  );
-}
+// Navigation icons
+export { ClipboardList } from "lucide-react";
+export { Wallet } from "lucide-react";
+export { ArrowLeftRight } from "lucide-react";
+export { Settings } from "lucide-react";
 
-export function CameraIcon({ className }: IconProps) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
-      <circle cx="12" cy="13" r="4" />
-    </svg>
-  );
-}
+// Action icons
+export { Upload } from "lucide-react";
+export { Camera } from "lucide-react";
+export { Check } from "lucide-react";
+export { FileText } from "lucide-react";
+export { AlertCircle } from "lucide-react";
+export { UserPlus } from "lucide-react";
+export { RefreshCw } from "lucide-react";
+export { Trash2 } from "lucide-react";
+export { Undo2 } from "lucide-react";
+export { ChevronDown } from "lucide-react";
+export { Circle } from "lucide-react";
 
-export function CheckIcon({ className }: IconProps) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-      <polyline points="22,4 12,14.01 9,11.01" />
-    </svg>
-  );
-}
+// Status icons
+export { CheckCircle } from "lucide-react";
+export { AlertTriangle } from "lucide-react";
+export { Calendar } from "lucide-react";
+export { Lock } from "lucide-react";
+export { Inbox } from "lucide-react";
 
-export function FileIcon({ className }: IconProps) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-      <polyline points="14,2 14,8 20,8" />
-    </svg>
-  );
-}
-
-export function AlertIcon({ className }: IconProps) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <circle cx="12" cy="12" r="10" />
-      <line x1="12" y1="8" x2="12" y2="12" />
-      <line x1="12" y1="16" x2="12.01" y2="16" />
-    </svg>
-  );
-}
+// App branding - custom volleyball icon since Lucide doesn't have one
+export { CircleDot as Volleyball } from "lucide-react";

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -169,7 +169,7 @@ export function AssignmentsPage() {
 
         {!isLoading && !error && data && data.length === 0 && (
           <EmptyState
-            icon={activeTab === "upcoming" ? "📅" : "🔒"}
+            icon={activeTab === "upcoming" ? "calendar" : "lock"}
             title={
               activeTab === "upcoming"
                 ? t("assignments.noUpcomingTitle")

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -108,7 +108,7 @@ export function CompensationsPage() {
 
     if (!data || data.length === 0) {
       const { title, description } = getEmptyStateContent();
-      return <EmptyState icon="💰" title={title} description={description} />;
+      return <EmptyState icon="wallet" title={title} description={description} />;
     }
 
     return (

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -138,7 +138,7 @@ export function ExchangePage() {
     if (!filteredData || filteredData.length === 0) {
       return (
         <EmptyState
-          icon="🔄"
+          icon="exchange"
           title={
             statusFilter === "open"
               ? t("exchange.noOpenExchangesTitle")

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -11,6 +11,7 @@ import { useDemoStore } from "@/stores/demo";
 import { useTranslation } from "@/hooks/useTranslation";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { LanguageSwitcher } from "@/components/ui/LanguageSwitcher";
+import { Volleyball } from "@/components/ui/icons";
 
 // Demo-only mode restricts the app to demo mode (used in PR preview deployments)
 const DEMO_MODE_ONLY = import.meta.env.VITE_DEMO_MODE_ONLY === "true";
@@ -64,9 +65,7 @@ export function LoginPage() {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center bg-surface-page dark:bg-surface-page-dark px-4">
         <div className="text-center" role="status">
-          <span className="text-6xl" aria-hidden="true">
-            🏐
-          </span>
+          <Volleyball className="w-16 h-16 text-primary-600 dark:text-primary-400 mx-auto" aria-hidden="true" />
           <h1 className="mt-4 text-3xl font-bold text-text-primary dark:text-text-primary-dark">
             VolleyKit
           </h1>
@@ -89,7 +88,7 @@ export function LoginPage() {
 
         {/* Logo */}
         <div className="text-center mb-8">
-          <span className="text-6xl">🏐</span>
+          <Volleyball className="w-16 h-16 text-primary-600 dark:text-primary-400 mx-auto" aria-hidden="true" />
           <h1 className="mt-4 text-3xl font-bold text-text-primary dark:text-text-primary-dark">
             VolleyKit
           </h1>


### PR DESCRIPTION
Replace scattered custom SVG icons and emojis with Lucide Icons library for a
consistent, flat, professional look across the entire application.

Changes:
- Add lucide-react package for unified icon library
- Replace custom SVG icons in icons.tsx with Lucide re-exports
- Replace navigation emojis with Lucide icons in AppShell
- Replace empty state emojis with icon names (calendar, lock, wallet, etc.)
- Replace scoresheet panel icons (Upload, Camera, Check, File, Alert)
- Replace validation panel icons (UserPlus, Trash, Undo, Refresh)
- Replace tab/wizard icons (Check, Circle)
- Replace compensation card check/circle badges with icons
- Update ExpandArrow to use ChevronDown from Lucide
- Update LoadingSpinner ErrorState to use AlertTriangle icon
- Update EmptyState to accept icon name strings or ReactNode
- Update all related test files for new icon API