### PR TITLE
refactor(ui): create ModalButton component to reduce button duplication

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -21,6 +21,7 @@ import {
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { ModalErrorBoundary } from "@/components/ui/ModalErrorBoundary";
+import { ModalButton } from "@/components/ui/ModalButton";
 
 interface EditCompensationModalProps {
   assignment?: Assignment;
@@ -256,13 +257,9 @@ export function EditCompensationModal({
               <p className="text-danger-600 dark:text-danger-400 mb-4">
                 {fetchError}
               </p>
-              <button
-                type="button"
-                onClick={onClose}
-                className="px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
-              >
+              <ModalButton variant="secondary" onClick={onClose}>
                 {t("common.close")}
-              </button>
+              </ModalButton>
             </div>
           ) : (
             <form onSubmit={handleSubmit} className="space-y-4">
@@ -319,19 +316,12 @@ export function EditCompensationModal({
               </div>
 
               <div className="flex gap-3 pt-2">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
-                >
+                <ModalButton variant="secondary" fullWidth onClick={onClose}>
                   {t("common.close")}
-                </button>
-                <button
-                  type="submit"
-                  className="flex-1 px-4 py-2 text-white bg-primary-500 rounded-md hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
-                >
+                </ModalButton>
+                <ModalButton variant="primary" fullWidth type="submit">
                   {t("common.save")}
-                </button>
+                </ModalButton>
               </div>
             </form>
           )}

--- a/web-app/src/components/features/ExchangeConfirmationModal.tsx
+++ b/web-app/src/components/features/ExchangeConfirmationModal.tsx
@@ -5,6 +5,7 @@ import { useModalDismissal } from "@/hooks/useModalDismissal";
 import { logger } from "@/utils/logger";
 import { formatDateTime } from "@/utils/date-helpers";
 import { ModalErrorBoundary } from "@/components/ui/ModalErrorBoundary";
+import { ModalButton } from "@/components/ui/ModalButton";
 
 interface ExchangeConfirmationModalProps {
   exchange: GameExchange;
@@ -85,10 +86,7 @@ export function ExchangeConfirmationModal({
     variant === "takeOver"
       ? "exchange.takeOverButton"
       : "exchange.removeButton";
-  const buttonColorClass =
-    variant === "takeOver"
-      ? "bg-green-600 hover:bg-green-700 focus:ring-green-500"
-      : "bg-red-600 hover:bg-red-700 focus:ring-red-500";
+  const confirmVariant = variant === "takeOver" ? "success" : "danger";
   const modalTitleId = `${variant}-exchange-title`;
 
   return (
@@ -172,23 +170,23 @@ export function ExchangeConfirmationModal({
             </p>
 
             <div className="flex gap-3">
-              <button
-                type="button"
+              <ModalButton
+                variant="secondary"
+                fullWidth
                 onClick={onClose}
                 disabled={isSubmitting}
-                className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {t("common.cancel")}
-              </button>
-              <button
-                type="button"
+              </ModalButton>
+              <ModalButton
+                variant={confirmVariant}
+                fullWidth
                 onClick={handleConfirm}
                 disabled={isSubmitting}
                 aria-busy={isSubmitting}
-                className={`flex-1 px-4 py-2 text-white rounded-md focus:outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed ${buttonColorClass}`}
               >
                 {isSubmitting ? t("common.loading") : t(buttonKey)}
-              </button>
+              </ModalButton>
             </div>
           </div>
         </ModalErrorBoundary>

--- a/web-app/src/components/features/PdfLanguageModal.tsx
+++ b/web-app/src/components/features/PdfLanguageModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { useModalDismissal } from '@/hooks/useModalDismissal';
 import { FileText } from 'lucide-react';
 import type { Language } from '@/utils/pdf-form-filler';
+import { ModalButton } from '@/components/ui/ModalButton';
 
 interface PdfLanguageModalProps {
   isOpen: boolean;
@@ -91,19 +92,15 @@ export function PdfLanguageModal({
         </div>
 
         <div className="flex gap-3">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={isLoading}
-            className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong disabled:opacity-50"
-          >
+          <ModalButton variant="secondary" fullWidth onClick={onClose} disabled={isLoading}>
             {t('common.cancel')}
-          </button>
-          <button
-            type="button"
+          </ModalButton>
+          <ModalButton
+            variant="blue"
+            fullWidth
             onClick={() => onConfirm(selected)}
             disabled={isLoading}
-            className="flex-1 px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 flex items-center justify-center gap-2"
+            className="flex items-center justify-center gap-2"
           >
             {isLoading ? (
               <>
@@ -113,7 +110,7 @@ export function PdfLanguageModal({
             ) : (
               t('pdf.export')
             )}
-          </button>
+          </ModalButton>
         </div>
       </div>
     </div>

--- a/web-app/src/components/features/SafeModeWarningModal.tsx
+++ b/web-app/src/components/features/SafeModeWarningModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useModalDismissal } from "@/hooks/useModalDismissal";
+import { ModalButton } from "@/components/ui/ModalButton";
 
 interface SafeModeWarningModalProps {
   isOpen: boolean;
@@ -103,20 +104,12 @@ export function SafeModeWarningModal({
 
         <div className="border-t border-border-default dark:border-border-default-dark pt-4">
           <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 px-4 py-2 text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
-            >
+            <ModalButton variant="secondary" fullWidth onClick={onClose}>
               {t("common.cancel")}
-            </button>
-            <button
-              type="button"
-              onClick={handleConfirm}
-              className="flex-1 px-4 py-2 text-white bg-red-600 rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
-            >
+            </ModalButton>
+            <ModalButton variant="danger" fullWidth onClick={handleConfirm}>
               {t("settings.safeModeConfirmButton")}
-            </button>
+            </ModalButton>
           </div>
         </div>
       </div>

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -8,6 +8,7 @@ import { useWizardNavigation } from "@/hooks/useWizardNavigation";
 import { WizardStepContainer } from "@/components/ui/WizardStepContainer";
 import { WizardStepIndicator } from "@/components/ui/WizardStepIndicator";
 import { ModalErrorBoundary } from "@/components/ui/ModalErrorBoundary";
+import { ModalButton } from "@/components/ui/ModalButton";
 import {
   HomeRosterPanel,
   AwayRosterPanel,
@@ -418,32 +419,20 @@ export function ValidateGameModal({
               <>
                 <div>
                   {!isFirstStep && (
-                    <button
-                      type="button"
-                      onClick={handleBack}
-                      className="px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong"
-                    >
+                    <ModalButton variant="secondary" onClick={handleBack}>
                       {t("validation.wizard.previous")}
-                    </button>
+                    </ModalButton>
                   )}
                 </div>
                 <div>
                   {isLastStep ? (
-                    <button
-                      type="button"
-                      onClick={onClose}
-                      className="px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
-                    >
+                    <ModalButton variant="primary" onClick={onClose}>
                       {t("common.close")}
-                    </button>
+                    </ModalButton>
                   ) : (
-                    <button
-                      type="button"
-                      onClick={handleNext}
-                      className="px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
-                    >
+                    <ModalButton variant="primary" onClick={handleNext}>
                       {t("validation.wizard.next")}
-                    </button>
+                    </ModalButton>
                   )}
                 </div>
               </>
@@ -451,30 +440,28 @@ export function ValidateGameModal({
               <>
                 <div>
                   {isFirstStep ? (
-                    <button
-                      type="button"
+                    <ModalButton
+                      variant="secondary"
                       onClick={() => attemptClose()}
                       disabled={isFinalizing}
-                      className="px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {t("common.cancel")}
-                    </button>
+                    </ModalButton>
                   ) : (
-                    <button
-                      type="button"
+                    <ModalButton
+                      variant="secondary"
                       onClick={handleBack}
                       disabled={isFinalizing}
-                      className="px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {t("validation.wizard.previous")}
-                    </button>
+                    </ModalButton>
                   )}
                 </div>
 
                 <div>
                   {isLastStep ? (
-                    <button
-                      type="button"
+                    <ModalButton
+                      variant="success"
                       onClick={() => handleFinish()}
                       disabled={
                         isFinalizing ||
@@ -488,15 +475,14 @@ export function ValidateGameModal({
                           ? t("validation.state.markAllStepsTooltip")
                           : undefined
                       }
-                      className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {isFinalizing
                         ? t("common.loading")
                         : t("validation.wizard.finish")}
-                    </button>
+                    </ModalButton>
                   ) : (
-                    <button
-                      type="button"
+                    <ModalButton
+                      variant="success"
                       onClick={handleValidateAndNext}
                       disabled={
                         isFinalizing ||
@@ -504,10 +490,9 @@ export function ValidateGameModal({
                         !!gameDetailsError ||
                         !canMarkCurrentStepDone
                       }
-                      className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {t("validation.wizard.validate")}
-                    </button>
+                    </ModalButton>
                   )}
                 </div>
               </>

--- a/web-app/src/components/features/validation/UnsavedChangesDialog.tsx
+++ b/web-app/src/components/features/validation/UnsavedChangesDialog.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
+import { ModalButton } from "@/components/ui/ModalButton";
 
 /** Z-index for confirmation dialog (above main modal) */
 const Z_INDEX_CONFIRMATION_DIALOG = 60;
@@ -63,30 +64,15 @@ export function UnsavedChangesDialog({
           {t("validation.state.unsavedChangesMessage")}
         </p>
         <div className="flex justify-end gap-3">
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={isSaving}
-            className="px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark rounded-md hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:outline-none focus:ring-2 focus:ring-border-strong disabled:opacity-50"
-          >
+          <ModalButton variant="secondary" onClick={onCancel} disabled={isSaving}>
             {t("validation.state.continueEditing")}
-          </button>
-          <button
-            type="button"
-            onClick={onDiscard}
-            disabled={isSaving}
-            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50"
-          >
+          </ModalButton>
+          <ModalButton variant="danger" onClick={onDiscard} disabled={isSaving}>
             {t("validation.state.discardChanges")}
-          </button>
-          <button
-            type="button"
-            onClick={onSaveAndClose}
-            disabled={isSaving}
-            className="px-4 py-2 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
-          >
+          </ModalButton>
+          <ModalButton variant="primary" onClick={onSaveAndClose} disabled={isSaving}>
             {isSaving ? t("common.loading") : t("validation.state.saveAndClose")}
-          </button>
+          </ModalButton>
         </div>
       </div>
     </div>

--- a/web-app/src/components/ui/ModalButton.test.tsx
+++ b/web-app/src/components/ui/ModalButton.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ModalButton } from "./ModalButton";
+
+describe("ModalButton", () => {
+  describe("rendering", () => {
+    it("renders children correctly", () => {
+      render(<ModalButton variant="primary">Click me</ModalButton>);
+      expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
+    });
+
+    it("renders as a button element", () => {
+      render(<ModalButton variant="primary">Test</ModalButton>);
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("has type='button' by default", () => {
+      render(<ModalButton variant="primary">Test</ModalButton>);
+      expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    });
+
+    it("applies custom className", () => {
+      render(
+        <ModalButton variant="primary" className="custom-class">
+          Test
+        </ModalButton>
+      );
+      expect(screen.getByRole("button")).toHaveClass("custom-class");
+    });
+
+    it("passes through additional button attributes", () => {
+      render(
+        <ModalButton variant="primary" aria-busy="true" data-testid="modal-btn">
+          Test
+        </ModalButton>
+      );
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-busy", "true");
+      expect(button).toHaveAttribute("data-testid", "modal-btn");
+    });
+  });
+
+  describe("variants", () => {
+    it("applies secondary variant styles", () => {
+      render(<ModalButton variant="secondary">Cancel</ModalButton>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-surface-subtle");
+      expect(button).toHaveClass("text-text-secondary");
+    });
+
+    it("applies primary variant styles", () => {
+      render(<ModalButton variant="primary">Save</ModalButton>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-primary-600");
+      expect(button).toHaveClass("text-white");
+    });
+
+    it("applies success variant styles", () => {
+      render(<ModalButton variant="success">Confirm</ModalButton>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-green-600");
+      expect(button).toHaveClass("text-white");
+    });
+
+    it("applies danger variant styles", () => {
+      render(<ModalButton variant="danger">Delete</ModalButton>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-red-600");
+      expect(button).toHaveClass("text-white");
+    });
+
+    it("applies blue variant styles", () => {
+      render(<ModalButton variant="blue">Export</ModalButton>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-blue-600");
+      expect(button).toHaveClass("text-white");
+    });
+  });
+
+  describe("base styles", () => {
+    it("applies base padding and text styles", () => {
+      render(<ModalButton variant="primary">Test</ModalButton>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("px-4");
+      expect(button).toHaveClass("py-2");
+      expect(button).toHaveClass("text-sm");
+      expect(button).toHaveClass("font-medium");
+      expect(button).toHaveClass("rounded-md");
+    });
+
+    it("applies focus ring styles", () => {
+      render(<ModalButton variant="primary">Test</ModalButton>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("focus:outline-none");
+      expect(button).toHaveClass("focus:ring-2");
+    });
+  });
+
+  describe("fullWidth prop", () => {
+    it("does not apply flex-1 by default", () => {
+      render(<ModalButton variant="primary">Test</ModalButton>);
+      expect(screen.getByRole("button")).not.toHaveClass("flex-1");
+    });
+
+    it("applies flex-1 when fullWidth is true", () => {
+      render(
+        <ModalButton variant="primary" fullWidth>
+          Test
+        </ModalButton>
+      );
+      expect(screen.getByRole("button")).toHaveClass("flex-1");
+    });
+  });
+
+  describe("disabled state", () => {
+    it("applies disabled attribute when disabled", () => {
+      render(
+        <ModalButton variant="primary" disabled>
+          Test
+        </ModalButton>
+      );
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    it("applies disabled styles", () => {
+      render(
+        <ModalButton variant="primary" disabled>
+          Test
+        </ModalButton>
+      );
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("disabled:opacity-50");
+      expect(button).toHaveClass("disabled:cursor-not-allowed");
+    });
+
+    it("does not call onClick when disabled", () => {
+      const handleClick = vi.fn();
+      render(
+        <ModalButton variant="primary" disabled onClick={handleClick}>
+          Test
+        </ModalButton>
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("interactions", () => {
+    it("calls onClick handler when clicked", () => {
+      const handleClick = vi.fn();
+      render(
+        <ModalButton variant="primary" onClick={handleClick}>
+          Test
+        </ModalButton>
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/web-app/src/components/ui/ModalButton.tsx
+++ b/web-app/src/components/ui/ModalButton.tsx
@@ -1,0 +1,61 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type ModalButtonVariant = "secondary" | "primary" | "success" | "danger" | "blue";
+
+interface ModalButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Visual style variant */
+  variant: ModalButtonVariant;
+  /** Whether the button should expand to fill available width (flex-1) */
+  fullWidth?: boolean;
+  /** Button content */
+  children: ReactNode;
+}
+
+const variantClasses: Record<ModalButtonVariant, string> = {
+  secondary:
+    "text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:ring-border-strong",
+  primary:
+    "text-white bg-primary-600 hover:bg-primary-700 focus:ring-primary-500",
+  success: "text-white bg-green-600 hover:bg-green-700 focus:ring-green-500",
+  danger: "text-white bg-red-600 hover:bg-red-700 focus:ring-red-500",
+  blue: "text-white bg-blue-600 hover:bg-blue-700 focus:ring-blue-500",
+};
+
+/**
+ * Standardized button component for use in modals and dialogs.
+ * Provides consistent styling, accessibility, and dark mode support.
+ *
+ * @example
+ * ```tsx
+ * <ModalButton variant="secondary" onClick={onClose}>
+ *   Cancel
+ * </ModalButton>
+ * <ModalButton variant="success" onClick={onConfirm} disabled={isLoading}>
+ *   {isLoading ? "Saving..." : "Save"}
+ * </ModalButton>
+ * ```
+ */
+export function ModalButton({
+  variant,
+  fullWidth = false,
+  children,
+  className = "",
+  disabled,
+  ...props
+}: ModalButtonProps) {
+  const baseClasses =
+    "px-4 py-2 text-sm font-medium rounded-md focus:outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed";
+  const widthClass = fullWidth ? "flex-1" : "";
+  const variantClass = variantClasses[variant];
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={`${baseClasses} ${variantClass} ${widthClass} ${className}`.trim()}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
Extract common modal button Tailwind classes into a reusable ModalButton
component with variants (secondary, primary, success, danger, blue).

- Add ModalButton component with fullWidth and disabled state support
- Add comprehensive tests for all variants and states
- Update 6 modal components to use the new ModalButton:
  - ExchangeConfirmationModal
  - UnsavedChangesDialog
  - ValidateGameModal
  - PdfLanguageModal
  - SafeModeWarningModal
  - EditCompensationModal