### PR TITLE
refactor(hooks): extract useModalDismissal hook to reduce duplication

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -133,6 +133,7 @@ export function EditCompensationModal({
   const { handleBackdropClick } = useModalDismissal({
     isOpen,
     onClose,
+    isLoading,
   });
 
   const handleSubmit = useCallback(

--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from "react";
 import type { Assignment, CompensationRecord } from "@/api/client";
 import { getApiClient } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useModalDismissal } from "@/hooks/useModalDismissal";
 import {
   useUpdateCompensation,
   useUpdateAssignmentCompensation,
@@ -129,18 +130,10 @@ export function EditCompensationModal({
     }
   }, [isOpen]);
 
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isOpen) {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener("keydown", handleEscape);
-      return () => document.removeEventListener("keydown", handleEscape);
-    }
-  }, [isOpen, onClose]);
+  const { handleBackdropClick } = useModalDismissal({
+    isOpen,
+    onClose,
+  });
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -205,15 +198,6 @@ export function EditCompensationModal({
       onClose,
       t,
     ],
-  );
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose],
   );
 
   if (!isOpen) return null;

--- a/web-app/src/components/features/ExchangeConfirmationModal.tsx
+++ b/web-app/src/components/features/ExchangeConfirmationModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { GameExchange } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useModalDismissal } from "@/hooks/useModalDismissal";
 import { logger } from "@/utils/logger";
 import { formatDateTime } from "@/utils/date-helpers";
 
@@ -21,27 +22,10 @@ export function ExchangeConfirmationModal({
 }: ExchangeConfirmationModalProps) {
   const { t } = useTranslation();
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isOpen, onClose]);
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose],
-  );
+  const { handleBackdropClick } = useModalDismissal({
+    isOpen,
+    onClose,
+  });
 
   const isSubmittingRef = useRef(false);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/web-app/src/components/features/PdfLanguageModal.tsx
+++ b/web-app/src/components/features/PdfLanguageModal.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useModalDismissal } from '@/hooks/useModalDismissal';
 import { FileText } from 'lucide-react';
 import type { Language } from '@/utils/pdf-form-filler';
 
@@ -30,28 +31,18 @@ export function PdfLanguageModal({
     if (isOpen) setSelected(defaultLanguage); // eslint-disable-line react-hooks/set-state-in-effect
   }, [isOpen, defaultLanguage]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isLoading) onClose();
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [isOpen, isLoading, onClose]);
-
-  const onBackdrop = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget && !isLoading) onClose();
-    },
-    [isLoading, onClose]
-  );
+  const { handleBackdropClick } = useModalDismissal({
+    isOpen,
+    onClose,
+    isLoading,
+  });
 
   if (!isOpen) return null;
 
   return (
     <div
       className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-      onClick={onBackdrop}
+      onClick={handleBackdropClick}
       aria-hidden="true"
     >
       <div

--- a/web-app/src/components/features/SafeModeWarningModal.tsx
+++ b/web-app/src/components/features/SafeModeWarningModal.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useModalDismissal } from "@/hooks/useModalDismissal";
 
 interface SafeModeWarningModalProps {
   isOpen: boolean;
@@ -15,27 +16,10 @@ export function SafeModeWarningModal({
   const { t } = useTranslation();
   const isConfirmingRef = useRef(false);
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isOpen, onClose]);
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose],
-  );
+  const { handleBackdropClick } = useModalDismissal({
+    isOpen,
+    onClose,
+  });
 
   const handleConfirm = useCallback(() => {
     if (isConfirmingRef.current) return;

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useModalDismissal } from "@/hooks/useModalDismissal";
 import { logger } from "@/utils/logger";
 import { getTeamNames } from "@/utils/assignment-helpers";
 import { useWizardNavigation } from "@/hooks/useWizardNavigation";
@@ -244,21 +245,13 @@ export function ValidateGameModal({
     }
   }, [onClose, isValidated]);
 
-  // Handle Escape key to close modal
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleEscape = (e: KeyboardEvent) => {
-      // Don't close if unsaved dialog is showing
-      if (showUnsavedDialog) return;
-      if (e.key === "Escape") {
-        attemptClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isOpen, attemptClose, showUnsavedDialog]);
+  // Handle Escape key and backdrop click dismissals
+  // Use showUnsavedDialog as isLoading to prevent dismissal when dialog is showing
+  const { handleBackdropClick } = useModalDismissal({
+    isOpen,
+    onClose: attemptClose,
+    isLoading: showUnsavedDialog,
+  });
 
   // Handle finish action (finalize validation)
   // If the last step is not optional, it marks the last step as done before finalizing
