### PR TITLE
feat(api): implement actual API calls for game validation (#171)

### DIFF
--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -3236,6 +3236,9 @@ components:
           $ref: '#/components/schemas/NominationList'
         nominationListOfTeamAway:
           $ref: '#/components/schemas/NominationList'
+        # Scoresheet (available when requested via showWithNestedObjects)
+        scoresheet:
+          $ref: '#/components/schemas/Scoresheet'
     RefereeConvocationDetails:
       type: object
       description: |

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -24,7 +24,7 @@
     {
       "name": "Main Bundle",
       "path": "dist/assets/index-*.js",
-      "limit": "115 kB",
+      "limit": "116 kB",
       "gzip": true
     },
     {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -28,6 +28,12 @@ if (!import.meta.env.DEV && !API_BASE) {
  */
 const DEFAULT_SEARCH_RESULTS_LIMIT = 50;
 
+/** Maximum allowed file size for uploads (10 MB). */
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Allowed MIME types for scoresheet uploads. */
+const ALLOWED_FILE_TYPES = ["application/pdf"];
+
 // Backend error response schema
 const backendErrorSchema = z
   .object({
@@ -898,6 +904,21 @@ export const api = {
 
   /** Uploads a file and returns a resource reference. */
   async uploadResource(file: File): Promise<FileResource[]> {
+    // Validate file type
+    if (!ALLOWED_FILE_TYPES.includes(file.type)) {
+      throw new Error(
+        `Invalid file type: ${file.type || "unknown"}. Only PDF files are allowed.`,
+      );
+    }
+
+    // Validate file size
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
+      throw new Error(
+        `File too large: ${sizeMB} MB. Maximum size is 10 MB.`,
+      );
+    }
+
     const formData = new FormData();
     formData.append("resource", file);
     if (csrfToken) {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -744,15 +744,8 @@ export const api = {
     );
   },
 
-  /**
-   * Fetches game details including scoresheet and nomination lists.
-   * Used during validation to get identifiers needed for API calls.
-   *
-   * @param gameId - UUID of the game
-   * @returns Game details with scoresheet and nomination list data
-   */
+  /** Fetches game details including scoresheet and nomination lists. */
   async getGameWithScoresheet(gameId: string): Promise<Schemas["GameDetails"]> {
-    // Properties needed for validation workflow
     const properties = [
       "scoresheet",
       "scoresheet.__identity",
@@ -792,16 +785,7 @@ export const api = {
     );
   },
 
-  /**
-   * Updates a nomination list with roster changes.
-   * Called when saving validation progress with roster modifications.
-   *
-   * @param nominationListId - UUID of the nomination list
-   * @param gameId - UUID of the game
-   * @param teamId - UUID of the team
-   * @param playerNominationIds - Array of player nomination UUIDs to include
-   * @returns Updated nomination list
-   */
+  /** Updates a nomination list with roster changes. */
   async updateNominationList(
     nominationListId: string,
     gameId: string,
@@ -829,17 +813,7 @@ export const api = {
     );
   },
 
-  /**
-   * Finalizes a nomination list (closes it for further modifications).
-   * Called when completing game validation.
-   *
-   * @param nominationListId - UUID of the nomination list
-   * @param gameId - UUID of the game
-   * @param teamId - UUID of the team
-   * @param playerNominationIds - Array of player nomination UUIDs to include
-   * @param validationId - Optional UUID of the nomination list validation record
-   * @returns Response with finalized nomination list
-   */
+  /** Finalizes a nomination list (closes it for further modifications). */
   async finalizeNominationList(
     nominationListId: string,
     gameId: string,
@@ -873,16 +847,7 @@ export const api = {
     );
   },
 
-  /**
-   * Updates a scoresheet with the selected scorer (writer person).
-   * Called when saving validation progress with scorer selection.
-   *
-   * @param scoresheetId - UUID of the scoresheet
-   * @param gameId - UUID of the game
-   * @param scorerPersonId - UUID of the person selected as scorer
-   * @param isSimpleScoresheet - Whether using simplified scoresheet format
-   * @returns Updated scoresheet
-   */
+  /** Updates a scoresheet with the selected scorer. */
   async updateScoresheet(
     scoresheetId: string,
     gameId: string,
@@ -902,18 +867,7 @@ export const api = {
     );
   },
 
-  /**
-   * Finalizes a scoresheet after the game.
-   * Requires a PDF file to be uploaded and attached first.
-   *
-   * @param scoresheetId - UUID of the scoresheet
-   * @param gameId - UUID of the game
-   * @param scorerPersonId - UUID of the person who filled out the scoresheet
-   * @param fileResourceId - UUID of the uploaded PDF file resource
-   * @param validationId - Optional UUID of the scoresheet validation record
-   * @param isSimpleScoresheet - Whether using simplified scoresheet format
-   * @returns Finalized scoresheet
-   */
+  /** Finalizes a scoresheet after the game. */
   async finalizeScoresheet(
     scoresheetId: string,
     gameId: string,
@@ -942,12 +896,7 @@ export const api = {
     );
   },
 
-  /**
-   * Uploads a file (e.g., scoresheet PDF) and returns a resource reference.
-   *
-   * @param file - The file to upload
-   * @returns Array containing the uploaded file resource
-   */
+  /** Uploads a file and returns a resource reference. */
   async uploadResource(file: File): Promise<FileResource[]> {
     const formData = new FormData();
     formData.append("resource", file);

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -20,6 +20,10 @@ import type {
   AssociationSettings,
   Season,
   NominationList,
+  NominationListFinalizeResponse,
+  Scoresheet,
+  FileResource,
+  GameDetails,
   PossibleNominationsResponse,
   PersonSearchFilter,
   PersonSearchResponse,
@@ -423,6 +427,131 @@ export const mockApi = {
       items: paginated,
       totalItemsCount: filtered.length,
     };
+  },
+
+  async getGameWithScoresheet(gameId: string): Promise<GameDetails> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+
+    const store = useDemoStore.getState();
+    const gameNominations = store.nominationLists[gameId];
+
+    // Build mock game details with scoresheet and nomination lists
+    const gameDetails: GameDetails = {
+      __identity: gameId,
+      scoresheet: {
+        __identity: `scoresheet-${gameId}`,
+        game: { __identity: gameId },
+        isSimpleScoresheet: false,
+        hasFile: false,
+      },
+      nominationListOfTeamHome: gameNominations?.home ?? undefined,
+      nominationListOfTeamAway: gameNominations?.away ?? undefined,
+    };
+
+    return gameDetails;
+  },
+
+  async updateNominationList(
+    nominationListId: string,
+    gameId: string,
+    teamId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
+    _playerNominationIds: string[],
+  ): Promise<NominationList> {
+    await delay(MOCK_MUTATION_DELAY_MS);
+
+    // In demo mode, return a mock updated nomination list
+    return {
+      __identity: nominationListId,
+      game: { __identity: gameId },
+      team: { __identity: teamId },
+      closed: false,
+      isClosedForTeam: true,
+    };
+  },
+
+  async finalizeNominationList(
+    nominationListId: string,
+    gameId: string,
+    teamId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
+    _playerNominationIds: string[],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
+    _validationId?: string,
+  ): Promise<NominationListFinalizeResponse> {
+    await delay(MOCK_MUTATION_DELAY_MS);
+
+    // In demo mode, return a mock finalized nomination list
+    return {
+      nominationList: {
+        __identity: nominationListId,
+        game: { __identity: gameId },
+        team: { __identity: teamId },
+        closed: true,
+        closedAt: new Date().toISOString(),
+        closedBy: "referee",
+        isClosedForTeam: true,
+      },
+    };
+  },
+
+  async updateScoresheet(
+    scoresheetId: string,
+    gameId: string,
+    scorerPersonId: string,
+    isSimpleScoresheet: boolean = false,
+  ): Promise<Scoresheet> {
+    await delay(MOCK_MUTATION_DELAY_MS);
+
+    // In demo mode, return a mock updated scoresheet
+    return {
+      __identity: scoresheetId,
+      game: { __identity: gameId },
+      writerPerson: { __identity: scorerPersonId },
+      isSimpleScoresheet,
+      hasFile: false,
+    };
+  },
+
+  async finalizeScoresheet(
+    scoresheetId: string,
+    gameId: string,
+    scorerPersonId: string,
+    fileResourceId: string,
+    _validationId?: string,
+    isSimpleScoresheet: boolean = false,
+  ): Promise<Scoresheet> {
+    await delay(MOCK_MUTATION_DELAY_MS);
+
+    // In demo mode, return a mock finalized scoresheet
+    return {
+      __identity: scoresheetId,
+      game: { __identity: gameId },
+      writerPerson: { __identity: scorerPersonId },
+      isSimpleScoresheet,
+      hasFile: true,
+      file: { __identity: fileResourceId },
+      closedAt: new Date().toISOString(),
+      closedBy: "referee",
+    };
+  },
+
+  async uploadResource(file: File): Promise<FileResource[]> {
+    await delay(MOCK_MUTATION_DELAY_MS);
+
+    // In demo mode, return a mock file resource
+    const mockResourceId = `resource-${Date.now()}`;
+    return [
+      {
+        __identity: mockResourceId,
+        persistentResource: {
+          __identity: `persistent-${mockResourceId}`,
+          filename: file.name,
+          mediaType: file.type,
+          fileSize: file.size,
+        },
+      },
+    ];
   },
 };
 

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -38,6 +38,12 @@ const MOCK_MUTATION_DELAY_MS = 100;
 /** Default limit for person search pagination */
 const DEFAULT_PERSON_SEARCH_LIMIT = 50;
 
+/** Maximum allowed file size for uploads (10 MB). */
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Allowed MIME types for scoresheet uploads. */
+const ALLOWED_FILE_TYPES = ["application/pdf"];
+
 /**
  * Normalize a string for accent-insensitive comparison.
  * Converts to lowercase, decomposes accented characters (NFD normalization),
@@ -537,6 +543,19 @@ export const mockApi = {
   },
 
   async uploadResource(file: File): Promise<FileResource[]> {
+    // Validate file type
+    if (!ALLOWED_FILE_TYPES.includes(file.type)) {
+      throw new Error(
+        `Invalid file type: ${file.type || "unknown"}. Only PDF files are allowed.`,
+      );
+    }
+
+    // Validate file size
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
+      throw new Error(`File too large: ${sizeMB} MB. Maximum size is 10 MB.`);
+    }
+
     await delay(MOCK_MUTATION_DELAY_MS);
 
     // In demo mode, return a mock file resource

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -2153,6 +2153,7 @@ export interface components {
             } | null;
             nominationListOfTeamHome?: components["schemas"]["NominationList"];
             nominationListOfTeamAway?: components["schemas"]["NominationList"];
+            scoresheet?: components["schemas"]["Scoresheet"];
         };
         /**
          * @description Detailed referee convocation information from showWithNestedObjects.

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -4,8 +4,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ValidateGameModal } from "./ValidateGameModal";
 import type { Assignment } from "@/api/client";
 import * as useNominationListModule from "@/hooks/useNominationList";
+import * as useValidationStateModule from "@/hooks/useValidationState";
 
 vi.mock("@/hooks/useNominationList");
+vi.mock("@/hooks/useValidationState");
 
 vi.mock("@/hooks/useScorerSearch", () => ({
   useScorerSearch: vi.fn(() => ({
@@ -22,36 +24,6 @@ vi.mock("@/hooks/useScorerSearch", () => ({
 
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
-}));
-
-vi.mock("@/hooks/useValidationState", () => ({
-  useValidationState: vi.fn(() => ({
-    state: {
-      homeRoster: { reviewed: false, modifications: { added: [], removed: [] } },
-      awayRoster: { reviewed: false, modifications: { added: [], removed: [] } },
-      scorer: { selected: null },
-      scoresheet: { file: null, uploaded: false },
-    },
-    isDirty: false,
-    completionStatus: {
-      homeRoster: false,
-      awayRoster: false,
-      scorer: false,
-      scoresheet: true,
-    },
-    isAllRequiredComplete: false,
-    setHomeRosterModifications: vi.fn(),
-    setAwayRosterModifications: vi.fn(),
-    setScorer: vi.fn(),
-    setScoresheet: vi.fn(),
-    reset: vi.fn(),
-    saveProgress: vi.fn().mockResolvedValue(undefined),
-    finalizeValidation: vi.fn().mockResolvedValue(undefined),
-    isSaving: false,
-    isFinalizing: false,
-    isLoadingGameDetails: false,
-    gameDetailsError: null,
-  })),
 }));
 
 function createMockAssignment(overrides: Partial<Assignment> = {}): Assignment {
@@ -106,6 +78,33 @@ describe("ValidateGameModal", () => {
       isError: false,
       error: null,
       refetch: vi.fn(),
+    });
+    vi.mocked(useValidationStateModule.useValidationState).mockReturnValue({
+      state: {
+        homeRoster: { reviewed: false, modifications: { added: [], removed: [] } },
+        awayRoster: { reviewed: false, modifications: { added: [], removed: [] } },
+        scorer: { selected: null },
+        scoresheet: { file: null, uploaded: false },
+      },
+      isDirty: false,
+      completionStatus: {
+        homeRoster: false,
+        awayRoster: false,
+        scorer: false,
+        scoresheet: true,
+      },
+      isAllRequiredComplete: false,
+      setHomeRosterModifications: vi.fn(),
+      setAwayRosterModifications: vi.fn(),
+      setScorer: vi.fn(),
+      setScoresheet: vi.fn(),
+      reset: vi.fn(),
+      saveProgress: vi.fn().mockResolvedValue(undefined),
+      finalizeValidation: vi.fn().mockResolvedValue(undefined),
+      isSaving: false,
+      isFinalizing: false,
+      isLoadingGameDetails: false,
+      gameDetailsError: null,
     });
   });
 

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -24,6 +24,36 @@ vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
 }));
 
+vi.mock("@/hooks/useValidationState", () => ({
+  useValidationState: vi.fn(() => ({
+    state: {
+      homeRoster: { reviewed: false, modifications: { added: [], removed: [] } },
+      awayRoster: { reviewed: false, modifications: { added: [], removed: [] } },
+      scorer: { selected: null },
+      scoresheet: { file: null, uploaded: false },
+    },
+    isDirty: false,
+    completionStatus: {
+      homeRoster: false,
+      awayRoster: false,
+      scorer: false,
+      scoresheet: true,
+    },
+    isAllRequiredComplete: false,
+    setHomeRosterModifications: vi.fn(),
+    setAwayRosterModifications: vi.fn(),
+    setScorer: vi.fn(),
+    setScoresheet: vi.fn(),
+    reset: vi.fn(),
+    saveProgress: vi.fn().mockResolvedValue(undefined),
+    finalizeValidation: vi.fn().mockResolvedValue(undefined),
+    isSaving: false,
+    isFinalizing: false,
+    isLoadingGameDetails: false,
+    gameDetailsError: null,
+  })),
+}));
+
 function createMockAssignment(overrides: Partial<Assignment> = {}): Assignment {
   return {
     __identity: "assignment-1",

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -147,6 +147,8 @@ export function ValidateGameModal({
     finalizeValidation,
     isSaving,
     isFinalizing,
+    isLoadingGameDetails,
+    gameDetailsError,
   } = useValidationState(gameId);
 
   // Define wizard steps with typed ids for type-safe panel switching
@@ -432,29 +434,55 @@ export function ValidateGameModal({
             totalSteps={totalSteps}
             onSwipeNext={handleNext}
             onSwipePrevious={handleBack}
-            swipeEnabled={!isFinalizing}
+            swipeEnabled={!isFinalizing && !isLoadingGameDetails}
           >
             <div className="max-h-80 overflow-y-auto">
-              {currentStepId === "home-roster" && (
-                <HomeRosterPanel
-                  assignment={assignment}
-                  onModificationsChange={setHomeRosterModifications}
-                />
+              {/* Show loading state while fetching game details */}
+              {isLoadingGameDetails && (
+                <div className="flex items-center justify-center py-8">
+                  <div className="text-sm text-text-muted dark:text-text-muted-dark">
+                    {t("common.loading")}
+                  </div>
+                </div>
               )}
 
-              {currentStepId === "away-roster" && (
-                <AwayRosterPanel
-                  assignment={assignment}
-                  onModificationsChange={setAwayRosterModifications}
-                />
+              {/* Show error if game details failed to load */}
+              {gameDetailsError && !isLoadingGameDetails && (
+                <div
+                  role="alert"
+                  className="p-3 bg-danger-50 dark:bg-danger-900/20 border border-danger-200 dark:border-danger-800 rounded-lg"
+                >
+                  <p className="text-sm text-danger-700 dark:text-danger-400">
+                    {gameDetailsError.message}
+                  </p>
+                </div>
               )}
 
-              {currentStepId === "scorer" && (
-                <ScorerPanel onScorerChange={setScorer} />
-              )}
+              {/* Show panels when not loading and no error */}
+              {!isLoadingGameDetails && !gameDetailsError && (
+                <>
+                  {currentStepId === "home-roster" && (
+                    <HomeRosterPanel
+                      assignment={assignment}
+                      onModificationsChange={setHomeRosterModifications}
+                    />
+                  )}
 
-              {currentStepId === "scoresheet" && (
-                <ScoresheetPanel onScoresheetChange={setScoresheet} />
+                  {currentStepId === "away-roster" && (
+                    <AwayRosterPanel
+                      assignment={assignment}
+                      onModificationsChange={setAwayRosterModifications}
+                    />
+                  )}
+
+                  {currentStepId === "scorer" && (
+                    <ScorerPanel onScorerChange={setScorer} />
+                  )}
+
+                  {currentStepId === "scoresheet" && (
+                    <ScoresheetPanel onScoresheetChange={setScoresheet} />
+                  )}
+                </>
               )}
             </div>
           </WizardStepContainer>
@@ -528,6 +556,8 @@ export function ValidateGameModal({
                   onClick={() => handleFinish()}
                   disabled={
                     isFinalizing ||
+                    isLoadingGameDetails ||
+                    !!gameDetailsError ||
                     !allPreviousRequiredStepsDone ||
                     (!currentStep.isOptional && !canMarkCurrentStepDone)
                   }
@@ -546,7 +576,12 @@ export function ValidateGameModal({
                 <button
                   type="button"
                   onClick={handleValidateAndNext}
-                  disabled={isFinalizing || !canMarkCurrentStepDone}
+                  disabled={
+                    isFinalizing ||
+                    isLoadingGameDetails ||
+                    !!gameDetailsError ||
+                    !canMarkCurrentStepDone
+                  }
                   className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {t("validation.wizard.validate")}

--- a/web-app/src/hooks/useValidationState.ts
+++ b/web-app/src/hooks/useValidationState.ts
@@ -286,7 +286,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
   const saveProgress = useCallback(async (): Promise<void> => {
     // Guard against concurrent saves
     if (isSavingRef.current) {
-      logger.debug("[useValidationState] Save already in progress, skipping");
+      logger.debug("[VS] save skip: in progress");
       return;
     }
 
@@ -298,13 +298,11 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
 
       // If no game details, we can't make API calls
       if (!gameId || !gameDetails) {
-        logger.warn(
-          "[useValidationState] No game ID or game details available for save",
-        );
+        logger.warn("[VS] no game data for save");
         return;
       }
 
-      logger.debug("[useValidationState] Saving validation progress:", state);
+      logger.debug("[VS] saving:", state);
 
       // Save home roster if modified
       const homeNomList = gameDetails.nominationListOfTeamHome;
@@ -323,7 +321,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
           homeNomList.team.__identity,
           playerIds,
         );
-        logger.debug("[useValidationState] Home roster updated");
+        logger.debug("[VS] home roster saved");
       }
 
       // Save away roster if modified
@@ -343,7 +341,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
           awayNomList.team.__identity,
           playerIds,
         );
-        logger.debug("[useValidationState] Away roster updated");
+        logger.debug("[VS] away roster saved");
       }
 
       // Save scoresheet with scorer if scorer is selected
@@ -358,12 +356,12 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
           state.scorer.selected.__identity,
           scoresheet.isSimpleScoresheet ?? false,
         );
-        logger.debug("[useValidationState] Scoresheet updated with scorer");
+        logger.debug("[VS] scoresheet saved");
       }
 
-      logger.debug("[useValidationState] Save complete");
+      logger.debug("[VS] save done");
     } catch (error) {
-      logger.error("[useValidationState] Save failed:", error);
+      logger.error("[VS] save failed:", error);
       throw error;
     } finally {
       isSavingRef.current = false;
@@ -381,9 +379,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
   const finalizeValidation = useCallback(async (): Promise<void> => {
     // Guard against concurrent operations
     if (isFinalizingRef.current) {
-      logger.debug(
-        "[useValidationState] Finalize already in progress, skipping",
-      );
+      logger.debug("[VS] finalize skip: in progress");
       return;
     }
 
@@ -395,16 +391,11 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
 
       // If no game details, we can't make API calls
       if (!gameId || !gameDetails) {
-        logger.warn(
-          "[useValidationState] No game ID or game details available for finalize",
-        );
+        logger.warn("[VS] no game data for finalize");
         return;
       }
 
-      logger.debug(
-        "[useValidationState] Finalizing validation for game:",
-        gameId,
-      );
+      logger.debug("[VS] finalizing:", gameId);
 
       // Upload scoresheet PDF if provided
       let fileResourceId: string | undefined;
@@ -413,10 +404,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
           state.scoresheet.file,
         );
         fileResourceId = uploadResult[0]?.__identity;
-        logger.debug(
-          "[useValidationState] Scoresheet PDF uploaded:",
-          fileResourceId,
-        );
+        logger.debug("[VS] PDF uploaded:", fileResourceId);
       }
 
       // Finalize home roster
@@ -433,7 +421,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
           playerIds,
           homeNomList.nominationListValidation?.__identity,
         );
-        logger.debug("[useValidationState] Home roster finalized");
+        logger.debug("[VS] home finalized");
       }
 
       // Finalize away roster
@@ -450,7 +438,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
           playerIds,
           awayNomList.nominationListValidation?.__identity,
         );
-        logger.debug("[useValidationState] Away roster finalized");
+        logger.debug("[VS] away finalized");
       }
 
       // Finalize scoresheet if scorer is selected and file is uploaded
@@ -468,7 +456,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
           scoresheet.scoresheetValidation?.__identity,
           scoresheet.isSimpleScoresheet ?? false,
         );
-        logger.debug("[useValidationState] Scoresheet finalized");
+        logger.debug("[VS] scoresheet finalized");
       } else if (state.scorer.selected?.__identity && scoresheet?.__identity) {
         // Update scoresheet with scorer even if no file is uploaded
         await apiClient.updateScoresheet(
@@ -477,14 +465,12 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
           state.scorer.selected.__identity,
           scoresheet.isSimpleScoresheet ?? false,
         );
-        logger.debug(
-          "[useValidationState] Scoresheet updated (no file for finalization)",
-        );
+        logger.debug("[VS] scoresheet saved (no file)");
       }
 
-      logger.debug("[useValidationState] Finalization complete");
+      logger.debug("[VS] finalize done");
     } catch (error) {
-      logger.error("[useValidationState] Finalization failed:", error);
+      logger.error("[VS] finalize failed:", error);
       throw error;
     } finally {
       isFinalizingRef.current = false;

--- a/web-app/src/hooks/useValidationState.ts
+++ b/web-app/src/hooks/useValidationState.ts
@@ -6,8 +6,8 @@ import type { RosterModifications } from "@/hooks/useNominationList";
 import { getApiClient } from "@/api/client";
 import { useAuthStore } from "@/stores/auth";
 
-/** Stale time for game details query */
-const GAME_DETAILS_STALE_TIME_MS = 300000; // 5 minutes
+const MINUTES_TO_MS = 60 * 1000;
+const GAME_DETAILS_STALE_TIME_MS = 5 * MINUTES_TO_MS;
 
 /**
  * State for a roster panel (home or away team).
@@ -161,11 +161,12 @@ async function saveRosterModifications(
   nomList: NominationListForApi | undefined,
   modifications: RosterModifications,
 ): Promise<void> {
-  if (
-    !hasRosterModifications(modifications) ||
-    !nomList?.__identity ||
-    !nomList.team?.__identity
-  ) {
+  if (!hasRosterModifications(modifications)) {
+    logger.debug("[VS] skip roster save: no modifications");
+    return;
+  }
+  if (!nomList?.__identity || !nomList.team?.__identity) {
+    logger.debug("[VS] skip roster save: missing nomination list or team ID");
     return;
   }
 
@@ -186,6 +187,7 @@ async function saveScorerSelection(
   scorerId: string | undefined,
 ): Promise<void> {
   if (!scorerId || !scoresheet?.__identity) {
+    logger.debug("[VS] skip scorer save: no scorer or scoresheet ID");
     return;
   }
 
@@ -205,6 +207,7 @@ async function finalizeRoster(
   modifications: RosterModifications,
 ): Promise<void> {
   if (!nomList?.__identity || !nomList.team?.__identity) {
+    logger.debug("[VS] skip roster finalize: missing nomination list or team ID");
     return;
   }
 
@@ -227,6 +230,7 @@ async function finalizeScoresheetWithFile(
   fileResourceId: string | undefined,
 ): Promise<void> {
   if (!scorerId || !scoresheet?.__identity) {
+    logger.debug("[VS] skip scoresheet finalize: no scorer or scoresheet ID");
     return;
   }
 


### PR DESCRIPTION
Replace simulated API operations with real API calls for game validation
workflow:

- Add API methods for scoresheet and nomination list operations:
  - getGameWithScoresheet: fetch game details with scoresheet info
  - updateNominationList/finalizeNominationList: roster management
  - updateScoresheet/finalizeScoresheet: scoresheet management
  - uploadResource: file upload for scoresheet PDFs

- Update useValidationState hook to:
  - Accept gameId parameter for API operations
  - Implement saveProgress with actual API calls
  - Add finalizeValidation method for completing validation

- Update ValidateGameModal to use the new API methods

- Add scoresheet property to GameDetails schema in OpenAPI spec