### PR TITLE
feat(i18n): extract hardcoded strings in AppShell to translations

### DIFF
--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -128,7 +128,7 @@ export function AppShell() {
                       <span className="max-w-[100px] truncate">
                         {activeOccupation
                           ? getOccupationLabel(activeOccupation)
-                          : "Select role"}
+                          : t("common.selectRole")}
                       </span>
                       <ChevronDown
                         className={`w-4 h-4 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
@@ -140,7 +140,7 @@ export function AppShell() {
                       <div
                         className="absolute right-0 mt-1 w-48 bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-lg border border-border-default dark:border-border-default-dark py-1 z-50"
                         role="listbox"
-                        aria-label="Select occupation"
+                        aria-label={t("common.selectOccupation")}
                       >
                         {user?.occupations?.map((occupation) => (
                           <button

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -26,6 +26,8 @@ const de: Translations = {
     optional: "Optional",
     tbd: "TBD",
     locationTbd: "Ort unbekannt",
+    selectRole: "Rolle wählen",
+    selectOccupation: "Funktion wählen",
   },
   auth: {
     login: "Anmelden",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -26,6 +26,8 @@ const en: Translations = {
     optional: "Optional",
     tbd: "TBD",
     locationTbd: "Location TBD",
+    selectRole: "Select role",
+    selectOccupation: "Select occupation",
   },
   auth: {
     login: "Login",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -26,6 +26,8 @@ const fr: Translations = {
     optional: "Optionnel",
     tbd: "À déterminer",
     locationTbd: "Lieu à déterminer",
+    selectRole: "Sélectionner le rôle",
+    selectOccupation: "Sélectionner la fonction",
   },
   auth: {
     login: "Connexion",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -26,6 +26,8 @@ const it: Translations = {
     optional: "Opzionale",
     tbd: "Da definire",
     locationTbd: "Luogo da definire",
+    selectRole: "Seleziona ruolo",
+    selectOccupation: "Seleziona funzione",
   },
   auth: {
     login: "Accesso",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -28,6 +28,8 @@ export interface Translations {
     optional: string;
     tbd: string;
     locationTbd: string;
+    selectRole: string;
+    selectOccupation: string;
   };
   auth: {
     login: string;


### PR DESCRIPTION
Extract "Select role" and "Select occupation" labels from AppShell
occupation selector dropdown to translation keys, making them available
in English, German, French, and Italian.