### PR TITLE
feat(api): implement API fetch for nomination list (TODO#37)

### DIFF
--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -3231,6 +3231,11 @@ components:
             summarizedSets:
               type: string
               description: Set scores (e.g., "25:20, 23:25, 25:18, 25:22")
+        # Nomination lists (available when requested via showWithNestedObjects)
+        nominationListOfTeamHome:
+          $ref: '#/components/schemas/NominationList'
+        nominationListOfTeamAway:
+          $ref: '#/components/schemas/NominationList'
     RefereeConvocationDetails:
       type: object
       description: |

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -548,6 +548,64 @@ export const api = {
   },
 
   /**
+   * Fetches nomination list for a specific team in a game.
+   * Uses the game showWithNestedObjects endpoint to retrieve nomination data.
+   *
+   * @param gameId - UUID of the game
+   * @param team - Which team's nomination list to fetch ("home" or "away")
+   * @returns The nomination list for the specified team, or null if not available
+   */
+  async getNominationList(
+    gameId: string,
+    team: "home" | "away",
+  ): Promise<NominationList | null> {
+    const nominationProperty =
+      team === "home"
+        ? "nominationListOfTeamHome"
+        : "nominationListOfTeamAway";
+
+    // Request the nomination list with nested player details
+    const properties = [
+      nominationProperty,
+      `${nominationProperty}.__identity`,
+      `${nominationProperty}.team`,
+      `${nominationProperty}.indoorPlayerNominations`,
+      `${nominationProperty}.indoorPlayerNominations.*.__identity`,
+      `${nominationProperty}.indoorPlayerNominations.*.shirtNumber`,
+      `${nominationProperty}.indoorPlayerNominations.*.isCaptain`,
+      `${nominationProperty}.indoorPlayerNominations.*.isLibero`,
+      `${nominationProperty}.indoorPlayerNominations.*.indoorPlayer.person.displayName`,
+      `${nominationProperty}.indoorPlayerNominations.*.indoorPlayer.person.firstName`,
+      `${nominationProperty}.indoorPlayerNominations.*.indoorPlayer.person.lastName`,
+      `${nominationProperty}.indoorPlayerNominations.*.indoorPlayerLicenseCategory.shortName`,
+      `${nominationProperty}.coachPerson`,
+      `${nominationProperty}.firstAssistantCoachPerson`,
+      `${nominationProperty}.secondAssistantCoachPerson`,
+      `${nominationProperty}.closed`,
+      `${nominationProperty}.closedAt`,
+      `${nominationProperty}.checked`,
+      `${nominationProperty}.isClosedForTeam`,
+    ];
+
+    const response = await apiRequest<Schemas["GameDetails"]>(
+      "/sportmanager.indoorvolleyball/api%5cgame/showWithNestedObjects",
+      "GET",
+      {
+        "game[__identity]": gameId,
+        propertyRenderConfiguration: properties,
+      },
+    );
+
+    // Extract the nomination list from the response
+    const nominationList =
+      team === "home"
+        ? response.nominationListOfTeamHome
+        : response.nominationListOfTeamAway;
+
+    return nominationList ?? null;
+  },
+
+  /**
    * Fetches possible player nominations for a nomination list.
    * Returns players that can be added to a team's roster for a game.
    *

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -19,6 +19,7 @@ import type {
   ExchangesResponse,
   AssociationSettings,
   Season,
+  NominationList,
   PossibleNominationsResponse,
   PersonSearchFilter,
   PersonSearchResponse,
@@ -329,6 +330,22 @@ export const mockApi = {
       seasonStartDate: seasonStart.toISOString(),
       seasonEndDate: seasonEnd.toISOString(),
     } as Season;
+  },
+
+  async getNominationList(
+    gameId: string,
+    team: "home" | "away",
+  ): Promise<NominationList | null> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+
+    const store = useDemoStore.getState();
+    const gameNominations = store.nominationLists[gameId];
+
+    if (!gameNominations) {
+      return null;
+    }
+
+    return gameNominations[team] ?? null;
   },
 
   async getPossiblePlayerNominations(

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -2151,6 +2151,8 @@ export interface components {
                 /** @description Set scores (e.g., "25:20, 23:25, 25:18, 25:22") */
                 summarizedSets?: string;
             } | null;
+            nominationListOfTeamHome?: components["schemas"]["NominationList"];
+            nominationListOfTeamAway?: components["schemas"]["NominationList"];
         };
         /**
          * @description Detailed referee convocation information from showWithNestedObjects.

--- a/web-app/src/hooks/useNominationList.ts
+++ b/web-app/src/hooks/useNominationList.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { NominationList, IndoorPlayerNomination } from "@/api/client";
+import { getApiClient } from "@/api/client";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 
@@ -102,11 +103,12 @@ export function useNominationList({
     );
   }, [demoNominationList]);
 
+  const apiClient = getApiClient(isDemoMode);
+
   const query = useQuery({
     queryKey: ["nominationList", gameId, team],
-    // TODO(#37): Implement API fetch for nomination list
     queryFn: async (): Promise<NominationList | null> => {
-      return null;
+      return apiClient.getNominationList(gameId, team);
     },
     enabled: enabled && !isDemoMode && !!gameId,
     staleTime: NOMINATION_LIST_STALE_TIME_MS,

--- a/web-app/src/hooks/useNominationList.ts
+++ b/web-app/src/hooks/useNominationList.ts
@@ -5,7 +5,10 @@ import { getApiClient } from "@/api/client";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 
-const NOMINATION_LIST_STALE_TIME_MS = 5 * 60 * 1000;
+const NOMINATION_LIST_STALE_TIME_MINUTES = 5;
+const MS_PER_MINUTE = 60 * 1000;
+const NOMINATION_LIST_STALE_TIME_MS =
+  NOMINATION_LIST_STALE_TIME_MINUTES * MS_PER_MINUTE;
 
 export interface RosterPlayer {
   id: string;


### PR DESCRIPTION
Add getNominationList API method that fetches team nomination lists
from the game showWithNestedObjects endpoint. The hook now calls
the real API in production mode while maintaining demo mode support.

Changes:
- Add getNominationList method to api/client.ts and mock-api.ts
- Update useNominationList hook to use the API client
- Add nomination list properties to GameDetails schema
- Expand tests for production mode API fetch scenarios