### PR TITLE
refactor(ui): replace emoji icons with Lucide icons in swipeable drawers

### DIFF
--- a/web-app/src/components/ui/SwipeableCard.tsx
+++ b/web-app/src/components/ui/SwipeableCard.tsx
@@ -489,7 +489,7 @@ export function SwipeableCard({
                 }}
                 aria-label={action.label}
               >
-                {action.icon && <span className="text-xl">{action.icon}</span>}
+                {action.icon}
                 <span className="text-xs font-medium">
                   {action.shortLabel || action.label.split(" ")[0]}
                 </span>

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -27,6 +27,7 @@ export { Trash2 } from "lucide-react";
 export { Undo2 } from "lucide-react";
 export { ChevronDown } from "lucide-react";
 export { Circle } from "lucide-react";
+export { X } from "lucide-react";
 
 // Status icons
 export { CheckCircle } from "lucide-react";

--- a/web-app/src/types/swipe.ts
+++ b/web-app/src/types/swipe.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 export interface SwipeAction {
   id: string;
   label: string;
@@ -5,7 +7,7 @@ export interface SwipeAction {
   shortLabel?: string;
   color: string;
   onAction: () => void;
-  icon?: string;
+  icon?: ReactNode;
 }
 
 export interface SwipeConfig {

--- a/web-app/src/types/swipe.ts
+++ b/web-app/src/types/swipe.ts
@@ -36,3 +36,9 @@ export interface SwipeConfig {
 export const DRAWER_OPEN_RATIO = 0.3;
 export const FULL_SWIPE_RATIO = 0.7;
 export const MINIMUM_SWIPE_RATIO = 0.03;
+
+/**
+ * Standard icon size for swipe action buttons.
+ * Used consistently across all swipe action configurations.
+ */
+export const SWIPE_ACTION_ICON_SIZE = 20;

--- a/web-app/src/utils/assignment-actions.test.ts
+++ b/web-app/src/utils/assignment-actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { isValidElement } from "react";
 import { createAssignmentActions, downloadPDF } from "./assignment-actions";
 import type { Assignment } from "@/api/client";
 
@@ -73,12 +74,12 @@ describe("createAssignmentActions", () => {
     expect(actions.editCompensation.id).toBe("edit-compensation");
     expect(actions.editCompensation.label).toBe("Edit Compensation");
     expect(actions.editCompensation.color).toBe("bg-primary-500");
-    expect(actions.editCompensation.icon).toBe("💰");
+    expect(isValidElement(actions.editCompensation.icon)).toBe(true);
 
     expect(actions.validateGame.id).toBe("validate-game");
     expect(actions.validateGame.label).toBe("Validate Game");
     expect(actions.validateGame.color).toBe("bg-success-500");
-    expect(actions.validateGame.icon).toBe("✓");
+    expect(isValidElement(actions.validateGame.icon)).toBe(true);
   });
 });
 

--- a/web-app/src/utils/assignment-actions.ts
+++ b/web-app/src/utils/assignment-actions.ts
@@ -1,5 +1,9 @@
+import { createElement } from "react";
 import type { Assignment } from "@/api/client";
 import type { SwipeAction } from "@/types/swipe";
+import { Wallet, Check, FileText, ArrowLeftRight } from "@/components/ui/icons";
+
+const ICON_SIZE = 20;
 
 export interface AssignmentActionConfig {
   editCompensation: SwipeAction;
@@ -25,7 +29,7 @@ export function createAssignmentActions(
       label: "Edit Compensation",
       shortLabel: "Edit",
       color: "bg-primary-500",
-      icon: "💰",
+      icon: createElement(Wallet, { size: ICON_SIZE }),
       onAction: () => handlers.onEditCompensation(assignment),
     },
     validateGame: {
@@ -33,7 +37,7 @@ export function createAssignmentActions(
       label: "Validate Game",
       shortLabel: "Validate",
       color: "bg-success-500",
-      icon: "✓",
+      icon: createElement(Check, { size: ICON_SIZE }),
       onAction: () => handlers.onValidateGame(assignment),
     },
     generateReport: {
@@ -41,7 +45,7 @@ export function createAssignmentActions(
       label: "Generate Report",
       shortLabel: "Report",
       color: "bg-warning-500",
-      icon: "📄",
+      icon: createElement(FileText, { size: ICON_SIZE }),
       onAction: () => handlers.onGenerateReport(assignment),
     },
     addToExchange: {
@@ -49,7 +53,7 @@ export function createAssignmentActions(
       label: "Add to Exchange",
       shortLabel: "Exchange",
       color: "bg-success-500",
-      icon: "↔",
+      icon: createElement(ArrowLeftRight, { size: ICON_SIZE }),
       onAction: () => handlers.onAddToExchange(assignment),
     },
   };

--- a/web-app/src/utils/assignment-actions.ts
+++ b/web-app/src/utils/assignment-actions.ts
@@ -1,9 +1,13 @@
 import { createElement } from "react";
 import type { Assignment } from "@/api/client";
-import type { SwipeAction } from "@/types/swipe";
+import { type SwipeAction, SWIPE_ACTION_ICON_SIZE } from "@/types/swipe";
 import { Wallet, Check, FileText, ArrowLeftRight } from "@/components/ui/icons";
 
-const ICON_SIZE = 20;
+// Pre-created icon elements to avoid recreating on each function call
+const ICON_WALLET = createElement(Wallet, { size: SWIPE_ACTION_ICON_SIZE });
+const ICON_CHECK = createElement(Check, { size: SWIPE_ACTION_ICON_SIZE });
+const ICON_FILE_TEXT = createElement(FileText, { size: SWIPE_ACTION_ICON_SIZE });
+const ICON_ARROW_LEFT_RIGHT = createElement(ArrowLeftRight, { size: SWIPE_ACTION_ICON_SIZE });
 
 export interface AssignmentActionConfig {
   editCompensation: SwipeAction;
@@ -29,7 +33,7 @@ export function createAssignmentActions(
       label: "Edit Compensation",
       shortLabel: "Edit",
       color: "bg-primary-500",
-      icon: createElement(Wallet, { size: ICON_SIZE }),
+      icon: ICON_WALLET,
       onAction: () => handlers.onEditCompensation(assignment),
     },
     validateGame: {
@@ -37,7 +41,7 @@ export function createAssignmentActions(
       label: "Validate Game",
       shortLabel: "Validate",
       color: "bg-success-500",
-      icon: createElement(Check, { size: ICON_SIZE }),
+      icon: ICON_CHECK,
       onAction: () => handlers.onValidateGame(assignment),
     },
     generateReport: {
@@ -45,7 +49,7 @@ export function createAssignmentActions(
       label: "Generate Report",
       shortLabel: "Report",
       color: "bg-warning-500",
-      icon: createElement(FileText, { size: ICON_SIZE }),
+      icon: ICON_FILE_TEXT,
       onAction: () => handlers.onGenerateReport(assignment),
     },
     addToExchange: {
@@ -53,7 +57,7 @@ export function createAssignmentActions(
       label: "Add to Exchange",
       shortLabel: "Exchange",
       color: "bg-success-500",
-      icon: createElement(ArrowLeftRight, { size: ICON_SIZE }),
+      icon: ICON_ARROW_LEFT_RIGHT,
       onAction: () => handlers.onAddToExchange(assignment),
     },
   };

--- a/web-app/src/utils/compensation-actions.test.ts
+++ b/web-app/src/utils/compensation-actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isValidElement } from "react";
 import {
   createCompensationActions,
   downloadCompensationPDF,
@@ -62,12 +63,12 @@ describe("createCompensationActions", () => {
     expect(actions.editCompensation.id).toBe("edit-compensation");
     expect(actions.editCompensation.label).toBe("Edit Compensation");
     expect(actions.editCompensation.color).toBe("bg-primary-500");
-    expect(actions.editCompensation.icon).toBe("💰");
+    expect(isValidElement(actions.editCompensation.icon)).toBe(true);
 
     expect(actions.generatePDF.id).toBe("generate-pdf");
     expect(actions.generatePDF.label).toBe("Generate PDF");
     expect(actions.generatePDF.color).toBe("bg-warning-500");
-    expect(actions.generatePDF.icon).toBe("📄");
+    expect(isValidElement(actions.generatePDF.icon)).toBe(true);
   });
 });
 

--- a/web-app/src/utils/compensation-actions.ts
+++ b/web-app/src/utils/compensation-actions.ts
@@ -1,9 +1,11 @@
 import { createElement } from "react";
 import type { CompensationRecord } from "@/api/client";
-import type { SwipeAction } from "@/types/swipe";
+import { type SwipeAction, SWIPE_ACTION_ICON_SIZE } from "@/types/swipe";
 import { Wallet, FileText } from "@/components/ui/icons";
 
-const ICON_SIZE = 20;
+// Pre-created icon elements to avoid recreating on each function call
+const ICON_WALLET = createElement(Wallet, { size: SWIPE_ACTION_ICON_SIZE });
+const ICON_FILE_TEXT = createElement(FileText, { size: SWIPE_ACTION_ICON_SIZE });
 
 export interface CompensationActionConfig {
   editCompensation: SwipeAction;
@@ -25,7 +27,7 @@ export function createCompensationActions(
       label: "Edit Compensation",
       shortLabel: "Edit",
       color: "bg-primary-500",
-      icon: createElement(Wallet, { size: ICON_SIZE }),
+      icon: ICON_WALLET,
       onAction: () => handlers.onEditCompensation(compensation),
     },
     generatePDF: {
@@ -33,7 +35,7 @@ export function createCompensationActions(
       label: "Generate PDF",
       shortLabel: "PDF",
       color: "bg-warning-500",
-      icon: createElement(FileText, { size: ICON_SIZE }),
+      icon: ICON_FILE_TEXT,
       onAction: () => handlers.onGeneratePDF(compensation),
     },
   };

--- a/web-app/src/utils/compensation-actions.ts
+++ b/web-app/src/utils/compensation-actions.ts
@@ -1,9 +1,9 @@
+import { createElement } from "react";
 import type { CompensationRecord } from "@/api/client";
 import type { SwipeAction } from "@/types/swipe";
+import { Wallet, FileText } from "@/components/ui/icons";
 
-// Swipe action icons
-const ICON_EDIT = "💰";
-const ICON_PDF = "📄";
+const ICON_SIZE = 20;
 
 export interface CompensationActionConfig {
   editCompensation: SwipeAction;
@@ -25,7 +25,7 @@ export function createCompensationActions(
       label: "Edit Compensation",
       shortLabel: "Edit",
       color: "bg-primary-500",
-      icon: ICON_EDIT,
+      icon: createElement(Wallet, { size: ICON_SIZE }),
       onAction: () => handlers.onEditCompensation(compensation),
     },
     generatePDF: {
@@ -33,7 +33,7 @@ export function createCompensationActions(
       label: "Generate PDF",
       shortLabel: "PDF",
       color: "bg-warning-500",
-      icon: ICON_PDF,
+      icon: createElement(FileText, { size: ICON_SIZE }),
       onAction: () => handlers.onGeneratePDF(compensation),
     },
   };

--- a/web-app/src/utils/exchange-actions.test.ts
+++ b/web-app/src/utils/exchange-actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { isValidElement } from "react";
 import { createExchangeActions } from "./exchange-actions";
 import type { GameExchange } from "@/api/client";
 
@@ -70,7 +71,7 @@ describe("createExchangeActions", () => {
     expect(actions.takeOver.label).toBe("Take Over");
     expect(actions.takeOver.shortLabel).toBe("Take Over");
     expect(actions.takeOver.color).toBe("bg-success-500");
-    expect(actions.takeOver.icon).toBe("✓");
+    expect(isValidElement(actions.takeOver.icon)).toBe(true);
   });
 
   it("should have correct remove from exchange action properties", () => {
@@ -85,6 +86,6 @@ describe("createExchangeActions", () => {
     expect(actions.removeFromExchange.label).toBe("Remove");
     expect(actions.removeFromExchange.shortLabel).toBe("Remove");
     expect(actions.removeFromExchange.color).toBe("bg-danger-500");
-    expect(actions.removeFromExchange.icon).toBe("✕");
+    expect(isValidElement(actions.removeFromExchange.icon)).toBe(true);
   });
 });

--- a/web-app/src/utils/exchange-actions.ts
+++ b/web-app/src/utils/exchange-actions.ts
@@ -1,9 +1,9 @@
+import { createElement } from "react";
 import type { GameExchange } from "@/api/client";
 import type { SwipeAction } from "@/types/swipe";
+import { Check, X } from "@/components/ui/icons";
 
-// Swipe action icons
-const ICON_CHECKMARK = "✓";
-const ICON_REMOVE = "✕";
+const ICON_SIZE = 20;
 
 export interface ExchangeActionConfig {
   takeOver: SwipeAction;
@@ -25,7 +25,7 @@ export function createExchangeActions(
       label: "Take Over",
       shortLabel: "Take Over",
       color: "bg-success-500",
-      icon: ICON_CHECKMARK,
+      icon: createElement(Check, { size: ICON_SIZE }),
       onAction: () => handlers.onTakeOver(exchange),
     },
     removeFromExchange: {
@@ -33,7 +33,7 @@ export function createExchangeActions(
       label: "Remove",
       shortLabel: "Remove",
       color: "bg-danger-500",
-      icon: ICON_REMOVE,
+      icon: createElement(X, { size: ICON_SIZE }),
       onAction: () => handlers.onRemoveFromExchange(exchange),
     },
   };

--- a/web-app/src/utils/exchange-actions.ts
+++ b/web-app/src/utils/exchange-actions.ts
@@ -1,9 +1,11 @@
 import { createElement } from "react";
 import type { GameExchange } from "@/api/client";
-import type { SwipeAction } from "@/types/swipe";
+import { type SwipeAction, SWIPE_ACTION_ICON_SIZE } from "@/types/swipe";
 import { Check, X } from "@/components/ui/icons";
 
-const ICON_SIZE = 20;
+// Pre-created icon elements to avoid recreating on each function call
+const ICON_CHECK = createElement(Check, { size: SWIPE_ACTION_ICON_SIZE });
+const ICON_X = createElement(X, { size: SWIPE_ACTION_ICON_SIZE });
 
 export interface ExchangeActionConfig {
   takeOver: SwipeAction;
@@ -25,7 +27,7 @@ export function createExchangeActions(
       label: "Take Over",
       shortLabel: "Take Over",
       color: "bg-success-500",
-      icon: createElement(Check, { size: ICON_SIZE }),
+      icon: ICON_CHECK,
       onAction: () => handlers.onTakeOver(exchange),
     },
     removeFromExchange: {
@@ -33,7 +35,7 @@ export function createExchangeActions(
       label: "Remove",
       shortLabel: "Remove",
       color: "bg-danger-500",
-      icon: createElement(X, { size: ICON_SIZE }),
+      icon: ICON_X,
       onAction: () => handlers.onRemoveFromExchange(exchange),
     },
   };


### PR DESCRIPTION
Update swipe action icons to use Lucide React components instead of emoji
characters for visual consistency with the rest of the application.

Changes:
- Update SwipeAction interface to accept ReactNode for icon field
- Add X icon to centralized icons.tsx exports
- Convert assignment-actions.ts to use Wallet, Check, FileText, ArrowLeftRight
- Convert compensation-actions.ts to use Wallet, FileText
- Convert exchange-actions.ts to use Check, X
- Update SwipeableCard to render ReactNode icons directly
- Update tests to verify icons are valid React elements