### PR TITLE
feat(i18n): extract hardcoded error messages in EditCompensationModal to translations

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -77,7 +77,7 @@ export function EditCompensationModal({
           error,
         );
         setFetchError(
-          error instanceof Error ? error.message : "Failed to load data",
+          error instanceof Error ? error.message : t("assignments.failedToLoadData"),
         );
       } finally {
         setIsLoading(false);
@@ -85,7 +85,7 @@ export function EditCompensationModal({
     };
 
     fetchDetails();
-  }, [isOpen, compensationId, isDemoMode]);
+  }, [isOpen, compensationId, isDemoMode, t]);
 
   // Reset form when modal closes
   useEffect(() => {
@@ -117,7 +117,7 @@ export function EditCompensationModal({
 
       const km = parseLocalizedNumber(kilometers);
       if (kilometers && (isNaN(km) || km < 0)) {
-        setErrors({ kilometers: "Please enter a valid positive number" });
+        setErrors({ kilometers: t("assignments.invalidKilometers") });
         return;
       }
 
@@ -161,6 +161,7 @@ export function EditCompensationModal({
       isDemoMode,
       updateCompensation,
       onClose,
+      t,
     ],
   );
 

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -76,6 +76,8 @@ const de: Translations = {
     gameReportNotAvailable:
       "Spielberichte sind nur für NLA- und NLB-Spiele verfügbar.",
     reportGenerated: "Bericht erfolgreich erstellt",
+    invalidKilometers: "Bitte geben Sie eine gültige positive Zahl ein",
+    failedToLoadData: "Daten konnten nicht geladen werden",
   },
   compensations: {
     title: "Entschädigungen",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -76,6 +76,8 @@ const en: Translations = {
     gameReportNotAvailable:
       "Game reports are only available for NLA and NLB games.",
     reportGenerated: "Report generated successfully",
+    invalidKilometers: "Please enter a valid positive number",
+    failedToLoadData: "Failed to load data",
   },
   compensations: {
     title: "Compensations",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -75,6 +75,8 @@ const fr: Translations = {
     gameReportNotAvailable:
       "Les rapports de match sont uniquement disponibles pour les matchs NLA et NLB.",
     reportGenerated: "Rapport généré avec succès",
+    invalidKilometers: "Veuillez entrer un nombre positif valide",
+    failedToLoadData: "Échec du chargement des données",
   },
   compensations: {
     title: "Indemnités",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -75,6 +75,8 @@ const it: Translations = {
     gameReportNotAvailable:
       "I rapporti delle partite sono disponibili solo per le partite NLA e NLB.",
     reportGenerated: "Rapporto generato con successo",
+    invalidKilometers: "Inserisci un numero positivo valido",
+    failedToLoadData: "Impossibile caricare i dati",
   },
   compensations: {
     title: "Compensi",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -75,6 +75,8 @@ export interface Translations {
     numberOfSets: string;
     gameReportNotAvailable: string;
     reportGenerated: string;
+    invalidKilometers: string;
+    failedToLoadData: string;
   };
   compensations: {
     title: string;


### PR DESCRIPTION
Add translation keys for:
- invalidKilometers: validation error for invalid kilometer input
- failedToLoadData: fallback error message when data fetch fails