### PR TITLE
feat(api): implement PDF generation for referee reports (#170)

### DIFF
--- a/web-app/src/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/hooks/useAssignmentActions.test.ts
@@ -216,6 +216,7 @@ describe("useAssignmentActions", () => {
     });
 
     expect(createElementSpy).toHaveBeenCalledWith("a");
+    expect(toast.success).toHaveBeenCalledWith("assignments.reportGenerated");
   });
 
   it("should block generate report for non-NLA/NLB games", () => {
@@ -243,6 +244,7 @@ describe("useAssignmentActions", () => {
     });
 
     expect(createElementSpy).toHaveBeenCalledWith("a");
+    expect(toast.success).toHaveBeenCalledWith("assignments.reportGenerated");
   });
 
   it("should block generate report when league data is undefined", () => {
@@ -308,7 +310,7 @@ describe("useAssignmentActions", () => {
       expect(toast.success).toHaveBeenCalledWith("exchange.addedToExchangeSuccess");
     });
 
-    it("should not download PDF in demo mode", () => {
+    it("should generate PDF report in demo mode", () => {
       const { result } = renderHook(() => useAssignmentActions());
       const createElementSpy = vi.spyOn(document, "createElement");
 
@@ -316,8 +318,9 @@ describe("useAssignmentActions", () => {
         result.current.handleGenerateReport(mockAssignment);
       });
 
-      expect(toast.info).toHaveBeenCalledWith("compensations.pdfNotAvailableDemo");
-      expect(createElementSpy).not.toHaveBeenCalledWith("a");
+      // PDF generation should work in demo mode
+      expect(createElementSpy).toHaveBeenCalledWith("a");
+      expect(toast.success).toHaveBeenCalledWith("assignments.reportGenerated");
     });
   });
 

--- a/web-app/src/hooks/useAssignmentActions.ts
+++ b/web-app/src/hooks/useAssignmentActions.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { Assignment } from "@/api/client";
-import { downloadPDF } from "@/utils/assignment-actions";
+import { downloadPDF, type ReportData } from "@/utils/assignment-actions";
 import { logger } from "@/utils/logger";
 import {
   getTeamNames,
@@ -116,36 +116,29 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
         return;
       }
 
-      if (isDemoMode) {
-        logger.debug("[useAssignmentActions] Demo mode: PDF download disabled");
-        toast.info(t("compensations.pdfNotAvailableDemo"));
-        return;
-      }
-
       const { homeTeam, awayTeam } = getTeamNames(assignment);
       const game = assignment.refereeGame?.game;
       const hallName = game?.hall?.name || "Location TBD";
       const date = game?.startingDateTime || new Date().toISOString();
 
-      const mockPDFContent = `Sports Hall Report
-Game: ${homeTeam} vs ${awayTeam}
-Venue: ${hallName}
-Date: ${new Date(date).toLocaleDateString()}
-Position: ${assignment.refereePosition}
+      const reportData: ReportData = {
+        title: "Sports Hall Report",
+        homeTeam,
+        awayTeam,
+        venue: hallName,
+        date: new Date(date).toLocaleDateString(),
+        position: assignment.refereePosition || "Unknown",
+      };
 
-This is a mock PDF report.`;
-
-      downloadPDF(
-        mockPDFContent,
-        `sports-hall-report-${assignment.__identity}.pdf`,
-      );
+      downloadPDF(reportData, `sports-hall-report-${assignment.__identity}.pdf`);
 
       logger.debug(
-        "[useAssignmentActions] Generated mock PDF report for:",
+        "[useAssignmentActions] Generated PDF report for:",
         assignment.__identity,
       );
+      toast.success(t("assignments.reportGenerated"));
     },
-    [isDemoMode, t],
+    [t],
   );
 
   const handleAddToExchange = useCallback(

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -72,6 +72,7 @@ const de: Translations = {
     numberOfSets: "Anzahl Sätze",
     gameReportNotAvailable:
       "Spielberichte sind nur für NLA- und NLB-Spiele verfügbar.",
+    reportGenerated: "Bericht erfolgreich erstellt",
   },
   compensations: {
     title: "Entschädigungen",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -72,6 +72,7 @@ const en: Translations = {
     numberOfSets: "Number of Sets",
     gameReportNotAvailable:
       "Game reports are only available for NLA and NLB games.",
+    reportGenerated: "Report generated successfully",
   },
   compensations: {
     title: "Compensations",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -71,6 +71,7 @@ const fr: Translations = {
     numberOfSets: "Nombre de sets",
     gameReportNotAvailable:
       "Les rapports de match sont uniquement disponibles pour les matchs NLA et NLB.",
+    reportGenerated: "Rapport généré avec succès",
   },
   compensations: {
     title: "Indemnités",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -71,6 +71,7 @@ const it: Translations = {
     numberOfSets: "Numero di set",
     gameReportNotAvailable:
       "I rapporti delle partite sono disponibili solo per le partite NLA e NLB.",
+    reportGenerated: "Rapporto generato con successo",
   },
   compensations: {
     title: "Compensi",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -71,6 +71,7 @@ export interface Translations {
     awayScore: string;
     numberOfSets: string;
     gameReportNotAvailable: string;
+    reportGenerated: string;
   };
   compensations: {
     title: string;

--- a/web-app/src/utils/assignment-actions.ts
+++ b/web-app/src/utils/assignment-actions.ts
@@ -55,14 +55,126 @@ export function createAssignmentActions(
   };
 }
 
-export function downloadPDF(content: string, filename: string): void {
-  // TODO(#170): Replace with actual PDF generation when API is available
-  // Currently creates a text file with mock content instead of a real PDF
-  const blob = new Blob([content], { type: "text/plain" });
+/**
+ * Report data structure for PDF generation.
+ */
+export interface ReportData {
+  title: string;
+  homeTeam: string;
+  awayTeam: string;
+  venue: string;
+  date: string;
+  position: string;
+}
+
+/**
+ * Generates a minimal valid PDF document from report data.
+ * Uses PDF 1.4 specification to create a basic document without external libraries.
+ *
+ * TODO(#170): Replace with template-based PDF generation. The real implementation
+ * should load a sports hall report PDF template from repository assets and fill in
+ * the form fields with assignment data (e.g., using pdf-lib).
+ */
+function generatePDFContent(data: ReportData): string {
+  // PDF text encoding helper - escapes special characters
+  const escapeText = (text: string): string =>
+    text
+      .replace(/\\/g, "\\\\")
+      .replace(/\(/g, "\\(")
+      .replace(/\)/g, "\\)");
+
+  // Build PDF content with embedded text
+  const title = escapeText(data.title);
+  const content = [
+    escapeText(`Game: ${data.homeTeam} vs ${data.awayTeam}`),
+    escapeText(`Venue: ${data.venue}`),
+    escapeText(`Date: ${data.date}`),
+    escapeText(`Position: ${data.position}`),
+  ];
+
+  // PDF objects - must track byte offsets for xref table
+  const objects: string[] = [];
+
+  // Object 1: Catalog (root)
+  objects.push("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+  // Object 2: Pages
+  objects.push(
+    "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+  );
+
+  // Object 3: Page
+  objects.push(
+    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n",
+  );
+
+  // Object 4: Content stream with text
+  // PDF uses bottom-left origin, so y=750 is near top of page
+  const streamContent = [
+    "BT", // Begin text
+    "/F1 18 Tf", // Font size 18 for title
+    "72 720 Td", // Move to position (72, 720)
+    `(${title}) Tj`, // Show title
+    "/F1 12 Tf", // Font size 12 for content
+    "0 -30 Td", // Move down 30 units
+    ...content.map((line, i) => (i === 0 ? `(${line}) Tj` : `0 -20 Td (${line}) Tj`)),
+    "ET", // End text
+  ].join("\n");
+
+  const streamBytes = new TextEncoder().encode(streamContent);
+  objects.push(
+    `4 0 obj\n<< /Length ${streamBytes.length} >>\nstream\n${streamContent}\nendstream\nendobj\n`,
+  );
+
+  // Object 5: Font (Helvetica - built-in PDF font, no embedding needed)
+  objects.push(
+    "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+  );
+
+  // Build PDF file
+  const header = "%PDF-1.4\n%\xFF\xFF\xFF\xFF\n";
+
+  // Calculate byte offsets for xref table
+  let offset = header.length;
+  const offsets: number[] = [];
+  for (const obj of objects) {
+    offsets.push(offset);
+    offset += new TextEncoder().encode(obj).length;
+  }
+
+  // Build xref table
+  const xrefStart = offset;
+  const xrefLines = [
+    "xref",
+    `0 ${objects.length + 1}`,
+    "0000000000 65535 f ",
+    ...offsets.map((o) => `${o.toString().padStart(10, "0")} 00000 n `),
+  ].join("\n");
+
+  // Trailer
+  const trailer = [
+    "\ntrailer",
+    `<< /Size ${objects.length + 1} /Root 1 0 R >>`,
+    "startxref",
+    xrefStart.toString(),
+    "%%EOF",
+  ].join("\n");
+
+  // Combine all parts
+  const pdfString = header + objects.join("") + xrefLines + trailer;
+  return pdfString;
+}
+
+/**
+ * Generates and downloads a PDF report for an assignment.
+ */
+export function downloadPDF(data: ReportData, filename: string): void {
+  const pdfContent = generatePDFContent(data);
+  const blob = new Blob([pdfContent], { type: "application/pdf" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  link.download = filename.replace(".pdf", ".txt");
+  link.download = filename;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);

--- a/web-app/src/utils/assignment-actions.ts
+++ b/web-app/src/utils/assignment-actions.ts
@@ -55,9 +55,6 @@ export function createAssignmentActions(
   };
 }
 
-/**
- * Report data structure for PDF generation.
- */
 export interface ReportData {
   title: string;
   homeTeam: string;
@@ -67,102 +64,98 @@ export interface ReportData {
   position: string;
 }
 
-/**
- * Generates a minimal valid PDF document from report data.
- * Uses PDF 1.4 specification to create a basic document without external libraries.
- *
- * TODO(#170): Replace with template-based PDF generation. The real implementation
- * should load a sports hall report PDF template from repository assets and fill in
- * the form fields with assignment data (e.g., using pdf-lib).
- */
-function generatePDFContent(data: ReportData): string {
-  // PDF text encoding helper - escapes special characters
-  const escapeText = (text: string): string =>
-    text
-      .replace(/\\/g, "\\\\")
-      .replace(/\(/g, "\\(")
-      .replace(/\)/g, "\\)");
+// PDF layout constants (US Letter: 612x792 points)
+const PDF_PAGE_WIDTH = 612;
+const PDF_PAGE_HEIGHT = 792;
+const PDF_LEFT_MARGIN = 72;
+const PDF_TOP_POSITION = 720;
+const PDF_TITLE_FONT_SIZE = 18;
+const PDF_CONTENT_FONT_SIZE = 12;
+const PDF_TITLE_SPACING = 30;
+const PDF_LINE_SPACING = 20;
 
-  // Build PDF content with embedded text
-  const title = escapeText(data.title);
-  const content = [
-    escapeText(`Game: ${data.homeTeam} vs ${data.awayTeam}`),
-    escapeText(`Venue: ${data.venue}`),
-    escapeText(`Date: ${data.date}`),
-    escapeText(`Position: ${data.position}`),
+const PDF_HEADER = "%PDF-1.4\n%\xFF\xFF\xFF\xFF\n";
+
+function escapePDFText(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)");
+}
+
+function buildContentStream(data: ReportData): string {
+  const title = escapePDFText(data.title);
+  const lines = [
+    escapePDFText(`Game: ${data.homeTeam} vs ${data.awayTeam}`),
+    escapePDFText(`Venue: ${data.venue}`),
+    escapePDFText(`Date: ${data.date}`),
+    escapePDFText(`Position: ${data.position}`),
   ];
 
-  // PDF objects - must track byte offsets for xref table
-  const objects: string[] = [];
-
-  // Object 1: Catalog (root)
-  objects.push("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
-
-  // Object 2: Pages
-  objects.push(
-    "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
-  );
-
-  // Object 3: Page
-  objects.push(
-    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n",
-  );
-
-  // Object 4: Content stream with text
-  // PDF uses bottom-left origin, so y=750 is near top of page
-  const streamContent = [
-    "BT", // Begin text
-    "/F1 18 Tf", // Font size 18 for title
-    "72 720 Td", // Move to position (72, 720)
-    `(${title}) Tj`, // Show title
-    "/F1 12 Tf", // Font size 12 for content
-    "0 -30 Td", // Move down 30 units
-    ...content.map((line, i) => (i === 0 ? `(${line}) Tj` : `0 -20 Td (${line}) Tj`)),
-    "ET", // End text
+  return [
+    "BT",
+    `/F1 ${PDF_TITLE_FONT_SIZE} Tf`,
+    `${PDF_LEFT_MARGIN} ${PDF_TOP_POSITION} Td`,
+    `(${title}) Tj`,
+    `/F1 ${PDF_CONTENT_FONT_SIZE} Tf`,
+    `0 -${PDF_TITLE_SPACING} Td`,
+    ...lines.map((line, i) =>
+      i === 0 ? `(${line}) Tj` : `0 -${PDF_LINE_SPACING} Td (${line}) Tj`
+    ),
+    "ET",
   ].join("\n");
+}
 
-  const streamBytes = new TextEncoder().encode(streamContent);
-  objects.push(
-    `4 0 obj\n<< /Length ${streamBytes.length} >>\nstream\n${streamContent}\nendstream\nendobj\n`,
-  );
+function buildPDFObjects(contentStream: string): string[] {
+  const streamLength = new TextEncoder().encode(contentStream).length;
 
-  // Object 5: Font (Helvetica - built-in PDF font, no embedding needed)
-  objects.push(
+  return [
+    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+    "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+    `3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${PDF_PAGE_WIDTH} ${PDF_PAGE_HEIGHT}] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n`,
+    `4 0 obj\n<< /Length ${streamLength} >>\nstream\n${contentStream}\nendstream\nendobj\n`,
     "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
-  );
+  ];
+}
 
-  // Build PDF file
-  const header = "%PDF-1.4\n%\xFF\xFF\xFF\xFF\n";
-
-  // Calculate byte offsets for xref table
-  let offset = header.length;
+function buildXRefTable(objects: string[], headerLength: number): { xref: string; startOffset: number } {
+  let offset = headerLength;
   const offsets: number[] = [];
+
   for (const obj of objects) {
     offsets.push(offset);
     offset += new TextEncoder().encode(obj).length;
   }
 
-  // Build xref table
-  const xrefStart = offset;
-  const xrefLines = [
+  const xref = [
     "xref",
     `0 ${objects.length + 1}`,
     "0000000000 65535 f ",
     ...offsets.map((o) => `${o.toString().padStart(10, "0")} 00000 n `),
   ].join("\n");
 
-  // Trailer
+  return { xref, startOffset: offset };
+}
+
+/**
+ * TODO(#170): Replace with template-based PDF generation. The real implementation
+ * should load a sports hall report PDF template from repository assets and fill in
+ * the form fields with assignment data (e.g., using pdf-lib).
+ */
+function generatePDFContent(data: ReportData): string {
+  const contentStream = buildContentStream(data);
+  const objects = buildPDFObjects(contentStream);
+  const { xref, startOffset } = buildXRefTable(objects, PDF_HEADER.length);
+
   const trailer = [
     "\ntrailer",
     `<< /Size ${objects.length + 1} /Root 1 0 R >>`,
     "startxref",
-    xrefStart.toString(),
+    startOffset.toString(),
     "%%EOF",
   ].join("\n");
 
-  // Combine all parts
-  const pdfString = header + objects.join("") + xrefLines + trailer;
-  return pdfString;
+  return PDF_HEADER + objects.join("") + xref + trailer;
 }
 
 /**


### PR DESCRIPTION
- Replace text file generation with actual PDF generation using PDF 1.4 spec
- Enable PDF generation in demo mode (previously blocked)
- Add ReportData interface for structured report content
- Add success toast notification when report is generated
- Add translations for report generation success message
- Update tests to verify PDF generation behavior