@@ -336,16 +329,6 @@ export function ValidateGameModal({
   const handleCancelClose = useCallback(() => {
     setShowUnsavedDialog(false);
   }, []);
-
-  // Handle backdrop click (only close if clicking the backdrop itself, not the dialog)
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) {
-        attemptClose();
-      }
-    },
-    [attemptClose],
-  );
 
   const handleNext = useCallback(() => {
     goNext();

--- a/web-app/src/components/ui/ResponsiveSheet.tsx
+++ b/web-app/src/components/ui/ResponsiveSheet.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 import { createPortal } from "react-dom";
+import { useModalDismissal } from "@/hooks/useModalDismissal";
 
 interface ResponsiveSheetProps {
   isOpen: boolean;
@@ -40,27 +41,10 @@ export function ResponsiveSheet({
     };
   }, [isOpen]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isOpen, onClose]);
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose],
-  );
+  const { handleBackdropClick } = useModalDismissal({
+    isOpen,
+    onClose,
+  });
 
   if (!isOpen) return null;
 

--- a/web-app/src/hooks/useModalDismissal.test.ts
+++ b/web-app/src/hooks/useModalDismissal.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useModalDismissal } from "./useModalDismissal";
+
+describe("useModalDismissal", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("escape key handling", () => {
+    it("should call onClose when Escape is pressed and modal is open", () => {
+      const onClose = vi.fn();
+      renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+        }),
+      );
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call onClose when Escape is pressed and modal is closed", () => {
+      const onClose = vi.fn();
+      renderHook(() =>
+        useModalDismissal({
+          isOpen: false,
+          onClose,
+        }),
+      );
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should not call onClose when Escape is pressed and isLoading is true", () => {
+      const onClose = vi.fn();
+      renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+          isLoading: true,
+        }),
+      );
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should not call onClose when other keys are pressed", () => {
+      const onClose = vi.fn();
+      renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+        }),
+      );
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should not add event listener when closeOnEscape is false", () => {
+      const onClose = vi.fn();
+      renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+          closeOnEscape: false,
+        }),
+      );
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should cleanup event listener when modal closes", () => {
+      const onClose = vi.fn();
+      const { rerender } = renderHook(
+        ({ isOpen }) =>
+          useModalDismissal({
+            isOpen,
+            onClose,
+          }),
+        { initialProps: { isOpen: true } },
+      );
+
+      // Verify listener is active
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      // Close modal
+      rerender({ isOpen: false });
+
+      // Verify listener is removed
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("should respond to Escape after isLoading changes from true to false", () => {
+      const onClose = vi.fn();
+      const { rerender } = renderHook(
+        ({ isLoading }) =>
+          useModalDismissal({
+            isOpen: true,
+            onClose,
+            isLoading,
+          }),
+        { initialProps: { isLoading: true } },
+      );
+
+      // Should not close while loading
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      // Loading finished
+      rerender({ isLoading: false });
+
+      // Should now close
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("backdrop click handling", () => {
+    function createMockClickEvent(
+      targetIsSelf: boolean,
+    ): React.MouseEvent<HTMLDivElement> {
+      const target = document.createElement("div");
+      const currentTarget = targetIsSelf ? target : document.createElement("div");
+      return {
+        target,
+        currentTarget,
+      } as unknown as React.MouseEvent<HTMLDivElement>;
+    }
+
+    it("should call onClose when backdrop is clicked", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+        }),
+      );
+
+      act(() => {
+        result.current.handleBackdropClick(createMockClickEvent(true));
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call onClose when clicking inside the modal", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+        }),
+      );
+
+      act(() => {
+        result.current.handleBackdropClick(createMockClickEvent(false));
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should not call onClose when isLoading is true", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+          isLoading: true,
+        }),
+      );
+
+      act(() => {
+        result.current.handleBackdropClick(createMockClickEvent(true));
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should not call onClose when closeOnBackdropClick is false", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+          closeOnBackdropClick: false,
+        }),
+      );
+
+      act(() => {
+        result.current.handleBackdropClick(createMockClickEvent(true));
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should maintain stable handleBackdropClick reference when options don't change", () => {
+      const onClose = vi.fn();
+      const { result, rerender } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+        }),
+      );
+
+      const firstReference = result.current.handleBackdropClick;
+      rerender();
+
+      expect(result.current.handleBackdropClick).toBe(firstReference);
+    });
+
+    it("should update handleBackdropClick when onClose changes", () => {
+      const onClose1 = vi.fn();
+      const onClose2 = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ closeFn }) =>
+          useModalDismissal({
+            isOpen: true,
+            onClose: closeFn,
+          }),
+        { initialProps: { closeFn: onClose1 } },
+      );
+
+      act(() => {
+        result.current.handleBackdropClick(createMockClickEvent(true));
+      });
+      expect(onClose1).toHaveBeenCalledTimes(1);
+      expect(onClose2).not.toHaveBeenCalled();
+
+      rerender({ closeFn: onClose2 });
+
+      act(() => {
+        result.current.handleBackdropClick(createMockClickEvent(true));
+      });
+      expect(onClose1).toHaveBeenCalledTimes(1);
+      expect(onClose2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("combined options", () => {
+    it("should disable both dismissal methods when isLoading is true", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+          isLoading: true,
+        }),
+      );
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      const target = document.createElement("div");
+      act(() => {
+        result.current.handleBackdropClick({
+          target,
+          currentTarget: target,
+        } as unknown as React.MouseEvent<HTMLDivElement>);
+      });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should allow disabling escape while keeping backdrop click enabled", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+          closeOnEscape: false,
+          closeOnBackdropClick: true,
+        }),
+      );
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      const target = document.createElement("div");
+      act(() => {
+        result.current.handleBackdropClick({
+          target,
+          currentTarget: target,
+        } as unknown as React.MouseEvent<HTMLDivElement>);
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("should allow disabling backdrop click while keeping escape enabled", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+          closeOnEscape: true,
+          closeOnBackdropClick: false,
+        }),
+      );
+
+      const target = document.createElement("div");
+      act(() => {
+        result.current.handleBackdropClick({
+          target,
+          currentTarget: target,
+        } as unknown as React.MouseEvent<HTMLDivElement>);
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("default options", () => {
+    it("should use sensible defaults", () => {
+      const onClose = vi.fn();
+      const { result } = renderHook(() =>
+        useModalDismissal({
+          isOpen: true,
+          onClose,
+        }),
+      );
+
+      // Default: closeOnEscape = true
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      // Default: closeOnBackdropClick = true
+      const target = document.createElement("div");
+      act(() => {
+        result.current.handleBackdropClick({
+          target,
+          currentTarget: target,
+        } as unknown as React.MouseEvent<HTMLDivElement>);
+      });
+      expect(onClose).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/web-app/src/hooks/useModalDismissal.ts
+++ b/web-app/src/hooks/useModalDismissal.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect } from "react";
+
+interface UseModalDismissalOptions {
+  /** Whether the modal is currently open */
+  isOpen: boolean;
+  /** Callback to close the modal */
+  onClose: () => void;
+  /** When true, dismissal is disabled (e.g., during loading) */
+  isLoading?: boolean;
+  /** Whether pressing Escape should close the modal (default: true) */
+  closeOnEscape?: boolean;
+  /** Whether clicking the backdrop should close the modal (default: true) */
+  closeOnBackdropClick?: boolean;
+}
+
+interface UseModalDismissalResult {
+  /** Click handler for the backdrop element */
+  handleBackdropClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+/**
+ * Hook for managing modal dismissal behavior.
+ * Handles both Escape key and backdrop click dismissals in a consistent way.
+ *
+ * @example
+ * ```tsx
+ * function Modal({ isOpen, onClose, isLoading }) {
+ *   const { handleBackdropClick } = useModalDismissal({
+ *     isOpen,
+ *     onClose,
+ *     isLoading,
+ *   });
+ *
+ *   if (!isOpen) return null;
+ *
+ *   return (
+ *     <div onClick={handleBackdropClick} aria-hidden="true">
+ *       <div role="dialog" aria-modal="true">
+ *         {content}
+ *       </div>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useModalDismissal(
+  options: UseModalDismissalOptions,
+): UseModalDismissalResult {
+  const {
+    isOpen,
+    onClose,
+    isLoading = false,
+    closeOnEscape = true,
+    closeOnBackdropClick = true,
+  } = options;
+
+  // Handle Escape key to close modal
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !isLoading) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen, isLoading, closeOnEscape, onClose]);
+
+  // Handle backdrop click to close modal
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget && closeOnBackdropClick && !isLoading) {
+        onClose();
+      }
+    },
+    [onClose, isLoading, closeOnBackdropClick],
+  );
+
+  return { handleBackdropClick };
+}


### PR DESCRIPTION
Create a new useModalDismissal hook that consolidates the repeated
Escape key and backdrop click dismissal logic from modal components.

The hook accepts configuration options:
- isOpen: whether the modal is open
- onClose: callback to close the modal
- isLoading: optional flag to disable dismissal during loading
- closeOnEscape: optional flag (default: true)
- closeOnBackdropClick: optional flag (default: true)

Refactored components:
- EditCompensationModal
- ExchangeConfirmationModal
- SafeModeWarningModal
- PdfLanguageModal
- ResponsiveSheet
- ValidateGameModal

Closes #250