### PR TITLE
refactor(ui): replace inline SVGs with unified Lucide icons

### DIFF
--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent } from "@/components/ui/Card";
 import { ExpandArrow } from "@/components/ui/ExpandArrow";
 import { Badge } from "@/components/ui/Badge";
+import { MapPin } from "@/components/ui/icons";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateFormat } from "@/hooks/useDateFormat";
@@ -135,14 +136,7 @@ export function AssignmentCard({
             <div className="px-2 pb-2 pt-0 border-t border-border-subtle dark:border-border-subtle-dark space-y-1">
               {/* Location */}
               <div className="flex items-center gap-2 text-sm text-text-muted dark:text-text-muted-dark pt-2">
-                <svg
-                  className="w-4 h-4 flex-shrink-0"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
-                </svg>
+                <MapPin className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
                 {googleMapsUrl ? (
                   <a
                     href={googleMapsUrl}

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -2,6 +2,7 @@ import { format, parseISO } from "date-fns";
 import { Card, CardContent } from "@/components/ui/Card";
 import { ExpandArrow } from "@/components/ui/ExpandArrow";
 import { Badge } from "@/components/ui/Badge";
+import { MapPin } from "@/components/ui/icons";
 import type { GameExchange } from "@/api/client";
 import { useExpandable } from "@/hooks/useExpandable";
 import { useDateLocale } from "@/hooks/useDateFormat";
@@ -100,14 +101,7 @@ export function ExchangeCard({
             <div className="px-2 pb-2 pt-0 border-t border-border-subtle dark:border-border-subtle-dark space-y-1">
               {/* Location */}
               <div className="flex items-center gap-2 text-sm text-text-muted dark:text-text-muted-dark pt-2">
-                <svg
-                  className="w-4 h-4 flex-shrink-0"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
-                </svg>
+                <MapPin className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
                 <span className="truncate">{hallName}</span>
               </div>
 

--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -5,7 +5,7 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { usePossiblePlayerNominations } from "@/hooks/usePlayerNominations";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { ResponsiveSheet } from "@/components/ui/ResponsiveSheet";
-import { Check } from "@/components/ui/icons";
+import { Check, X, Plus } from "@/components/ui/icons";
 import { formatDOB } from "@/utils/date-helpers";
 
 // Delay before focusing search input to ensure the sheet animation has started
@@ -135,19 +135,7 @@ export function AddPlayerSheet({
               transition-colors
             "
           >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+            <X className="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
 
@@ -233,37 +221,17 @@ export function AddPlayerSheet({
                             aria-hidden="true"
                           />
                           {/* X icon shown on hover */}
-                          <svg
+                          <X
                             className="w-5 h-5 text-danger-500 dark:text-danger-400 absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
                             aria-hidden="true"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M6 18L18 6M6 6l12 12"
-                            />
-                          </svg>
+                          />
                           <span className="sr-only">{t("validation.roster.added")}</span>
                         </span>
                       ) : (
-                        <svg
+                        <Plus
                           className="w-5 h-5 text-text-subtle flex-shrink-0 ml-2"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
                           aria-hidden="true"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M12 4v16m8-8H4"
-                          />
-                        </svg>
+                        />
                       )}
                     </button>
                   </li>

--- a/web-app/src/components/features/validation/ScorerResultsList.tsx
+++ b/web-app/src/components/features/validation/ScorerResultsList.tsx
@@ -2,6 +2,7 @@ import type { ValidatedPersonSearchResult } from "@/api/validation";
 import { useTranslation } from "@/hooks/useTranslation";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { formatDOB } from "@/utils/date-helpers";
+import { ChevronRight } from "@/components/ui/icons";
 
 interface ScorerResultsListProps {
   results: ValidatedPersonSearchResult[] | undefined;
@@ -105,19 +106,10 @@ export function ScorerResultsList({
                   )}
                 </div>
               </div>
-              <svg
+              <ChevronRight
                 className="w-5 h-5 text-text-subtle flex-shrink-0 ml-2"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
+                aria-hidden="true"
+              />
             </button>
           </li>
         );

--- a/web-app/src/components/features/validation/SelectedScorerCard.tsx
+++ b/web-app/src/components/features/validation/SelectedScorerCard.tsx
@@ -1,6 +1,7 @@
 import type { ValidatedPersonSearchResult } from "@/api/validation";
 import { useTranslation } from "@/hooks/useTranslation";
 import { formatDOB } from "@/utils/date-helpers";
+import { X } from "@/components/ui/icons";
 
 interface SelectedScorerCardProps {
   scorer: ValidatedPersonSearchResult;
@@ -38,19 +39,7 @@ export function SelectedScorerCard({
             transition-colors
           "
         >
-          <svg
-            className="w-5 h-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
+          <X className="w-5 h-5" aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -26,8 +26,11 @@ export { RefreshCw } from "lucide-react";
 export { Trash2 } from "lucide-react";
 export { Undo2 } from "lucide-react";
 export { ChevronDown } from "lucide-react";
+export { ChevronRight } from "lucide-react";
 export { Circle } from "lucide-react";
 export { X } from "lucide-react";
+export { Plus } from "lucide-react";
+export { MapPin } from "lucide-react";
 
 // Status icons
 export { CheckCircle } from "lucide-react";


### PR DESCRIPTION
Replace inline SVG icons with standardized Lucide icon components for
consistency across the codebase. This aligns with the project's unified
icon system in icons.tsx.

- Add MapPin, ChevronRight, and Plus to icons.tsx exports
- Replace inline X icon in SelectedScorerCard and AddPlayerSheet
- Replace inline ChevronRight in ScorerResultsList
- Replace inline Plus in AddPlayerSheet
- Replace inline MapPin in AssignmentCard and ExchangeCard