### PR TITLE
test(validation): add tests for roster modification persistence

### DIFF
--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -540,10 +540,20 @@ export const mockApi = {
     nominationListId: string,
     gameId: string,
     teamId: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
-    _playerNominationIds: string[],
+    playerNominationIds: string[],
   ): Promise<NominationList> {
     await delay(MOCK_MUTATION_DELAY_MS);
+
+    const store = useDemoStore.getState();
+
+    // Determine which team (home or away) based on the nomination list
+    const gameNominations = store.nominationLists[gameId];
+    if (gameNominations) {
+      const team =
+        gameNominations.home?.__identity === nominationListId ? "home" : "away";
+      // Persist player changes to demo store
+      store.updateNominationListPlayers(gameId, team, playerNominationIds);
+    }
 
     // In demo mode, return a mock updated nomination list
     return {
@@ -559,8 +569,7 @@ export const mockApi = {
     nominationListId: string,
     gameId: string,
     teamId: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
-    _playerNominationIds: string[],
+    playerNominationIds: string[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
     _validationId?: string,
   ): Promise<NominationListFinalizeResponse> {
@@ -573,6 +582,8 @@ export const mockApi = {
     if (gameNominations) {
       const team =
         gameNominations.home?.__identity === nominationListId ? "home" : "away";
+      // Persist player changes and mark as closed
+      store.updateNominationListPlayers(gameId, team, playerNominationIds);
       store.updateNominationListClosed(gameId, team, true);
     }
 

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -1531,9 +1531,12 @@ export const useDemoStore = create<DemoState>()(
           );
 
           // Build the new nominations list based on the provided IDs
+          // Type guard to filter out undefined values
           const newNominations = playerNominationIds
             .map((id) => existingById.get(id) ?? possiblePlayersById.get(id))
-            .filter(Boolean);
+            .filter(
+              (n): n is NonNullable<typeof n> => n !== undefined && n !== null,
+            );
 
           return {
             nominationLists: {

--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -166,6 +166,11 @@ interface DemoState {
     team: "home" | "away",
     closed: boolean,
   ) => void;
+  updateNominationListPlayers: (
+    gameId: string,
+    team: "home" | "away",
+    playerNominationIds: string[],
+  ) => void;
 }
 
 type Weekday = "Sun" | "Mon" | "Tue" | "Wed" | "Thu" | "Fri" | "Sat";
@@ -1487,6 +1492,57 @@ export const useDemoStore = create<DemoState>()(
                     closedAt: new Date().toISOString(),
                     closedBy: "referee",
                   }),
+                },
+              },
+            },
+          };
+        }),
+
+      updateNominationListPlayers: (
+        gameId: string,
+        team: "home" | "away",
+        playerNominationIds: string[],
+      ) =>
+        set((state) => {
+          const gameNominations = state.nominationLists[gameId];
+          if (!gameNominations) return state;
+
+          const nominationList = gameNominations[team];
+          if (!nominationList) return state;
+
+          // Filter existing nominations to only include those in the new list
+          // and maintain order based on playerNominationIds
+          const existingNominations =
+            nominationList.indoorPlayerNominations ?? [];
+          const existingById = new Map(
+            existingNominations.map((n) => [n.__identity, n]),
+          );
+
+          // Also include nominations from possiblePlayers for newly added players
+          const possiblePlayersById = new Map(
+            state.possiblePlayers.map((p) => [
+              p.indoorPlayer?.__identity,
+              {
+                __identity: p.indoorPlayer?.__identity ?? "",
+                person: p.indoorPlayer?.person,
+                shirtNumber: 0, // New players don't have shirt numbers
+              },
+            ]),
+          );
+
+          // Build the new nominations list based on the provided IDs
+          const newNominations = playerNominationIds
+            .map((id) => existingById.get(id) ?? possiblePlayersById.get(id))
+            .filter(Boolean);
+
+          return {
+            nominationLists: {
+              ...state.nominationLists,
+              [gameId]: {
+                ...gameNominations,
+                [team]: {
+                  ...nominationList,
+                  indoorPlayerNominations: newNominations,
                 },
               },
             },


### PR DESCRIPTION
Add comprehensive tests verifying roster modifications persist across
wizard step navigation:
- Test initialModifications prop restores added players on mount
- Test initialModifications prop restores removed players on mount
- Test state persists after unmount/remount (simulating wizard navigation)