### PR TITLE
fix(demo): reset validated games state when resetting demo data

### DIFF
--- a/web-app/src/stores/demo.ts
+++ b/web-app/src/stores/demo.ts
@@ -1335,7 +1335,7 @@ export const useDemoStore = create<DemoState>()(
         set(() => {
           const currentAssociation = get().activeAssociationCode ?? "SV";
           const newData = generateDummyData(currentAssociation);
-          // Note: validatedGames is preserved to maintain user's validation history
+          // Reset all user-generated state including validated games
           return {
             assignments: newData.assignments,
             compensations: newData.compensations,
@@ -1343,6 +1343,9 @@ export const useDemoStore = create<DemoState>()(
             nominationLists: generateMockNominationLists(),
             possiblePlayers: newData.possiblePlayers,
             scorers: newData.scorers,
+            validatedGames: {},
+            pendingScorers: {},
+            assignmentCompensations: {},
             generatedAt: Date.now(),
           };
         }),


### PR DESCRIPTION
The reset demo data button in Settings now clears validatedGames,
pendingScorers, and assignmentCompensations to allow users to
re-validate games after resetting.