### PR TITLE
fix(e2e): use stable IDs instead of text content for locale independence

### DIFF
--- a/web-app/e2e/app.spec.ts
+++ b/web-app/e2e/app.spec.ts
@@ -8,26 +8,25 @@ test.describe("VolleyKit App", () => {
       // Check page title
       await expect(page).toHaveTitle(/VolleyKit/);
 
-      // Check login form elements are present
-      await expect(page.getByLabel(/username/i)).toBeVisible();
-      await expect(page.getByLabel(/password/i)).toBeVisible();
-      await expect(
-        page.getByRole("button", { name: /login|sign in/i }),
-      ).toBeVisible();
+      // Check login form elements are present using stable test IDs (locale-independent)
+      await expect(page.getByTestId("username-input")).toBeVisible();
+      await expect(page.getByTestId("password-input")).toBeVisible();
+      await expect(page.getByTestId("login-button")).toBeVisible();
     });
 
     test("shows demo mode option", async ({ page }) => {
       await page.goto("/login");
 
-      // Check demo mode button is present
-      await expect(page.getByRole("button", { name: /demo/i })).toBeVisible();
+      // Check demo mode button is present using stable test ID (locale-independent)
+      await expect(page.getByTestId("demo-button")).toBeVisible();
     });
 
     test("validates empty form submission", async ({ page }) => {
       await page.goto("/login");
 
-      const usernameInput = page.getByLabel(/username/i);
-      const loginButton = page.getByRole("button", { name: /login|sign in/i });
+      // Use stable test IDs (locale-independent)
+      const usernameInput = page.getByTestId("username-input");
+      const loginButton = page.getByTestId("login-button");
 
       // Verify the input has the required attribute for HTML5 validation
       const isRequired = await usernameInput.getAttribute("required");
@@ -53,8 +52,8 @@ test.describe("VolleyKit App", () => {
     test("can enter demo mode", async ({ page }) => {
       await page.goto("/login");
 
-      // Click demo mode button
-      await page.getByRole("button", { name: /demo/i }).click();
+      // Click demo mode button using stable test ID (locale-independent)
+      await page.getByTestId("demo-button").click();
 
       // Should navigate away from login page
       await expect(page).not.toHaveURL(/login/);
@@ -63,8 +62,8 @@ test.describe("VolleyKit App", () => {
     test("demo mode shows assignments page", async ({ page }) => {
       await page.goto("/login");
 
-      // Enter demo mode
-      await page.getByRole("button", { name: /demo/i }).click();
+      // Enter demo mode using stable test ID (locale-independent)
+      await page.getByTestId("demo-button").click();
 
       // Should show some content (assignments, dashboard, etc.)
       // Wait for navigation to complete
@@ -97,9 +96,9 @@ test.describe("VolleyKit App", () => {
     test("login form inputs have labels", async ({ page }) => {
       await page.goto("/login");
 
-      // Inputs should be accessible via labels
-      const usernameInput = page.getByLabel(/username/i);
-      const passwordInput = page.getByLabel(/password/i);
+      // Inputs should be accessible via stable test IDs (locale-independent)
+      const usernameInput = page.getByTestId("username-input");
+      const passwordInput = page.getByTestId("password-input");
 
       await expect(usernameInput).toBeVisible();
       await expect(passwordInput).toBeVisible();
@@ -111,10 +110,8 @@ test.describe("VolleyKit App", () => {
       await page.setViewportSize({ width: 375, height: 667 });
       await page.goto("/login");
 
-      // Form should still be visible
-      await expect(
-        page.getByRole("button", { name: /login|sign in/i }),
-      ).toBeVisible();
+      // Form should still be visible using stable test ID (locale-independent)
+      await expect(page.getByTestId("login-button")).toBeVisible();
     });
   });
 });

--- a/web-app/e2e/pages/assignments.page.ts
+++ b/web-app/e2e/pages/assignments.page.ts
@@ -21,10 +21,9 @@ export class AssignmentsPage {
   constructor(page: Page) {
     this.page = page;
     this.tablist = page.getByRole("tablist");
-    this.upcomingTab = page.getByRole("tab", { name: /upcoming/i });
-    this.validationClosedTab = page.getByRole("tab", {
-      name: /validation/i,
-    });
+    // Use stable IDs for tabs (locale-independent)
+    this.upcomingTab = page.locator("#tab-upcoming");
+    this.validationClosedTab = page.locator("#tab-validationClosed");
     this.tabPanel = page.getByRole("tabpanel");
     this.assignmentCards = this.tabPanel.getByRole("button");
   }
@@ -41,10 +40,11 @@ export class AssignmentsPage {
   async switchToUpcomingTab() {
     await this.upcomingTab.waitFor({ state: "visible" });
     await this.upcomingTab.click();
+    // Wait for the "upcoming" tab to become selected using its stable ID (locale-independent)
     await this.page.waitForFunction(
       () => {
-        const tab = document.querySelector('[role="tab"][aria-selected="true"]');
-        return tab?.textContent?.toLowerCase().includes("upcoming");
+        const tab = document.querySelector("#tab-upcoming");
+        return tab?.getAttribute("aria-selected") === "true";
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
@@ -53,10 +53,11 @@ export class AssignmentsPage {
   async switchToValidationClosedTab() {
     await this.validationClosedTab.waitFor({ state: "visible" });
     await this.validationClosedTab.click();
+    // Wait for the "validationClosed" tab to become selected using its stable ID (locale-independent)
     await this.page.waitForFunction(
       () => {
-        const tab = document.querySelector('[role="tab"][aria-selected="true"]');
-        return tab?.textContent?.toLowerCase().includes("validation");
+        const tab = document.querySelector("#tab-validationClosed");
+        return tab?.getAttribute("aria-selected") === "true";
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
@@ -69,7 +70,8 @@ export class AssignmentsPage {
   async waitForAssignmentsLoaded() {
     await expect(this.tabPanel).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT_MS });
 
-    const loadingIndicator = this.page.getByText(/loading/i).first();
+    // Use stable test ID for loading indicator (locale-independent)
+    const loadingIndicator = this.page.getByTestId("loading-state");
     await loadingIndicator
       .waitFor({ state: "hidden", timeout: LOADING_TIMEOUT_MS })
       .catch(() => {

--- a/web-app/e2e/pages/compensations.page.ts
+++ b/web-app/e2e/pages/compensations.page.ts
@@ -22,9 +22,10 @@ export class CompensationsPage {
   constructor(page: Page) {
     this.page = page;
     this.tablist = page.getByRole("tablist");
-    this.pendingTab = page.getByRole("tab", { name: /pending|unpaid/i });
-    this.paidTab = page.getByRole("tab", { name: /paid/i });
-    this.allTab = page.getByRole("tab", { name: /all/i });
+    // Use stable IDs for tabs (locale-independent)
+    this.pendingTab = page.locator("#tab-unpaid");
+    this.paidTab = page.locator("#tab-paid");
+    this.allTab = page.locator("#tab-all");
     this.tabPanel = page.getByRole("tabpanel");
     this.compensationCards = this.tabPanel.getByRole("button");
   }
@@ -40,11 +41,11 @@ export class CompensationsPage {
   async switchToPendingTab() {
     await this.pendingTab.waitFor({ state: "visible" });
     await this.pendingTab.click();
+    // Wait for the "unpaid" tab to become selected using its stable ID (locale-independent)
     await this.page.waitForFunction(
       () => {
-        const tab = document.querySelector('[role="tab"][aria-selected="true"]');
-        const text = tab?.textContent?.toLowerCase() ?? "";
-        return text.includes("pending") || text.includes("unpaid");
+        const tab = document.querySelector("#tab-unpaid");
+        return tab?.getAttribute("aria-selected") === "true";
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
@@ -53,10 +54,11 @@ export class CompensationsPage {
   async switchToPaidTab() {
     await this.paidTab.waitFor({ state: "visible" });
     await this.paidTab.click();
+    // Wait for the "paid" tab to become selected using its stable ID (locale-independent)
     await this.page.waitForFunction(
       () => {
-        const tab = document.querySelector('[role="tab"][aria-selected="true"]');
-        return tab?.textContent?.toLowerCase().includes("paid");
+        const tab = document.querySelector("#tab-paid");
+        return tab?.getAttribute("aria-selected") === "true";
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
@@ -65,10 +67,11 @@ export class CompensationsPage {
   async switchToAllTab() {
     await this.allTab.waitFor({ state: "visible" });
     await this.allTab.click();
+    // Wait for the "all" tab to become selected using its stable ID (locale-independent)
     await this.page.waitForFunction(
       () => {
-        const tab = document.querySelector('[role="tab"][aria-selected="true"]');
-        return tab?.textContent?.toLowerCase().includes("all");
+        const tab = document.querySelector("#tab-all");
+        return tab?.getAttribute("aria-selected") === "true";
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
@@ -81,7 +84,8 @@ export class CompensationsPage {
   async waitForCompensationsLoaded() {
     await expect(this.tabPanel).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT_MS });
 
-    const loadingIndicator = this.page.getByText(/loading/i).first();
+    // Use stable test ID for loading indicator (locale-independent)
+    const loadingIndicator = this.page.getByTestId("loading-state");
     await loadingIndicator
       .waitFor({ state: "hidden", timeout: LOADING_TIMEOUT_MS })
       .catch(() => {

--- a/web-app/e2e/pages/exchanges.page.ts
+++ b/web-app/e2e/pages/exchanges.page.ts
@@ -84,7 +84,8 @@ export class ExchangesPage {
   async waitForExchangesLoaded() {
     await expect(this.tabPanel).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT_MS });
 
-    const loadingIndicator = this.page.getByText(/loading/i).first();
+    // Use stable test ID for loading indicator (locale-independent)
+    const loadingIndicator = this.page.getByTestId("loading-state");
     await loadingIndicator
       .waitFor({ state: "hidden", timeout: LOADING_TIMEOUT_MS })
       .catch(() => {

--- a/web-app/e2e/pages/login.page.ts
+++ b/web-app/e2e/pages/login.page.ts
@@ -13,10 +13,11 @@ export class LoginPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.usernameInput = page.getByLabel(/username/i);
-    this.passwordInput = page.getByLabel(/password/i);
-    this.loginButton = page.getByRole("button", { name: /login|sign in/i });
-    this.demoButton = page.getByRole("button", { name: /demo/i });
+    // Use stable test IDs for locale independence
+    this.usernameInput = page.getByTestId("username-input");
+    this.passwordInput = page.getByTestId("password-input");
+    this.loginButton = page.getByTestId("login-button");
+    this.demoButton = page.getByTestId("demo-button");
   }
 
   async goto() {

--- a/web-app/e2e/pages/navigation.page.ts
+++ b/web-app/e2e/pages/navigation.page.ts
@@ -15,15 +15,11 @@ export class NavigationPage {
   constructor(page: Page) {
     this.page = page;
     this.navigation = page.getByRole("navigation");
-    // Navigation links - match by accessible name patterns
-    this.assignmentsLink = page.getByRole("link", {
-      name: /assignment|home/i,
-    });
-    this.compensationsLink = page.getByRole("link", {
-      name: /compensation|wallet/i,
-    });
-    this.exchangeLink = page.getByRole("link", { name: /exchange/i });
-    this.settingsLink = page.getByRole("link", { name: /settings/i });
+    // Use stable test IDs for locale independence
+    this.assignmentsLink = page.getByTestId("nav-assignments");
+    this.compensationsLink = page.getByTestId("nav-compensations");
+    this.exchangeLink = page.getByTestId("nav-exchange");
+    this.settingsLink = page.getByTestId("nav-settings");
   }
 
   async expectToBeVisible() {

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -20,13 +20,14 @@ interface NavItem {
   path: string;
   labelKey: "nav.assignments" | "nav.compensations" | "nav.exchange" | "nav.settings";
   icon: LucideIcon;
+  testId: string;
 }
 
 const navItems: NavItem[] = [
-  { path: "/", labelKey: "nav.assignments", icon: ClipboardList },
-  { path: "/compensations", labelKey: "nav.compensations", icon: Wallet },
-  { path: "/exchange", labelKey: "nav.exchange", icon: ArrowLeftRight },
-  { path: "/settings", labelKey: "nav.settings", icon: Settings },
+  { path: "/", labelKey: "nav.assignments", icon: ClipboardList, testId: "nav-assignments" },
+  { path: "/compensations", labelKey: "nav.compensations", icon: Wallet, testId: "nav-compensations" },
+  { path: "/exchange", labelKey: "nav.exchange", icon: ArrowLeftRight, testId: "nav-exchange" },
+  { path: "/settings", labelKey: "nav.settings", icon: Settings, testId: "nav-settings" },
 ];
 
 // Valid association codes that can be used for demo mode data generation
@@ -214,6 +215,7 @@ export function AppShell() {
                 <NavLink
                   key={item.path}
                   to={item.path}
+                  data-testid={item.testId}
                   className={`
                     flex flex-col items-center py-2 px-4 text-[10px] font-medium
                     transition-all duration-150 rounded-lg mx-1

--- a/web-app/src/components/ui/LoadingSpinner.tsx
+++ b/web-app/src/components/ui/LoadingSpinner.tsx
@@ -52,6 +52,7 @@ export function LoadingState({ message }: LoadingStateProps) {
       className="flex flex-col items-center justify-center py-12 gap-4"
       role="status"
       aria-label={displayMessage}
+      data-testid="loading-state"
     >
       {/* Use visual-only spinner here since container has role="status" */}
       <div

--- a/web-app/src/hooks/useTabNavigation.ts
+++ b/web-app/src/hooks/useTabNavigation.ts
@@ -61,6 +61,7 @@ export function useTabNavigation<T extends string>({
     (tabId: T, index: number) => ({
       ref: setTabRef(tabId),
       role: "tab" as const,
+      // ID format used by E2E tests for locale-independent tab selection
       id: `tab-${tabId}`,
       "aria-selected": activeTab === tabId,
       "aria-controls": `tabpanel-${tabId}`,

--- a/web-app/src/pages/AssignmentsPage.test.tsx
+++ b/web-app/src/pages/AssignmentsPage.test.tsx
@@ -267,8 +267,9 @@ describe("AssignmentsPage", () => {
       render(<AssignmentsPage />);
 
       const tabpanel = screen.getByRole("tabpanel");
-      expect(tabpanel).toHaveAttribute("id", "upcoming-tabpanel");
-      expect(tabpanel).toHaveAttribute("aria-labelledby", "upcoming-tab");
+      // Tab IDs follow the pattern: tab-{tabId}, tabpanel-{tabId}
+      expect(tabpanel).toHaveAttribute("id", "tabpanel-upcoming");
+      expect(tabpanel).toHaveAttribute("aria-labelledby", "tab-upcoming");
     });
 
     it("should have proper tabpanel aria attributes for validation closed tab", () => {
@@ -276,10 +277,11 @@ describe("AssignmentsPage", () => {
       fireEvent.click(screen.getByRole("tab", { name: /validation closed/i }));
 
       const tabpanel = screen.getByRole("tabpanel");
-      expect(tabpanel).toHaveAttribute("id", "validation-closed-tabpanel");
+      // Tab IDs follow the pattern: tab-{tabId}, tabpanel-{tabId}
+      expect(tabpanel).toHaveAttribute("id", "tabpanel-validationClosed");
       expect(tabpanel).toHaveAttribute(
         "aria-labelledby",
-        "validation-closed-tab",
+        "tab-validationClosed",
       );
     });
   });

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -117,8 +117,8 @@ export function AssignmentsPage() {
         <button
           role="tab"
           aria-selected={activeTab === "upcoming"}
-          aria-controls="upcoming-tabpanel"
-          id="upcoming-tab"
+          aria-controls="tabpanel-upcoming"
+          id="tab-upcoming"
           onClick={() => setActiveTab("upcoming")}
           className={`
             px-4 py-2 text-sm font-medium border-b-2 transition-colors
@@ -139,8 +139,8 @@ export function AssignmentsPage() {
         <button
           role="tab"
           aria-selected={activeTab === "validationClosed"}
-          aria-controls="validation-closed-tabpanel"
-          id="validation-closed-tab"
+          aria-controls="tabpanel-validationClosed"
+          id="tab-validationClosed"
           onClick={() => setActiveTab("validationClosed")}
           className={`
             px-4 py-2 text-sm font-medium border-b-2 transition-colors
@@ -165,11 +165,11 @@ export function AssignmentsPage() {
         role="tabpanel"
         id={
           activeTab === "upcoming"
-            ? "upcoming-tabpanel"
-            : "validation-closed-tabpanel"
+            ? "tabpanel-upcoming"
+            : "tabpanel-validationClosed"
         }
         aria-labelledby={
-          activeTab === "upcoming" ? "upcoming-tab" : "validation-closed-tab"
+          activeTab === "upcoming" ? "tab-upcoming" : "tab-validationClosed"
         }
         className="space-y-3"
       >

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -109,6 +109,7 @@ export function LoginPage() {
               </label>
               <input
                 id="username"
+                data-testid="username-input"
                 type="text"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
@@ -128,6 +129,7 @@ export function LoginPage() {
               </label>
               <input
                 id="password"
+                data-testid="password-input"
                 type="password"
                 ref={passwordRef}
                 autoComplete="current-password"
@@ -148,6 +150,7 @@ export function LoginPage() {
             <button
               type="submit"
               disabled={isLoading}
+              data-testid="login-button"
               className="btn btn-primary w-full flex items-center justify-center gap-2"
             >
               {isLoading ? (
@@ -175,6 +178,7 @@ export function LoginPage() {
               type="button"
               onClick={handleDemoLogin}
               disabled={isLoading}
+              data-testid="demo-button"
               className="btn btn-secondary w-full"
             >
               {t("auth.demoMode")}


### PR DESCRIPTION
Replace text-based selectors with stable IDs across all E2E tests and
Page Object Models to ensure tests work regardless of locale:

Components updated:
- LoginPage: Added data-testid for username, password, login, demo inputs
- AppShell: Added data-testid for navigation links
- AssignmentsPage: Updated tab IDs to follow tab-{id}/tabpanel-{id} pattern
- LoadingSpinner: Added data-testid="loading-state" to LoadingState

E2E Page Objects updated:
- login.page.ts: Use getByTestId for form elements
- navigation.page.ts: Use getByTestId for nav links
- assignments.page.ts: Use #tab-upcoming, #tab-validationClosed selectors
- compensations.page.ts: Use #tab-unpaid, #tab-paid, #tab-all selectors
- exchanges.page.ts: Update loading indicator to use getByTestId

Test files updated:
- app.spec.ts: Use getByTestId instead of text patterns
- AssignmentsPage.test.tsx: Update expected tab IDs to match new pattern