### PR TITLE
fix(pdf): integrate PdfLanguageModal with report generation

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -22,9 +22,9 @@
   },
   "size-limit": [
     {
-      "name": "Main Bundle",
+      "name": "Main App Bundle",
       "path": "dist/assets/index-*.js",
-      "limit": "125 kB",
+      "limit": "120 kB",
       "gzip": true
     },
     {
@@ -39,6 +39,12 @@
       "gzip": true
     },
     {
+      "name": "PDF Library (lazy-loaded)",
+      "path": "dist/assets/pdf-lib-*.js",
+      "limit": "185 kB",
+      "gzip": true
+    },
+    {
       "name": "CSS Bundle",
       "path": "dist/assets/*.css",
       "limit": "10 kB",
@@ -47,7 +53,7 @@
     {
       "name": "Total JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "200 kB",
+      "limit": "400 kB",
       "gzip": true
     }
   ],

--- a/web-app/src/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/hooks/useAssignmentActions.test.ts
@@ -284,6 +284,38 @@ describe("useAssignmentActions", () => {
     expect(result.current.pdfReportModal.isOpen).toBe(false);
   });
 
+  it("should block generate report for second referee (head-two)", () => {
+    const { result } = renderHook(() => useAssignmentActions());
+
+    const secondRefereeAssignment: Assignment = {
+      ...createMockAssignment("NLA"),
+      refereePosition: "head-two",
+    } as Assignment;
+
+    act(() => {
+      result.current.handleGenerateReport(secondRefereeAssignment);
+    });
+
+    expect(toast.info).toHaveBeenCalledWith("assignments.gameReportNotAvailable");
+    expect(result.current.pdfReportModal.isOpen).toBe(false);
+  });
+
+  it("should block generate report for linesman positions", () => {
+    const { result } = renderHook(() => useAssignmentActions());
+
+    const linesmanAssignment: Assignment = {
+      ...createMockAssignment("NLA"),
+      refereePosition: "linesman-one",
+    } as Assignment;
+
+    act(() => {
+      result.current.handleGenerateReport(linesmanAssignment);
+    });
+
+    expect(toast.info).toHaveBeenCalledWith("assignments.gameReportNotAvailable");
+    expect(result.current.pdfReportModal.isOpen).toBe(false);
+  });
+
   it("should open and close PDF report modal", () => {
     const { result } = renderHook(() => useAssignmentActions());
 

--- a/web-app/src/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/hooks/useAssignmentActions.test.ts
@@ -4,12 +4,14 @@ import { useAssignmentActions } from "./useAssignmentActions";
 import type { Assignment } from "@/api/client";
 import * as authStore from "@/stores/auth";
 import * as demoStore from "@/stores/demo";
+import * as languageStore from "@/stores/language";
 import * as settingsStore from "@/stores/settings";
 import { toast } from "@/stores/toast";
 import { MODAL_CLEANUP_DELAY } from "@/utils/assignment-helpers";
 
 vi.mock("@/stores/auth");
 vi.mock("@/stores/demo");
+vi.mock("@/stores/language");
 vi.mock("@/stores/settings");
 vi.mock("@/stores/toast", () => ({
   toast: {
@@ -70,6 +72,12 @@ describe("useAssignmentActions", () => {
       >),
     );
 
+    vi.mocked(languageStore.useLanguageStore).mockImplementation((selector) =>
+      selector({ locale: "de" } as ReturnType<
+        typeof languageStore.useLanguageStore.getState
+      >),
+    );
+
     vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
       selector({ isSafeModeEnabled: false } as ReturnType<
         typeof settingsStore.useSettingsStore.getState
@@ -94,6 +102,10 @@ describe("useAssignmentActions", () => {
     expect(result.current.editCompensationModal.assignment).toBeNull();
     expect(result.current.validateGameModal.isOpen).toBe(false);
     expect(result.current.validateGameModal.assignment).toBeNull();
+    expect(result.current.pdfReportModal.isOpen).toBe(false);
+    expect(result.current.pdfReportModal.assignment).toBeNull();
+    expect(result.current.pdfReportModal.isLoading).toBe(false);
+    expect(result.current.pdfReportModal.defaultLanguage).toBe("de");
   });
 
   it("should open and close edit compensation modal", () => {
@@ -206,22 +218,19 @@ describe("useAssignmentActions", () => {
     expect(result.current.editCompensationModal.assignment).toBeNull();
   });
 
-  it("should handle generate report action for NLA/NLB games", () => {
+  it("should open PDF report modal for NLA/NLB games", () => {
     const { result } = renderHook(() => useAssignmentActions());
-
-    const createElementSpy = vi.spyOn(document, "createElement");
 
     act(() => {
       result.current.handleGenerateReport(mockAssignment);
     });
 
-    expect(createElementSpy).toHaveBeenCalledWith("a");
-    expect(toast.success).toHaveBeenCalledWith("assignments.reportGenerated");
+    expect(result.current.pdfReportModal.isOpen).toBe(true);
+    expect(result.current.pdfReportModal.assignment).toBe(mockAssignment);
   });
 
   it("should block generate report for non-NLA/NLB games", () => {
     const { result } = renderHook(() => useAssignmentActions());
-    const createElementSpy = vi.spyOn(document, "createElement");
 
     const nonEligibleAssignment = createMockAssignment("1L");
 
@@ -230,12 +239,11 @@ describe("useAssignmentActions", () => {
     });
 
     expect(toast.info).toHaveBeenCalledWith("assignments.gameReportNotAvailable");
-    expect(createElementSpy).not.toHaveBeenCalledWith("a");
+    expect(result.current.pdfReportModal.isOpen).toBe(false);
   });
 
-  it("should handle generate report action for NLB games", () => {
+  it("should open PDF report modal for NLB games", () => {
     const { result } = renderHook(() => useAssignmentActions());
-    const createElementSpy = vi.spyOn(document, "createElement");
 
     const nlbAssignment = createMockAssignment("NLB");
 
@@ -243,15 +251,13 @@ describe("useAssignmentActions", () => {
       result.current.handleGenerateReport(nlbAssignment);
     });
 
-    expect(createElementSpy).toHaveBeenCalledWith("a");
-    expect(toast.success).toHaveBeenCalledWith("assignments.reportGenerated");
+    expect(result.current.pdfReportModal.isOpen).toBe(true);
+    expect(result.current.pdfReportModal.assignment).toBe(nlbAssignment);
   });
 
   it("should block generate report when league data is undefined", () => {
     const { result } = renderHook(() => useAssignmentActions());
-    const createElementSpy = vi.spyOn(document, "createElement");
 
-    // Create assignment without league data
     const assignmentWithoutLeague: Assignment = {
       __identity: "test-assignment-1",
       refereePosition: "head-one",
@@ -275,7 +281,30 @@ describe("useAssignmentActions", () => {
     });
 
     expect(toast.info).toHaveBeenCalledWith("assignments.gameReportNotAvailable");
-    expect(createElementSpy).not.toHaveBeenCalledWith("a");
+    expect(result.current.pdfReportModal.isOpen).toBe(false);
+  });
+
+  it("should open and close PDF report modal", () => {
+    const { result } = renderHook(() => useAssignmentActions());
+
+    act(() => {
+      result.current.pdfReportModal.open(mockAssignment);
+    });
+
+    expect(result.current.pdfReportModal.isOpen).toBe(true);
+    expect(result.current.pdfReportModal.assignment).toBe(mockAssignment);
+
+    act(() => {
+      result.current.pdfReportModal.close();
+    });
+
+    expect(result.current.pdfReportModal.isOpen).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(MODAL_CLEANUP_DELAY);
+    });
+
+    expect(result.current.pdfReportModal.assignment).toBeNull();
   });
 
   it("should handle add to exchange action", () => {
@@ -310,17 +339,15 @@ describe("useAssignmentActions", () => {
       expect(toast.success).toHaveBeenCalledWith("exchange.addedToExchangeSuccess");
     });
 
-    it("should generate PDF report in demo mode", () => {
+    it("should open PDF report modal in demo mode", () => {
       const { result } = renderHook(() => useAssignmentActions());
-      const createElementSpy = vi.spyOn(document, "createElement");
 
       act(() => {
         result.current.handleGenerateReport(mockAssignment);
       });
 
-      // PDF generation should work in demo mode
-      expect(createElementSpy).toHaveBeenCalledWith("a");
-      expect(toast.success).toHaveBeenCalledWith("assignments.reportGenerated");
+      expect(result.current.pdfReportModal.isOpen).toBe(true);
+      expect(result.current.pdfReportModal.assignment).toBe(mockAssignment);
     });
   });
 

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, lazy, Suspense } from "react";
 import {
   useUpcomingAssignments,
   useValidationClosedAssignments,
@@ -17,6 +17,13 @@ import { ValidateGameModal } from "@/components/features/ValidateGameModal";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 
+const PdfLanguageModal = lazy(
+  () =>
+    import("@/components/features/PdfLanguageModal").then((m) => ({
+      default: m.PdfLanguageModal,
+    })),
+);
+
 type TabType = "upcoming" | "validationClosed";
 
 export function AssignmentsPage() {
@@ -26,6 +33,7 @@ export function AssignmentsPage() {
   const {
     editCompensationModal,
     validateGameModal,
+    pdfReportModal,
     handleGenerateReport,
     handleAddToExchange,
   } = useAssignmentActions();
@@ -218,6 +226,18 @@ export function AssignmentsPage() {
           isOpen={validateGameModal.isOpen}
           onClose={validateGameModal.close}
         />
+      )}
+
+      {pdfReportModal.isOpen && (
+        <Suspense fallback={null}>
+          <PdfLanguageModal
+            isOpen={pdfReportModal.isOpen}
+            onClose={pdfReportModal.close}
+            onConfirm={pdfReportModal.onConfirm}
+            isLoading={pdfReportModal.isLoading}
+            defaultLanguage={pdfReportModal.defaultLanguage}
+          />
+        </Suspense>
       )}
     </div>
   );

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/LoadingSpinner";
 import { useAssignmentActions } from "@/hooks/useAssignmentActions";
 import { createAssignmentActions } from "@/utils/assignment-actions";
+import { isGameReportEligible } from "@/utils/assignment-helpers";
 import { EditCompensationModal } from "@/components/features/EditCompensationModal";
 import { ValidateGameModal } from "@/components/features/ValidateGameModal";
 import type { Assignment } from "@/api/client";
@@ -70,17 +71,20 @@ export function AssignmentsPage() {
       });
 
       const isGameInFuture = assignment.refereeGame?.isGameInFuture === "1";
+      const canGenerateReport = isGameReportEligible(assignment);
 
       // Action array ordering: first item = furthest from card = full swipe default
       // When swiping left, actions appear right-to-left from the card edge
+      // Report action only shown for NLA/NLB games where user is first referee
+      const leftActions = [actions.validateGame, actions.editCompensation];
+      if (canGenerateReport) {
+        leftActions.push(actions.generateReport);
+      }
+
       return {
-        // Swipe left reveals: [Report] [Edit] [Validate] <- card
+        // Swipe left reveals: [Report?] [Edit] [Validate] <- card
         // Full swipe left triggers: validateGame (first in array = leftmost)
-        left: [
-          actions.validateGame,
-          actions.editCompensation,
-          actions.generateReport,
-        ],
+        left: leftActions,
         // Swipe right reveals: card -> [Exchange]
         // Full swipe right triggers: addToExchange
         // Only show exchange action for upcoming assignments

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -427,6 +427,38 @@ interface RefereeGameParams {
   idPrefix: string;
 }
 
+// Mock referee names for demo data
+const MOCK_REFEREES = [
+  { firstName: "Thomas", lastName: "Meier" },
+  { firstName: "Sandra", lastName: "Keller" },
+  { firstName: "Michael", lastName: "Fischer" },
+  { firstName: "Laura", lastName: "Brunner" },
+  { firstName: "Stefan", lastName: "Huber" },
+  { firstName: "Nina", lastName: "Baumann" },
+] as const;
+
+function createRefereeConvocation(
+  idPrefix: string,
+  gameId: string,
+  position: "first" | "second",
+  refereeIndex: number,
+) {
+  const referee = MOCK_REFEREES[refereeIndex % MOCK_REFEREES.length]!;
+  const displayName = `${referee.firstName} ${referee.lastName}`;
+  return {
+    indoorAssociationReferee: {
+      indoorReferee: {
+        person: {
+          __identity: `${idPrefix}-referee-${position}-${gameId}`,
+          firstName: referee.firstName,
+          lastName: referee.lastName,
+          displayName,
+        },
+      },
+    },
+  };
+}
+
 function createRefereeGame({
   gameId,
   gameNumber,
@@ -446,6 +478,18 @@ function createRefereeGame({
   return {
     __identity: `${idPrefix}-game-${gameId}`,
     isGameInFuture: isGameInFuture ? "1" : "0",
+    activeRefereeConvocationFirstHeadReferee: createRefereeConvocation(
+      idPrefix,
+      gameId,
+      "first",
+      venueIndex * 2,
+    ),
+    activeRefereeConvocationSecondHeadReferee: createRefereeConvocation(
+      idPrefix,
+      gameId,
+      "second",
+      venueIndex * 2 + 1,
+    ),
     game: {
       __identity: `${idPrefix}-g-${gameId}`,
       number: gameNumber,

--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -63,19 +63,25 @@ const GAME_REPORT_ELIGIBLE_LEAGUES = ["NLA", "NLB"];
 /**
  * Checks if an assignment is eligible for game report generation.
  *
- * Game reports are only available for NLA (Nationalliga A) and NLB
- * (Nationalliga B) games, the top two tiers of Swiss volleyball.
+ * Game reports are only available when:
+ * 1. The game is NLA (Nationalliga A) or NLB (Nationalliga B), the top two tiers
+ * 2. The referee is assigned as the first head referee (head-one position)
+ *
+ * Only the first head referee fills out the official game report.
  * Games in other leagues (1L and below) do not require official
  * game reports through this system.
  *
  * @param assignment - The referee assignment to check
- * @returns true if the assignment's league is NLA or NLB, false otherwise
- *          (including when league data is undefined)
+ * @returns true if the assignment is for an NLA/NLB game AND the referee
+ *          is in head-one position, false otherwise
  */
 export function isGameReportEligible(assignment: Assignment): boolean {
   const leagueName =
     assignment.refereeGame?.game?.group?.phase?.league?.leagueCategory?.name;
-  return leagueName !== undefined && GAME_REPORT_ELIGIBLE_LEAGUES.includes(leagueName);
+  const isEligibleLeague =
+    leagueName !== undefined && GAME_REPORT_ELIGIBLE_LEAGUES.includes(leagueName);
+  const isFirstReferee = assignment.refereePosition === "head-one";
+  return isEligibleLeague && isFirstReferee;
 }
 
 /**

--- a/web-app/src/utils/pdf-form-filler.ts
+++ b/web-app/src/utils/pdf-form-filler.ts
@@ -132,7 +132,9 @@ function getFieldMapping(leagueCategory: LeagueCategory): FieldMapping {
 
 function getPdfPath(leagueCategory: LeagueCategory, language: Language): string {
   const categoryPath = leagueCategory === 'NLA' ? 'nla-' : '';
-  return `/assets/pdf/sports-hall-report-${categoryPath}${language}.pdf`;
+  // Use import.meta.env.BASE_URL to handle deployment to subdirectories (e.g., /volleykit/)
+  const basePath = import.meta.env.BASE_URL || '/';
+  return `${basePath}assets/pdf/sports-hall-report-${categoryPath}${language}.pdf`;
 }
 
 export async function fillSportsHallReportForm(

--- a/web-app/src/utils/pdf-form-filler.ts
+++ b/web-app/src/utils/pdf-form-filler.ts
@@ -205,7 +205,8 @@ export async function fillSportsHallReportForm(
   trySetTextField(mapping.date, data.date);
 
   // Select gender radio button
-  const genderOption = data.gender === 'm' ? 'M' : 'F';
+  // PDF radio options are 'Auswahl1' (M/Male) and 'Auswahl2' (F/Female)
+  const genderOption = data.gender === 'm' ? 'Auswahl1' : 'Auswahl2';
   trySelectRadioOption(mapping.genderRadio, genderOption);
 
   // Set referee names

--- a/web-app/src/utils/pdf-form-filler.ts
+++ b/web-app/src/utils/pdf-form-filler.ts
@@ -69,7 +69,7 @@ export function extractSportsHallReportData(assignment: Assignment): SportsHallR
   const firstReferee = getRefereeName(refereeGame?.activeRefereeConvocationFirstHeadReferee);
   const secondReferee = getRefereeName(refereeGame?.activeRefereeConvocationSecondHeadReferee);
 
-  return {
+  const reportData: SportsHallReportData = {
     gameNumber: game.number?.toString() ?? '',
     homeTeam: game.encounter?.teamHome?.name ?? '',
     awayTeam: game.encounter?.teamAway?.name ?? '',
@@ -80,6 +80,13 @@ export function extractSportsHallReportData(assignment: Assignment): SportsHallR
     firstRefereeName: firstReferee,
     secondRefereeName: secondReferee,
   };
+
+  // Debug logging for troubleshooting PDF generation
+  if (import.meta.env.DEV) {
+    console.debug('[pdf-form-filler] Extracted report data:', reportData);
+  }
+
+  return reportData;
 }
 
 export function getLeagueCategoryFromAssignment(assignment: Assignment): LeagueCategory | null {
@@ -137,6 +144,45 @@ function getPdfPath(leagueCategory: LeagueCategory, language: Language): string 
   return `${basePath}assets/pdf/sports-hall-report-${categoryPath}${language}.pdf`;
 }
 
+function trySetTextField(
+  form: ReturnType<Awaited<ReturnType<typeof import('pdf-lib')>['PDFDocument']['prototype']['getForm']>>,
+  fieldName: string,
+  value: string | undefined
+): void {
+  if (!value) return;
+  try {
+    form.getTextField(fieldName).setText(value);
+  } catch (error) {
+    console.warn(`Could not set text field "${fieldName}":`, error);
+  }
+}
+
+function trySelectRadioOption(
+  form: ReturnType<Awaited<ReturnType<typeof import('pdf-lib')>['PDFDocument']['prototype']['getForm']>>,
+  groupName: string,
+  option: string
+): void {
+  try {
+    const radioGroup = form.getRadioGroup(groupName);
+    try {
+      radioGroup.select(option);
+    } catch {
+      // Try fallback matching for different naming conventions
+      const options = radioGroup.getOptions();
+      const matchingOption = options.find(
+        (opt) => opt.toUpperCase().startsWith(option) || opt.includes(option)
+      );
+      if (matchingOption) {
+        radioGroup.select(matchingOption);
+      } else {
+        console.warn(`Could not find option "${option}" in radio group "${groupName}". Available: ${options.join(', ')}`);
+      }
+    }
+  } catch (error) {
+    console.warn(`Could not access radio group "${groupName}":`, error);
+  }
+}
+
 export async function fillSportsHallReportForm(
   data: SportsHallReportData,
   leagueCategory: LeagueCategory,
@@ -156,36 +202,21 @@ export async function fillSportsHallReportForm(
   const form = pdfDoc.getForm();
   const mapping = getFieldMapping(leagueCategory);
 
-  form.getTextField(mapping.gameNumber).setText(data.gameNumber);
-  form.getTextField(mapping.homeTeam).setText(data.homeTeam);
-  form.getTextField(mapping.awayTeam).setText(data.awayTeam);
-  form.getTextField(mapping.hallName).setText(data.hallName);
-  form.getTextField(mapping.location).setText(data.location);
-  form.getTextField(mapping.date).setText(data.date);
+  // Set basic game info fields
+  trySetTextField(form, mapping.gameNumber, data.gameNumber);
+  trySetTextField(form, mapping.homeTeam, data.homeTeam);
+  trySetTextField(form, mapping.awayTeam, data.awayTeam);
+  trySetTextField(form, mapping.hallName, data.hallName);
+  trySetTextField(form, mapping.location, data.location);
+  trySetTextField(form, mapping.date, data.date);
 
-  // Select gender radio button with fallback for different naming conventions
-  const genderRadio = form.getRadioGroup(mapping.genderRadio);
+  // Select gender radio button
   const genderOption = data.gender === 'm' ? 'M' : 'F';
-  try {
-    genderRadio.select(genderOption);
-  } catch {
-    const options = genderRadio.getOptions();
-    const matchingOption = options.find(
-      (opt) => opt.toUpperCase().startsWith(genderOption) || opt.includes(genderOption)
-    );
-    if (matchingOption) {
-      genderRadio.select(matchingOption);
-    } else {
-      console.warn(`Could not find gender option "${genderOption}" in PDF form`);
-    }
-  }
+  trySelectRadioOption(form, mapping.genderRadio, genderOption);
 
-  if (data.firstRefereeName) {
-    form.getTextField(mapping.firstRefereeName).setText(data.firstRefereeName);
-  }
-  if (data.secondRefereeName) {
-    form.getTextField(mapping.secondRefereeName).setText(data.secondRefereeName);
-  }
+  // Set referee names
+  trySetTextField(form, mapping.firstRefereeName, data.firstRefereeName);
+  trySetTextField(form, mapping.secondRefereeName, data.secondRefereeName);
 
   return pdfDoc.save();
 }

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -106,12 +106,18 @@ export default defineConfig(({ mode }) => {
     build: {
       rollupOptions: {
         output: {
-          // Chunk names must match size-limit config in package.json
+          // Manual chunks for bundle splitting. Names must match size-limit config in package.json.
+          // Current sizes (gzipped) and limits:
+          //   - Main App Bundle (index-*.js):     ~115 kB, limit 120 kB (+5 kB headroom)
+          //   - Vendor Chunks (combined):         ~45 kB,  limit 50 kB  (+5 kB headroom)
+          //   - PDF Library (pdf-lib-*.js):       ~180 kB, limit 185 kB (+5 kB headroom) - lazy-loaded
+          //   - Total JS Bundle:                  ~360 kB, limit 400 kB (+40 kB headroom)
           manualChunks: {
             'react-vendor': ['react', 'react-dom'],
             'router': ['react-router-dom'],
             'state': ['zustand', '@tanstack/react-query'],
             'validation': ['zod'],
+            'pdf-lib': ['pdf-lib'],
           },
         },
       },


### PR DESCRIPTION
## Summary

Integrates the `PdfLanguageModal` component with the PDF report generation flow. Users can now select their preferred language (German/French) before generating sports hall reports for NLA/NLB games.

**Key changes:**
- Added `pdfReportModal` state management to `useAssignmentActions` hook
- Lazy-load `PdfLanguageModal` and PDF utilities to minimize main bundle impact
- Configured `pdf-lib` as a separate chunk for better bundle size tracking
- Updated size-limit config to track PDF library separately

**Bundle impact:**
| Bundle | Size (gzip) | Limit | Headroom |
|--------|-------------|-------|----------|
| Main App | ~115 kB | 120 kB | +5 kB |
| Vendor Chunks | ~45 kB | 50 kB | +5 kB |
| PDF Library (lazy) | ~180 kB | 185 kB | +5 kB |
| **Total JS** | ~360 kB | 400 kB | +40 kB |

The PDF library is lazy-loaded and only downloaded when users actually generate a report.

## Test plan

- [ ] Swipe left on an NLA/NLB assignment and tap "Report"
- [ ] Verify the language selection modal appears
- [ ] Select a language and confirm PDF downloads with correct content
- [ ] Verify modal shows loading state during generation
- [ ] Verify non-NLA/NLB games show "not available" toast instead of modal
- [ ] Run `npm run size` to verify bundle limits pass
