### PR TITLE
feat(i18n): extract hardcoded strings in ReloadPromptPWA to translations

### DIFF
--- a/web-app/src/components/ui/ReloadPromptPWA.tsx
+++ b/web-app/src/components/ui/ReloadPromptPWA.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { usePWA } from "@/contexts/PWAContext";
+import { useTranslation } from "@/hooks/useTranslation";
 
 export default function ReloadPromptPWA() {
   const { offlineReady, needRefresh, updateApp, dismissPrompt } = usePWA();
   const [isUpdating, setIsUpdating] = useState(false);
+  const { t } = useTranslation();
 
   if (!offlineReady && !needRefresh) {
     return null;
@@ -29,13 +31,13 @@ export default function ReloadPromptPWA() {
         <div className="flex-1">
           <p className="text-sm font-medium text-gray-900">
             {offlineReady
-              ? "App ready for offline use"
-              : "New version available"}
+              ? t("pwa.offlineReady")
+              : t("pwa.newVersionAvailable")}
           </p>
           <p className="mt-1 text-sm text-gray-500">
             {offlineReady
-              ? "Content has been cached for offline access."
-              : "Click reload to update to the latest version."}
+              ? t("pwa.offlineReadyDescription")
+              : t("pwa.newVersionDescription")}
           </p>
         </div>
       </div>
@@ -46,19 +48,19 @@ export default function ReloadPromptPWA() {
             disabled={isUpdating}
             aria-busy={isUpdating}
             className="rounded-md bg-primary-500 px-3 py-2 text-sm font-medium text-primary-950 hover:bg-primary-600 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-            aria-label="Reload application to update to the latest version"
+            aria-label={t("pwa.reloadAriaLabel")}
           >
-            {isUpdating ? "Reloading..." : "Reload"}
+            {isUpdating ? t("pwa.reloading") : t("pwa.reload")}
           </button>
         )}
         <button
           onClick={dismissPrompt}
           className="rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
           aria-label={
-            needRefresh ? "Dismiss update notification" : "Close notification"
+            needRefresh ? t("pwa.dismissAriaLabel") : t("pwa.closeAriaLabel")
           }
         >
-          {needRefresh ? "Dismiss" : "Close"}
+          {needRefresh ? t("pwa.dismiss") : t("common.close")}
         </button>
       </div>
     </div>

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -202,6 +202,18 @@ const de: Translations = {
     updateNow: "Jetzt aktualisieren",
     updateCheckFailed: "Update-Prüfung fehlgeschlagen",
   },
+  pwa: {
+    offlineReady: "App bereit für Offline-Nutzung",
+    newVersionAvailable: "Neue Version verfügbar",
+    offlineReadyDescription: "Inhalte wurden für den Offline-Zugriff gespeichert.",
+    newVersionDescription: "Klicken Sie auf Neu laden, um auf die neueste Version zu aktualisieren.",
+    reload: "Neu laden",
+    reloading: "Wird neu geladen...",
+    dismiss: "Schliessen",
+    reloadAriaLabel: "Anwendung neu laden, um auf die neueste Version zu aktualisieren",
+    dismissAriaLabel: "Update-Benachrichtigung schliessen",
+    closeAriaLabel: "Benachrichtigung schliessen",
+  },
   pdf: {
     exportTitle: "PDF exportieren",
     selectLanguage: "Sprache für das PDF-Dokument auswählen:",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -200,6 +200,18 @@ const en: Translations = {
     updateNow: "Update Now",
     updateCheckFailed: "Update check failed",
   },
+  pwa: {
+    offlineReady: "App ready for offline use",
+    newVersionAvailable: "New version available",
+    offlineReadyDescription: "Content has been cached for offline access.",
+    newVersionDescription: "Click reload to update to the latest version.",
+    reload: "Reload",
+    reloading: "Reloading...",
+    dismiss: "Dismiss",
+    reloadAriaLabel: "Reload application to update to the latest version",
+    dismissAriaLabel: "Dismiss update notification",
+    closeAriaLabel: "Close notification",
+  },
   pdf: {
     exportTitle: "Export PDF",
     selectLanguage: "Select the language for the PDF document:",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -201,6 +201,18 @@ const fr: Translations = {
     updateNow: "Mettre à jour",
     updateCheckFailed: "Échec de la vérification",
   },
+  pwa: {
+    offlineReady: "Application prête pour le mode hors ligne",
+    newVersionAvailable: "Nouvelle version disponible",
+    offlineReadyDescription: "Le contenu a été mis en cache pour l'accès hors ligne.",
+    newVersionDescription: "Cliquez sur Recharger pour mettre à jour vers la dernière version.",
+    reload: "Recharger",
+    reloading: "Rechargement...",
+    dismiss: "Ignorer",
+    reloadAriaLabel: "Recharger l'application pour mettre à jour vers la dernière version",
+    dismissAriaLabel: "Ignorer la notification de mise à jour",
+    closeAriaLabel: "Fermer la notification",
+  },
   pdf: {
     exportTitle: "Exporter PDF",
     selectLanguage: "Sélectionner la langue du document PDF :",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -199,6 +199,18 @@ const it: Translations = {
     updateNow: "Aggiorna ora",
     updateCheckFailed: "Verifica aggiornamenti fallita",
   },
+  pwa: {
+    offlineReady: "App pronta per l'uso offline",
+    newVersionAvailable: "Nuova versione disponibile",
+    offlineReadyDescription: "I contenuti sono stati salvati per l'accesso offline.",
+    newVersionDescription: "Clicca Ricarica per aggiornare all'ultima versione.",
+    reload: "Ricarica",
+    reloading: "Ricaricamento...",
+    dismiss: "Ignora",
+    reloadAriaLabel: "Ricarica l'applicazione per aggiornare all'ultima versione",
+    dismissAriaLabel: "Ignora notifica di aggiornamento",
+    closeAriaLabel: "Chiudi notifica",
+  },
   pdf: {
     exportTitle: "Esporta PDF",
     selectLanguage: "Seleziona la lingua del documento PDF:",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -187,6 +187,18 @@ export interface Translations {
     updateNow: string;
     updateCheckFailed: string;
   };
+  pwa: {
+    offlineReady: string;
+    newVersionAvailable: string;
+    offlineReadyDescription: string;
+    newVersionDescription: string;
+    reload: string;
+    reloading: string;
+    dismiss: string;
+    reloadAriaLabel: string;
+    dismissAriaLabel: string;
+    closeAriaLabel: string;
+  };
   pdf: {
     exportTitle: string;
     selectLanguage: string;


### PR DESCRIPTION
Extract hardcoded strings from the PWA reload prompt component to use
the translation system. This enables proper localization of:
- Offline ready notification
- New version available notification
- Reload/dismiss button labels
- Accessibility labels

Adds new 'pwa' translation section with strings in all supported
languages (en, de, fr, it).