### PR TITLE
feat(validation): add read-only wizard for validated games

### DIFF
--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -96,6 +96,8 @@ describe("ValidateGameModal", () => {
         scoresheet: true,
       },
       isAllRequiredComplete: false,
+      isValidated: false,
+      validatedInfo: null,
       setHomeRosterModifications: vi.fn(),
       setAwayRosterModifications: vi.fn(),
       setScorer: vi.fn(),

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -424,7 +424,10 @@ export function ValidateGameModal({
 
           {/* Validated status banner */}
           {isValidated && validatedInfo && (
-            <div className="mb-4 p-3 bg-success-50 dark:bg-success-900/20 border border-success-200 dark:border-success-800 rounded-lg">
+            <div
+              role="status"
+              className="mb-4 p-3 bg-success-50 dark:bg-success-900/20 border border-success-200 dark:border-success-800 rounded-lg"
+            >
               <p className="text-sm font-medium text-success-700 dark:text-success-400">
                 {t("validation.wizard.alreadyValidated")}
               </p>

--- a/web-app/src/components/features/validation/AwayRosterPanel.tsx
+++ b/web-app/src/components/features/validation/AwayRosterPanel.tsx
@@ -7,12 +7,15 @@ interface AwayRosterPanelProps {
   assignment: Assignment;
   onModificationsChange?: (modifications: RosterModifications) => void;
   onAddPlayerSheetOpenChange?: (isOpen: boolean) => void;
+  /** When true, shows roster in view-only mode */
+  readOnly?: boolean;
 }
 
 export function AwayRosterPanel({
   assignment,
   onModificationsChange,
   onAddPlayerSheetOpenChange,
+  readOnly = false,
 }: AwayRosterPanelProps) {
   const { awayTeam } = getTeamNames(assignment);
   const gameId = assignment.refereeGame?.game?.__identity ?? "";
@@ -24,6 +27,7 @@ export function AwayRosterPanel({
       gameId={gameId}
       onModificationsChange={onModificationsChange}
       onAddPlayerSheetOpenChange={onAddPlayerSheetOpenChange}
+      readOnly={readOnly}
     />
   );
 }

--- a/web-app/src/components/features/validation/HomeRosterPanel.tsx
+++ b/web-app/src/components/features/validation/HomeRosterPanel.tsx
@@ -7,12 +7,15 @@ interface HomeRosterPanelProps {
   assignment: Assignment;
   onModificationsChange?: (modifications: RosterModifications) => void;
   onAddPlayerSheetOpenChange?: (isOpen: boolean) => void;
+  /** When true, shows roster in view-only mode */
+  readOnly?: boolean;
 }
 
 export function HomeRosterPanel({
   assignment,
   onModificationsChange,
   onAddPlayerSheetOpenChange,
+  readOnly = false,
 }: HomeRosterPanelProps) {
   const { homeTeam } = getTeamNames(assignment);
   const gameId = assignment.refereeGame?.game?.__identity ?? "";
@@ -24,6 +27,7 @@ export function HomeRosterPanel({
       gameId={gameId}
       onModificationsChange={onModificationsChange}
       onAddPlayerSheetOpenChange={onAddPlayerSheetOpenChange}
+      readOnly={readOnly}
     />
   );
 }

--- a/web-app/src/components/features/validation/PlayerListItem.tsx
+++ b/web-app/src/components/features/validation/PlayerListItem.tsx
@@ -15,8 +15,10 @@ function formatPlayerName(player: RosterPlayer): string {
 interface PlayerListItemProps {
   player: RosterPlayer;
   isMarkedForRemoval: boolean;
-  onRemove: () => void;
-  onUndoRemoval: () => void;
+  onRemove?: () => void;
+  onUndoRemoval?: () => void;
+  /** When true, hides action buttons */
+  readOnly?: boolean;
 }
 
 export function PlayerListItem({
@@ -24,6 +26,7 @@ export function PlayerListItem({
   isMarkedForRemoval,
   onRemove,
   onUndoRemoval,
+  readOnly = false,
 }: PlayerListItemProps) {
   const { t } = useTranslation();
 
@@ -91,30 +94,32 @@ export function PlayerListItem({
         </div>
       </div>
 
-      {/* Action button */}
-      <div className="flex-shrink-0 ml-2">
-        {isMarkedForRemoval ? (
-          <button
-            type="button"
-            onClick={onUndoRemoval}
-            className="p-1.5 rounded-full text-primary-600 hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-primary-900/50 transition-colors"
-            aria-label={t("validation.roster.undoRemoval")}
-            title={t("validation.roster.undoRemoval")}
-          >
-            <Undo2 className="w-4 h-4" aria-hidden="true" />
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onRemove}
-            className="p-1.5 rounded-full text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/50 transition-colors"
-            aria-label={t("validation.roster.removePlayer")}
-            title={t("validation.roster.removePlayer")}
-          >
-            <Trash2 className="w-4 h-4" aria-hidden="true" />
-          </button>
-        )}
-      </div>
+      {/* Action button - hidden in read-only mode */}
+      {!readOnly && (
+        <div className="flex-shrink-0 ml-2">
+          {isMarkedForRemoval ? (
+            <button
+              type="button"
+              onClick={onUndoRemoval}
+              className="p-1.5 rounded-full text-primary-600 hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-primary-900/50 transition-colors"
+              aria-label={t("validation.roster.undoRemoval")}
+              title={t("validation.roster.undoRemoval")}
+            >
+              <Undo2 className="w-4 h-4" aria-hidden="true" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onRemove}
+              className="p-1.5 rounded-full text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/50 transition-colors"
+              aria-label={t("validation.roster.removePlayer")}
+              title={t("validation.roster.removePlayer")}
+            >
+              <Trash2 className="w-4 h-4" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -16,6 +16,8 @@ interface RosterVerificationPanelProps {
   gameId: string;
   onModificationsChange?: (modifications: RosterModifications) => void;
   onAddPlayerSheetOpenChange?: (isOpen: boolean) => void;
+  /** When true, shows roster in view-only mode without edit controls */
+  readOnly?: boolean;
 }
 
 export function RosterVerificationPanel({
@@ -24,6 +26,7 @@ export function RosterVerificationPanel({
   gameId,
   onModificationsChange,
   onAddPlayerSheetOpenChange,
+  readOnly = false,
 }: RosterVerificationPanelProps) {
   const { t } = useTranslation();
   const { nominationList, players, isLoading, isError, refetch } =
@@ -176,34 +179,39 @@ export function RosterVerificationPanel({
               key={player.id}
               player={player}
               isMarkedForRemoval={removedPlayerIds.has(player.id)}
-              onRemove={() => handleRemovePlayer(player.id)}
-              onUndoRemoval={() => handleUndoRemoval(player.id)}
+              onRemove={readOnly ? undefined : () => handleRemovePlayer(player.id)}
+              onUndoRemoval={readOnly ? undefined : () => handleUndoRemoval(player.id)}
+              readOnly={readOnly}
             />
           ))}
         </div>
       )}
 
-      {/* Add Player button */}
-      <div className="mt-4">
-        <button
-          type="button"
-          onClick={() => setIsAddPlayerSheetOpen(true)}
-          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 hover:bg-primary-100 dark:hover:bg-primary-900/50 rounded-lg border border-primary-200 dark:border-primary-800 transition-colors"
-        >
-          <UserPlus className="w-4 h-4" aria-hidden="true" />
-          {t("validation.roster.addPlayer")}
-        </button>
-      </div>
+      {/* Add Player button - hidden in read-only mode */}
+      {!readOnly && (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setIsAddPlayerSheetOpen(true)}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 hover:bg-primary-100 dark:hover:bg-primary-900/50 rounded-lg border border-primary-200 dark:border-primary-800 transition-colors"
+          >
+            <UserPlus className="w-4 h-4" aria-hidden="true" />
+            {t("validation.roster.addPlayer")}
+          </button>
+        </div>
+      )}
 
-      {/* AddPlayerSheet */}
-      <AddPlayerSheet
-        isOpen={isAddPlayerSheetOpen}
-        onClose={() => setIsAddPlayerSheetOpen(false)}
-        nominationListId={nominationList?.__identity ?? ""}
-        excludePlayerIds={players.map((p) => p.id)}
-        onAddPlayer={handleAddPlayer}
-        onRemovePlayer={handleRemoveAddedPlayer}
-      />
+      {/* AddPlayerSheet - only available in edit mode */}
+      {!readOnly && (
+        <AddPlayerSheet
+          isOpen={isAddPlayerSheetOpen}
+          onClose={() => setIsAddPlayerSheetOpen(false)}
+          nominationListId={nominationList?.__identity ?? ""}
+          excludePlayerIds={players.map((p) => p.id)}
+          onAddPlayer={handleAddPlayer}
+          onRemovePlayer={handleRemoveAddedPlayer}
+        />
+      )}
     </div>
   );
 }

--- a/web-app/src/components/features/validation/ScorerPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerPanel.tsx
@@ -5,6 +5,10 @@ import { ScorerSearchPanel } from "./ScorerSearchPanel";
 interface ScorerPanelProps {
   onScorerChange?: (scorer: ValidatedPersonSearchResult | null) => void;
   initialScorer?: ValidatedPersonSearchResult | null;
+  /** When true, shows scorer in view-only mode without edit controls */
+  readOnly?: boolean;
+  /** Scorer name to display in read-only mode when no scorer data is available */
+  readOnlyScorerName?: string;
 }
 
 /**
@@ -15,6 +19,8 @@ interface ScorerPanelProps {
 export function ScorerPanel({
   onScorerChange,
   initialScorer = null,
+  readOnly = false,
+  readOnlyScorerName,
 }: ScorerPanelProps) {
   const [selectedScorer, setSelectedScorer] =
     useState<ValidatedPersonSearchResult | null>(initialScorer);
@@ -28,6 +34,8 @@ export function ScorerPanel({
     <ScorerSearchPanel
       selectedScorer={selectedScorer}
       onScorerSelect={handleScorerSelect}
+      readOnly={readOnly}
+      readOnlyScorerName={readOnlyScorerName}
     />
   );
 }

--- a/web-app/src/components/features/validation/ScorerSearchPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.tsx
@@ -31,6 +31,10 @@ const SCORER_SEARCH_HINT_ID = "scorer-search-hint";
 interface ScorerSearchPanelProps {
   selectedScorer?: ValidatedPersonSearchResult | null;
   onScorerSelect: (scorer: ValidatedPersonSearchResult | null) => void;
+  /** When true, shows scorer in view-only mode without edit controls */
+  readOnly?: boolean;
+  /** Scorer name to display in read-only mode when no scorer data is available */
+  readOnlyScorerName?: string;
 }
 
 /**
@@ -40,6 +44,8 @@ interface ScorerSearchPanelProps {
 export function ScorerSearchPanel({
   selectedScorer,
   onScorerSelect,
+  readOnly = false,
+  readOnlyScorerName,
 }: ScorerSearchPanelProps) {
   const { t, tInterpolate } = useTranslation();
   const [searchQuery, setSearchQuery] = useState("");
@@ -131,6 +137,25 @@ export function ScorerSearchPanel({
   const hasResults = results && results.length > 0;
 
   const showResults = debouncedQuery.trim() && !selectedScorer;
+
+  // In read-only mode, show a simple display of the scorer
+  if (readOnly) {
+    return (
+      <div className="py-4">
+        {(selectedScorer || readOnlyScorerName) ? (
+          <SelectedScorerCard
+            scorer={selectedScorer}
+            displayName={readOnlyScorerName}
+            readOnly
+          />
+        ) : (
+          <p className="text-sm text-text-muted dark:text-text-muted-dark">
+            {t("validation.scorerSearch.noScorerSelected")}
+          </p>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="py-4">

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -12,6 +12,10 @@ import {
 interface ScoresheetPanelProps {
   /** Callback when scoresheet state changes */
   onScoresheetChange?: (file: File | null, uploaded: boolean) => void;
+  /** When true, shows panel in view-only mode */
+  readOnly?: boolean;
+  /** Whether a scoresheet was uploaded (for read-only mode) */
+  hasScoresheet?: boolean;
 }
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
@@ -36,7 +40,11 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
+export function ScoresheetPanel({
+  onScoresheetChange,
+  readOnly = false,
+  hasScoresheet = false,
+}: ScoresheetPanelProps) {
   const { t } = useTranslation();
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
   const onScoresheetChangeRef = useRef(onScoresheetChange);
@@ -195,6 +203,31 @@ export function ScoresheetPanel({ onScoresheetChange }: ScoresheetPanelProps) {
 
   const tKey = (key: string) =>
     t(`validation.scoresheetUpload.${key}` as Parameters<typeof t>[0]);
+
+  // In read-only mode, show a simple status display
+  if (readOnly) {
+    return (
+      <div className="py-4">
+        <div className="border border-border-default dark:border-border-default-dark rounded-lg p-4 text-center">
+          {hasScoresheet ? (
+            <>
+              <CheckCircle className="w-12 h-12 mx-auto text-green-500 mb-3" aria-hidden="true" />
+              <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                {t("validation.scoresheetUpload.scoresheetUploaded")}
+              </h3>
+            </>
+          ) : (
+            <>
+              <FileText className="w-12 h-12 mx-auto text-text-subtle dark:text-text-subtle-dark mb-3" aria-hidden="true" />
+              <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                {t("validation.scoresheetUpload.noScoresheet")}
+              </h3>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="py-4">

--- a/web-app/src/components/features/validation/SelectedScorerCard.tsx
+++ b/web-app/src/components/features/validation/SelectedScorerCard.tsx
@@ -4,8 +4,14 @@ import { formatDOB } from "@/utils/date-helpers";
 import { X } from "@/components/ui/icons";
 
 interface SelectedScorerCardProps {
-  scorer: ValidatedPersonSearchResult;
-  onClear: () => void;
+  /** Scorer data from search (may be null in read-only mode) */
+  scorer?: ValidatedPersonSearchResult | null;
+  /** Fallback display name to use when scorer data is not available */
+  displayName?: string;
+  /** Callback to clear the selection */
+  onClear?: () => void;
+  /** When true, hides the clear button */
+  readOnly?: boolean;
 }
 
 /**
@@ -13,34 +19,43 @@ interface SelectedScorerCardProps {
  */
 export function SelectedScorerCard({
   scorer,
+  displayName,
   onClear,
+  readOnly = false,
 }: SelectedScorerCardProps) {
   const { t } = useTranslation();
+
+  // Use scorer displayName if available, otherwise use the displayName prop
+  const name = scorer?.displayName ?? displayName ?? "";
 
   return (
     <div className="mb-4 p-4 bg-primary-50 dark:bg-primary-900/20 rounded-lg border border-primary-200 dark:border-primary-800">
       <div className="flex items-center justify-between">
         <div>
           <div className="font-medium text-text-primary dark:text-text-primary-dark">
-            {scorer.displayName}
+            {name}
           </div>
-          <div className="flex items-center gap-3 text-sm text-text-muted dark:text-text-muted-dark">
-            {scorer.associationId && <span>ID: {scorer.associationId}</span>}
-            {scorer.birthday && <span>{formatDOB(scorer.birthday)}</span>}
-          </div>
+          {scorer && (
+            <div className="flex items-center gap-3 text-sm text-text-muted dark:text-text-muted-dark">
+              {scorer.associationId && <span>ID: {scorer.associationId}</span>}
+              {scorer.birthday && <span>{formatDOB(scorer.birthday)}</span>}
+            </div>
+          )}
         </div>
-        <button
-          onClick={onClear}
-          aria-label={t("common.close")}
-          className="
-            p-2 rounded-lg
-            text-text-muted hover:text-text-secondary dark:text-text-muted-dark dark:hover:text-text-secondary-dark
-            hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark
-            transition-colors
-          "
-        >
-          <X className="w-5 h-5" aria-hidden="true" />
-        </button>
+        {!readOnly && onClear && (
+          <button
+            onClick={onClear}
+            aria-label={t("common.close")}
+            className="
+              p-2 rounded-lg
+              text-text-muted hover:text-text-secondary dark:text-text-muted-dark dark:hover:text-text-secondary-dark
+              hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark
+              transition-colors
+            "
+          >
+            <X className="w-5 h-5" aria-hidden="true" />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -312,6 +312,8 @@ const de: Translations = {
         "Ungültiger Dateityp. Bitte verwenden Sie JPEG, PNG oder PDF.",
       demoModeNote: "Demo-Modus: Uploads werden simuliert",
       previewAlt: "Spielbericht-Vorschau",
+      scoresheetUploaded: "Spielbericht hochgeladen",
+      noScoresheet: "Kein Spielbericht hochgeladen",
     },
     state: {
       unsavedChangesTitle: "Ungespeicherte Änderungen",
@@ -334,6 +336,8 @@ const de: Translations = {
       stepOf: "Schritt {current} von {total}",
       saving: "Speichern...",
       markAsReviewed: "Als geprüft markieren",
+      alreadyValidated: "Dieses Spiel wurde bereits validiert",
+      validatedBy: "Schreiber: {scorer}",
     },
   },
 };

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -307,6 +307,8 @@ const en: Translations = {
       invalidFileType: "Invalid file type. Please use JPEG, PNG, or PDF.",
       demoModeNote: "Demo mode: uploads are simulated",
       previewAlt: "Scoresheet preview",
+      scoresheetUploaded: "Scoresheet uploaded",
+      noScoresheet: "No scoresheet uploaded",
     },
     state: {
       unsavedChangesTitle: "Unsaved Changes",
@@ -328,6 +330,8 @@ const en: Translations = {
       stepOf: "Step {current} of {total}",
       saving: "Saving...",
       markAsReviewed: "Mark as reviewed",
+      alreadyValidated: "This game has already been validated",
+      validatedBy: "Scorer: {scorer}",
     },
   },
 };

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -311,6 +311,8 @@ const fr: Translations = {
         "Type de fichier invalide. Veuillez utiliser JPEG, PNG ou PDF.",
       demoModeNote: "Mode démo: les téléchargements sont simulés",
       previewAlt: "Aperçu de la feuille de match",
+      scoresheetUploaded: "Feuille de match téléchargée",
+      noScoresheet: "Aucune feuille de match téléchargée",
     },
     state: {
       unsavedChangesTitle: "Modifications non enregistrées",
@@ -333,6 +335,8 @@ const fr: Translations = {
       stepOf: "Étape {current} sur {total}",
       saving: "Enregistrement...",
       markAsReviewed: "Marquer comme vérifié",
+      alreadyValidated: "Ce match a déjà été validé",
+      validatedBy: "Marqueur: {scorer}",
     },
   },
 };

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -306,6 +306,8 @@ const it: Translations = {
       invalidFileType: "Tipo di file non valido. Usa JPEG, PNG o PDF.",
       demoModeNote: "Modalità demo: i caricamenti sono simulati",
       previewAlt: "Anteprima referto",
+      scoresheetUploaded: "Referto caricato",
+      noScoresheet: "Nessun referto caricato",
     },
     state: {
       unsavedChangesTitle: "Modifiche non salvate",
@@ -328,6 +330,8 @@ const it: Translations = {
       stepOf: "Passo {current} di {total}",
       saving: "Salvataggio...",
       markAsReviewed: "Segna come verificato",
+      alreadyValidated: "Questa partita è già stata validata",
+      validatedBy: "Segnapunti: {scorer}",
     },
   },
 };

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -287,6 +287,8 @@ export interface Translations {
       invalidFileType: string;
       demoModeNote: string;
       previewAlt: string;
+      scoresheetUploaded: string;
+      noScoresheet: string;
     };
     state: {
       unsavedChangesTitle: string;
@@ -307,6 +309,8 @@ export interface Translations {
       stepOf: string;
       saving: string;
       markAsReviewed: string;
+      alreadyValidated: string;
+      validatedBy: string;
     };
   };
 }


### PR DESCRIPTION
- Show read-only version of validation wizard for already validated games
- Detect validated state from scoresheet.closedAt (works with both real and demo API)
- Display validation banner with scorer name when viewing validated game
- Hide edit controls (add player, remove player, search scorer) in read-only mode
- Persist validated games in demo store across page reloads
- Update mock API to persist validation state and nomination list closures
- Preserve validated games when demo data becomes stale (6h threshold)

Includes translations for all 4 languages (de, en, fr, it).