### PR TITLE
fix(e2e): use stable tab IDs instead of text content for locale independence

### DIFF
--- a/web-app/e2e/pages/exchanges.page.ts
+++ b/web-app/e2e/pages/exchanges.page.ts
@@ -22,10 +22,9 @@ export class ExchangesPage {
   constructor(page: Page) {
     this.page = page;
     this.tablist = page.getByRole("tablist");
-    this.openTab = page.getByRole("tab", { name: /open/i });
-    this.myApplicationsTab = page.getByRole("tab", {
-      name: /my applications|applied/i,
-    });
+    // Use stable IDs for tabs (locale-independent)
+    this.openTab = page.locator('#tab-open');
+    this.myApplicationsTab = page.locator('#tab-applied');
     this.tabPanel = page.getByRole("tabpanel");
     this.exchangeCards = this.tabPanel.getByRole("button");
     this.levelFilterToggle = page.getByRole("checkbox");
@@ -43,10 +42,11 @@ export class ExchangesPage {
   async switchToOpenTab() {
     await this.openTab.waitFor({ state: "visible" });
     await this.openTab.click();
+    // Wait for the "open" tab to become selected using its stable ID (locale-independent)
     await this.page.waitForFunction(
       () => {
-        const tab = document.querySelector('[role="tab"][aria-selected="true"]');
-        return tab?.textContent?.toLowerCase().includes("open");
+        const tab = document.querySelector('#tab-open');
+        return tab?.getAttribute("aria-selected") === "true";
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
@@ -55,11 +55,11 @@ export class ExchangesPage {
   async switchToMyApplicationsTab() {
     await this.myApplicationsTab.waitFor({ state: "visible" });
     await this.myApplicationsTab.click();
+    // Wait for the "applied" tab to become selected using its stable ID (locale-independent)
     await this.page.waitForFunction(
       () => {
-        const tab = document.querySelector('[role="tab"][aria-selected="true"]');
-        const text = tab?.textContent?.toLowerCase() ?? "";
-        return text.includes("application") || text.includes("applied");
+        const tab = document.querySelector('#tab-applied');
+        return tab?.getAttribute("aria-selected") === "true";
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );


### PR DESCRIPTION
The exchanges E2E tests were failing in CI because the tab switch
wait functions checked for English text content ("application",
"applied", "open") to verify tab selection state. When running
with non-English locales (German, French, Italian), the translated
tab labels didn't match these patterns, causing timeouts.

Fixed by:
- Using tab element IDs (#tab-open, #tab-applied) instead of
  text-based role queries for tab locators
- Updating waitForFunction to check aria-selected on the specific
  tab ID rather than searching by text content