### PR TITLE
refactor(utils): extract safe mode guard utility to reduce duplication

### DIFF
--- a/web-app/src/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/hooks/useAssignmentActions.test.ts
@@ -27,6 +27,12 @@ vi.mock("@/hooks/useTranslation", () => ({
     language: "en",
   }),
 }));
+vi.mock("@/i18n", () => ({
+  t: (key: string) => key,
+  getLocale: () => "en",
+  setLocale: vi.fn(),
+  setLocaleImmediate: vi.fn(),
+}));
 
 function createMockAssignment(leagueName = "NLA"): Assignment {
   return {

--- a/web-app/src/hooks/useAssignmentActions.ts
+++ b/web-app/src/hooks/useAssignmentActions.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import type { Assignment } from "@/api/client";
 import { logger } from "@/utils/logger";
 import { getTeamNames, isGameReportEligible } from "@/utils/assignment-helpers";
+import { checkSafeMode } from "@/utils/safe-mode-guard";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { useLanguageStore } from "@/stores/language";
@@ -60,18 +61,19 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
 
   const openValidateGame = useCallback(
     (assignment: Assignment) => {
-      // Safe mode only applies to real API calls; demo mode is local-only and poses no risk
-      if (!isDemoMode && isSafeModeEnabled) {
-        logger.debug(
-          "[useAssignmentActions] Safe mode: game validation blocked",
-        );
-        toast.warning(t("settings.safeModeBlocked"));
+      if (
+        checkSafeMode({
+          isDemoMode,
+          isSafeModeEnabled,
+          context: "[useAssignmentActions] game validation",
+        })
+      ) {
         return;
       }
 
       validateGameModal.open(assignment);
     },
-    [isDemoMode, isSafeModeEnabled, t, validateGameModal],
+    [isDemoMode, isSafeModeEnabled, validateGameModal],
   );
 
   const openPdfReport = useCallback(
@@ -153,12 +155,13 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
     (assignment: Assignment) => {
       const { homeTeam, awayTeam } = getTeamNames(assignment);
 
-      // Safe mode only applies to real API calls; demo mode is local-only and poses no risk
-      if (!isDemoMode && isSafeModeEnabled) {
-        logger.debug(
-          "[useAssignmentActions] Safe mode: adding to exchange blocked",
-        );
-        toast.warning(t("settings.safeModeBlocked"));
+      if (
+        checkSafeMode({
+          isDemoMode,
+          isSafeModeEnabled,
+          context: "[useAssignmentActions] adding to exchange",
+        })
+      ) {
         return;
       }
 

--- a/web-app/src/hooks/useCompensationActions.test.ts
+++ b/web-app/src/hooks/useCompensationActions.test.ts
@@ -24,6 +24,12 @@ vi.mock("@/hooks/useTranslation", () => ({
     language: "en",
   }),
 }));
+vi.mock("@/i18n", () => ({
+  t: (key: string) => key,
+  getLocale: () => "en",
+  setLocale: vi.fn(),
+  setLocaleImmediate: vi.fn(),
+}));
 
 function createMockCompensation(): CompensationRecord {
   return {

--- a/web-app/src/hooks/useCompensationActions.ts
+++ b/web-app/src/hooks/useCompensationActions.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from "react";
 import type { CompensationRecord } from "@/api/client";
 import { downloadCompensationPDF } from "@/utils/compensation-actions";
 import { logger } from "@/utils/logger";
+import { checkSafeMode } from "@/utils/safe-mode-guard";
 import { useAuthStore } from "@/stores/auth";
 import { useSettingsStore } from "@/stores/settings";
 import { toast } from "@/stores/toast";
@@ -29,18 +30,19 @@ export function useCompensationActions(): UseCompensationActionsResult {
 
   const openEditCompensation = useCallback(
     (compensation: CompensationRecord) => {
-      // Safe mode blocks dangerous operations; demo mode bypasses since it's local-only
-      if (!isDemoMode && isSafeModeEnabled) {
-        logger.debug(
-          "[useCompensationActions] Safe mode: editing compensation blocked",
-        );
-        toast.warning(t("settings.safeModeBlocked"));
+      if (
+        checkSafeMode({
+          isDemoMode,
+          isSafeModeEnabled,
+          context: "[useCompensationActions] editing compensation",
+        })
+      ) {
         return;
       }
 
       editCompensationModal.open(compensation);
     },
-    [isDemoMode, isSafeModeEnabled, t, editCompensationModal],
+    [isDemoMode, isSafeModeEnabled, editCompensationModal],
   );
 
   const handleGeneratePDF = useCallback(

--- a/web-app/src/hooks/useExchangeActions.test.ts
+++ b/web-app/src/hooks/useExchangeActions.test.ts
@@ -26,6 +26,12 @@ vi.mock("@/hooks/useTranslation", () => ({
     language: "en",
   }),
 }));
+vi.mock("@/i18n", () => ({
+  t: (key: string) => key,
+  getLocale: () => "en",
+  setLocale: vi.fn(),
+  setLocaleImmediate: vi.fn(),
+}));
 
 function createMockExchange(): GameExchange {
   return {

--- a/web-app/src/hooks/useExchangeActions.ts
+++ b/web-app/src/hooks/useExchangeActions.ts
@@ -5,6 +5,7 @@ import {
   useWithdrawFromExchange,
 } from "./useConvocations";
 import { logger } from "@/utils/logger";
+import { checkSafeMode } from "@/utils/safe-mode-guard";
 import { useAuthStore } from "@/stores/auth";
 import { toast } from "@/stores/toast";
 import { useSettingsStore } from "@/stores/settings";
@@ -47,12 +48,13 @@ export function useExchangeActions(): UseExchangeActionsResult {
 
   const handleTakeOver = useCallback(
     async (exchange: GameExchange) => {
-      // Safe mode blocks dangerous operations; demo mode bypasses since it's local-only
-      if (!isDemoMode && isSafeModeEnabled) {
-        logger.debug(
-          "[useExchangeActions] Safe mode: taking exchange blocked",
-        );
-        toast.warning(t("settings.safeModeBlocked"));
+      if (
+        checkSafeMode({
+          isDemoMode,
+          isSafeModeEnabled,
+          context: "[useExchangeActions] taking exchange",
+        })
+      ) {
         return;
       }
 
@@ -87,12 +89,13 @@ export function useExchangeActions(): UseExchangeActionsResult {
 
   const handleRemoveFromExchange = useCallback(
     async (exchange: GameExchange) => {
-      // Safe mode blocks dangerous operations; demo mode bypasses since it's local-only
-      if (!isDemoMode && isSafeModeEnabled) {
-        logger.debug(
-          "[useExchangeActions] Safe mode: withdrawing from exchange blocked",
-        );
-        toast.warning(t("settings.safeModeBlocked"));
+      if (
+        checkSafeMode({
+          isDemoMode,
+          isSafeModeEnabled,
+          context: "[useExchangeActions] withdrawing from exchange",
+        })
+      ) {
         return;
       }
 

--- a/web-app/src/utils/safe-mode-guard.test.ts
+++ b/web-app/src/utils/safe-mode-guard.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { checkSafeMode } from "./safe-mode-guard";
+import { logger } from "@/utils/logger";
+import { toast } from "@/stores/toast";
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/stores/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/i18n", () => ({
+  t: (key: string) => key,
+}));
+
+describe("checkSafeMode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("demo mode bypass", () => {
+    it("should return false when in demo mode, even if safe mode is enabled", () => {
+      const result = checkSafeMode({
+        isDemoMode: true,
+        isSafeModeEnabled: true,
+        context: "[test] operation",
+      });
+
+      expect(result).toBe(false);
+      expect(logger.debug).not.toHaveBeenCalled();
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
+
+    it("should return false when in demo mode and safe mode is disabled", () => {
+      const result = checkSafeMode({
+        isDemoMode: true,
+        isSafeModeEnabled: false,
+        context: "[test] operation",
+      });
+
+      expect(result).toBe(false);
+      expect(logger.debug).not.toHaveBeenCalled();
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("safe mode disabled", () => {
+    it("should return false when safe mode is disabled (not in demo mode)", () => {
+      const result = checkSafeMode({
+        isDemoMode: false,
+        isSafeModeEnabled: false,
+        context: "[test] operation",
+      });
+
+      expect(result).toBe(false);
+      expect(logger.debug).not.toHaveBeenCalled();
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("active blocking", () => {
+    it("should return true and show warning when safe mode is active and not in demo mode", () => {
+      const result = checkSafeMode({
+        isDemoMode: false,
+        isSafeModeEnabled: true,
+        context: "[useAssignmentActions] game validation",
+      });
+
+      expect(result).toBe(true);
+      expect(logger.debug).toHaveBeenCalledWith(
+        "[useAssignmentActions] game validation blocked by safe mode",
+      );
+      expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
+    });
+
+    it("should use provided context in log message", () => {
+      checkSafeMode({
+        isDemoMode: false,
+        isSafeModeEnabled: true,
+        context: "[useExchangeActions] take over",
+      });
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        "[useExchangeActions] take over blocked by safe mode",
+      );
+    });
+  });
+
+  describe("logging behavior", () => {
+    it("should log with correct format when blocking operation", () => {
+      checkSafeMode({
+        isDemoMode: false,
+        isSafeModeEnabled: true,
+        context: "[custom] my action",
+      });
+
+      expect(logger.debug).toHaveBeenCalledTimes(1);
+      expect(logger.debug).toHaveBeenCalledWith(
+        "[custom] my action blocked by safe mode",
+      );
+    });
+
+    it("should not log when operation is allowed", () => {
+      checkSafeMode({
+        isDemoMode: false,
+        isSafeModeEnabled: false,
+        context: "[test] allowed operation",
+      });
+
+      expect(logger.debug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("toast behavior", () => {
+    it("should show warning toast with translation key when blocking", () => {
+      checkSafeMode({
+        isDemoMode: false,
+        isSafeModeEnabled: true,
+        context: "[test] blocked",
+      });
+
+      expect(toast.warning).toHaveBeenCalledTimes(1);
+      expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
+    });
+
+    it("should not show toast when operation is allowed", () => {
+      checkSafeMode({
+        isDemoMode: true,
+        isSafeModeEnabled: true,
+        context: "[test] allowed",
+      });
+
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("return value semantics", () => {
+    it("should return true to indicate operation should be blocked", () => {
+      const result = checkSafeMode({
+        isDemoMode: false,
+        isSafeModeEnabled: true,
+        context: "[test]",
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false to indicate operation can proceed", () => {
+      const result = checkSafeMode({
+        isDemoMode: false,
+        isSafeModeEnabled: false,
+        context: "[test]",
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/web-app/src/utils/safe-mode-guard.ts
+++ b/web-app/src/utils/safe-mode-guard.ts
@@ -1,0 +1,37 @@
+import { logger } from "@/utils/logger";
+import { toast } from "@/stores/toast";
+import { t } from "@/i18n";
+
+interface SafeModeGuardOptions {
+  isDemoMode: boolean;
+  isSafeModeEnabled: boolean;
+  context: string;
+}
+
+/**
+ * Checks if an operation should be blocked due to safe mode.
+ * Safe mode prevents dangerous operations when accessing the real API.
+ * Demo mode bypasses this check since it only uses local mock data.
+ *
+ * @param options - Configuration for the safe mode check
+ * @returns true if the operation should be blocked, false otherwise
+ *
+ * @example
+ * const isBlocked = checkSafeMode({
+ *   isDemoMode: false,
+ *   isSafeModeEnabled: true,
+ *   context: "[useAssignmentActions] game validation",
+ * });
+ * if (isBlocked) return;
+ */
+export function checkSafeMode(options: SafeModeGuardOptions): boolean {
+  const { isDemoMode, isSafeModeEnabled, context } = options;
+
+  if (!isDemoMode && isSafeModeEnabled) {
+    logger.debug(`${context} blocked by safe mode`);
+    toast.warning(t("settings.safeModeBlocked"));
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Extract the repeated safe mode check pattern (~25 lines of duplicated
code across 5 locations) into a reusable checkSafeMode utility function.

- Create src/utils/safe-mode-guard.ts with checkSafeMode function
- Add comprehensive unit tests for all scenarios (demo mode bypass,
  safe mode disabled, active blocking, logging behavior)
- Refactor useAssignmentActions (2 occurrences)
- Refactor useCompensationActions (1 occurrence)
- Refactor useExchangeActions (2 occurrences)

This establishes a single source of truth for safe mode behavior and
makes future UX modifications easier to implement.

Closes #255