### PR TITLE
fix(demo): persist compensation edits from assignments tab

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.test.tsx
+++ b/web-app/src/components/features/EditCompensationModal.test.tsx
@@ -608,6 +608,44 @@ describe("EditCompensationModal", () => {
         );
       });
     });
+
+    it("calls updateAssignmentCompensation mutation when editing an assignment", async () => {
+      render(
+        <EditCompensationModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+        { wrapper: createWrapper() },
+      );
+
+      // Form renders immediately for assignments (no API fetch needed)
+      const kmInput = screen.getByLabelText("Kilometers");
+      const reasonInput = screen.getByLabelText("Reason");
+
+      fireEvent.change(kmInput, { target: { value: "35" } });
+      fireEvent.change(reasonInput, { target: { value: "Construction detour" } });
+
+      // Submit form programmatically
+      const form = kmInput.closest("form");
+      fireEvent.submit(form!);
+
+      await waitFor(() => {
+        // Should call assignment mutation, not compensation mutation
+        expect(mockAssignmentMutate).toHaveBeenCalledWith(
+          {
+            assignmentId: "assignment-1",
+            data: {
+              distanceInMetres: 35000,
+              correctionReason: "Construction detour",
+            },
+          },
+          expect.objectContaining({ onSuccess: expect.any(Function) }),
+        );
+        // Compensation mutation should NOT be called
+        expect(mockMutate).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("accessibility", () => {

--- a/web-app/src/components/features/EditCompensationModal.test.tsx
+++ b/web-app/src/components/features/EditCompensationModal.test.tsx
@@ -5,6 +5,7 @@ import { EditCompensationModal } from "./EditCompensationModal";
 import type { CompensationRecord, Assignment } from "@/api/client";
 import { getApiClient } from "@/api/client";
 import { useAuthStore } from "@/stores/auth";
+import { useDemoStore } from "@/stores/demo";
 import * as useConvocationsModule from "@/hooks/useConvocations";
 
 vi.mock("@/api/client", () => ({
@@ -15,8 +16,13 @@ vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn(),
 }));
 
+vi.mock("@/stores/demo", () => ({
+  useDemoStore: vi.fn(),
+}));
+
 vi.mock("@/hooks/useConvocations", () => ({
   useUpdateCompensation: vi.fn(),
+  useUpdateAssignmentCompensation: vi.fn(),
 }));
 
 // Shared QueryClient for tests
@@ -85,7 +91,9 @@ async function waitForFormToLoad() {
 describe("EditCompensationModal", () => {
   const mockOnClose = vi.fn();
   const mockMutate = vi.fn();
+  const mockAssignmentMutate = vi.fn();
   const mockGetCompensationDetails = vi.fn();
+  const mockGetAssignmentCompensation = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -102,8 +110,34 @@ describe("EditCompensationModal", () => {
       selector({ isDemoMode: false }),
     );
 
+    // Mock useDemoStore to return getAssignmentCompensation
+    (useDemoStore as unknown as Mock).mockImplementation((selector) =>
+      selector({ getAssignmentCompensation: mockGetAssignmentCompensation }),
+    );
+
+    mockGetAssignmentCompensation.mockReturnValue(null);
+
     vi.mocked(useConvocationsModule.useUpdateCompensation).mockReturnValue({
       mutate: mockMutate,
+      mutateAsync: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      isIdle: true,
+      isPaused: false,
+      error: null,
+      data: undefined,
+      variables: undefined,
+      reset: vi.fn(),
+      context: undefined,
+      failureCount: 0,
+      failureReason: null,
+      status: "idle",
+      submittedAt: 0,
+    });
+
+    vi.mocked(useConvocationsModule.useUpdateAssignmentCompensation).mockReturnValue({
+      mutate: mockAssignmentMutate,
       mutateAsync: vi.fn(),
       isPending: false,
       isSuccess: false,
@@ -502,6 +536,9 @@ describe("EditCompensationModal", () => {
       (useAuthStore as unknown as Mock).mockImplementation((selector) =>
         selector({ isDemoMode: true }),
       );
+
+      // In demo mode, also mock getAssignmentCompensation with demo values
+      mockGetAssignmentCompensation.mockReturnValue(null);
     });
 
     it("calls updateCompensation mutation on submit", async () => {
@@ -524,9 +561,10 @@ describe("EditCompensationModal", () => {
       fireEvent.submit(form!);
 
       await waitFor(() => {
+        // compensationId comes from convocationCompensation.__identity, not record.__identity
         expect(mockMutate).toHaveBeenCalledWith(
           {
-            compensationId: "comp-1",
+            compensationId: "conv-comp-1",
             data: { distanceInMetres: 42000 },
           },
           expect.objectContaining({ onSuccess: expect.any(Function) }),
@@ -557,9 +595,10 @@ describe("EditCompensationModal", () => {
       fireEvent.submit(form!);
 
       await waitFor(() => {
+        // compensationId comes from convocationCompensation.__identity, not record.__identity
         expect(mockMutate).toHaveBeenCalledWith(
           {
-            compensationId: "comp-1",
+            compensationId: "conv-comp-1",
             data: {
               distanceInMetres: 25000,
               correctionReason: "Road work detour",

--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -677,7 +677,10 @@ export function useUpdateAssignmentCompensation(): UseMutationResult<
         // Demo mode: update the demo store directly
         updateAssignmentCompensation(assignmentId, data);
       } else {
-        // Non-demo mode: log for debugging until API endpoint is implemented
+        // TODO(#231): Implement real API support for assignment compensation updates.
+        // The existing PUT /convocationcompensation endpoint requires a convocationCompensation.__identity,
+        // which only exists on CompensationRecord objects, not Assignment objects.
+        // Options: (1) Find corresponding CompensationRecord by game ID, or (2) new backend endpoint.
         logger.debug("[useUpdateAssignmentCompensation] Non-demo mode update:", {
           assignmentId,
           data,

--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -652,6 +652,45 @@ export function useUpdateCompensation(): UseMutationResult<
   });
 }
 
+// Assignment compensation update mutation
+// Used when editing compensation from the assignments tab (where we have an Assignment, not a CompensationRecord)
+export function useUpdateAssignmentCompensation(): UseMutationResult<
+  void,
+  Error,
+  { assignmentId: string; data: CompensationUpdateData }
+> {
+  const queryClient = useQueryClient();
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const updateAssignmentCompensation = useDemoStore(
+    (state) => state.updateAssignmentCompensation,
+  );
+
+  return useMutation({
+    mutationFn: async ({
+      assignmentId,
+      data,
+    }: {
+      assignmentId: string;
+      data: CompensationUpdateData;
+    }) => {
+      if (isDemoMode) {
+        // Demo mode: update the demo store directly
+        updateAssignmentCompensation(assignmentId, data);
+      } else {
+        // Non-demo mode: log for debugging until API endpoint is implemented
+        logger.debug("[useUpdateAssignmentCompensation] Non-demo mode update:", {
+          assignmentId,
+          data,
+        });
+      }
+    },
+    onSuccess: () => {
+      // Invalidate assignment queries to refetch fresh data
+      queryClient.invalidateQueries({ queryKey: ["assignments"] });
+    },
+  });
+}
+
 // Settings hooks
 export function useAssociationSettings(): UseQueryResult<
   AssociationSettings,


### PR DESCRIPTION
Previously, editing compensation from the assignments tab in demo mode
did not persist because the EditCompensationModal used compensation
record IDs which don't exist for assignment objects.

Changes:
- Add assignmentCompensations storage to demo store to track edits
  made from the assignments tab
- Add updateAssignmentCompensation method to persist these edits
- Add getAssignmentCompensation method to retrieve stored edits
- Create useUpdateAssignmentCompensation hook for assignment edits
- Update EditCompensationModal to detect assignment vs compensation
  and use the appropriate mutation
- Preserve assignmentCompensations when demo data becomes stale

The modal now correctly:
- Pre-fills the form with stored assignment compensation data
- Calls updateAssignmentCompensation for assignments
- Calls updateCompensation for compensation records
- Persists both types of edits to localStorage via Zustand persist