### PR TITLE
fix(layout): prevent bottom navigation bar from scrolling

### DIFF
--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -102,7 +102,7 @@ export function AppShell() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-surface-page dark:bg-surface-page-dark">
+    <div className="flex flex-col flex-1 bg-surface-page dark:bg-surface-page-dark">
       {/* Header */}
       <header className="bg-surface-card dark:bg-surface-card-dark shadow-sm border-b border-border-default dark:border-border-default-dark">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/web-app/src/index.css
+++ b/web-app/src/index.css
@@ -120,15 +120,28 @@
 @layer base {
   html {
     @apply antialiased;
+    /* Prevent body from overscrolling on iOS */
+    height: 100%;
   }
 
   body {
     @apply min-h-screen bg-surface-page text-text-primary;
     @apply dark:bg-surface-page-dark dark:text-text-primary-dark;
+    /* Allow body to scroll normally, not the root container */
+    height: 100%;
+    overflow-x: hidden;
   }
 
   #root {
     @apply min-h-screen flex flex-col;
+  }
+}
+
+/* Utility classes */
+@layer utilities {
+  /* Safe area padding for iOS devices with notch/home indicator */
+  .safe-area-inset-bottom {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
   }
 }
 


### PR DESCRIPTION
- Define safe-area-inset-bottom utility for iOS devices with notch/home indicator
- Fix redundant min-h-screen on AppShell (already set on #root)
- Add height: 100% to html/body to prevent iOS overscrolling
- Add overflow-x: hidden to body for better scroll control