### PR TITLE
feat(ui): add page and modal error boundaries with fallback UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ CI will fail if limits are exceeded (gzipped):
 
 | Component | Limit |
 |-----------|-------|
-| Main App | 120 KB |
+| Main App | 122 KB |
 | Vendor Chunks | 50 KB each |
 | PDF Library | 185 KB (lazy-loaded) |
 | CSS | 10 KB |

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -24,7 +24,7 @@
     {
       "name": "Main App Bundle",
       "path": "dist/assets/index-*.js",
-      "limit": "120 kB",
+      "limit": "122 kB",
       "gzip": true
     },
     {

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -12,6 +12,7 @@ import { useDemoStore } from "@/stores/demo";
 import { AppShell } from "@/components/layout/AppShell";
 import { LoadingState } from "@/components/ui/LoadingSpinner";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { PageErrorBoundary } from "@/components/ui/PageErrorBoundary";
 import { ReloadPrompt } from "@/components/ui/ReloadPrompt";
 import { ToastContainer } from "@/components/ui/Toast";
 import { PWAProvider } from "@/contexts/PWAContext";
@@ -239,10 +240,10 @@ export default function App() {
                     </ProtectedRoute>
                   }
                 >
-                  <Route path="/" element={<AssignmentsPage />} />
-                  <Route path="/compensations" element={<CompensationsPage />} />
-                  <Route path="/exchange" element={<ExchangePage />} />
-                  <Route path="/settings" element={<SettingsPage />} />
+                  <Route path="/" element={<PageErrorBoundary pageName="AssignmentsPage"><AssignmentsPage /></PageErrorBoundary>} />
+                  <Route path="/compensations" element={<PageErrorBoundary pageName="CompensationsPage"><CompensationsPage /></PageErrorBoundary>} />
+                  <Route path="/exchange" element={<PageErrorBoundary pageName="ExchangePage"><ExchangePage /></PageErrorBoundary>} />
+                  <Route path="/settings" element={<PageErrorBoundary pageName="SettingsPage"><SettingsPage /></PageErrorBoundary>} />
                 </Route>
 
                 {/* Fallback */}

--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/utils/distance";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
+import { ModalErrorBoundary } from "@/components/ui/ModalErrorBoundary";
 
 interface EditCompensationModalProps {
   assignment?: Assignment;
@@ -232,107 +233,109 @@ export function EditCompensationModal({
         aria-modal="true"
         aria-labelledby="edit-compensation-title"
       >
-        <h2
-          id="edit-compensation-title"
-          className="text-xl font-semibold text-text-primary dark:text-text-primary-dark mb-4"
-        >
-          {t("assignments.editCompensation")}
-        </h2>
+        <ModalErrorBoundary modalName="EditCompensationModal" onClose={onClose}>
+          <h2
+            id="edit-compensation-title"
+            className="text-xl font-semibold text-text-primary dark:text-text-primary-dark mb-4"
+          >
+            {t("assignments.editCompensation")}
+          </h2>
 
-        <div className="mb-4 text-sm text-text-muted dark:text-text-muted-dark">
-          <div className="font-medium text-text-primary dark:text-text-primary-dark">
-            {homeTeam} {t("common.vs")} {awayTeam}
-          </div>
-        </div>
-
-        {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500" />
-          </div>
-        ) : fetchError ? (
-          <div className="py-6 text-center">
-            <p className="text-danger-600 dark:text-danger-400 mb-4">
-              {fetchError}
-            </p>
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
-            >
-              {t("common.close")}
-            </button>
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label
-                htmlFor="kilometers"
-                className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1"
-              >
-                {t("assignments.kilometers")}
-              </label>
-              <div className="relative">
-                <input
-                  id="kilometers"
-                  type="text"
-                  inputMode="decimal"
-                  pattern={DECIMAL_INPUT_PATTERN}
-                  value={kilometers}
-                  onChange={(e) => setKilometers(e.target.value)}
-                  className="w-full px-3 py-2 pr-10 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
-                  aria-invalid={errors.kilometers ? "true" : "false"}
-                  aria-describedby={
-                    errors.kilometers ? "kilometers-error" : undefined
-                  }
-                />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted dark:text-text-muted-dark text-sm pointer-events-none">
-                  {t("common.distanceUnit")}
-                </span>
-              </div>
-              {errors.kilometers && (
-                <p
-                  id="kilometers-error"
-                  className="mt-1 text-sm text-danger-600 dark:text-danger-400"
-                >
-                  {errors.kilometers}
-                </p>
-              )}
+          <div className="mb-4 text-sm text-text-muted dark:text-text-muted-dark">
+            <div className="font-medium text-text-primary dark:text-text-primary-dark">
+              {homeTeam} {t("common.vs")} {awayTeam}
             </div>
+          </div>
 
-            <div>
-              <label
-                htmlFor="reason"
-                className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1"
-              >
-                {t("assignments.reason")}
-              </label>
-              <textarea
-                id="reason"
-                value={reason}
-                onChange={(e) => setReason(e.target.value)}
-                rows={4}
-                className="w-full px-3 py-2 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
-                placeholder={t("assignments.reasonPlaceholder")}
-              />
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500" />
             </div>
-
-            <div className="flex gap-3 pt-2">
+          ) : fetchError ? (
+            <div className="py-6 text-center">
+              <p className="text-danger-600 dark:text-danger-400 mb-4">
+                {fetchError}
+              </p>
               <button
                 type="button"
                 onClick={onClose}
-                className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
+                className="px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
               >
                 {t("common.close")}
               </button>
-              <button
-                type="submit"
-                className="flex-1 px-4 py-2 text-white bg-primary-500 rounded-md hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
-              >
-                {t("common.save")}
-              </button>
             </div>
-          </form>
-        )}
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label
+                  htmlFor="kilometers"
+                  className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1"
+                >
+                  {t("assignments.kilometers")}
+                </label>
+                <div className="relative">
+                  <input
+                    id="kilometers"
+                    type="text"
+                    inputMode="decimal"
+                    pattern={DECIMAL_INPUT_PATTERN}
+                    value={kilometers}
+                    onChange={(e) => setKilometers(e.target.value)}
+                    className="w-full px-3 py-2 pr-10 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    aria-invalid={errors.kilometers ? "true" : "false"}
+                    aria-describedby={
+                      errors.kilometers ? "kilometers-error" : undefined
+                    }
+                  />
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted dark:text-text-muted-dark text-sm pointer-events-none">
+                    {t("common.distanceUnit")}
+                  </span>
+                </div>
+                {errors.kilometers && (
+                  <p
+                    id="kilometers-error"
+                    className="mt-1 text-sm text-danger-600 dark:text-danger-400"
+                  >
+                    {errors.kilometers}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label
+                  htmlFor="reason"
+                  className="block text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1"
+                >
+                  {t("assignments.reason")}
+                </label>
+                <textarea
+                  id="reason"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  rows={4}
+                  className="w-full px-3 py-2 border border-border-strong dark:border-border-strong-dark rounded-md bg-surface-card dark:bg-surface-subtle-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  placeholder={t("assignments.reasonPlaceholder")}
+                />
+              </div>
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
+                >
+                  {t("common.close")}
+                </button>
+                <button
+                  type="submit"
+                  className="flex-1 px-4 py-2 text-white bg-primary-500 rounded-md hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                >
+                  {t("common.save")}
+                </button>
+              </div>
+            </form>
+          )}
+        </ModalErrorBoundary>
       </div>
     </div>
   );

--- a/web-app/src/components/features/ExchangeConfirmationModal.tsx
+++ b/web-app/src/components/features/ExchangeConfirmationModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { useModalDismissal } from "@/hooks/useModalDismissal";
 import { logger } from "@/utils/logger";
 import { formatDateTime } from "@/utils/date-helpers";
+import { ModalErrorBoundary } from "@/components/ui/ModalErrorBoundary";
 
 interface ExchangeConfirmationModalProps {
   exchange: GameExchange;
@@ -102,93 +103,95 @@ export function ExchangeConfirmationModal({
         aria-modal="true"
         aria-labelledby={modalTitleId}
       >
-        <h2
-          id={modalTitleId}
-          className="text-xl font-semibold text-text-primary dark:text-text-primary-dark mb-4"
-        >
-          {t(titleKey)}
-        </h2>
+        <ModalErrorBoundary modalName="ExchangeConfirmationModal" onClose={onClose}>
+          <h2
+            id={modalTitleId}
+            className="text-xl font-semibold text-text-primary dark:text-text-primary-dark mb-4"
+          >
+            {t(titleKey)}
+          </h2>
 
-        <div className="mb-6 space-y-3">
-          <div>
-            <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-              {t("common.match")}
+          <div className="mb-6 space-y-3">
+            <div>
+              <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+                {t("common.match")}
+              </div>
+              <div className="text-base text-text-primary dark:text-text-primary-dark font-medium">
+                {homeTeam} {t("common.vs")} {awayTeam}
+              </div>
             </div>
-            <div className="text-base text-text-primary dark:text-text-primary-dark font-medium">
-              {homeTeam} {t("common.vs")} {awayTeam}
-            </div>
+
+            {dateTime && (
+              <div>
+                <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+                  {t("common.dateTime")}
+                </div>
+                <div className="text-base text-text-primary dark:text-text-primary-dark">
+                  {formatDateTime(dateTime)}
+                </div>
+              </div>
+            )}
+
+            {location && (
+              <div>
+                <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+                  {t("common.location")}
+                </div>
+                <div className="text-base text-text-primary dark:text-text-primary-dark">
+                  {location}
+                </div>
+              </div>
+            )}
+
+            {position && (
+              <div>
+                <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+                  {t("common.position")}
+                </div>
+                <div className="text-base text-text-primary dark:text-text-primary-dark">
+                  {position}
+                </div>
+              </div>
+            )}
+
+            {level && (
+              <div>
+                <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+                  {t("common.requiredLevel")}
+                </div>
+                <div className="text-base text-text-primary dark:text-text-primary-dark">
+                  {level}
+                </div>
+              </div>
+            )}
           </div>
 
-          {dateTime && (
-            <div>
-              <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                {t("common.dateTime")}
-              </div>
-              <div className="text-base text-text-primary dark:text-text-primary-dark">
-                {formatDateTime(dateTime)}
-              </div>
+          <div className="border-t border-border-default dark:border-border-default-dark pt-4">
+            <p className="text-sm text-text-muted dark:text-text-muted-dark mb-4">
+              {t(confirmKey)}
+            </p>
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isSubmitting}
+                className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {t("common.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                disabled={isSubmitting}
+                aria-busy={isSubmitting}
+                className={`flex-1 px-4 py-2 text-white rounded-md focus:outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed ${buttonColorClass}`}
+              >
+                {isSubmitting ? t("common.loading") : t(buttonKey)}
+              </button>
             </div>
-          )}
-
-          {location && (
-            <div>
-              <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                {t("common.location")}
-              </div>
-              <div className="text-base text-text-primary dark:text-text-primary-dark">
-                {location}
-              </div>
-            </div>
-          )}
-
-          {position && (
-            <div>
-              <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                {t("common.position")}
-              </div>
-              <div className="text-base text-text-primary dark:text-text-primary-dark">
-                {position}
-              </div>
-            </div>
-          )}
-
-          {level && (
-            <div>
-              <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                {t("common.requiredLevel")}
-              </div>
-              <div className="text-base text-text-primary dark:text-text-primary-dark">
-                {level}
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="border-t border-border-default dark:border-border-default-dark pt-4">
-          <p className="text-sm text-text-muted dark:text-text-muted-dark mb-4">
-            {t(confirmKey)}
-          </p>
-
-          <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={isSubmitting}
-              className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {t("common.cancel")}
-            </button>
-            <button
-              type="button"
-              onClick={handleConfirm}
-              disabled={isSubmitting}
-              aria-busy={isSubmitting}
-              className={`flex-1 px-4 py-2 text-white rounded-md focus:outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed ${buttonColorClass}`}
-            >
-              {isSubmitting ? t("common.loading") : t(buttonKey)}
-            </button>
           </div>
-        </div>
+        </ModalErrorBoundary>
       </div>
     </div>
   );

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -7,6 +7,7 @@ import { getTeamNames } from "@/utils/assignment-helpers";
 import { useWizardNavigation } from "@/hooks/useWizardNavigation";
 import { WizardStepContainer } from "@/components/ui/WizardStepContainer";
 import { WizardStepIndicator } from "@/components/ui/WizardStepIndicator";
+import { ModalErrorBoundary } from "@/components/ui/ModalErrorBoundary";
 import {
   HomeRosterPanel,
   AwayRosterPanel,
@@ -474,7 +475,7 @@ export function ValidateGameModal({
 
               {/* Show panels when not loading and no error */}
               {!isLoadingGameDetails && !gameDetailsError && (
-                <>
+                <ModalErrorBoundary modalName="ValidateGameModal" onClose={onClose}>
                   {currentStepId === "home-roster" && (
                     <HomeRosterPanel
                       assignment={assignment}
@@ -520,7 +521,7 @@ export function ValidateGameModal({
                       hasScoresheet={validatedInfo?.hasScoresheet}
                     />
                   )}
-                </>
+                </ModalErrorBoundary>
               )}
             </div>
           </WizardStepContainer>

--- a/web-app/src/components/ui/ErrorBoundary.tsx
+++ b/web-app/src/components/ui/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ReactNode } from "react";
 import { ErrorFallbackUI } from "./ErrorFallbackUI";
+import { classifyError, type ErrorType } from "../../utils/error-helpers";
 import { logger } from "../../utils/logger";
 
 interface Props {
@@ -7,37 +8,10 @@ interface Props {
   fallback?: ReactNode;
 }
 
-type ErrorType = "network" | "application";
-
 interface State {
   hasError: boolean;
   error: Error | null;
   errorType: ErrorType;
-}
-
-/**
- * Classify an error as network-related or application-related.
- * Network errors typically allow retry, while application errors may need a refresh.
- */
-function classifyError(error: Error): ErrorType {
-  const message = error.message.toLowerCase();
-  const name = error.name.toLowerCase();
-
-  // Network-related errors
-  if (
-    (name === "typeerror" && message.includes("fetch")) ||
-    name === "networkerror" ||
-    message.includes("network") ||
-    message.includes("failed to fetch") ||
-    message.includes("connection") ||
-    message.includes("timeout") ||
-    message.includes("cors") ||
-    message.includes("offline")
-  ) {
-    return "network";
-  }
-
-  return "application";
 }
 
 /**

--- a/web-app/src/components/ui/ModalErrorBoundary.test.tsx
+++ b/web-app/src/components/ui/ModalErrorBoundary.test.tsx
@@ -1,0 +1,236 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ModalErrorBoundary } from "./ModalErrorBoundary";
+
+// Component that throws an error
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Test modal error");
+  }
+  return <div>Modal content</div>;
+}
+
+// Component that throws a network error
+function ThrowNetworkError(): React.ReactNode {
+  throw new Error("Failed to fetch data");
+}
+
+describe("ModalErrorBoundary", () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Suppress console.error for expected errors
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  describe("when no error occurs", () => {
+    it("renders children normally", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <div>Modal content</div>
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByText("Modal content")).toBeInTheDocument();
+    });
+
+    it("does not show error UI when children render successfully", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={false} />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByText("Modal content")).toBeInTheDocument();
+      expect(screen.queryByTestId("modal-error-boundary")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when an application error occurs", () => {
+    it("renders error fallback UI", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByTestId("modal-error-boundary")).toBeInTheDocument();
+    });
+
+    it("displays application error title", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
+
+    it("displays application error description", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      expect(
+        screen.getByText("Something went wrong with this action. Please try again."),
+      ).toBeInTheDocument();
+    });
+
+    it("displays error details in collapsible section", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByText("Error details")).toBeInTheDocument();
+      expect(screen.getByText("Test modal error")).toBeInTheDocument();
+    });
+
+    it("shows Try Again button", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+    });
+
+    it("shows Close button when onClose is provided", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    });
+
+    it("does not show Close button when onClose is not provided", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal">
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      // Should only have Try Again button
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0]).toHaveTextContent("Try Again");
+    });
+
+    it("resets error state when Try Again is clicked and children succeed", () => {
+      // Use a stateful component to control throwing behavior
+      let shouldThrowNow = true;
+
+      function ConditionalError() {
+        if (shouldThrowNow) {
+          throw new Error("Test modal error");
+        }
+        return <div>Modal content</div>;
+      }
+
+      const { rerender } = render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ConditionalError />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByTestId("modal-error-boundary")).toBeInTheDocument();
+
+      // Change the throwing behavior before clicking Try Again
+      shouldThrowNow = false;
+
+      fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+
+      // Force rerender to pick up the new state
+      rerender(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ConditionalError />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByText("Modal content")).toBeInTheDocument();
+    });
+
+    it("calls onClose when Close button is clicked", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when a network error occurs", () => {
+    it("displays network error title", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowNetworkError />
+        </ModalErrorBoundary>,
+      );
+
+      expect(screen.getByText("Connection Problem")).toBeInTheDocument();
+    });
+
+    it("displays network error description", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowNetworkError />
+        </ModalErrorBoundary>,
+      );
+
+      expect(
+        screen.getByText("Unable to complete this action due to a connection issue."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("styling", () => {
+    it("renders warning icon with aria-hidden", () => {
+      const { container } = render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      const iconContainer = container.querySelector('[aria-hidden="true"]');
+      expect(iconContainer).toBeInTheDocument();
+    });
+
+    it("has centered layout", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      const container = screen.getByTestId("modal-error-boundary");
+      expect(container).toHaveClass("flex");
+      expect(container).toHaveClass("flex-col");
+      expect(container).toHaveClass("items-center");
+      expect(container).toHaveClass("justify-center");
+    });
+
+    it("has compact padding for modal context", () => {
+      render(
+        <ModalErrorBoundary modalName="TestModal" onClose={mockOnClose}>
+          <ThrowError shouldThrow={true} />
+        </ModalErrorBoundary>,
+      );
+
+      const container = screen.getByTestId("modal-error-boundary");
+      expect(container).toHaveClass("p-6");
+    });
+  });
+});

--- a/web-app/src/components/ui/ModalErrorBoundary.tsx
+++ b/web-app/src/components/ui/ModalErrorBoundary.tsx
@@ -1,0 +1,175 @@
+import { Component, type ReactNode } from "react";
+import { AlertTriangle } from "@/components/ui/icons";
+import { useTranslation } from "@/hooks/useTranslation";
+import { logger } from "../../utils/logger";
+
+type ErrorType = "network" | "application";
+
+interface ModalErrorBoundaryClassProps {
+  children: ReactNode;
+  modalName: string;
+  onClose?: () => void;
+  translations: {
+    connectionProblem: string;
+    somethingWentWrong: string;
+    networkDescription: string;
+    errorDescription: string;
+    errorDetails: string;
+    tryAgain: string;
+    closeModal: string;
+  };
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  errorType: ErrorType;
+}
+
+/**
+ * Classify an error as network-related or application-related.
+ */
+function classifyError(error: Error): ErrorType {
+  const message = error.message.toLowerCase();
+  const name = error.name.toLowerCase();
+
+  if (
+    (name === "typeerror" && message.includes("fetch")) ||
+    name === "networkerror" ||
+    message.includes("network") ||
+    message.includes("failed to fetch") ||
+    message.includes("connection") ||
+    message.includes("timeout") ||
+    message.includes("cors") ||
+    message.includes("offline")
+  ) {
+    return "network";
+  }
+
+  return "application";
+}
+
+/**
+ * Error boundary class component for modal-level errors.
+ * Displays a compact fallback UI within the modal that allows users to retry or close.
+ * Prevents modal errors from crashing the entire application.
+ */
+class ModalErrorBoundaryClass extends Component<ModalErrorBoundaryClassProps, State> {
+  constructor(props: ModalErrorBoundaryClassProps) {
+    super(props);
+    this.state = { hasError: false, error: null, errorType: "application" };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return {
+      hasError: true,
+      error,
+      errorType: classifyError(error),
+    };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    logger.error(`ModalErrorBoundary caught an error in ${this.props.modalName}:`, {
+      error,
+      errorType: this.state.errorType,
+      modalName: this.props.modalName,
+      componentStack: errorInfo.componentStack,
+    });
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null, errorType: "application" });
+  };
+
+  handleClose = () => {
+    this.props.onClose?.();
+  };
+
+  override render() {
+    if (this.state.hasError) {
+      const { translations, onClose } = this.props;
+      const isNetworkError = this.state.errorType === "network";
+
+      return (
+        <div
+          className="flex flex-col items-center justify-center p-6"
+          data-testid="modal-error-boundary"
+        >
+          <AlertTriangle
+            className="w-10 h-10 mb-3 text-warning-500"
+            aria-hidden="true"
+          />
+          <h3 className="text-base font-semibold text-text-primary dark:text-text-primary-dark mb-2 text-center">
+            {isNetworkError
+              ? translations.connectionProblem
+              : translations.somethingWentWrong}
+          </h3>
+          <p className="text-sm text-text-muted dark:text-text-muted-dark mb-4 text-center">
+            {isNetworkError
+              ? translations.networkDescription
+              : translations.errorDescription}
+          </p>
+          {this.state.error && (
+            <details className="w-full text-left mb-4 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg p-3">
+              <summary className="text-sm text-text-muted dark:text-text-muted-dark cursor-pointer">
+                {translations.errorDetails}
+              </summary>
+              <pre className="mt-2 text-xs overflow-auto text-text-secondary dark:text-text-secondary-dark">
+                {this.state.error.message}
+              </pre>
+            </details>
+          )}
+          <div className="flex gap-3 justify-center">
+            <button
+              onClick={this.handleReset}
+              className="btn btn-secondary"
+            >
+              {translations.tryAgain}
+            </button>
+            {onClose && (
+              <button
+                onClick={this.handleClose}
+                className="btn btn-primary"
+              >
+                {translations.closeModal}
+              </button>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+interface ModalErrorBoundaryProps {
+  children: ReactNode;
+  modalName: string;
+  onClose?: () => void;
+}
+
+/**
+ * Error boundary for modal-level errors.
+ * Wraps modal content and provides a compact fallback UI with retry and close options.
+ * Prevents modal errors from crashing the page or other parts of the application.
+ */
+export function ModalErrorBoundary({ children, modalName, onClose }: ModalErrorBoundaryProps) {
+  const { t } = useTranslation();
+
+  const translations = {
+    connectionProblem: t("errorBoundary.connectionProblem"),
+    somethingWentWrong: t("errorBoundary.somethingWentWrong"),
+    networkDescription: t("errorBoundary.modal.networkDescription"),
+    errorDescription: t("errorBoundary.modal.errorDescription"),
+    errorDetails: t("errorBoundary.errorDetails"),
+    tryAgain: t("errorBoundary.tryAgain"),
+    closeModal: t("errorBoundary.modal.closeModal"),
+  };
+
+  return (
+    <ModalErrorBoundaryClass modalName={modalName} onClose={onClose} translations={translations}>
+      {children}
+    </ModalErrorBoundaryClass>
+  );
+}

--- a/web-app/src/components/ui/ModalErrorBoundary.tsx
+++ b/web-app/src/components/ui/ModalErrorBoundary.tsx
@@ -1,9 +1,8 @@
 import { Component, type ReactNode } from "react";
 import { AlertTriangle } from "@/components/ui/icons";
 import { useTranslation } from "@/hooks/useTranslation";
+import { classifyError, type ErrorType } from "@/utils/error-helpers";
 import { logger } from "../../utils/logger";
-
-type ErrorType = "network" | "application";
 
 interface ModalErrorBoundaryClassProps {
   children: ReactNode;
@@ -24,29 +23,6 @@ interface State {
   hasError: boolean;
   error: Error | null;
   errorType: ErrorType;
-}
-
-/**
- * Classify an error as network-related or application-related.
- */
-function classifyError(error: Error): ErrorType {
-  const message = error.message.toLowerCase();
-  const name = error.name.toLowerCase();
-
-  if (
-    (name === "typeerror" && message.includes("fetch")) ||
-    name === "networkerror" ||
-    message.includes("network") ||
-    message.includes("failed to fetch") ||
-    message.includes("connection") ||
-    message.includes("timeout") ||
-    message.includes("cors") ||
-    message.includes("offline")
-  ) {
-    return "network";
-  }
-
-  return "application";
 }
 
 /**

--- a/web-app/src/components/ui/PageErrorBoundary.test.tsx
+++ b/web-app/src/components/ui/PageErrorBoundary.test.tsx
@@ -1,0 +1,218 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PageErrorBoundary } from "./PageErrorBoundary";
+
+// Mock window.location for navigation tests
+Object.defineProperty(window, "location", {
+  value: { href: "" },
+  writable: true,
+});
+
+// Component that throws an error
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Test application error");
+  }
+  return <div>Child content</div>;
+}
+
+// Component that throws a network error
+function ThrowNetworkError(): React.ReactNode {
+  throw new Error("Failed to fetch data");
+}
+
+describe("PageErrorBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset location.href before each test
+    window.location.href = "";
+    // Suppress console.error for expected errors
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  describe("when no error occurs", () => {
+    it("renders children normally", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <div>Child content</div>
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByText("Child content")).toBeInTheDocument();
+    });
+
+    it("does not show error UI when children render successfully", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={false} />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByText("Child content")).toBeInTheDocument();
+      expect(screen.queryByTestId("page-error-boundary")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when an application error occurs", () => {
+    it("renders error fallback UI", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByTestId("page-error-boundary")).toBeInTheDocument();
+    });
+
+    it("displays application error title", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
+
+    it("displays application error description", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      expect(
+        screen.getByText("This page encountered an error. You can try again or return to the home page."),
+      ).toBeInTheDocument();
+    });
+
+    it("displays error details in collapsible section", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByText("Error details")).toBeInTheDocument();
+      expect(screen.getByText("Test application error")).toBeInTheDocument();
+    });
+
+    it("shows Try Again button", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+    });
+
+    it("shows Go Home button", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByRole("button", { name: /Go Home/i })).toBeInTheDocument();
+    });
+
+    it("resets error state when Try Again is clicked and children succeed", () => {
+      // Use a stateful component to control throwing behavior
+      let shouldThrowNow = true;
+
+      function ConditionalError() {
+        if (shouldThrowNow) {
+          throw new Error("Test application error");
+        }
+        return <div>Child content</div>;
+      }
+
+      const { rerender } = render(
+        <PageErrorBoundary pageName="TestPage">
+          <ConditionalError />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByTestId("page-error-boundary")).toBeInTheDocument();
+
+      // Change the throwing behavior before clicking Try Again
+      shouldThrowNow = false;
+
+      fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+
+      // Force rerender to pick up the new state
+      rerender(
+        <PageErrorBoundary pageName="TestPage">
+          <ConditionalError />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByText("Child content")).toBeInTheDocument();
+    });
+
+    it("navigates to home when Go Home is clicked", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /Go Home/i }));
+
+      expect(window.location.href).toBe("/");
+    });
+  });
+
+  describe("when a network error occurs", () => {
+    it("displays network error title", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowNetworkError />
+        </PageErrorBoundary>,
+      );
+
+      expect(screen.getByText("Connection Problem")).toBeInTheDocument();
+    });
+
+    it("displays network error description", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowNetworkError />
+        </PageErrorBoundary>,
+      );
+
+      expect(
+        screen.getByText("Unable to load this page due to a connection issue. Please check your internet connection."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("styling", () => {
+    it("renders warning icon with aria-hidden", () => {
+      const { container } = render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      const iconContainer = container.querySelector('[aria-hidden="true"]');
+      expect(iconContainer).toBeInTheDocument();
+    });
+
+    it("has centered layout", () => {
+      render(
+        <PageErrorBoundary pageName="TestPage">
+          <ThrowError shouldThrow={true} />
+        </PageErrorBoundary>,
+      );
+
+      const container = screen.getByTestId("page-error-boundary");
+      expect(container).toHaveClass("flex");
+      expect(container).toHaveClass("flex-col");
+      expect(container).toHaveClass("items-center");
+      expect(container).toHaveClass("justify-center");
+    });
+  });
+});

--- a/web-app/src/components/ui/PageErrorBoundary.tsx
+++ b/web-app/src/components/ui/PageErrorBoundary.tsx
@@ -1,9 +1,8 @@
 import { Component, type ReactNode } from "react";
-import { AlertTriangle, Home } from "@/components/ui/icons";
+import { AlertTriangle } from "@/components/ui/icons";
 import { useTranslation } from "@/hooks/useTranslation";
+import { classifyError, type ErrorType } from "@/utils/error-helpers";
 import { logger } from "../../utils/logger";
-
-type ErrorType = "network" | "application";
 
 interface PageErrorBoundaryClassProps {
   children: ReactNode;
@@ -23,29 +22,6 @@ interface State {
   hasError: boolean;
   error: Error | null;
   errorType: ErrorType;
-}
-
-/**
- * Classify an error as network-related or application-related.
- */
-function classifyError(error: Error): ErrorType {
-  const message = error.message.toLowerCase();
-  const name = error.name.toLowerCase();
-
-  if (
-    (name === "typeerror" && message.includes("fetch")) ||
-    name === "networkerror" ||
-    message.includes("network") ||
-    message.includes("failed to fetch") ||
-    message.includes("connection") ||
-    message.includes("timeout") ||
-    message.includes("cors") ||
-    message.includes("offline")
-  ) {
-    return "network";
-  }
-
-  return "application";
 }
 
 /**
@@ -128,9 +104,8 @@ class PageErrorBoundaryClass extends Component<PageErrorBoundaryClassProps, Stat
               </button>
               <button
                 onClick={this.handleGoHome}
-                className="btn btn-primary flex items-center gap-2"
+                className="btn btn-primary"
               >
-                <Home className="w-4 h-4" aria-hidden="true" />
                 {translations.goHome}
               </button>
             </div>

--- a/web-app/src/components/ui/PageErrorBoundary.tsx
+++ b/web-app/src/components/ui/PageErrorBoundary.tsx
@@ -1,0 +1,174 @@
+import { Component, type ReactNode } from "react";
+import { AlertTriangle, Home } from "@/components/ui/icons";
+import { useTranslation } from "@/hooks/useTranslation";
+import { logger } from "../../utils/logger";
+
+type ErrorType = "network" | "application";
+
+interface PageErrorBoundaryClassProps {
+  children: ReactNode;
+  pageName: string;
+  translations: {
+    connectionProblem: string;
+    somethingWentWrong: string;
+    networkDescription: string;
+    errorDescription: string;
+    errorDetails: string;
+    tryAgain: string;
+    goHome: string;
+  };
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  errorType: ErrorType;
+}
+
+/**
+ * Classify an error as network-related or application-related.
+ */
+function classifyError(error: Error): ErrorType {
+  const message = error.message.toLowerCase();
+  const name = error.name.toLowerCase();
+
+  if (
+    (name === "typeerror" && message.includes("fetch")) ||
+    name === "networkerror" ||
+    message.includes("network") ||
+    message.includes("failed to fetch") ||
+    message.includes("connection") ||
+    message.includes("timeout") ||
+    message.includes("cors") ||
+    message.includes("offline")
+  ) {
+    return "network";
+  }
+
+  return "application";
+}
+
+/**
+ * Error boundary class component for page-level errors.
+ * Displays a contextual fallback UI that allows users to retry or navigate home.
+ * Unlike the global ErrorBoundary, this keeps the app shell intact.
+ */
+class PageErrorBoundaryClass extends Component<PageErrorBoundaryClassProps, State> {
+  constructor(props: PageErrorBoundaryClassProps) {
+    super(props);
+    this.state = { hasError: false, error: null, errorType: "application" };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return {
+      hasError: true,
+      error,
+      errorType: classifyError(error),
+    };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    logger.error(`PageErrorBoundary caught an error in ${this.props.pageName}:`, {
+      error,
+      errorType: this.state.errorType,
+      pageName: this.props.pageName,
+      componentStack: errorInfo.componentStack,
+    });
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null, errorType: "application" });
+  };
+
+  handleGoHome = () => {
+    window.location.href = "/";
+  };
+
+  override render() {
+    if (this.state.hasError) {
+      const { translations } = this.props;
+      const isNetworkError = this.state.errorType === "network";
+
+      return (
+        <div
+          className="flex flex-col items-center justify-center py-12 px-4"
+          data-testid="page-error-boundary"
+        >
+          <div className="max-w-md w-full text-center">
+            <AlertTriangle
+              className="w-12 h-12 mx-auto mb-4 text-warning-500"
+              aria-hidden="true"
+            />
+            <h2 className="text-lg font-semibold text-text-primary dark:text-text-primary-dark mb-2">
+              {isNetworkError
+                ? translations.connectionProblem
+                : translations.somethingWentWrong}
+            </h2>
+            <p className="text-sm text-text-muted dark:text-text-muted-dark mb-4">
+              {isNetworkError
+                ? translations.networkDescription
+                : translations.errorDescription}
+            </p>
+            {this.state.error && (
+              <details className="text-left mb-4 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg p-3">
+                <summary className="text-sm text-text-muted dark:text-text-muted-dark cursor-pointer">
+                  {translations.errorDetails}
+                </summary>
+                <pre className="mt-2 text-xs overflow-auto text-text-secondary dark:text-text-secondary-dark">
+                  {this.state.error.message}
+                </pre>
+              </details>
+            )}
+            <div className="flex gap-3 justify-center">
+              <button
+                onClick={this.handleReset}
+                className="btn btn-secondary flex items-center gap-2"
+              >
+                {translations.tryAgain}
+              </button>
+              <button
+                onClick={this.handleGoHome}
+                className="btn btn-primary flex items-center gap-2"
+              >
+                <Home className="w-4 h-4" aria-hidden="true" />
+                {translations.goHome}
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+interface PageErrorBoundaryProps {
+  children: ReactNode;
+  pageName: string;
+}
+
+/**
+ * Error boundary for page-level errors.
+ * Wraps page content and provides contextual fallback UI with retry and navigation options.
+ * Keeps the app shell (navigation, header) intact when a page crashes.
+ */
+export function PageErrorBoundary({ children, pageName }: PageErrorBoundaryProps) {
+  const { t } = useTranslation();
+
+  const translations = {
+    connectionProblem: t("errorBoundary.connectionProblem"),
+    somethingWentWrong: t("errorBoundary.somethingWentWrong"),
+    networkDescription: t("errorBoundary.page.networkDescription"),
+    errorDescription: t("errorBoundary.page.errorDescription"),
+    errorDetails: t("errorBoundary.errorDetails"),
+    tryAgain: t("errorBoundary.tryAgain"),
+    goHome: t("errorBoundary.page.goHome"),
+  };
+
+  return (
+    <PageErrorBoundaryClass pageName={pageName} translations={translations}>
+      {children}
+    </PageErrorBoundaryClass>
+  );
+}

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -38,6 +38,7 @@ export { AlertTriangle } from "lucide-react";
 export { Calendar } from "lucide-react";
 export { Lock } from "lucide-react";
 export { Inbox } from "lucide-react";
+export { Home } from "lucide-react";
 
 // App branding - custom volleyball icon since Lucide doesn't have one
 export { CircleDot as Volleyball } from "lucide-react";

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -38,7 +38,6 @@ export { AlertTriangle } from "lucide-react";
 export { Calendar } from "lucide-react";
 export { Lock } from "lucide-react";
 export { Inbox } from "lucide-react";
-export { Home } from "lucide-react";
 
 // App branding - custom volleyball icon since Lucide doesn't have one
 export { CircleDot as Volleyball } from "lucide-react";

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -253,6 +253,20 @@ const de: Translations = {
     errorDetails: "Fehlerdetails",
     tryAgain: "Erneut versuchen",
     refreshPage: "Seite neu laden",
+    page: {
+      networkDescription:
+        "Diese Seite konnte aufgrund eines Verbindungsproblems nicht geladen werden. Bitte überprüfen Sie Ihre Internetverbindung.",
+      errorDescription:
+        "Auf dieser Seite ist ein Fehler aufgetreten. Sie können es erneut versuchen oder zur Startseite zurückkehren.",
+      goHome: "Zur Startseite",
+    },
+    modal: {
+      networkDescription:
+        "Diese Aktion konnte aufgrund eines Verbindungsproblems nicht abgeschlossen werden.",
+      errorDescription:
+        "Bei dieser Aktion ist etwas schiefgelaufen. Bitte versuchen Sie es erneut.",
+      closeModal: "Schliessen",
+    },
   },
   validation: {
     homeRoster: "Heimkader",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -251,6 +251,20 @@ const en: Translations = {
     errorDetails: "Error details",
     tryAgain: "Try Again",
     refreshPage: "Refresh Page",
+    page: {
+      networkDescription:
+        "Unable to load this page due to a connection issue. Please check your internet connection.",
+      errorDescription:
+        "This page encountered an error. You can try again or return to the home page.",
+      goHome: "Go Home",
+    },
+    modal: {
+      networkDescription:
+        "Unable to complete this action due to a connection issue.",
+      errorDescription:
+        "Something went wrong with this action. Please try again.",
+      closeModal: "Close",
+    },
   },
   validation: {
     homeRoster: "Home Roster",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -252,6 +252,20 @@ const fr: Translations = {
     errorDetails: "Détails de l'erreur",
     tryAgain: "Réessayer",
     refreshPage: "Actualiser la page",
+    page: {
+      networkDescription:
+        "Impossible de charger cette page en raison d'un problème de connexion. Veuillez vérifier votre connexion internet.",
+      errorDescription:
+        "Cette page a rencontré une erreur. Vous pouvez réessayer ou retourner à l'accueil.",
+      goHome: "Retour à l'accueil",
+    },
+    modal: {
+      networkDescription:
+        "Impossible de terminer cette action en raison d'un problème de connexion.",
+      errorDescription:
+        "Une erreur s'est produite avec cette action. Veuillez réessayer.",
+      closeModal: "Fermer",
+    },
   },
   validation: {
     homeRoster: "Effectif domicile",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -250,6 +250,20 @@ const it: Translations = {
     errorDetails: "Dettagli errore",
     tryAgain: "Riprova",
     refreshPage: "Ricarica pagina",
+    page: {
+      networkDescription:
+        "Impossibile caricare questa pagina a causa di un problema di connessione. Verifica la tua connessione internet.",
+      errorDescription:
+        "Questa pagina ha riscontrato un errore. Puoi riprovare o tornare alla home.",
+      goHome: "Vai alla home",
+    },
+    modal: {
+      networkDescription:
+        "Impossibile completare questa azione a causa di un problema di connessione.",
+      errorDescription:
+        "Qualcosa è andato storto con questa azione. Riprova.",
+      closeModal: "Chiudi",
+    },
   },
   validation: {
     homeRoster: "Rosa di casa",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -235,6 +235,16 @@ export interface Translations {
     errorDetails: string;
     tryAgain: string;
     refreshPage: string;
+    page: {
+      networkDescription: string;
+      errorDescription: string;
+      goHome: string;
+    };
+    modal: {
+      networkDescription: string;
+      errorDescription: string;
+      closeModal: string;
+    };
   };
   validation: {
     homeRoster: string;

--- a/web-app/src/utils/error-helpers.test.ts
+++ b/web-app/src/utils/error-helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { classifyError } from "./error-helpers";
+
+describe("classifyError", () => {
+  describe("network errors", () => {
+    it("classifies TypeError with fetch as network error", () => {
+      const error = new TypeError("Failed to fetch");
+      expect(classifyError(error)).toBe("network");
+    });
+
+    it("classifies NetworkError as network error", () => {
+      const error = new Error("Network error");
+      error.name = "NetworkError";
+      expect(classifyError(error)).toBe("network");
+    });
+
+    it("classifies errors containing 'network' as network error", () => {
+      const error = new Error("A network issue occurred");
+      expect(classifyError(error)).toBe("network");
+    });
+
+    it("classifies errors containing 'failed to fetch' as network error", () => {
+      const error = new Error("Request failed to fetch");
+      expect(classifyError(error)).toBe("network");
+    });
+
+    it("classifies errors containing 'connection' as network error", () => {
+      const error = new Error("Connection refused");
+      expect(classifyError(error)).toBe("network");
+    });
+
+    it("classifies errors containing 'timeout' as network error", () => {
+      const error = new Error("Request timeout");
+      expect(classifyError(error)).toBe("network");
+    });
+
+    it("classifies errors containing 'cors' as network error", () => {
+      const error = new Error("CORS policy blocked the request");
+      expect(classifyError(error)).toBe("network");
+    });
+
+    it("classifies errors containing 'offline' as network error", () => {
+      const error = new Error("Device is offline");
+      expect(classifyError(error)).toBe("network");
+    });
+  });
+
+  describe("application errors", () => {
+    it("classifies generic errors as application error", () => {
+      const error = new Error("Something went wrong");
+      expect(classifyError(error)).toBe("application");
+    });
+
+    it("classifies TypeError without fetch as application error", () => {
+      const error = new TypeError("Cannot read property of undefined");
+      expect(classifyError(error)).toBe("application");
+    });
+
+    it("classifies ReferenceError as application error", () => {
+      const error = new ReferenceError("variable is not defined");
+      expect(classifyError(error)).toBe("application");
+    });
+
+    it("classifies SyntaxError as application error", () => {
+      const error = new SyntaxError("Unexpected token");
+      expect(classifyError(error)).toBe("application");
+    });
+  });
+
+  describe("case insensitivity", () => {
+    it("handles uppercase error messages", () => {
+      const error = new Error("NETWORK ERROR OCCURRED");
+      expect(classifyError(error)).toBe("network");
+    });
+
+    it("handles mixed case error names", () => {
+      const error = new Error("Failed");
+      error.name = "NetworkError";
+      expect(classifyError(error)).toBe("network");
+    });
+  });
+});

--- a/web-app/src/utils/error-helpers.ts
+++ b/web-app/src/utils/error-helpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Error classification type for error boundaries.
+ * Network errors typically allow retry, while application errors may need a refresh.
+ */
+export type ErrorType = "network" | "application";
+
+/**
+ * Classify an error as network-related or application-related.
+ * Network errors typically allow retry, while application errors may need a refresh.
+ */
+export function classifyError(error: Error): ErrorType {
+  const message = error.message.toLowerCase();
+  const name = error.name.toLowerCase();
+
+  // Network-related errors
+  if (
+    (name === "typeerror" && message.includes("fetch")) ||
+    name === "networkerror" ||
+    message.includes("network") ||
+    message.includes("failed to fetch") ||
+    message.includes("connection") ||
+    message.includes("timeout") ||
+    message.includes("cors") ||
+    message.includes("offline")
+  ) {
+    return "network";
+  }
+
+  return "application";
+}


### PR DESCRIPTION
This adds specialized error boundary components for isolated error handling:

- PageErrorBoundary: Wraps page content with contextual fallback UI,
  including "Try Again" and "Go Home" buttons. Keeps app shell intact
  when a page crashes.

- ModalErrorBoundary: Wraps modal content with compact fallback UI,
  including "Try Again" and "Close" buttons. Prevents modal errors
  from crashing the page.

Both components:
- Classify errors as network vs application errors
- Log errors with component context for debugging
- Support dark mode styling
- Include i18n translations for all 4 languages (de, en, fr, it)

Wrapped components:
- Pages: AssignmentsPage, CompensationsPage, ExchangePage, SettingsPage
- Modals: ValidateGameModal, EditCompensationModal, ExchangeConfirmationModal

Closes #252