### PR TITLE
fix(compensation): normalize decimal separator for kilometer input

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -7,7 +7,11 @@ import {
   getTeamNames,
   getTeamNamesFromCompensation,
 } from "@/utils/assignment-helpers";
-import { formatDistanceKm, kilometresToMetres } from "@/utils/distance";
+import {
+  formatDistanceKm,
+  kilometresToMetres,
+  parseLocalizedNumber,
+} from "@/utils/distance";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 
@@ -110,7 +114,7 @@ export function EditCompensationModal({
       e.preventDefault();
       setErrors({});
 
-      const km = parseFloat(kilometers);
+      const km = parseLocalizedNumber(kilometers);
       if (kilometers && (isNaN(km) || km < 0)) {
         setErrors({ kilometers: "Please enter a valid positive number" });
         return;
@@ -241,9 +245,9 @@ export function EditCompensationModal({
               <div className="relative">
                 <input
                   id="kilometers"
-                  type="number"
-                  min="0"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
                   value={kilometers}
                   onChange={(e) => setKilometers(e.target.value)}
                   className="w-full px-3 py-2 pr-10 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"

--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -247,9 +247,11 @@ export function EditCompensationModal({
                   id="kilometers"
                   type="text"
                   inputMode="decimal"
-                  pattern="[0-9]*[.,]?[0-9]*"
+                  pattern="[0-9]*\.?[0-9]*"
                   value={kilometers}
-                  onChange={(e) => setKilometers(e.target.value)}
+                  onChange={(e) =>
+                    setKilometers(e.target.value.replace(",", "."))
+                  }
                   className="w-full px-3 py-2 pr-10 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
                   aria-invalid={errors.kilometers ? "true" : "false"}
                   aria-describedby={

--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -8,6 +8,7 @@ import {
   getTeamNamesFromCompensation,
 } from "@/utils/assignment-helpers";
 import {
+  DECIMAL_INPUT_PATTERN,
   formatDistanceKm,
   kilometresToMetres,
   parseLocalizedNumber,
@@ -247,11 +248,9 @@ export function EditCompensationModal({
                   id="kilometers"
                   type="text"
                   inputMode="decimal"
-                  pattern="[0-9]*\.?[0-9]*"
+                  pattern={DECIMAL_INPUT_PATTERN}
                   value={kilometers}
-                  onChange={(e) =>
-                    setKilometers(e.target.value.replace(",", "."))
-                  }
+                  onChange={(e) => setKilometers(e.target.value)}
                   className="w-full px-3 py-2 pr-10 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
                   aria-invalid={errors.kilometers ? "true" : "false"}
                   aria-describedby={

--- a/web-app/src/utils/distance.test.ts
+++ b/web-app/src/utils/distance.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   METRES_PER_KILOMETRE,
   DISTANCE_DISPLAY_PRECISION,
+  DECIMAL_INPUT_PATTERN,
   metresToKilometres,
   kilometresToMetres,
   formatDistanceKm,
@@ -16,6 +17,10 @@ describe("distance utilities", () => {
 
     it("DISTANCE_DISPLAY_PRECISION is 1", () => {
       expect(DISTANCE_DISPLAY_PRECISION).toBe(1);
+    });
+
+    it("DECIMAL_INPUT_PATTERN accepts period or comma as decimal separator", () => {
+      expect(DECIMAL_INPUT_PATTERN).toBe("[0-9]*[.,]?[0-9]*");
     });
   });
 

--- a/web-app/src/utils/distance.test.ts
+++ b/web-app/src/utils/distance.test.ts
@@ -5,6 +5,7 @@ import {
   metresToKilometres,
   kilometresToMetres,
   formatDistanceKm,
+  parseLocalizedNumber,
 } from "./distance";
 
 describe("distance utilities", () => {
@@ -71,6 +72,36 @@ describe("distance utilities", () => {
     it("handles small distances", () => {
       expect(formatDistanceKm(100)).toBe("0.1");
       expect(formatDistanceKm(50)).toBe("0.1"); // rounds up
+    });
+  });
+
+  describe("parseLocalizedNumber", () => {
+    it("parses numbers with period as decimal separator", () => {
+      expect(parseLocalizedNumber("48.5")).toBe(48.5);
+      expect(parseLocalizedNumber("1.0")).toBe(1);
+      expect(parseLocalizedNumber("123.456")).toBe(123.456);
+    });
+
+    it("parses numbers with comma as decimal separator", () => {
+      expect(parseLocalizedNumber("48,5")).toBe(48.5);
+      expect(parseLocalizedNumber("1,0")).toBe(1);
+      expect(parseLocalizedNumber("123,456")).toBe(123.456);
+    });
+
+    it("parses integers without decimal separator", () => {
+      expect(parseLocalizedNumber("48")).toBe(48);
+      expect(parseLocalizedNumber("0")).toBe(0);
+      expect(parseLocalizedNumber("123")).toBe(123);
+    });
+
+    it("returns NaN for invalid input", () => {
+      expect(parseLocalizedNumber("")).toBeNaN();
+      expect(parseLocalizedNumber("abc")).toBeNaN();
+    });
+
+    it("parseFloat stops at invalid characters", () => {
+      // parseFloat stops at the second period, returning 12.34
+      expect(parseLocalizedNumber("12.34.56")).toBe(12.34);
     });
   });
 });

--- a/web-app/src/utils/distance.ts
+++ b/web-app/src/utils/distance.ts
@@ -30,3 +30,14 @@ export function kilometresToMetres(kilometres: number): number {
 export function formatDistanceKm(metres: number): string {
   return metresToKilometres(metres).toFixed(DISTANCE_DISPLAY_PRECISION);
 }
+
+/**
+ * Parses a localized number string that may use either "." or "," as decimal separator.
+ * Always normalizes to use "." before parsing.
+ * @param value - String value that may contain "," or "." as decimal separator
+ * @returns Parsed number, or NaN if invalid
+ */
+export function parseLocalizedNumber(value: string): number {
+  const normalized = value.replace(",", ".");
+  return parseFloat(normalized);
+}

--- a/web-app/src/utils/distance.ts
+++ b/web-app/src/utils/distance.ts
@@ -9,6 +9,12 @@ export const METRES_PER_KILOMETRE = 1000;
 export const DISTANCE_DISPLAY_PRECISION = 1;
 
 /**
+ * HTML input pattern for decimal numbers.
+ * Accepts digits with optional single decimal separator (period or comma).
+ */
+export const DECIMAL_INPUT_PATTERN = "[0-9]*[.,]?[0-9]*";
+
+/**
  * Converts metres to kilometres.
  */
 export function metresToKilometres(metres: number): number {
@@ -34,6 +40,10 @@ export function formatDistanceKm(metres: number): string {
 /**
  * Parses a localized number string that may use either "." or "," as decimal separator.
  * Always normalizes to use "." before parsing.
+ *
+ * Note: This simple replacement doesn't handle thousands separators (e.g., "1.234,56"
+ * in German format). This is acceptable for single decimal values like distance in km.
+ *
  * @param value - String value that may contain "," or "." as decimal separator
  * @returns Parsed number, or NaN if invalid
  */


### PR DESCRIPTION
Add parseLocalizedNumber utility to handle both period and comma as
decimal separators in the kilometers input field. Change input type
from "number" to "text" with inputMode="decimal" for consistent
cross-locale behavior.