### PR TITLE
feat(demo): persist demo data modifications across page refreshes

### DIFF
--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -201,6 +201,11 @@ const de: Translations = {
     lastChecked: "Zuletzt geprüft",
     updateNow: "Jetzt aktualisieren",
     updateCheckFailed: "Update-Prüfung fehlgeschlagen",
+    demoData: "Demo-Daten",
+    demoDataDescription:
+      "Ihre Demo-Daten werden im Browser gespeichert. Zurücksetzen, um mit neuen Demo-Daten zu starten.",
+    resetDemoData: "Demo-Daten zurücksetzen",
+    demoDataReset: "Demo-Daten wurden zurückgesetzt",
   },
   pwa: {
     offlineReady: "App bereit für Offline-Nutzung",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -199,6 +199,11 @@ const en: Translations = {
     lastChecked: "Last checked",
     updateNow: "Update Now",
     updateCheckFailed: "Update check failed",
+    demoData: "Demo Data",
+    demoDataDescription:
+      "Your demo data modifications are saved in your browser. Reset to start fresh with new demo data.",
+    resetDemoData: "Reset Demo Data",
+    demoDataReset: "Demo data has been reset",
   },
   pwa: {
     offlineReady: "App ready for offline use",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -200,6 +200,11 @@ const fr: Translations = {
     lastChecked: "Dernière vérification",
     updateNow: "Mettre à jour",
     updateCheckFailed: "Échec de la vérification",
+    demoData: "Données de démonstration",
+    demoDataDescription:
+      "Vos modifications de démonstration sont enregistrées dans le navigateur. Réinitialisez pour repartir avec de nouvelles données.",
+    resetDemoData: "Réinitialiser les données",
+    demoDataReset: "Données de démonstration réinitialisées",
   },
   pwa: {
     offlineReady: "Application prête pour le mode hors ligne",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -198,6 +198,11 @@ const it: Translations = {
     lastChecked: "Ultimo controllo",
     updateNow: "Aggiorna ora",
     updateCheckFailed: "Verifica aggiornamenti fallita",
+    demoData: "Dati demo",
+    demoDataDescription:
+      "Le modifiche ai dati demo vengono salvate nel browser. Reimposta per ricominciare con nuovi dati demo.",
+    resetDemoData: "Reimposta dati demo",
+    demoDataReset: "I dati demo sono stati reimpostati",
   },
   pwa: {
     offlineReady: "App pronta per l'uso offline",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -186,6 +186,10 @@ export interface Translations {
     lastChecked: string;
     updateNow: string;
     updateCheckFailed: string;
+    demoData: string;
+    demoDataDescription: string;
+    resetDemoData: string;
+    demoDataReset: string;
   };
   pwa: {
     offlineReady: string;

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { useAuthStore } from "@/stores/auth";
+import { useDemoStore } from "@/stores/demo";
 import { useSettingsStore } from "@/stores/settings";
 import { useTranslation } from "@/hooks/useTranslation";
 import { usePWA } from "@/contexts/PWAContext";
@@ -11,6 +12,7 @@ import { SafeModeWarningModal } from "@/components/features/SafeModeWarningModal
 
 export function SettingsPage() {
   const { user, logout, isDemoMode } = useAuthStore();
+  const { activeAssociationCode, refreshData } = useDemoStore();
   const { isSafeModeEnabled, setSafeMode } = useSettingsStore();
   const { t, locale } = useTranslation();
   const {
@@ -22,6 +24,14 @@ export function SettingsPage() {
     updateApp,
   } = usePWA();
   const [showSafeModeWarning, setShowSafeModeWarning] = useState(false);
+  const [demoDataReset, setDemoDataReset] = useState(false);
+
+  const handleResetDemoData = useCallback(() => {
+    refreshData();
+    setDemoDataReset(true);
+    // Reset the success message after a few seconds
+    setTimeout(() => setDemoDataReset(false), 3000);
+  }, [refreshData]);
 
   const formatLastChecked = useCallback(
     (date: Date) => {
@@ -124,6 +134,50 @@ export function SettingsPage() {
           <LanguageSwitcher variant="grid" />
         </CardContent>
       </Card>
+
+      {/* Demo Data section - only show in demo mode */}
+      {isDemoMode && (
+        <Card>
+          <CardHeader>
+            <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
+              {t("settings.demoData")}
+            </h2>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-text-muted dark:text-text-muted-dark">
+              {t("settings.demoDataDescription")}
+            </p>
+
+            <div className="flex items-center justify-between py-2">
+              <div className="flex-1">
+                {demoDataReset && (
+                  <div
+                    className="text-sm font-medium text-success-600 dark:text-success-400"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    {t("settings.demoDataReset")}
+                  </div>
+                )}
+                {activeAssociationCode && !demoDataReset && (
+                  <div className="text-sm text-text-muted dark:text-text-muted-dark">
+                    {activeAssociationCode}
+                  </div>
+                )}
+              </div>
+
+              <button
+                type="button"
+                onClick={handleResetDemoData}
+                className="rounded-md bg-surface-subtle dark:bg-surface-subtle-dark px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark hover:bg-gray-200 dark:hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
+                aria-label={t("settings.resetDemoData")}
+              >
+                {t("settings.resetDemoData")}
+              </button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Safe Mode section - only show in non-demo mode */}
       {!isDemoMode && (

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import type {
   Assignment,
   CompensationRecord,
@@ -1183,34 +1184,9 @@ function generateMockNominationLists(): MockNominationLists {
 const DEMO_USER_REFEREE_LEVEL = "N2";
 const DEMO_USER_REFEREE_LEVEL_GRADATION_VALUE = 2;
 
-export const useDemoStore = create<DemoState>()((set, get) => ({
-  assignments: [],
-  compensations: [],
-  exchanges: [],
-  nominationLists: {},
-  possiblePlayers: [],
-  scorers: [],
-  activeAssociationCode: null,
-  userRefereeLevel: null,
-  userRefereeLevelGradationValue: null,
-
-  initializeDemoData: (associationCode: DemoAssociationCode = "SV") => {
-    const data = generateDummyData(associationCode);
-    set({
-      assignments: data.assignments,
-      compensations: data.compensations,
-      exchanges: data.exchanges,
-      nominationLists: generateMockNominationLists(),
-      possiblePlayers: data.possiblePlayers,
-      scorers: data.scorers,
-      activeAssociationCode: associationCode,
-      userRefereeLevel: DEMO_USER_REFEREE_LEVEL,
-      userRefereeLevelGradationValue: DEMO_USER_REFEREE_LEVEL_GRADATION_VALUE,
-    });
-  },
-
-  clearDemoData: () =>
-    set({
+export const useDemoStore = create<DemoState>()(
+  persist(
+    (set, get) => ({
       assignments: [],
       compensations: [],
       exchanges: [],
@@ -1220,112 +1196,167 @@ export const useDemoStore = create<DemoState>()((set, get) => ({
       activeAssociationCode: null,
       userRefereeLevel: null,
       userRefereeLevelGradationValue: null,
-    }),
 
-  refreshData: () =>
-    set(() => {
-      const currentAssociation = get().activeAssociationCode ?? "SV";
-      const newData = generateDummyData(currentAssociation);
-      return {
-        assignments: newData.assignments,
-        compensations: newData.compensations,
-        exchanges: newData.exchanges,
-        nominationLists: generateMockNominationLists(),
-        possiblePlayers: newData.possiblePlayers,
-        scorers: newData.scorers,
-      };
-    }),
+      initializeDemoData: (associationCode: DemoAssociationCode = "SV") => {
+        // Only regenerate if no data exists or association is changing
+        const currentState = get();
+        const hasExistingData = currentState.assignments.length > 0;
+        const isSameAssociation =
+          currentState.activeAssociationCode === associationCode;
 
-  setActiveAssociation: (associationCode: DemoAssociationCode) => {
-    // Regenerate all data for the new association
-    const data = generateDummyData(associationCode);
-    set({
-      assignments: data.assignments,
-      compensations: data.compensations,
-      exchanges: data.exchanges,
-      nominationLists: generateMockNominationLists(),
-      possiblePlayers: data.possiblePlayers,
-      scorers: data.scorers,
-      activeAssociationCode: associationCode,
-    });
-  },
+        if (hasExistingData && isSameAssociation) {
+          // Preserve existing modifications
+          return;
+        }
 
-  applyForExchange: (exchangeId: string) =>
-    set((state) => {
-      const now = new Date();
-      return {
-        exchanges: state.exchanges.map((exchange) =>
-          exchange.__identity === exchangeId
-            ? {
-                ...exchange,
-                status: "applied" as const,
-                appliedAt: now.toISOString(),
-                appliedBy: {
-                  indoorReferee: {
-                    person: {
-                      __identity: "demo-me",
-                      firstName: "Demo",
-                      lastName: "User",
-                      displayName: "Demo User",
+        const data = generateDummyData(associationCode);
+        set({
+          assignments: data.assignments,
+          compensations: data.compensations,
+          exchanges: data.exchanges,
+          nominationLists: generateMockNominationLists(),
+          possiblePlayers: data.possiblePlayers,
+          scorers: data.scorers,
+          activeAssociationCode: associationCode,
+          userRefereeLevel: DEMO_USER_REFEREE_LEVEL,
+          userRefereeLevelGradationValue: DEMO_USER_REFEREE_LEVEL_GRADATION_VALUE,
+        });
+      },
+
+      clearDemoData: () =>
+        set({
+          assignments: [],
+          compensations: [],
+          exchanges: [],
+          nominationLists: {},
+          possiblePlayers: [],
+          scorers: [],
+          activeAssociationCode: null,
+          userRefereeLevel: null,
+          userRefereeLevelGradationValue: null,
+        }),
+
+      refreshData: () =>
+        set(() => {
+          const currentAssociation = get().activeAssociationCode ?? "SV";
+          const newData = generateDummyData(currentAssociation);
+          return {
+            assignments: newData.assignments,
+            compensations: newData.compensations,
+            exchanges: newData.exchanges,
+            nominationLists: generateMockNominationLists(),
+            possiblePlayers: newData.possiblePlayers,
+            scorers: newData.scorers,
+          };
+        }),
+
+      setActiveAssociation: (associationCode: DemoAssociationCode) => {
+        // Regenerate all data for the new association
+        const data = generateDummyData(associationCode);
+        set({
+          assignments: data.assignments,
+          compensations: data.compensations,
+          exchanges: data.exchanges,
+          nominationLists: generateMockNominationLists(),
+          possiblePlayers: data.possiblePlayers,
+          scorers: data.scorers,
+          activeAssociationCode: associationCode,
+        });
+      },
+
+      applyForExchange: (exchangeId: string) =>
+        set((state) => {
+          const now = new Date();
+          return {
+            exchanges: state.exchanges.map((exchange) =>
+              exchange.__identity === exchangeId
+                ? {
+                    ...exchange,
+                    status: "applied" as const,
+                    appliedAt: now.toISOString(),
+                    appliedBy: {
+                      indoorReferee: {
+                        person: {
+                          __identity: "demo-me",
+                          firstName: "Demo",
+                          lastName: "User",
+                          displayName: "Demo User",
+                        },
+                      },
                     },
-                  },
-                },
-              }
-            : exchange,
-        ),
-      };
+                  }
+                : exchange,
+            ),
+          };
+        }),
+
+      withdrawFromExchange: (exchangeId: string) =>
+        set((state) => ({
+          exchanges: state.exchanges.map((exchange) =>
+            exchange.__identity === exchangeId
+              ? {
+                  ...exchange,
+                  status: "open" as const,
+                  appliedAt: undefined,
+                  appliedBy: undefined,
+                }
+              : exchange,
+          ),
+        })),
+
+      addAssignmentToExchange: (assignmentId: string) =>
+        set((state) => {
+          const assignment = state.assignments.find(
+            (a) => a.__identity === assignmentId,
+          );
+          if (!assignment) return state;
+
+          const now = new Date();
+          const newExchange: GameExchange = {
+            __identity: `demo-exchange-new-${Date.now()}`,
+            status: "open",
+            submittedAt: now.toISOString(),
+            submittingType: "referee",
+            refereePosition: assignment.refereePosition,
+            requiredRefereeLevel: "N3",
+            submittedByPerson: {
+              __identity: "demo-me",
+              firstName: "Demo",
+              lastName: "User",
+              displayName: "Demo User",
+            },
+            refereeGame: assignment.refereeGame,
+          };
+
+          return {
+            exchanges: [...state.exchanges, newExchange],
+          };
+        }),
+
+      updateCompensation: (
+        compensationId: string,
+        data: { distanceInMetres?: number; correctionReason?: string },
+      ) =>
+        set((state) => ({
+          compensations: state.compensations.map((comp) =>
+            updateCompensationRecord(comp, compensationId, data),
+          ),
+        })),
     }),
-
-  withdrawFromExchange: (exchangeId: string) =>
-    set((state) => ({
-      exchanges: state.exchanges.map((exchange) =>
-        exchange.__identity === exchangeId
-          ? {
-              ...exchange,
-              status: "open" as const,
-              appliedAt: undefined,
-              appliedBy: undefined,
-            }
-          : exchange,
-      ),
-    })),
-
-  addAssignmentToExchange: (assignmentId: string) =>
-    set((state) => {
-      const assignment = state.assignments.find(
-        (a) => a.__identity === assignmentId,
-      );
-      if (!assignment) return state;
-
-      const now = new Date();
-      const newExchange: GameExchange = {
-        __identity: `demo-exchange-new-${Date.now()}`,
-        status: "open",
-        submittedAt: now.toISOString(),
-        submittingType: "referee",
-        refereePosition: assignment.refereePosition,
-        requiredRefereeLevel: "N3",
-        submittedByPerson: {
-          __identity: "demo-me",
-          firstName: "Demo",
-          lastName: "User",
-          displayName: "Demo User",
-        },
-        refereeGame: assignment.refereeGame,
-      };
-
-      return {
-        exchanges: [...state.exchanges, newExchange],
-      };
-    }),
-
-  updateCompensation: (
-    compensationId: string,
-    data: { distanceInMetres?: number; correctionReason?: string },
-  ) =>
-    set((state) => ({
-      compensations: state.compensations.map((comp) =>
-        updateCompensationRecord(comp, compensationId, data),
-      ),
-    })),
-}));
+    {
+      name: "volleykit-demo",
+      partialize: (state) => ({
+        // Persist demo data arrays to preserve modifications across page refreshes
+        assignments: state.assignments,
+        compensations: state.compensations,
+        exchanges: state.exchanges,
+        nominationLists: state.nominationLists,
+        possiblePlayers: state.possiblePlayers,
+        scorers: state.scorers,
+        activeAssociationCode: state.activeAssociationCode,
+        userRefereeLevel: state.userRefereeLevel,
+        userRefereeLevelGradationValue: state.userRefereeLevelGradationValue,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
Add localStorage persistence to the demo store so that modifications
made in demo mode (e.g., changing kilometers, validating games) survive
page refreshes. Also adds a "Reset Demo Data" button in Settings that
allows users to start fresh with new demo data.

Changes:
- Add Zustand persist middleware to useDemoStore
- Update initializeDemoData to preserve existing data when association
  hasn't changed
- Add Demo Data section to Settings page (visible only in demo mode)
- Add translations for new settings section in all 4 languages