### PR TITLE
feat(settings): use dynamic version from package.json

### DIFF
--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -276,7 +276,7 @@ export function SettingsPage() {
             <span className="text-text-muted dark:text-text-muted-dark">
               {t("settings.version")}
             </span>
-            <span className="text-text-primary dark:text-text-primary-dark">1.0.0</span>
+            <span className="text-text-primary dark:text-text-primary-dark">{__APP_VERSION__}</span>
           </div>
           <div className="flex justify-between">
             <span className="text-text-muted dark:text-text-muted-dark">

--- a/web-app/src/types/pwa.d.ts
+++ b/web-app/src/types/pwa.d.ts
@@ -1,6 +1,8 @@
-// Global flag set by vite.config.ts to indicate if PWA is enabled
-// This is false for PR preview builds to avoid service worker scope conflicts
+// Global constants set by vite.config.ts at build time
+// __PWA_ENABLED__ is false for PR preview builds to avoid service worker scope conflicts
 declare const __PWA_ENABLED__: boolean;
+// __APP_VERSION__ is the version from package.json
+declare const __APP_VERSION__: string;
 
 // Type declarations for vite-plugin-pwa's vanilla register module
 declare module "virtual:pwa-register" {

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -7,6 +7,7 @@ import { visualizer } from 'rollup-plugin-visualizer'
 import path from 'path'
 import { readFileSync, writeFileSync, existsSync } from 'fs'
 import { normalizeBasePath } from './src/utils/basePath'
+import packageJson from './package.json' with { type: 'json' }
 
 // Plugin to exclude Zod v4 locale files from the bundle.
 // Zod v4 includes ~50 locale files for i18n error messages that we don't use.
@@ -102,6 +103,8 @@ export default defineConfig(({ mode }) => {
     define: {
       // Expose PWA enabled state to the app
       '__PWA_ENABLED__': JSON.stringify(!isPrPreview),
+      // Expose app version from package.json
+      '__APP_VERSION__': JSON.stringify(packageJson.version),
     },
     build: {
       rollupOptions: {


### PR DESCRIPTION
Replace hardcoded "1.0.0" version in SettingsPage with a build-time
constant injected by Vite from package.json. This ensures the displayed
version always matches the actual package version.