### PR TITLE
chore(worker): remove stale TODO comment

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -47,7 +47,6 @@ compatibility_flags = ["nodejs_compat"]
 #   - Only change if you're proxying to a different backend
 # =============================================================================
 [vars]
-# TODO: Change this to your GitHub Pages URL or custom domain
 ALLOWED_ORIGINS = "https://takishima.github.io"
 TARGET_HOST = "https://volleymanager.volleyball.ch"
 


### PR DESCRIPTION
The ALLOWED_ORIGINS value is already configured, so the TODO
reminder to change it is no longer needed.