### PR TITLE
fix(compensations): use correct color palette shades for amounts

### DIFF
--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -66,7 +66,7 @@ export function CompensationCard({
             {/* Amount & status */}
             <div className="flex items-center gap-2">
               <div
-                className={`text-sm font-bold ${isPaid ? "text-success-600 dark:text-success-400" : "text-warning-600 dark:text-warning-400"}`}
+                className={`text-sm font-bold ${isPaid ? "text-success-500 dark:text-success-400" : "text-warning-500 dark:text-warning-400"}`}
               >
                 {total.toFixed(0)}
               </div>
@@ -97,7 +97,7 @@ export function CompensationCard({
                     Total:
                   </span>
                   <span
-                    className={`font-bold ${isPaid ? "text-success-600 dark:text-success-400" : "text-warning-600 dark:text-warning-400"}`}
+                    className={`font-bold ${isPaid ? "text-success-500 dark:text-success-400" : "text-warning-500 dark:text-warning-400"}`}
                   >
                     CHF {total.toFixed(2)}
                   </span>
@@ -142,8 +142,8 @@ export function CompensationCard({
                   <span
                     className={
                       isPaid
-                        ? "text-success-600 dark:text-success-400"
-                        : "text-warning-600 dark:text-warning-400"
+                        ? "text-success-500 dark:text-success-400"
+                        : "text-warning-500 dark:text-warning-400"
                     }
                   >
                     {isPaid

--- a/web-app/src/components/ui/Tabs.tsx
+++ b/web-app/src/components/ui/Tabs.tsx
@@ -62,7 +62,7 @@ export function Tabs({
                 `}
               >
                 {tab.status === "complete" && (
-                  <Check className="w-4 h-4 mr-1.5 text-success-600 dark:text-success-400" aria-hidden="true" />
+                  <Check className="w-4 h-4 mr-1.5 text-success-500 dark:text-success-400" aria-hidden="true" />
                 )}
                 {tab.status === "incomplete" && (
                   <Circle className="w-3 h-3 mr-1.5 text-warning-500 dark:text-warning-400 fill-current" aria-hidden="true" />

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -139,7 +139,7 @@ export function CompensationsPage() {
             <div className="text-sm text-text-muted dark:text-text-muted-dark">
               {t("compensations.pending")}
             </div>
-            <div className="text-lg font-bold text-warning-600 dark:text-warning-400">
+            <div className="text-lg font-bold text-warning-500 dark:text-warning-400">
               CHF {totals.unpaid.toFixed(2)}
             </div>
           </div>
@@ -147,7 +147,7 @@ export function CompensationsPage() {
             <div className="text-sm text-text-muted dark:text-text-muted-dark">
               {t("compensations.received")}
             </div>
-            <div className="text-lg font-bold text-success-600 dark:text-success-400">
+            <div className="text-lg font-bold text-success-500 dark:text-success-400">
               CHF {totals.paid.toFixed(2)}
             </div>
           </div>


### PR DESCRIPTION
The color palette defines -500 as the "Main" color and -600 as
"Hover/emphasis". Update compensation totals and card amounts
to use -500 for consistent palette usage.

Also fixes Tabs component success icon to match the pattern.