### PR TITLE
feat(api): implement real API support for assignment compensation updates

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -326,6 +326,76 @@ describe("API Client", () => {
     });
   });
 
+  describe("updateCompensation", () => {
+    it("sends PUT request to correct endpoint", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({}));
+
+      await api.updateCompensation("comp-123", { distanceInMetres: 50000 });
+
+      // Note: backslash in path is required by Neos/Flow backend
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "/indoorvolleyball.refadmin/api%5cconvocationcompensation",
+        ),
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    it("includes compensation ID in request body", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({}));
+
+      await api.updateCompensation("comp-456", { distanceInMetres: 60000 });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      const body = options.body as URLSearchParams;
+      expect(body.get("__identity")).toBe("comp-456");
+    });
+
+    it("includes distanceInMetres in nested convocationCompensation object", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({}));
+
+      await api.updateCompensation("comp-789", { distanceInMetres: 75000 });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      const body = options.body as URLSearchParams;
+      expect(body.get("convocationCompensation[distanceInMetres]")).toBe(
+        "75000",
+      );
+    });
+
+    it("includes correctionReason in nested convocationCompensation object", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({}));
+
+      await api.updateCompensation("comp-abc", {
+        correctionReason: "Umweg wegen Baustelle",
+      });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      const body = options.body as URLSearchParams;
+      expect(body.get("convocationCompensation[correctionReason]")).toBe(
+        "Umweg wegen Baustelle",
+      );
+    });
+
+    it("includes both distanceInMetres and correctionReason when provided", async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse({}));
+
+      await api.updateCompensation("comp-xyz", {
+        distanceInMetres: 88000,
+        correctionReason: "Alternative route",
+      });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      const body = options.body as URLSearchParams;
+      expect(body.get("convocationCompensation[distanceInMetres]")).toBe(
+        "88000",
+      );
+      expect(body.get("convocationCompensation[correctionReason]")).toBe(
+        "Alternative route",
+      );
+    });
+  });
+
   describe("searchExchanges", () => {
     it("sends POST request to correct endpoint", async () => {
       mockFetch.mockResolvedValueOnce(

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -542,6 +542,42 @@ export const api = {
     );
   },
 
+  /**
+   * Updates compensation data for a convocation.
+   * Used by the edit compensation modal to save distance corrections.
+   *
+   * @param compensationId - UUID of the convocation compensation record
+   * @param data - Update data (distance in metres, correction reason)
+   */
+  async updateCompensation(
+    compensationId: string,
+    data: { distanceInMetres?: number; correctionReason?: string },
+  ): Promise<void> {
+    const requestBody: Record<string, unknown> = {
+      __identity: compensationId,
+    };
+
+    if (data.distanceInMetres !== undefined) {
+      requestBody["convocationCompensation"] = {
+        ...(requestBody["convocationCompensation"] as object),
+        distanceInMetres: data.distanceInMetres,
+      };
+    }
+
+    if (data.correctionReason !== undefined) {
+      requestBody["convocationCompensation"] = {
+        ...(requestBody["convocationCompensation"] as object),
+        correctionReason: data.correctionReason,
+      };
+    }
+
+    return apiRequest(
+      "/indoorvolleyball.refadmin/api%5cconvocationcompensation",
+      "PUT",
+      requestBody,
+    );
+  },
+
   // Game Exchanges
   async searchExchanges(
     config: SearchConfiguration = {},

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -343,6 +343,16 @@ export const mockApi = {
     };
   },
 
+  async updateCompensation(
+    compensationId: string,
+    data: { distanceInMetres?: number; correctionReason?: string },
+  ): Promise<void> {
+    await delay(MOCK_MUTATION_DELAY_MS);
+
+    const store = useDemoStore.getState();
+    store.updateCompensation(compensationId, data);
+  },
+
   async searchExchanges(
     config: SearchConfiguration = {},
   ): Promise<ExchangesResponse> {


### PR DESCRIPTION
Implements TODO(#231) by adding the ability to update compensation from
the assignments tab using the real API endpoint.

Changes:
- Add updateCompensation method to API client for PUT /convocationcompensation
- Add updateCompensation to mock API for demo mode
- Update useUpdateCompensation hook to call real API
- Update useUpdateAssignmentCompensation to find compensation record by
  game number and update via API

The implementation searches for the matching compensation record by game
number (from cache or API), then uses its convocationCompensation.__identity
to call the update endpoint.