### PR TITLE
docs(api): replace TODO placeholders with captured request parameters

### DIFF
--- a/docs/api/ANALYSIS.md
+++ b/docs/api/ANALYSIS.md
@@ -202,6 +202,6 @@ Our app must handle these gracefully.
 1. ✅ Capture assignments response
 1. ⏳ Capture compensations response
 1. ⏳ Capture exchanges response
-1. ⏳ Capture request payloads (form data)
+1. ✅ Capture request payloads (form data) - see `captures/*.txt`
 1. ⏳ Document minimal vs full schema
 1. ⏳ Build mock server with simplified schema

--- a/docs/api/CAPTURE_INSTRUCTIONS.md
+++ b/docs/api/CAPTURE_INSTRUCTIONS.md
@@ -119,35 +119,9 @@ copy(await (await fetch('/api/...')).text())
 
 This copies the response to clipboard.
 
-## What We Need for Each Endpoint
+## Capture Status
 
-✅ = Captured, ❌ = Still needed
-
-### Assignments (`searchMyRefereeConvocations`)
-
-- ❌ Complete request parameters
-- ❌ Complete response structure
-- ❌ Field descriptions
-- ❌ Error response examples
-
-### Compensations (`search`)
-
-- ❌ Complete request parameters
-- ❌ Complete response structure
-- ❌ Payment status field values
-- ❌ Additional expense types
-
-### Exchanges (`search`)
-
-- ❌ Complete request parameters
-- ❌ Complete response structure
-- ❌ Status field values
-- ❌ Referee level codes
-
-### Settings Endpoints
-
-- ❌ Active season response
-- ❌ Association settings response
+See [CAPTURE_PLAN.md](CAPTURE_PLAN.md) for the current capture checklist and status.
 
 ## Next Steps After Capture
 

--- a/docs/api/CAPTURE_INSTRUCTIONS.md
+++ b/docs/api/CAPTURE_INSTRUCTIONS.md
@@ -41,8 +41,9 @@ Example for Assignments:
   searchConfiguration[dateRange][from]: "2025-12-08"
   searchConfiguration[dateRange][to]: "2026-05-20"
   searchConfiguration[dateProperty]: "refereeConvocation.refereeGame.game.startingDateTime"
-  searchConfiguration[sorting][0][field]: "refereeGame.game.startingDateTime"
-  searchConfiguration[sorting][0][direction]: "asc"
+  searchConfiguration[propertyOrderings][0][propertyName]: "refereeGame.game.startingDateTime"
+  searchConfiguration[propertyOrderings][0][descending]: false
+  searchConfiguration[propertyOrderings][0][isSetByUser]: true
   pagination[page]: "1"
   pagination[itemsPerPage]: "50"
 ```

--- a/docs/api/CAPTURE_INSTRUCTIONS.md
+++ b/docs/api/CAPTURE_INSTRUCTIONS.md
@@ -37,15 +37,17 @@ In the Network tab, look for the POST/GET request to the endpoint. Click on it t
 # In volleymanager-openapi.yaml, update the requestBody schema
 
 Example for Assignments:
-  __csrfToken: "abc123..."
-  searchConfiguration[dateRange][from]: "2025-12-08"
-  searchConfiguration[dateRange][to]: "2026-05-20"
-  searchConfiguration[dateProperty]: "refereeConvocation.refereeGame.game.startingDateTime"
+  searchConfiguration[propertyFilters][0][propertyName]: "refereeGame.game.startingDateTime"
+  searchConfiguration[propertyFilters][0][dateRange][from]: "2025-12-07T23:00:00.000Z"
+  searchConfiguration[propertyFilters][0][dateRange][to]: "2025-12-15T22:59:59.000Z"
+  searchConfiguration[customFilters]: ""
   searchConfiguration[propertyOrderings][0][propertyName]: "refereeGame.game.startingDateTime"
   searchConfiguration[propertyOrderings][0][descending]: false
   searchConfiguration[propertyOrderings][0][isSetByUser]: true
-  pagination[page]: "1"
-  pagination[itemsPerPage]: "50"
+  searchConfiguration[offset]: 0
+  searchConfiguration[limit]: 10
+  searchConfiguration[textSearchOperator]: "AND"
+  __csrfToken: "abc123..."
 ```
 
 ### Step 4: Copy Response Data

--- a/docs/api/CAPTURE_PLAN.md
+++ b/docs/api/CAPTURE_PLAN.md
@@ -6,7 +6,7 @@ This document outlines what we need to capture from the browser to build an accu
 
 ✅ Endpoints identified
 ✅ Test data samples collected
-❌ Exact request parameters
+✅ Exact request parameters (see `captures/*.txt`)
 ❌ Complete response structures
 ❌ CSRF token mechanism
 
@@ -39,27 +39,27 @@ For each endpoint, we need to capture:
 
 ### Assignments Endpoint
 
