### PR TITLE
fix(demo): persist validation state across wizard steps and after finalization

### DIFF
--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -137,6 +137,7 @@ export function ValidateGameModal({
   const gameId = assignment.refereeGame?.game?.__identity;
 
   const {
+    state: validationState,
     isDirty,
     completionStatus,
     isValidated,
@@ -496,6 +497,7 @@ export function ValidateGameModal({
                       onModificationsChange={setHomeRosterModifications}
                       onAddPlayerSheetOpenChange={handleAddPlayerSheetOpenChange}
                       readOnly={isValidated}
+                      initialModifications={validationState.homeRoster.modifications}
                     />
                   )}
 
@@ -505,6 +507,7 @@ export function ValidateGameModal({
                       onModificationsChange={setAwayRosterModifications}
                       onAddPlayerSheetOpenChange={handleAddPlayerSheetOpenChange}
                       readOnly={isValidated}
+                      initialModifications={validationState.awayRoster.modifications}
                     />
                   )}
 

--- a/web-app/src/components/features/validation/AwayRosterPanel.tsx
+++ b/web-app/src/components/features/validation/AwayRosterPanel.tsx
@@ -9,6 +9,8 @@ interface AwayRosterPanelProps {
   onAddPlayerSheetOpenChange?: (isOpen: boolean) => void;
   /** When true, shows roster in view-only mode */
   readOnly?: boolean;
+  /** Initial modifications to restore state when remounting */
+  initialModifications?: RosterModifications;
 }
 
 export function AwayRosterPanel({
@@ -16,6 +18,7 @@ export function AwayRosterPanel({
   onModificationsChange,
   onAddPlayerSheetOpenChange,
   readOnly = false,
+  initialModifications,
 }: AwayRosterPanelProps) {
   const { awayTeam } = getTeamNames(assignment);
   const gameId = assignment.refereeGame?.game?.__identity ?? "";
@@ -28,6 +31,7 @@ export function AwayRosterPanel({
       onModificationsChange={onModificationsChange}
       onAddPlayerSheetOpenChange={onAddPlayerSheetOpenChange}
       readOnly={readOnly}
+      initialModifications={initialModifications}
     />
   );
 }

--- a/web-app/src/components/features/validation/HomeRosterPanel.tsx
+++ b/web-app/src/components/features/validation/HomeRosterPanel.tsx
@@ -9,6 +9,8 @@ interface HomeRosterPanelProps {
   onAddPlayerSheetOpenChange?: (isOpen: boolean) => void;
   /** When true, shows roster in view-only mode */
   readOnly?: boolean;
+  /** Initial modifications to restore state when remounting */
+  initialModifications?: RosterModifications;
 }
 
 export function HomeRosterPanel({
@@ -16,6 +18,7 @@ export function HomeRosterPanel({
   onModificationsChange,
   onAddPlayerSheetOpenChange,
   readOnly = false,
+  initialModifications,
 }: HomeRosterPanelProps) {
   const { homeTeam } = getTeamNames(assignment);
   const gameId = assignment.refereeGame?.game?.__identity ?? "";
@@ -28,6 +31,7 @@ export function HomeRosterPanel({
       onModificationsChange={onModificationsChange}
       onAddPlayerSheetOpenChange={onAddPlayerSheetOpenChange}
       readOnly={readOnly}
+      initialModifications={initialModifications}
     />
   );
 }

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -18,6 +18,8 @@ interface RosterVerificationPanelProps {
   onAddPlayerSheetOpenChange?: (isOpen: boolean) => void;
   /** When true, shows roster in view-only mode without edit controls */
   readOnly?: boolean;
+  /** Initial modifications to restore state when remounting */
+  initialModifications?: RosterModifications;
 }
 
 export function RosterVerificationPanel({
@@ -27,6 +29,7 @@ export function RosterVerificationPanel({
   onModificationsChange,
   onAddPlayerSheetOpenChange,
   readOnly = false,
+  initialModifications,
 }: RosterVerificationPanelProps) {
   const { t } = useTranslation();
   const { nominationList, players, isLoading, isError, refetch } =
@@ -35,15 +38,17 @@ export function RosterVerificationPanel({
       team,
     });
 
-  // Track locally added players
-  const [addedPlayers, setAddedPlayers] = useState<RosterPlayer[]>([]);
+  // Track locally added players - initialize from props to restore state when remounting
+  const [addedPlayers, setAddedPlayers] = useState<RosterPlayer[]>(
+    () => initialModifications?.added ?? [],
+  );
 
   // Track AddPlayerSheet open state
   const [isAddPlayerSheetOpen, setIsAddPlayerSheetOpen] = useState(false);
 
-  // Track IDs of players marked for removal
+  // Track IDs of players marked for removal - initialize from props
   const [removedPlayerIds, setRemovedPlayerIds] = useState<Set<string>>(
-    new Set(),
+    () => new Set(initialModifications?.removed ?? []),
   );
 
   // Use ref to avoid stale closure when callback isn't memoized by parent


### PR DESCRIPTION
- Invalidate gameWithScoresheet query cache after finalizing validation
  so reopening the modal shows the validated state
- Pass initialModifications prop to roster panels to restore state when
  switching between wizard steps (prevents loss of added/removed players)