### PR TITLE
fix(assignments): show validate button only for first referee

### DIFF
--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -12,7 +12,10 @@ import {
 } from "@/components/ui/LoadingSpinner";
 import { useAssignmentActions } from "@/hooks/useAssignmentActions";
 import { createAssignmentActions } from "@/utils/assignment-actions";
-import { isGameReportEligible } from "@/utils/assignment-helpers";
+import {
+  isGameReportEligible,
+  isValidationEligible,
+} from "@/utils/assignment-helpers";
 import { EditCompensationModal } from "@/components/features/EditCompensationModal";
 import { ValidateGameModal } from "@/components/features/ValidateGameModal";
 import type { Assignment } from "@/api/client";
@@ -71,12 +74,16 @@ export function AssignmentsPage() {
       });
 
       const isGameInFuture = assignment.refereeGame?.isGameInFuture === "1";
+      const canValidateGame = isValidationEligible(assignment);
       const canGenerateReport = isGameReportEligible(assignment);
 
       // Action array ordering: first item = furthest from card = full swipe default
       // When swiping left, actions appear right-to-left from the card edge
+      // Validate action only shown for first referee (head-one position)
       // Report action only shown for NLA/NLB games where user is first referee
-      const leftActions = [actions.validateGame, actions.editCompensation];
+      const leftActions = canValidateGame
+        ? [actions.validateGame, actions.editCompensation]
+        : [actions.editCompensation];
       if (canGenerateReport) {
         leftActions.push(actions.generateReport);
       }

--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -85,6 +85,21 @@ export function isGameReportEligible(assignment: Assignment): boolean {
 }
 
 /**
+ * Checks if an assignment is eligible for game validation.
+ *
+ * Game validation is only available for referees assigned as the first
+ * head referee (head-one position), as they are responsible for validating
+ * game results. This applies to all game levels, unlike game reports which
+ * are restricted to NLA/NLB games.
+ *
+ * @param assignment - The referee assignment to check
+ * @returns true if the referee is in head-one position, false otherwise
+ */
+export function isValidationEligible(assignment: Assignment): boolean {
+  return assignment.refereePosition === "head-one";
+}
+
+/**
  * Default validation deadline in hours after game start.
  * Used as fallback when association settings are not available.
  * Common values in Swiss volleyball: 6-24 hours.


### PR DESCRIPTION
The validate game button now only appears for assignments where
the user is the first referee (head-one position), matching the
game report button behavior.