-- [ ] Request: Sorting parameters
-- [ ] Request: Exact date range format
-- [ ] Request: All filter options
+- [x] Request: Sorting parameters (`captures/assignments_request.txt`)
+- [x] Request: Exact date range format
+- [x] Request: All filter options
 - [ ] Response: Complete item structure
 - [ ] Response: Pagination details
 - [ ] Response: Status indicators
 
 ### Compensations Endpoint
 
-- [ ] Request: Sorting parameters
-- [ ] Request: Date property name
-- [ ] Request: Filter options (paid/unpaid, etc.)
+- [x] Request: Sorting parameters (`captures/compensations_request.txt`)
+- [x] Request: Date property name
+- [x] Request: Filter options (paid/unpaid, etc.)
 - [ ] Response: Complete item structure
 - [ ] Response: Payment status fields
 - [ ] Response: Calculation breakdowns
 
 ### Exchanges Endpoint
 
-- [ ] Request: Sorting parameters
-- [ ] Request: Date property name
-- [ ] Request: Status filters
+- [x] Request: Sorting parameters (`captures/exchanges_request.txt`)
+- [x] Request: Date property name
+- [x] Request: Status filters
 - [ ] Response: Complete item structure
 - [ ] Response: Qualification details
 - [ ] Response: Application status

--- a/docs/api/assignments_api.md
+++ b/docs/api/assignments_api.md
@@ -13,8 +13,9 @@ Form-encoded POST body with the following parameters:
 ### Observed Parameters (from browser network logs)
 
 ```
-searchConfiguration[sorting][0][field]: TODO - capture from browser
-searchConfiguration[sorting][0][direction]: TODO - capture from browser
+searchConfiguration[propertyOrderings][0][propertyName]: refereeGame.game.startingDateTime
+searchConfiguration[propertyOrderings][0][descending]: false
+searchConfiguration[propertyOrderings][0][isSetByUser]: true
 searchConfiguration[dateRange][from]: YYYY-MM-DD
 searchConfiguration[dateRange][to]: YYYY-MM-DD
 searchConfiguration[dateProperty]: refereeConvocation.refereeGame.game.startingDateTime

--- a/docs/api/assignments_api.md
+++ b/docs/api/assignments_api.md
@@ -13,14 +13,16 @@ Form-encoded POST body with the following parameters:
 ### Observed Parameters (from browser network logs)
 
 ```
+searchConfiguration[propertyFilters][0][propertyName]: refereeGame.game.startingDateTime
+searchConfiguration[propertyFilters][0][dateRange][from]: YYYY-MM-DDTHH:MM:SS.000Z
+searchConfiguration[propertyFilters][0][dateRange][to]: YYYY-MM-DDTHH:MM:SS.000Z
+searchConfiguration[customFilters]: (empty)
 searchConfiguration[propertyOrderings][0][propertyName]: refereeGame.game.startingDateTime
 searchConfiguration[propertyOrderings][0][descending]: false
 searchConfiguration[propertyOrderings][0][isSetByUser]: true
-searchConfiguration[dateRange][from]: YYYY-MM-DD
-searchConfiguration[dateRange][to]: YYYY-MM-DD
-searchConfiguration[dateProperty]: refereeConvocation.refereeGame.game.startingDateTime
-pagination[page]: 1
-pagination[itemsPerPage]: 50
+searchConfiguration[offset]: 0
+searchConfiguration[limit]: 10
+searchConfiguration[textSearchOperator]: AND
 __csrfToken: <token_value>
 ```
 
@@ -102,6 +104,7 @@ JSON response with structure:
 
 ## Notes
 
-- The date property used for filtering is `refereeConvocation.refereeGame.game.startingDateTime`
+- Date filtering uses `propertyFilters` with `refereeGame.game.startingDateTime`
+- Pagination uses `offset`/`limit` (not page-based)
 - Results are sorted by date/time by default (ascending)
 - Only returns assignments for the authenticated referee

--- a/docs/api/compensations_api.md
+++ b/docs/api/compensations_api.md
@@ -13,8 +13,9 @@ Form-encoded POST body with the following parameters:
 ### Observed Parameters (from browser network logs)
 
 ```
-searchConfiguration[sorting][0][field]: TODO - capture from browser
-searchConfiguration[sorting][0][direction]: TODO - capture from browser
+searchConfiguration[propertyOrderings][0][propertyName]: refereeGame.game.startingDateTime
+searchConfiguration[propertyOrderings][0][descending]: false
+searchConfiguration[propertyOrderings][0][isSetByUser]: true
 searchConfiguration[dateRange][from]: YYYY-MM-DD
 searchConfiguration[dateRange][to]: YYYY-MM-DD
 searchConfiguration[dateProperty]: compensationDate

