### PR TITLE
fix(demo): ensure compensation edits persist and refresh UI

### DIFF
--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -638,8 +638,7 @@ export function useUpdateCompensation(): UseMutationResult<
         // Demo mode: update the demo store directly
         updateCompensation(compensationId, data);
       } else {
-        // Non-demo mode: API call would go here
-        // TODO: Implement real API call when endpoint is available
+        // Non-demo mode: log for debugging until API endpoint is implemented
         logger.debug("[useUpdateCompensation] Non-demo mode update:", {
           compensationId,
           data,

--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -611,6 +611,48 @@ export function useWithdrawFromExchange(): UseMutationResult<
   });
 }
 
+// Compensation update mutation
+export interface CompensationUpdateData {
+  distanceInMetres?: number;
+  correctionReason?: string;
+}
+
+export function useUpdateCompensation(): UseMutationResult<
+  void,
+  Error,
+  { compensationId: string; data: CompensationUpdateData }
+> {
+  const queryClient = useQueryClient();
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const updateCompensation = useDemoStore((state) => state.updateCompensation);
+
+  return useMutation({
+    mutationFn: async ({
+      compensationId,
+      data,
+    }: {
+      compensationId: string;
+      data: CompensationUpdateData;
+    }) => {
+      if (isDemoMode) {
+        // Demo mode: update the demo store directly
+        updateCompensation(compensationId, data);
+      } else {
+        // Non-demo mode: API call would go here
+        // TODO: Implement real API call when endpoint is available
+        logger.debug("[useUpdateCompensation] Non-demo mode update:", {
+          compensationId,
+          data,
+        });
+      }
+    },
+    onSuccess: () => {
+      // Invalidate compensations queries to refetch fresh data
+      queryClient.invalidateQueries({ queryKey: ["compensations"] });
+    },
+  });
+}
+
 // Settings hooks
 export function useAssociationSettings(): UseQueryResult<
   AssociationSettings,


### PR DESCRIPTION
The demo mode compensation editing was not persisting because the
EditCompensationModal was calling updateCompensation on the Zustand
demo store directly, but the TanStack Query cache was never invalidated.

Changes:
- Add useUpdateCompensation mutation hook that updates the demo store
  and invalidates the compensations query cache on success
- Update EditCompensationModal to use the new mutation hook instead
  of calling the demo store directly
- Update tests to use QueryClientProvider wrapper and mock the new hook

This ensures that after editing a compensation in demo mode, the
CompensationsPage refreshes to show the updated values.