### PR TITLE
feat(api): add distanceInMetres to compensation API properties

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -261,6 +261,71 @@ describe("API Client", () => {
     });
   });
 
+  describe("getCompensationDetails", () => {
+    it("sends GET request to showWithNestedObjects endpoint", async () => {
+      const mockDetailsResponse = {
+        convocationCompensation: {
+          __identity: "comp-123",
+          distanceInMetres: 48000,
+          correctionReason: "Test reason",
+        },
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockDetailsResponse));
+
+      await api.getCompensationDetails("comp-123");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "/indoorvolleyball.refadmin/api%5cconvocationcompensation/showWithNestedObjects",
+        ),
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("includes compensation ID in query parameters", async () => {
+      const mockDetailsResponse = { convocationCompensation: {} };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockDetailsResponse));
+
+      await api.getCompensationDetails("test-comp-id");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toContain(
+        "convocationCompensation%5B__identity%5D=test-comp-id",
+      );
+    });
+
+    it("requests correctionReason and distance properties", async () => {
+      const mockDetailsResponse = { convocationCompensation: {} };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockDetailsResponse));
+
+      await api.getCompensationDetails("comp-123");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toContain("propertyRenderConfiguration");
+      expect(url).toContain("correctionReason");
+      expect(url).toContain("distanceInMetres");
+    });
+
+    it("returns detailed compensation data", async () => {
+      const mockDetailsResponse = {
+        convocationCompensation: {
+          __identity: "comp-123",
+          distanceInMetres: 48000,
+          distanceFormatted: "48.0",
+          correctionReason: "Ich wohne in Oberengstringen",
+        },
+      };
+      mockFetch.mockResolvedValueOnce(createMockResponse(mockDetailsResponse));
+
+      const result = await api.getCompensationDetails("comp-123");
+
+      expect(result.convocationCompensation?.distanceInMetres).toBe(48000);
+      expect(result.convocationCompensation?.correctionReason).toBe(
+        "Ich wohne in Oberengstringen",
+      );
+    });
+  });
+
   describe("searchExchanges", () => {
     it("sends POST request to correct endpoint", async () => {
       mockFetch.mockResolvedValueOnce(

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -105,6 +105,8 @@ export type Schemas = components["schemas"];
 export type Assignment = Schemas["Assignment"];
 export type CompensationRecord = Schemas["CompensationRecord"];
 export type ConvocationCompensation = Schemas["ConvocationCompensation"];
+export type ConvocationCompensationDetailed =
+  Schemas["ConvocationCompensationDetailed"];
 export type GameExchange = Schemas["GameExchange"];
 export type Game = Schemas["Game"];
 export type Team = Schemas["Team"];
@@ -514,6 +516,28 @@ export const api = {
     // Validate response structure, then cast to expected type
     validateResponse(data, compensationsResponseSchema, "searchCompensations");
     return data as CompensationsResponse;
+  },
+
+  /**
+   * Fetches detailed compensation data including correctionReason.
+   * Used by the edit compensation modal to display existing correction reasons.
+   *
+   * @param compensationId - UUID of the convocation compensation record
+   * @returns Detailed compensation data with correction history
+   */
+  async getCompensationDetails(
+    compensationId: string,
+  ): Promise<ConvocationCompensationDetailed> {
+    const query = new URLSearchParams();
+    query.set("convocationCompensation[__identity]", compensationId);
+    // Request properties needed for the edit modal
+    query.append("propertyRenderConfiguration[]", "correctionReason");
+    query.append("propertyRenderConfiguration[]", "distanceInMetres");
+    query.append("propertyRenderConfiguration[]", "distanceFormatted");
+
+    return apiRequest<ConvocationCompensationDetailed>(
+      `/indoorvolleyball.refadmin/api%5cconvocationcompensation/showWithNestedObjects?${query}`,
+    );
   },
 
   // Game Exchanges

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -444,6 +444,7 @@ const COMPENSATION_PROPERTIES = [
   "convocationCompensation.hasFlexibleCateringExpenses",
   "convocationCompensation.cateringExpensesFormatted",
   "convocationCompensation.costFormatted",
+  "convocationCompensation.distanceInMetres",
   "convocationCompensation.distanceFormatted",
   "convocationCompensation.transportationMode",
   "convocationCompensation.paymentDone",

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -13,6 +13,7 @@ import type {
   PropertyOrdering,
   Assignment,
   CompensationRecord,
+  ConvocationCompensationDetailed,
   GameExchange,
   AssignmentsResponse,
   CompensationsResponse,
@@ -286,6 +287,40 @@ export const mockApi = {
     return {
       items: items as CompensationRecord[],
       totalItemsCount: total,
+    };
+  },
+
+  async getCompensationDetails(
+    compensationId: string,
+  ): Promise<ConvocationCompensationDetailed> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+
+    const store = useDemoStore.getState();
+    const compensation = store.compensations.find(
+      (c) => c.convocationCompensation?.__identity === compensationId,
+    );
+
+    if (!compensation?.convocationCompensation) {
+      throw new Error(`Compensation not found: ${compensationId}`);
+    }
+
+    // Access the extended demo data which includes correctionReason
+    // The demo store adds correctionReason to the compensation data
+    const demoCompensation = compensation.convocationCompensation as {
+      __identity?: string;
+      distanceInMetres?: number;
+      distanceFormatted?: string;
+      correctionReason?: string | null;
+    };
+
+    // Return detailed compensation data matching the real API structure
+    return {
+      convocationCompensation: {
+        __identity: demoCompensation.__identity,
+        distanceInMetres: demoCompensation.distanceInMetres,
+        distanceFormatted: demoCompensation.distanceFormatted,
+        correctionReason: demoCompensation.correctionReason ?? null,
+      },
     };
   },
 

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -46,6 +46,18 @@ const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const ALLOWED_FILE_TYPES = ["application/pdf"];
 
 /**
+ * Extended compensation data type for demo mode.
+ * The demo store adds additional fields like correctionReason that aren't
+ * in the base ConvocationCompensation type (they're in ConvocationCompensationDetailed).
+ */
+interface DemoConvocationCompensation {
+  __identity?: string;
+  distanceInMetres?: number;
+  distanceFormatted?: string;
+  correctionReason?: string | null;
+}
+
+/**
  * Normalize a string for accent-insensitive comparison.
  * Converts to lowercase, decomposes accented characters (NFD normalization),
  * then removes diacritical marks.
@@ -304,14 +316,9 @@ export const mockApi = {
       throw new Error(`Compensation not found: ${compensationId}`);
     }
 
-    // Access the extended demo data which includes correctionReason
-    // The demo store adds correctionReason to the compensation data
-    const demoCompensation = compensation.convocationCompensation as {
-      __identity?: string;
-      distanceInMetres?: number;
-      distanceFormatted?: string;
-      correctionReason?: string | null;
-    };
+    // Cast to extended type that includes demo-specific fields
+    const demoCompensation =
+      compensation.convocationCompensation as DemoConvocationCompensation;
 
     // Return detailed compensation data matching the real API structure
     return {

--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -6,6 +6,7 @@ import { Check, Circle } from "@/components/ui/icons";
 import type { CompensationRecord } from "@/api/client";
 import { useExpandable } from "@/hooks/useExpandable";
 import { useTranslation } from "@/hooks/useTranslation";
+import { formatDistanceKm } from "@/utils/distance";
 
 interface CompensationCardProps {
   compensation: CompensationRecord;
@@ -130,7 +131,7 @@ export function CompensationCard({
                         Distance:
                       </span>
                       <span className="text-text-secondary dark:text-text-muted-dark">
-                        {(comp.distanceInMetres / 1000).toFixed(1)} km
+                        {formatDistanceKm(comp.distanceInMetres)} km
                       </span>
                     </div>
                   )}

--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -218,19 +218,24 @@ export function EditCompensationModal({
               >
                 {t("assignments.kilometers")}
               </label>
-              <input
-                id="kilometers"
-                type="number"
-                min="0"
-                step="0.1"
-                value={kilometers}
-                onChange={(e) => setKilometers(e.target.value)}
-                className="w-full px-3 py-2 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
-                aria-invalid={errors.kilometers ? "true" : "false"}
-                aria-describedby={
-                  errors.kilometers ? "kilometers-error" : undefined
-                }
-              />
+              <div className="relative">
+                <input
+                  id="kilometers"
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={kilometers}
+                  onChange={(e) => setKilometers(e.target.value)}
+                  className="w-full px-3 py-2 pr-10 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  aria-invalid={errors.kilometers ? "true" : "false"}
+                  aria-describedby={
+                    errors.kilometers ? "kilometers-error" : undefined
+                  }
+                />
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted dark:text-text-muted-dark text-sm pointer-events-none">
+                  km
+                </span>
+              </div>
               {errors.kilometers && (
                 <p
                   id="kilometers-error"

--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import type { Assignment, CompensationRecord } from "@/api/client";
+import { getApiClient } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { logger } from "@/utils/logger";
 import {
@@ -29,6 +30,60 @@ export function EditCompensationModal({
   const [kilometers, setKilometers] = useState("");
   const [reason, setReason] = useState("");
   const [errors, setErrors] = useState<{ kilometers?: string }>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Get the compensation ID from the compensation record
+  // Assignments don't have convocationCompensation, only CompensationRecord does
+  const compensationId = compensation?.convocationCompensation?.__identity;
+
+  // Fetch detailed compensation data when modal opens
+  useEffect(() => {
+    if (!isOpen || !compensationId) return;
+
+    const fetchDetails = async () => {
+      setIsLoading(true);
+      try {
+        const apiClient = getApiClient(isDemoMode);
+        const details = await apiClient.getCompensationDetails(compensationId);
+
+        // Pre-fill form with existing values
+        const distanceInMetres =
+          details.convocationCompensation?.distanceInMetres;
+        if (distanceInMetres !== undefined && distanceInMetres > 0) {
+          setKilometers((distanceInMetres / 1000).toFixed(1));
+        }
+
+        const existingReason =
+          details.convocationCompensation?.correctionReason;
+        if (existingReason) {
+          setReason(existingReason);
+        }
+
+        logger.debug(
+          "[EditCompensationModal] Loaded compensation details:",
+          details,
+        );
+      } catch (error) {
+        logger.error(
+          "[EditCompensationModal] Failed to fetch compensation details:",
+          error,
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchDetails();
+  }, [isOpen, compensationId, isDemoMode]);
+
+  // Reset form when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setKilometers("");
+      setReason("");
+      setErrors({});
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -57,25 +112,27 @@ export function EditCompensationModal({
       const recordId = assignment?.__identity || compensation?.__identity;
 
       if (isDemoMode) {
-        if (recordId && kilometers) {
-          updateCompensation(recordId, {
-            distanceInMetres: km * 1000,
-          });
-          logger.debug(
-            "[EditCompensationModal] Demo mode: updated compensation:",
-            {
-              recordId,
-              distanceInMetres: km * 1000,
-            },
-          );
-        } else {
-          logger.debug(
-            "[EditCompensationModal] Demo mode: no distance provided, skipping update",
-          );
+        if (recordId) {
+          const updateData: { distanceInMetres?: number; correctionReason?: string } = {};
+
+          if (kilometers) {
+            updateData.distanceInMetres = km * 1000;
+          }
+          if (reason) {
+            updateData.correctionReason = reason;
+          }
+
+          if (Object.keys(updateData).length > 0) {
+            updateCompensation(recordId, updateData);
+            logger.debug(
+              "[EditCompensationModal] Demo mode: updated compensation:",
+              { recordId, ...updateData },
+            );
+          }
         }
       } else {
         // Non-demo mode: API call would go here
-        logger.debug("[EditCompensationModal] Mock submit:", {
+        logger.debug("[EditCompensationModal] Submit:", {
           recordId,
           kilometers,
           reason,
@@ -148,70 +205,76 @@ export function EditCompensationModal({
           </div>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label
-              htmlFor="kilometers"
-              className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1"
-            >
-              {t("assignments.kilometers")}
-            </label>
-            <input
-              id="kilometers"
-              type="number"
-              min="0"
-              step="0.1"
-              value={kilometers}
-              onChange={(e) => setKilometers(e.target.value)}
-              className="w-full px-3 py-2 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
-              aria-invalid={errors.kilometers ? "true" : "false"}
-              aria-describedby={
-                errors.kilometers ? "kilometers-error" : undefined
-              }
-            />
-            {errors.kilometers && (
-              <p
-                id="kilometers-error"
-                className="mt-1 text-sm text-danger-600 dark:text-danger-400"
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500" />
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label
+                htmlFor="kilometers"
+                className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1"
               >
-                {errors.kilometers}
-              </p>
-            )}
-          </div>
+                {t("assignments.kilometers")}
+              </label>
+              <input
+                id="kilometers"
+                type="number"
+                min="0"
+                step="0.1"
+                value={kilometers}
+                onChange={(e) => setKilometers(e.target.value)}
+                className="w-full px-3 py-2 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
+                aria-invalid={errors.kilometers ? "true" : "false"}
+                aria-describedby={
+                  errors.kilometers ? "kilometers-error" : undefined
+                }
+              />
+              {errors.kilometers && (
+                <p
+                  id="kilometers-error"
+                  className="mt-1 text-sm text-danger-600 dark:text-danger-400"
+                >
+                  {errors.kilometers}
+                </p>
+              )}
+            </div>
 
-          <div>
-            <label
-              htmlFor="reason"
-              className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1"
-            >
-              {t("assignments.reason")}
-            </label>
-            <textarea
-              id="reason"
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              rows={4}
-              className="w-full px-3 py-2 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
-              placeholder={t("assignments.reasonPlaceholder")}
-            />
-          </div>
+            <div>
+              <label
+                htmlFor="reason"
+                className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1"
+              >
+                {t("assignments.reason")}
+              </label>
+              <textarea
+                id="reason"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                rows={4}
+                className="w-full px-3 py-2 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
+                placeholder={t("assignments.reasonPlaceholder")}
+              />
+            </div>
 
-          <div className="flex gap-3 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
-            >
-              {t("common.close")}
-            </button>
-            <button
-              type="submit"
-              className="flex-1 px-4 py-2 text-white bg-primary-500 rounded-md hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
-            >
-              {t("common.save")}
-            </button>
-          </div>
-        </form>
+            <div className="flex gap-3 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
+              >
+                {t("common.close")}
+              </button>
+              <button
+                type="submit"
+                className="flex-1 px-4 py-2 text-white bg-primary-500 rounded-md hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+              >
+                {t("common.save")}
+              </button>
+            </div>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -9,6 +9,7 @@ import type {
   RefereeGame,
 } from "@/api/client";
 import { addDays, addHours, subDays } from "date-fns";
+import { formatDistanceKm, metresToKilometres } from "@/utils/distance";
 
 // Mock player for roster display
 export interface MockRosterPlayer {
@@ -107,7 +108,7 @@ const DEMO_GAME_NUMBERS = {
 } as const;
 
 function calculateTravelExpenses(distanceInMetres: number): number {
-  const distanceInKm = distanceInMetres / 1000;
+  const distanceInKm = metresToKilometres(distanceInMetres);
   return Math.round(distanceInKm * TRAVEL_EXPENSE_RATE_PER_KM * 100) / 100;
 }
 
@@ -162,7 +163,6 @@ function createCompensationData({
 }: CompensationParams) {
   const gameCompensation = getCompensationForPosition(position, isSV);
   const travelExpenses = calculateTravelExpenses(distanceInMetres);
-  const distanceInKm = distanceInMetres / 1000;
 
   return {
     gameCompensation,
@@ -170,7 +170,7 @@ function createCompensationData({
     travelExpenses,
     travelExpensesFormatted: formatCurrency(travelExpenses),
     distanceInMetres,
-    distanceFormatted: distanceInKm.toFixed(1),
+    distanceFormatted: formatDistanceKm(distanceInMetres),
     costFormatted: calculateTotalCost(gameCompensation, travelExpenses),
     transportationMode,
     paymentDone,

--- a/web-app/src/utils/distance.test.ts
+++ b/web-app/src/utils/distance.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  METRES_PER_KILOMETRE,
+  DISTANCE_DISPLAY_PRECISION,
+  metresToKilometres,
+  kilometresToMetres,
+  formatDistanceKm,
+} from "./distance";
+
+describe("distance utilities", () => {
+  describe("constants", () => {
+    it("METRES_PER_KILOMETRE is 1000", () => {
+      expect(METRES_PER_KILOMETRE).toBe(1000);
+    });
+
+    it("DISTANCE_DISPLAY_PRECISION is 1", () => {
+      expect(DISTANCE_DISPLAY_PRECISION).toBe(1);
+    });
+  });
+
+  describe("metresToKilometres", () => {
+    it("converts metres to kilometres", () => {
+      expect(metresToKilometres(1000)).toBe(1);
+      expect(metresToKilometres(48000)).toBe(48);
+      expect(metresToKilometres(500)).toBe(0.5);
+    });
+
+    it("handles zero", () => {
+      expect(metresToKilometres(0)).toBe(0);
+    });
+
+    it("handles decimal values", () => {
+      expect(metresToKilometres(1500)).toBe(1.5);
+      expect(metresToKilometres(48317)).toBe(48.317);
+    });
+  });
+
+  describe("kilometresToMetres", () => {
+    it("converts kilometres to metres", () => {
+      expect(kilometresToMetres(1)).toBe(1000);
+      expect(kilometresToMetres(48)).toBe(48000);
+      expect(kilometresToMetres(0.5)).toBe(500);
+    });
+
+    it("handles zero", () => {
+      expect(kilometresToMetres(0)).toBe(0);
+    });
+
+    it("handles decimal values", () => {
+      expect(kilometresToMetres(1.5)).toBe(1500);
+      expect(kilometresToMetres(48.3)).toBe(48300);
+    });
+  });
+
+  describe("formatDistanceKm", () => {
+    it("formats distance with one decimal place", () => {
+      expect(formatDistanceKm(48000)).toBe("48.0");
+      expect(formatDistanceKm(48500)).toBe("48.5");
+      expect(formatDistanceKm(48317)).toBe("48.3");
+    });
+
+    it("rounds to one decimal place", () => {
+      expect(formatDistanceKm(48350)).toBe("48.4"); // rounds up
+      expect(formatDistanceKm(48340)).toBe("48.3"); // rounds down
+    });
+
+    it("handles zero", () => {
+      expect(formatDistanceKm(0)).toBe("0.0");
+    });
+
+    it("handles small distances", () => {
+      expect(formatDistanceKm(100)).toBe("0.1");
+      expect(formatDistanceKm(50)).toBe("0.1"); // rounds up
+    });
+  });
+});

--- a/web-app/src/utils/distance.ts
+++ b/web-app/src/utils/distance.ts
@@ -1,0 +1,32 @@
+/**
+ * Distance conversion utilities for compensation calculations.
+ */
+
+/** Number of metres in one kilometre */
+export const METRES_PER_KILOMETRE = 1000;
+
+/** Number of decimal places to display for distance values */
+export const DISTANCE_DISPLAY_PRECISION = 1;
+
+/**
+ * Converts metres to kilometres.
+ */
+export function metresToKilometres(metres: number): number {
+  return metres / METRES_PER_KILOMETRE;
+}
+
+/**
+ * Converts kilometres to metres.
+ */
+export function kilometresToMetres(kilometres: number): number {
+  return kilometres * METRES_PER_KILOMETRE;
+}
+
+/**
+ * Formats a distance in metres as a human-readable kilometre string.
+ * @param metres - Distance in metres
+ * @returns Formatted string like "48.0"
+ */
+export function formatDistanceKm(metres: number): string {
+  return metresToKilometres(metres).toFixed(DISTANCE_DISPLAY_PRECISION);
+}


### PR DESCRIPTION
## Summary

Load compensation distance and reason fields from the API for both real and demo modes, and display them in the edit compensation modal.

- Add `distanceInMetres` to compensation search API properties
- Add `getCompensationDetails` API method to fetch detailed compensation data
- Pre-fill the edit modal with existing distance and correction reason values
- Add "km" suffix to the distance input field for clarity

## Changes

### API Client (`web-app/src/api/client.ts`)
- Added `distanceInMetres` to `COMPENSATION_PROPERTIES` so the search endpoint returns distance data
- Added `ConvocationCompensationDetailed` type export
- Added `getCompensationDetails()` method to fetch detailed compensation data (including `correctionReason`) from the `showWithNestedObjects` endpoint

### Mock API (`web-app/src/api/mock-api.ts`)
- Added `getCompensationDetails()` method that mirrors the real API behavior
- Returns consistent data structure with distance and correction reason fields

### Demo Store (`web-app/src/stores/demo.ts`)
- Added `correctionReason` field to compensation data generation
- Updated `updateCompensation` action to handle `correctionReason` updates
- Added sample correction reasons to demo records (e.g., "Ich wohne in Oberengstringen")

### Edit Compensation Modal (`web-app/src/components/features/EditCompensationModal.tsx`)
- Fetches detailed compensation data when the modal opens
- Pre-fills the distance field with existing value (converted to km)
- Pre-fills the reason field with existing `correctionReason`
- Shows loading spinner while fetching
- Added "km" suffix to the distance input field
- Saves both fields when submitting

## Test plan

- [ ] Open demo mode and navigate to the Compensations tab
- [ ] Verify compensation cards show the distance value
- [ ] Click edit on a compensation record
- [ ] Verify the modal shows a loading spinner briefly
- [ ] Verify the distance field is pre-filled with the existing value and shows "km" suffix
- [ ] Verify the reason field is pre-filled for records that have a correction reason
- [ ] Change the distance and reason, save, and verify the values persist
