### PR TITLE
feat(i18n): extract hardcoded labels in ExchangeCard to translations

### DIFF
--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -4,6 +4,7 @@ import { ExpandArrow } from "@/components/ui/ExpandArrow";
 import { Badge } from "@/components/ui/Badge";
 import type { GameExchange } from "@/api/client";
 import { useExpandable } from "@/hooks/useExpandable";
+import { t, tInterpolate } from "@/i18n";
 
 interface ExchangeCardProps {
   exchange: GameExchange;
@@ -24,18 +25,18 @@ export function ExchangeCard({
     ? parseISO(game.startingDateTime)
     : null;
 
-  const homeTeam = game?.encounter?.teamHome?.name || "TBD";
-  const awayTeam = game?.encounter?.teamAway?.name || "TBD";
-  const hallName = game?.hall?.name || "Location TBD";
+  const homeTeam = game?.encounter?.teamHome?.name || t("common.tbd");
+  const awayTeam = game?.encounter?.teamAway?.name || t("common.tbd");
+  const hallName = game?.hall?.name || t("common.locationTbd");
 
   const status = exchange.status;
   const requiredLevel = exchange.requiredRefereeLevel;
 
-  const defaultStatus = { label: "Open", variant: "warning" as const };
+  const defaultStatus = { label: t("exchange.open"), variant: "warning" as const };
   const statusConfig = {
-    open: { label: "Open", variant: "warning" as const },
-    applied: { label: "Applied", variant: "success" as const },
-    closed: { label: "Closed", variant: "neutral" as const },
+    open: { label: t("exchange.open"), variant: "warning" as const },
+    applied: { label: t("exchange.applied"), variant: "success" as const },
+    closed: { label: t("exchange.closed"), variant: "neutral" as const },
   };
 
   const currentStatus =
@@ -58,7 +59,7 @@ export function ExchangeCard({
           <div className="flex items-center gap-3">
             {/* Date/Time */}
             <div className="text-xs text-text-muted dark:text-text-muted-dark min-w-[4rem]">
-              {startDate ? format(startDate, "MMM d") : "TBD"}
+              {startDate ? format(startDate, "MMM d") : t("common.tbd")}
               <div className="font-medium text-text-secondary dark:text-text-secondary-dark">
                 {startDate ? format(startDate, "HH:mm") : ""}
               </div>
@@ -71,7 +72,7 @@ export function ExchangeCard({
               </div>
               {requiredLevel && (
                 <div className="text-xs text-text-subtle dark:text-text-subtle-dark">
-                  Level {requiredLevel}+
+                  {tInterpolate("exchange.levelRequired", { level: requiredLevel })}
                 </div>
               )}
             </div>
@@ -113,14 +114,14 @@ export function ExchangeCard({
                 <div className="text-xs text-text-subtle dark:text-text-subtle-dark">
                   {game.group.phase.league.leagueCategory.name}
                   {game.group.phase.league.gender &&
-                    ` • ${game.group.phase.league.gender === "m" ? "Men" : "Women"}`}
+                    ` • ${game.group.phase.league.gender === "m" ? t("common.men") : t("common.women")}`}
                 </div>
               )}
 
               {/* Submitter info */}
               {exchange.submittedByPerson && (
                 <div className="text-xs text-text-muted dark:text-text-muted-dark">
-                  By: {exchange.submittedByPerson.firstName}{" "}
+                  {t("exchange.submittedBy")} {exchange.submittedByPerson.firstName}{" "}
                   {exchange.submittedByPerson.lastName}
                 </div>
               )}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -24,6 +24,8 @@ const de: Translations = {
     requiredLevel: "Erforderliches Niveau",
     demoModeBanner: "Demo-Modus - Beispieldaten werden angezeigt",
     optional: "Optional",
+    tbd: "TBD",
+    locationTbd: "Ort unbekannt",
   },
   auth: {
     login: "Anmelden",
@@ -132,6 +134,8 @@ const de: Translations = {
       "Rückzug vom Tausch fehlgeschlagen. Bitte erneut versuchen.",
     addedToExchangeSuccess: "Einsatz zur Tauschbörse hinzugefügt",
     addedToExchangeError: "Einsatz konnte nicht zur Tauschbörse hinzugefügt werden",
+    submittedBy: "Von:",
+    levelRequired: "Niveau {level}+",
   },
   positions: {
     "head-one": "1. Schiedsrichter",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -24,6 +24,8 @@ const en: Translations = {
     requiredLevel: "Required Level",
     demoModeBanner: "Demo Mode - Viewing sample data",
     optional: "Optional",
+    tbd: "TBD",
+    locationTbd: "Location TBD",
   },
   auth: {
     login: "Login",
@@ -130,6 +132,8 @@ const en: Translations = {
     withdrawError: "Failed to remove from exchange. Please try again.",
     addedToExchangeSuccess: "Assignment added to exchange list",
     addedToExchangeError: "Failed to add assignment to exchange",
+    submittedBy: "By:",
+    levelRequired: "Level {level}+",
   },
   positions: {
     "head-one": "1st Referee",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -24,6 +24,8 @@ const fr: Translations = {
     requiredLevel: "Niveau requis",
     demoModeBanner: "Mode Démo - Données d'exemple",
     optional: "Optionnel",
+    tbd: "À déterminer",
+    locationTbd: "Lieu à déterminer",
   },
   auth: {
     login: "Connexion",
@@ -131,6 +133,8 @@ const fr: Translations = {
     withdrawError: "Échec du retrait de l'échange. Veuillez réessayer.",
     addedToExchangeSuccess: "Désignation ajoutée à la bourse aux échanges",
     addedToExchangeError: "Impossible d'ajouter la désignation à la bourse",
+    submittedBy: "Par :",
+    levelRequired: "Niveau {level}+",
   },
   positions: {
     "head-one": "1er Arbitre",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -24,6 +24,8 @@ const it: Translations = {
     requiredLevel: "Livello richiesto",
     demoModeBanner: "Modalità Demo - Dati di esempio",
     optional: "Opzionale",
+    tbd: "Da definire",
+    locationTbd: "Luogo da definire",
   },
   auth: {
     login: "Accesso",
@@ -129,6 +131,8 @@ const it: Translations = {
     withdrawError: "Ritiro dallo scambio fallito. Riprova.",
     addedToExchangeSuccess: "Designazione aggiunta alla borsa scambi",
     addedToExchangeError: "Impossibile aggiungere la designazione alla borsa",
+    submittedBy: "Da:",
+    levelRequired: "Livello {level}+",
   },
   positions: {
     "head-one": "1° Arbitro",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -26,6 +26,8 @@ export interface Translations {
     requiredLevel: string;
     demoModeBanner: string;
     optional: string;
+    tbd: string;
+    locationTbd: string;
   };
   auth: {
     login: string;
@@ -126,6 +128,8 @@ export interface Translations {
     withdrawError: string;
     addedToExchangeSuccess: string;
     addedToExchangeError: string;
+    submittedBy: string;
+    levelRequired: string;
   };
   positions: {
     "head-one": string;


### PR DESCRIPTION
Replace hardcoded strings with i18n translation keys for proper
localization support. Added new translation keys:
- common.tbd, common.locationTbd for fallback placeholders
- exchange.submittedBy for submitter prefix
- exchange.levelRequired for required level display

Also updated status labels (open/applied/closed) and gender labels
(men/women) to use existing translation keys.