### PR TITLE
feat(api): add contract tests and validation for mock API

### DIFF
--- a/web-app/src/api/contract.test.ts
+++ b/web-app/src/api/contract.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Contract tests to verify mock data matches API schemas.
+ *
+ * These tests ensure that demo mode data conforms to the same Zod schemas
+ * used to validate real API responses. When these tests fail, it indicates
+ * a divergence between mock and real API that would cause issues when
+ * switching from demo mode to production.
+ *
+ * Run these tests before deploying to catch mock/API mismatches early.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { useDemoStore } from "@/stores/demo";
+import {
+  assignmentSchema,
+  compensationRecordSchema,
+  gameExchangeSchema,
+  personSearchResultSchema,
+  assignmentsResponseSchema,
+  compensationsResponseSchema,
+  exchangesResponseSchema,
+  personSearchResponseSchema,
+} from "./validation";
+import { mockApi } from "./mock-api";
+
+describe("Mock data contract tests", () => {
+  beforeEach(() => {
+    useDemoStore.getState().initializeDemoData();
+  });
+
+  describe("Assignments", () => {
+    it("each assignment passes schema validation", () => {
+      const { assignments } = useDemoStore.getState();
+
+      expect(assignments.length).toBeGreaterThan(0);
+
+      assignments.forEach((assignment, index) => {
+        const result = assignmentSchema.safeParse(assignment);
+        if (!result.success) {
+          const errors = result.error.issues
+            .map((i) => `${i.path.join(".")}: ${i.message}`)
+            .join("\n");
+          throw new Error(
+            `Assignment ${index} failed validation:\n${errors}\n\nData: ${JSON.stringify(assignment, null, 2)}`,
+          );
+        }
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it("searchAssignments response passes schema validation", async () => {
+      const response = await mockApi.searchAssignments();
+
+      const result = assignmentsResponseSchema.safeParse(response);
+      if (!result.success) {
+        const errors = result.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("\n");
+        throw new Error(`Assignments response failed validation:\n${errors}`);
+      }
+      expect(result.success).toBe(true);
+    });
+
+    it("assignments have required fields for UI", () => {
+      const { assignments } = useDemoStore.getState();
+
+      assignments.forEach((assignment) => {
+        expect(assignment.__identity).toBeDefined();
+        expect(assignment.refereeConvocationStatus).toBeDefined();
+        expect(assignment.refereePosition).toBeDefined();
+        expect(assignment.refereeGame).toBeDefined();
+        expect(assignment.refereeGame?.game).toBeDefined();
+      });
+    });
+  });
+
+  describe("Compensations", () => {
+    it("each compensation passes schema validation", () => {
+      const { compensations } = useDemoStore.getState();
+
+      expect(compensations.length).toBeGreaterThan(0);
+
+      compensations.forEach((compensation, index) => {
+        const result = compensationRecordSchema.safeParse(compensation);
+        if (!result.success) {
+          const errors = result.error.issues
+            .map((i) => `${i.path.join(".")}: ${i.message}`)
+            .join("\n");
+          throw new Error(
+            `Compensation ${index} failed validation:\n${errors}\n\nData: ${JSON.stringify(compensation, null, 2)}`,
+          );
+        }
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it("searchCompensations response passes schema validation", async () => {
+      const response = await mockApi.searchCompensations();
+
+      const result = compensationsResponseSchema.safeParse(response);
+      if (!result.success) {
+        const errors = result.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("\n");
+        throw new Error(
+          `Compensations response failed validation:\n${errors}`,
+        );
+      }
+      expect(result.success).toBe(true);
+    });
+
+    it("compensations have required fields for UI", () => {
+      const { compensations } = useDemoStore.getState();
+
+      compensations.forEach((comp) => {
+        expect(comp.__identity).toBeDefined();
+        expect(comp.refereeConvocationStatus).toBeDefined();
+        expect(comp.refereePosition).toBeDefined();
+        expect(comp.convocationCompensation).toBeDefined();
+        expect(comp.refereeGame).toBeDefined();
+      });
+    });
+  });
+
+  describe("Exchanges", () => {
+    it("each exchange passes schema validation", () => {
+      const { exchanges } = useDemoStore.getState();
+
+      expect(exchanges.length).toBeGreaterThan(0);
+
+      exchanges.forEach((exchange, index) => {
+        const result = gameExchangeSchema.safeParse(exchange);
+        if (!result.success) {
+          const errors = result.error.issues
+            .map((i) => `${i.path.join(".")}: ${i.message}`)
+            .join("\n");
+          throw new Error(
+            `Exchange ${index} failed validation:\n${errors}\n\nData: ${JSON.stringify(exchange, null, 2)}`,
+          );
+        }
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it("searchExchanges response passes schema validation", async () => {
+      const response = await mockApi.searchExchanges();
+
+      const result = exchangesResponseSchema.safeParse(response);
+      if (!result.success) {
+        const errors = result.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("\n");
+        throw new Error(`Exchanges response failed validation:\n${errors}`);
+      }
+      expect(result.success).toBe(true);
+    });
+
+    it("exchanges have required fields for UI", () => {
+      const { exchanges } = useDemoStore.getState();
+
+      exchanges.forEach((exchange) => {
+        expect(exchange.__identity).toBeDefined();
+        expect(exchange.status).toBeDefined();
+        expect(exchange.refereePosition).toBeDefined();
+        expect(exchange.refereeGame).toBeDefined();
+      });
+    });
+  });
+
+  describe("Person Search (Scorers)", () => {
+    it("each scorer passes schema validation", () => {
+      const { scorers } = useDemoStore.getState();
+
+      expect(scorers.length).toBeGreaterThan(0);
+
+      scorers.forEach((scorer, index) => {
+        const result = personSearchResultSchema.safeParse(scorer);
+        if (!result.success) {
+          const errors = result.error.issues
+            .map((i) => `${i.path.join(".")}: ${i.message}`)
+            .join("\n");
+          throw new Error(
+            `Scorer ${index} failed validation:\n${errors}\n\nData: ${JSON.stringify(scorer, null, 2)}`,
+          );
+        }
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it("searchPersons response passes schema validation", async () => {
+      const response = await mockApi.searchPersons({});
+
+      const result = personSearchResponseSchema.safeParse(response);
+      if (!result.success) {
+        const errors = result.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("\n");
+        throw new Error(
+          `Person search response failed validation:\n${errors}`,
+        );
+      }
+      expect(result.success).toBe(true);
+    });
+
+    it("scorers have required fields for UI", () => {
+      const { scorers } = useDemoStore.getState();
+
+      scorers.forEach((scorer) => {
+        expect(scorer.__identity).toBeDefined();
+        expect(scorer.firstName).toBeDefined();
+        expect(scorer.lastName).toBeDefined();
+        expect(scorer.displayName).toBeDefined();
+      });
+    });
+  });
+
+  describe("Association switching", () => {
+    it("SV association data passes validation", () => {
+      useDemoStore.getState().setActiveAssociation("SV");
+      const { assignments, compensations, exchanges } =
+        useDemoStore.getState();
+
+      expect(assignments.length).toBeGreaterThan(0);
+      expect(compensations.length).toBeGreaterThan(0);
+      expect(exchanges.length).toBeGreaterThan(0);
+
+      // Validate first item of each type
+      expect(assignmentSchema.safeParse(assignments[0]).success).toBe(true);
+      expect(compensationRecordSchema.safeParse(compensations[0]).success).toBe(
+        true,
+      );
+      expect(gameExchangeSchema.safeParse(exchanges[0]).success).toBe(true);
+    });
+
+    it("Regional association data passes validation", () => {
+      useDemoStore.getState().setActiveAssociation("SVRBA");
+      const { assignments, compensations, exchanges } =
+        useDemoStore.getState();
+
+      expect(assignments.length).toBeGreaterThan(0);
+      expect(compensations.length).toBeGreaterThan(0);
+      expect(exchanges.length).toBeGreaterThan(0);
+
+      // Validate first item of each type
+      expect(assignmentSchema.safeParse(assignments[0]).success).toBe(true);
+      expect(compensationRecordSchema.safeParse(compensations[0]).success).toBe(
+        true,
+      );
+      expect(gameExchangeSchema.safeParse(exchanges[0]).success).toBe(true);
+    });
+  });
+});
+
+describe("Mock API response structure matches real API", () => {
+  beforeEach(() => {
+    useDemoStore.getState().initializeDemoData();
+  });
+
+  it("assignments response has same shape as real API", async () => {
+    const response = await mockApi.searchAssignments();
+
+    expect(response).toHaveProperty("items");
+    expect(response).toHaveProperty("totalItemsCount");
+    expect(Array.isArray(response.items)).toBe(true);
+    expect(typeof response.totalItemsCount).toBe("number");
+  });
+
+  it("compensations response has same shape as real API", async () => {
+    const response = await mockApi.searchCompensations();
+
+    expect(response).toHaveProperty("items");
+    expect(response).toHaveProperty("totalItemsCount");
+    expect(Array.isArray(response.items)).toBe(true);
+    expect(typeof response.totalItemsCount).toBe("number");
+  });
+
+  it("exchanges response has same shape as real API", async () => {
+    const response = await mockApi.searchExchanges();
+
+    expect(response).toHaveProperty("items");
+    expect(response).toHaveProperty("totalItemsCount");
+    expect(Array.isArray(response.items)).toBe(true);
+    expect(typeof response.totalItemsCount).toBe("number");
+  });
+
+  it("person search response has same shape as real API", async () => {
+    const response = await mockApi.searchPersons({});
+
+    expect(response).toHaveProperty("items");
+    expect(response).toHaveProperty("totalItemsCount");
+    expect(Array.isArray(response.items)).toBe(true);
+    expect(typeof response.totalItemsCount).toBe("number");
+  });
+});

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -31,6 +31,13 @@ import type {
   PersonSearchResult,
 } from "./client";
 import { useDemoStore } from "@/stores/demo";
+import {
+  assignmentsResponseSchema,
+  compensationsResponseSchema,
+  exchangesResponseSchema,
+  personSearchResponseSchema,
+  validateResponse,
+} from "./validation";
 
 // Network delay constants for realistic demo behavior
 const MOCK_NETWORK_DELAY_MS = 50;
@@ -259,12 +266,15 @@ export const mockApi = {
     const store = useDemoStore.getState();
     const { items, total } = processSearchRequest(store.assignments, config);
 
-    // Type assertion safe by design: store.assignments is Assignment[], and
-    // processSearchRequest only filters/sorts/paginates without type transformation
-    return {
+    const response = {
       items: items as Assignment[],
       totalItemsCount: total,
     };
+
+    // Validate mock response matches real API schema, then cast back to expected type
+    // (validation ensures data structure is correct, cast preserves original type compatibility)
+    validateResponse(response, assignmentsResponseSchema, "mock:searchAssignments");
+    return response;
   },
 
   async getAssignmentDetails(
@@ -294,12 +304,14 @@ export const mockApi = {
     const store = useDemoStore.getState();
     const { items, total } = processSearchRequest(store.compensations, config);
 
-    // Type assertion safe by design: store.compensations is CompensationRecord[], and
-    // processSearchRequest only filters/sorts/paginates without type transformation
-    return {
+    const response = {
       items: items as CompensationRecord[],
       totalItemsCount: total,
     };
+
+    // Validate mock response matches real API schema, then cast back to expected type
+    validateResponse(response, compensationsResponseSchema, "mock:searchCompensations");
+    return response;
   },
 
   async getCompensationDetails(
@@ -339,12 +351,14 @@ export const mockApi = {
     const store = useDemoStore.getState();
     const { items, total } = processSearchRequest(store.exchanges, config);
 
-    // Type assertion safe by design: store.exchanges is GameExchange[], and
-    // processSearchRequest only filters/sorts/paginates without type transformation
-    return {
+    const response = {
       items: items as GameExchange[],
       totalItemsCount: total,
     };
+
+    // Validate mock response matches real API schema, then cast back to expected type
+    validateResponse(response, exchangesResponseSchema, "mock:searchExchanges");
+    return response;
   },
 
   async applyForExchange(exchangeId: string): Promise<void> {
@@ -471,10 +485,14 @@ export const mockApi = {
     const limit = options?.limit ?? DEFAULT_PERSON_SEARCH_LIMIT;
     const paginated = filtered.slice(offset, offset + limit);
 
-    return {
+    const response = {
       items: paginated,
       totalItemsCount: filtered.length,
     };
+
+    // Validate mock response matches real API schema, then cast back to expected type
+    validateResponse(response, personSearchResponseSchema, "mock:searchPersons");
+    return response;
   },
 
   async getGameWithScoresheet(gameId: string): Promise<GameDetails> {

--- a/web-app/src/stores/demo.test.ts
+++ b/web-app/src/stores/demo.test.ts
@@ -109,14 +109,22 @@ describe("useDemoStore", () => {
   describe("updateCompensation", () => {
     const TRAVEL_EXPENSE_RATE_PER_KM = 0.7;
 
+    // Helper to get compensation ID from store by index (0-based)
+    const getCompensationId = (index: number) => {
+      const compensations = useDemoStore.getState().compensations;
+      return compensations[index]?.__identity;
+    };
+
     it("updates distance and recalculates travel expenses", () => {
       useDemoStore.getState().initializeDemoData();
-      const compensationId = "demo-comp-1";
+      const compensationId = getCompensationId(0);
+      expect(compensationId).toBeDefined();
+
       const newDistanceInMetres = 50000;
       const expectedTravelExpenses =
         (newDistanceInMetres / 1000) * TRAVEL_EXPENSE_RATE_PER_KM;
 
-      useDemoStore.getState().updateCompensation(compensationId, {
+      useDemoStore.getState().updateCompensation(compensationId!, {
         distanceInMetres: newDistanceInMetres,
       });
 
@@ -134,7 +142,9 @@ describe("useDemoStore", () => {
 
     it("calculates travel expenses at 0.7 CHF per kilometer", () => {
       useDemoStore.getState().initializeDemoData();
-      const compensationId = "demo-comp-2";
+      const compensationId = getCompensationId(1);
+      expect(compensationId).toBeDefined();
+
       const testCases = [
         { distance: 10000, expected: 7.0 },
         { distance: 25000, expected: 17.5 },
@@ -143,7 +153,7 @@ describe("useDemoStore", () => {
       ];
 
       for (const { distance, expected } of testCases) {
-        useDemoStore.getState().updateCompensation(compensationId, {
+        useDemoStore.getState().updateCompensation(compensationId!, {
           distanceInMetres: distance,
         });
 
@@ -159,8 +169,10 @@ describe("useDemoStore", () => {
 
     it("does not modify other compensations", () => {
       useDemoStore.getState().initializeDemoData();
-      const targetId = "demo-comp-1";
-      const otherId = "demo-comp-2";
+      const targetId = getCompensationId(0);
+      const otherId = getCompensationId(1);
+      expect(targetId).toBeDefined();
+      expect(otherId).toBeDefined();
 
       const originalOther = useDemoStore
         .getState()
@@ -170,7 +182,7 @@ describe("useDemoStore", () => {
       const originalExpenses =
         originalOther?.convocationCompensation?.travelExpenses;
 
-      useDemoStore.getState().updateCompensation(targetId, {
+      useDemoStore.getState().updateCompensation(targetId!, {
         distanceInMetres: 99999,
       });
 
@@ -200,7 +212,8 @@ describe("useDemoStore", () => {
 
     it("preserves other compensation fields when updating distance", () => {
       useDemoStore.getState().initializeDemoData();
-      const compensationId = "demo-comp-1";
+      const compensationId = getCompensationId(0);
+      expect(compensationId).toBeDefined();
 
       const originalComp = useDemoStore
         .getState()
@@ -212,7 +225,7 @@ describe("useDemoStore", () => {
       const originalTransportationMode =
         originalComp?.convocationCompensation?.transportationMode;
 
-      useDemoStore.getState().updateCompensation(compensationId, {
+      useDemoStore.getState().updateCompensation(compensationId!, {
         distanceInMetres: 75000,
       });
 


### PR DESCRIPTION
Ensure demo mode translates smoothly to real API testing:

- Add contract tests that verify mock data passes Zod schemas
- Validate mock API responses against the same schemas as real API
- Generate valid UUIDs for demo data (instead of string identifiers)
- Fix demo store tests to use actual IDs from store

This catches mock/real API divergence early in development.