### PR TITLE
fix(demo): persist scorer selection and enforce read-only for validated games

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -941,7 +941,7 @@ export const api = {
     scoresheetId: string,
     gameId: string,
     scorerPersonId: string,
-    fileResourceId: string,
+    fileResourceId?: string,
     validationId?: string,
     isSimpleScoresheet: boolean = false,
   ): Promise<Scoresheet> {
@@ -949,10 +949,13 @@ export const api = {
       "scoresheet[__identity]": scoresheetId,
       "scoresheet[game][__identity]": gameId,
       "scoresheet[writerPerson][__identity]": scorerPersonId,
-      "scoresheet[file][__identity]": fileResourceId,
-      "scoresheet[hasFile]": "true",
+      "scoresheet[hasFile]": fileResourceId ? "true" : "false",
       "scoresheet[isSimpleScoresheet]": isSimpleScoresheet ? "true" : "false",
     };
+
+    if (fileResourceId) {
+      body["scoresheet[file][__identity]"] = fileResourceId;
+    }
 
     if (validationId) {
       body["scoresheet[scoresheetValidation][__identity]"] = validationId;

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -98,6 +98,7 @@ describe("ValidateGameModal", () => {
       isAllRequiredComplete: false,
       isValidated: false,
       validatedInfo: null,
+      pendingScorer: null,
       setHomeRosterModifications: vi.fn(),
       setAwayRosterModifications: vi.fn(),
       setScorer: vi.fn(),

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -142,6 +142,7 @@ export function ValidateGameModal({
     completionStatus,
     isValidated,
     validatedInfo,
+    pendingScorer,
     setHomeRosterModifications,
     setAwayRosterModifications,
     setScorer,
@@ -513,9 +514,19 @@ export function ValidateGameModal({
 
                   {currentStepId === "scorer" && (
                     <ScorerPanel
+                      key={pendingScorer?.__identity ?? "no-pending-scorer"}
                       onScorerChange={setScorer}
                       readOnly={isValidated}
                       readOnlyScorerName={validatedInfo?.scorerName}
+                      initialScorer={
+                        pendingScorer
+                          ? {
+                              __identity: pendingScorer.__identity,
+                              displayName: pendingScorer.displayName,
+                              birthday: "", // Minimal required field
+                            }
+                          : null
+                      }
                     />
                   )}
 

--- a/web-app/src/components/features/validation/ScorerPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { ValidatedPersonSearchResult } from "@/api/validation";
 import { ScorerSearchPanel } from "./ScorerSearchPanel";
 
@@ -24,6 +24,15 @@ export function ScorerPanel({
 }: ScorerPanelProps) {
   const [selectedScorer, setSelectedScorer] =
     useState<ValidatedPersonSearchResult | null>(initialScorer);
+
+  // Notify parent of initial scorer on mount (so completionStatus is updated)
+  useEffect(() => {
+    if (initialScorer) {
+      onScorerChange?.(initialScorer);
+    }
+    // Only run on mount - when key changes, component remounts with new initialScorer
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleScorerSelect = (scorer: ValidatedPersonSearchResult | null) => {
     setSelectedScorer(scorer);

--- a/web-app/src/components/features/validation/ScorerPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerPanel.tsx
@@ -26,13 +26,12 @@ export function ScorerPanel({
     useState<ValidatedPersonSearchResult | null>(initialScorer);
 
   // Notify parent of initial scorer on mount (so completionStatus is updated)
+  // Note: Component uses key={pendingScorer?.__identity} to force remount when scorer changes
   useEffect(() => {
     if (initialScorer) {
       onScorerChange?.(initialScorer);
     }
-    // Only run on mount - when key changes, component remounts with new initialScorer
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [initialScorer, onScorerChange]);
 
   const handleScorerSelect = (scorer: ValidatedPersonSearchResult | null) => {
     setSelectedScorer(scorer);

--- a/web-app/src/hooks/useValidationState.ts
+++ b/web-app/src/hooks/useValidationState.ts
@@ -66,13 +66,11 @@ export interface ValidatedGameInfo {
   hasScoresheet: boolean;
 }
 
-/**
- * Pending scorer data from the game details (previously saved but not finalized).
- */
-export interface PendingScorerInfo {
-  __identity: string;
-  displayName: string;
-}
+// Use the same type definition as demo store for consistency
+import type { PendingScorerData } from "@/stores/demo";
+
+// Re-export for consumers of this hook
+export type { PendingScorerData as PendingScorerInfo } from "@/stores/demo";
 
 /**
  * Result from the useValidationState hook.
@@ -91,7 +89,7 @@ export interface UseValidationStateResult {
   /** Information about the validated game (if validated) */
   validatedInfo: ValidatedGameInfo | null;
   /** Pending scorer from previous save (if any) */
-  pendingScorer: PendingScorerInfo | null;
+  pendingScorer: PendingScorerData | null;
   /** Update home roster modifications (auto-marks roster as reviewed) */
   setHomeRosterModifications: (modifications: RosterModifications) => void;
   /** Update away roster modifications (auto-marks roster as reviewed) */
@@ -350,7 +348,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
   }, [gameDetailsQuery.data]);
 
   // Get pending scorer from game details (if game is not validated but has a saved scorer)
-  const pendingScorer = useMemo<PendingScorerInfo | null>(() => {
+  const pendingScorer = useMemo<PendingScorerData | null>(() => {
     // Don't show pending scorer if game is already validated
     if (isValidated) return null;
 


### PR DESCRIPTION
Two issues fixed in game validation:

1. Scorer selection now persists across wizard sessions (demo mode):
   - Added pendingScorers state to demo store
   - updateScoresheet now saves pending scorer before finalization
   - getGameWithScoresheet returns pending scorer in response
   - ScorerPanel initializes with pending scorer when reopening

2. Validated games now correctly become read-only:
   - Made fileResourceId optional in finalizeScoresheet API
   - finalizeValidation now always calls finalizeScoresheet
   - This ensures games are marked validated even without PDF upload
   - clearPendingScorer is called after game validation