### PR TITLE
fix(ci): remove continue-on-error from security audit step

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Audit dependencies
         # Check for high/critical vulnerabilities in production dependencies
         # Using --omit=dev to avoid false positives from dev dependencies
-        # TODO: Remove continue-on-error once existing vulnerabilities are addressed
-        # Using continue-on-error temporarily to not block PRs
-        continue-on-error: true
         run: npm audit --audit-level=high --omit=dev
   lint:
     name: Lint


### PR DESCRIPTION
The npm audit check now passes with 0 vulnerabilities, so we can remove
the continue-on-error workaround that was temporarily allowing the audit
step to fail without blocking PRs.