--- a/docs/api/compensations_api.md
+++ b/docs/api/compensations_api.md
@@ -13,14 +13,18 @@ Form-encoded POST body with the following parameters:
 ### Observed Parameters (from browser network logs)
 
 ```
+searchConfiguration[propertyFilters][0][propertyName]: refereeGame.game.startingDateTime
+searchConfiguration[propertyFilters][0][dateRange][from]: YYYY-MM-DDTHH:MM:SS.000Z
+searchConfiguration[propertyFilters][0][dateRange][to]: YYYY-MM-DDTHH:MM:SS.000Z
+searchConfiguration[propertyFilters][1][propertyName]: convocationCompensation.paymentDone
+searchConfiguration[propertyFilters][1][values][0]: NOT_NULL
+searchConfiguration[customFilters][0][name]: archivedRefereeConvocations
 searchConfiguration[propertyOrderings][0][propertyName]: refereeGame.game.startingDateTime
 searchConfiguration[propertyOrderings][0][descending]: false
 searchConfiguration[propertyOrderings][0][isSetByUser]: true
-searchConfiguration[dateRange][from]: YYYY-MM-DD
-searchConfiguration[dateRange][to]: YYYY-MM-DD
-searchConfiguration[dateProperty]: compensationDate
-pagination[page]: 1
-pagination[itemsPerPage]: 50
+searchConfiguration[offset]: 0
+searchConfiguration[limit]: 10
+searchConfiguration[textSearchOperator]: AND
 __csrfToken: <token_value>
 ```
 
@@ -135,10 +139,12 @@ JSON response with structure (see `docs/api/volleymanager-openapi.yaml` for full
 
 ## Notes
 
-- The date property used for filtering is `compensationDate` (not the game date)
+- Date filtering uses `propertyFilters` with `refereeGame.game.startingDateTime`
+- Additional filter for payment status: `convocationCompensation.paymentDone = NOT_NULL`
+- Custom filter: `archivedRefereeConvocations`
+- Pagination uses `offset`/`limit` (not page-based)
 - Amounts are in Swiss Francs (CHF)
 - Distance is in kilometers
-- Payment status fields also exist but need to capture details
 
 ## PDF Download Endpoint
 

--- a/docs/api/exchanges_api.md
+++ b/docs/api/exchanges_api.md
@@ -13,11 +13,12 @@ Form-encoded POST body with the following parameters:
 ### Observed Parameters (from browser network logs)
 
 ```
-searchConfiguration[sorting][0][field]: TODO - capture from browser
-searchConfiguration[sorting][0][direction]: TODO - capture from browser
-searchConfiguration[dateRange][from]: YYYY-MM-DD
-searchConfiguration[dateRange][to]: YYYY-MM-DD
-searchConfiguration[dateProperty]: TODO - capture from browser
+searchConfiguration[propertyFilters][0][propertyName]: refereeGame.game.startingDateTime
+searchConfiguration[propertyFilters][0][dateRange][from]: YYYY-MM-DDTHH:MM:SS.000Z
+searchConfiguration[propertyFilters][0][dateRange][to]: YYYY-MM-DDTHH:MM:SS.000Z
+searchConfiguration[propertyFilters][1][propertyName]: status
+searchConfiguration[propertyFilters][1][enumValues][0]: open
+searchConfiguration[propertyOrderings]: (not specified - no default sorting)
 pagination[page]: 1
 pagination[itemsPerPage]: 50
 __csrfToken: <token_value>

--- a/docs/api/exchanges_api.md
+++ b/docs/api/exchanges_api.md
@@ -18,9 +18,11 @@ searchConfiguration[propertyFilters][0][dateRange][from]: YYYY-MM-DDTHH:MM:SS.00
 searchConfiguration[propertyFilters][0][dateRange][to]: YYYY-MM-DDTHH:MM:SS.000Z
 searchConfiguration[propertyFilters][1][propertyName]: status
 searchConfiguration[propertyFilters][1][enumValues][0]: open
-searchConfiguration[propertyOrderings]: (not specified - no default sorting)
-pagination[page]: 1
-pagination[itemsPerPage]: 50
+searchConfiguration[customFilters]: (empty)
+searchConfiguration[propertyOrderings]: (empty - no default sorting)
+searchConfiguration[offset]: 0
+searchConfiguration[limit]: 10
+searchConfiguration[textSearchOperator]: AND
 __csrfToken: <token_value>
 ```
 
@@ -148,7 +150,10 @@ __csrfToken: <token>
 
 ## Notes
 
+- Date filtering uses `propertyFilters` with `refereeGame.game.startingDateTime`
+- Status filter uses `enumValues`: open, applied, closed
+- Pagination uses `offset`/`limit` (not page-based)
+- No default sorting (propertyOrderings is empty)
 - Shows exchanges where referees can take over positions
 - Filtered by required qualification level (referee can only see exchanges they're qualified for)
-- Status can be: open, applied, closed
 - Multiple referees can apply for the same exchange


### PR DESCRIPTION
Update API documentation to use correct request parameter format based
on captured browser network logs. Replace outdated sorting[field]/direction
format with actual propertyOrderings format used by the API.