### PR TITLE
fix(i18n): use translated error messages instead of hardcoded strings

### DIFF
--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -288,7 +288,8 @@ export function ValidateGameModal({
 
       onClose();
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to save";
+      const message =
+        error instanceof Error ? error.message : t("validation.state.saveError");
       setSaveError(message);
     } finally {
       isFinalizingRef.current = false;

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -153,6 +153,7 @@ const de: Translations = {
     addedToExchangeError: "Einsatz konnte nicht zur Tauschbörse hinzugefügt werden",
     submittedBy: "Von:",
     levelRequired: "Niveau {level}+",
+    errorLoading: "Fehler beim Laden der Tauschangebote",
   },
   positions: {
     "head-one": "1. Schiedsrichter",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -151,6 +151,7 @@ const en: Translations = {
     addedToExchangeError: "Failed to add assignment to exchange",
     submittedBy: "By:",
     levelRequired: "Level {level}+",
+    errorLoading: "Failed to load exchanges",
   },
   positions: {
     "head-one": "1st Referee",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -152,6 +152,7 @@ const fr: Translations = {
     addedToExchangeError: "Impossible d'ajouter la désignation à la bourse",
     submittedBy: "Par :",
     levelRequired: "Niveau {level}+",
+    errorLoading: "Échec du chargement des échanges",
   },
   positions: {
     "head-one": "1er Arbitre",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -150,6 +150,7 @@ const it: Translations = {
     addedToExchangeError: "Impossibile aggiungere la designazione alla borsa",
     submittedBy: "Da:",
     levelRequired: "Livello {level}+",
+    errorLoading: "Impossibile caricare gli scambi",
   },
   positions: {
     "head-one": "1° Arbitro",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -147,6 +147,7 @@ export interface Translations {
     addedToExchangeError: string;
     submittedBy: string;
     levelRequired: string;
+    errorLoading: string;
   };
   positions: {
     "head-one": string;

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -180,7 +180,7 @@ export function AssignmentsPage() {
             message={
               error instanceof Error
                 ? error.message
-                : "Failed to load assignments"
+                : t("assignments.failedToLoadData")
             }
             onRetry={() => refetch()}
           />

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -128,7 +128,7 @@ export function ExchangePage() {
       return (
         <ErrorState
           message={
-            error instanceof Error ? error.message : "Failed to load exchanges"
+            error instanceof Error ? error.message : t("exchange.errorLoading")
           }
           onRetry={() => refetch()}
         />


### PR DESCRIPTION
Replace hardcoded fallback error messages with i18n translations for
proper multi-language support. Added exchange.errorLoading key and
updated ExchangePage, AssignmentsPage, and ValidateGameModal to use
existing and new translations for error states.