### PR TITLE
refactor(logger): add createLogger factory for context prefixes

### DIFF
--- a/web-app/src/contexts/PWAContext.test.tsx
+++ b/web-app/src/contexts/PWAContext.test.tsx
@@ -583,7 +583,7 @@ describe("PWAContext", () => {
       });
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[VolleyKit]",
+        "[VolleyKit][App]",
         "updateApp called but service worker is not ready",
       );
       consoleWarnSpy.mockRestore();

--- a/web-app/src/hooks/useAssignmentActions.ts
+++ b/web-app/src/hooks/useAssignmentActions.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import type { Assignment } from "@/api/client";
-import { logger } from "@/utils/logger";
+import { createLogger } from "@/utils/logger";
 import { getTeamNames, isGameReportEligible } from "@/utils/assignment-helpers";
 import { checkSafeMode } from "@/utils/safe-mode-guard";
 import { useAuthStore } from "@/stores/auth";
@@ -10,6 +10,8 @@ import { useSettingsStore } from "@/stores/settings";
 import { toast } from "@/stores/toast";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useModalState } from "./useModalState";
+
+const log = createLogger("useAssignmentActions");
 
 type PdfLanguage = "de" | "fr";
 
@@ -65,7 +67,8 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
         checkSafeMode({
           isDemoMode,
           isSafeModeEnabled,
-          context: "[useAssignmentActions] game validation",
+          context: "useAssignmentActions",
+          action: "game validation",
         })
       ) {
         return;
@@ -79,9 +82,7 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
   const openPdfReport = useCallback(
     (assignment: Assignment) => {
       if (!isGameReportEligible(assignment)) {
-        logger.debug(
-          "[useAssignmentActions] Game report not available for this league",
-        );
+        log.debug("Game report not available for this league");
         toast.info(t("assignments.gameReportNotAvailable"));
         return;
       }
@@ -115,8 +116,8 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
         );
 
         if (!reportData || !leagueCategory) {
-          logger.error(
-            "[useAssignmentActions] Failed to extract report data for:",
+          log.error(
+            "Failed to extract report data for:",
             pdfReportModal.data.__identity,
           );
           toast.error(t("pdf.exportError"));
@@ -128,14 +129,11 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
           leagueCategory,
           language,
         );
-        logger.debug(
-          "[useAssignmentActions] Generated PDF report for:",
-          pdfReportModal.data.__identity,
-        );
+        log.debug("Generated PDF report for:", pdfReportModal.data.__identity);
         toast.success(t("assignments.reportGenerated"));
         closePdfReport();
       } catch (error) {
-        logger.error("[useAssignmentActions] PDF generation failed:", error);
+        log.error("PDF generation failed:", error);
         toast.error(t("pdf.exportError"));
       } finally {
         setPdfReportLoading(false);
@@ -159,7 +157,8 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
         checkSafeMode({
           isDemoMode,
           isSafeModeEnabled,
-          context: "[useAssignmentActions] adding to exchange",
+          context: "useAssignmentActions",
+          action: "adding to exchange",
         })
       ) {
         return;
@@ -167,15 +166,15 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
 
       if (isDemoMode) {
         addAssignmentToExchange(assignment.__identity);
-        logger.debug(
-          "[useAssignmentActions] Demo mode: added assignment to exchange:",
+        log.debug(
+          "Demo mode: added assignment to exchange:",
           assignment.__identity,
         );
         toast.success(t("exchange.addedToExchangeSuccess"));
         return;
       }
 
-      logger.debug("[useAssignmentActions] Mock add to exchange:", {
+      log.debug("Mock add to exchange:", {
         assignmentId: assignment.__identity,
         game: `${homeTeam} vs ${awayTeam}`,
       });

--- a/web-app/src/hooks/useCompensationActions.ts
+++ b/web-app/src/hooks/useCompensationActions.ts
@@ -1,13 +1,15 @@
 import { useCallback, useRef } from "react";
 import type { CompensationRecord } from "@/api/client";
 import { downloadCompensationPDF } from "@/utils/compensation-actions";
-import { logger } from "@/utils/logger";
+import { createLogger } from "@/utils/logger";
 import { checkSafeMode } from "@/utils/safe-mode-guard";
 import { useAuthStore } from "@/stores/auth";
 import { useSettingsStore } from "@/stores/settings";
 import { toast } from "@/stores/toast";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useModalState } from "./useModalState";
+
+const log = createLogger("useCompensationActions");
 
 interface UseCompensationActionsResult {
   editCompensationModal: {
@@ -34,7 +36,8 @@ export function useCompensationActions(): UseCompensationActionsResult {
         checkSafeMode({
           isDemoMode,
           isSafeModeEnabled,
-          context: "[useCompensationActions] editing compensation",
+          context: "useCompensationActions",
+          action: "editing compensation",
         })
       ) {
         return;
@@ -48,33 +51,23 @@ export function useCompensationActions(): UseCompensationActionsResult {
   const handleGeneratePDF = useCallback(
     async (compensation: CompensationRecord) => {
       if (isDemoMode) {
-        logger.debug(
-          "[useCompensationActions] Demo mode: PDF download disabled",
-        );
+        log.debug("Demo mode: PDF download disabled");
         toast.info(t("compensations.pdfNotAvailableDemo"));
         return;
       }
 
       if (isDownloadingRef.current) {
-        logger.debug(
-          "[useCompensationActions] PDF download already in progress, ignoring",
-        );
+        log.debug("PDF download already in progress, ignoring");
         return;
       }
 
       isDownloadingRef.current = true;
       try {
-        logger.debug(
-          "[useCompensationActions] Generating PDF for:",
-          compensation.__identity,
-        );
+        log.debug("Generating PDF for:", compensation.__identity);
         await downloadCompensationPDF(compensation.__identity);
-        logger.debug(
-          "[useCompensationActions] PDF downloaded successfully:",
-          compensation.__identity,
-        );
+        log.debug("PDF downloaded successfully:", compensation.__identity);
       } catch (error) {
-        logger.error("[useCompensationActions] Failed to generate PDF:", error);
+        log.error("Failed to generate PDF:", error);
         toast.error(t("compensations.pdfDownloadFailed"));
       } finally {
         isDownloadingRef.current = false;

--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -28,7 +28,9 @@ import {
 } from "@/utils/assignment-helpers";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
-import { logger } from "@/utils/logger";
+import { createLogger } from "@/utils/logger";
+
+const log = createLogger("useConvocations");
 
 // Pagination constants
 // Note: The API doesn't support cursor-based pagination, so we use offset-based.
@@ -180,8 +182,8 @@ async function fetchAllAssignmentPages(
 
   // Log warning if we hit the page limit before fetching all items
   if (pagesFetched >= MAX_FETCH_ALL_PAGES && allItems.length < totalCount) {
-    logger.warn(
-      `[fetchAllAssignmentPages] Reached MAX_FETCH_ALL_PAGES limit (${MAX_FETCH_ALL_PAGES}). ` +
+    log.warn(
+      `Reached MAX_FETCH_ALL_PAGES limit (${MAX_FETCH_ALL_PAGES}). ` +
         `Fetched ${allItems.length} of ${totalCount} total items. Some data may be missing.`,
     );
   }
@@ -639,7 +641,7 @@ export function useUpdateCompensation(): UseMutationResult<
       compensationId: string;
       data: CompensationUpdateData;
     }) => {
-      logger.debug("[useUpdateCompensation] Updating compensation:", {
+      log.debug("Updating compensation:", {
         compensationId,
         data,
         isDemoMode,
@@ -705,10 +707,7 @@ function findCompensationInCache(
 async function fetchCompensationByGameNumber(
   gameNumber: number,
 ): Promise<CompensationRecord | null> {
-  logger.debug(
-    "[fetchCompensationByGameNumber] Fetching compensations from API:",
-    { gameNumber },
-  );
+  log.debug("Fetching compensations from API:", { gameNumber });
 
   const compensations = await api.searchCompensations({
     limit: COMPENSATION_LOOKUP_LIMIT,
@@ -749,7 +748,7 @@ async function findCompensationForAssignment(
   // Try to find compensation in cache first
   const cachedComp = findCompensationInCache(gameNumber, queryClient);
   if (cachedComp) {
-    logger.debug("[findCompensationForAssignment] Found compensation in cache:", {
+    log.debug("Found compensation in cache:", {
       gameNumber,
       compensationId: cachedComp.convocationCompensation?.__identity,
     });
@@ -759,7 +758,7 @@ async function findCompensationForAssignment(
   // Fetch from API if not in cache
   const fetchedComp = await fetchCompensationByGameNumber(gameNumber);
   if (fetchedComp) {
-    logger.debug("[findCompensationForAssignment] Found compensation via API:", {
+    log.debug("Found compensation via API:", {
       gameNumber,
       compensationId: fetchedComp.convocationCompensation?.__identity,
     });
@@ -799,7 +798,7 @@ export function useUpdateAssignmentCompensation(): UseMutationResult<
       }
 
       // Non-demo mode: find the corresponding compensation record and update it via API
-      logger.debug("[useUpdateAssignmentCompensation] Looking up compensation for assignment:", {
+      log.debug("Looking up compensation for assignment:", {
         assignmentId,
         data,
       });
@@ -814,7 +813,7 @@ export function useUpdateAssignmentCompensation(): UseMutationResult<
         );
       }
 
-      logger.debug("[useUpdateAssignmentCompensation] Updating compensation via API:", {
+      log.debug("Updating compensation via API:", {
         assignmentId,
         compensationId,
         data,

--- a/web-app/src/hooks/useDateFormat.ts
+++ b/web-app/src/hooks/useDateFormat.ts
@@ -11,7 +11,9 @@ import { type Locale as DateFnsLocale } from "date-fns/locale";
 import { enUS } from "date-fns/locale/en-US";
 import { t } from "@/i18n";
 import { useLanguageStore } from "@/stores/language";
-import { logger } from "@/utils/logger";
+import { createLogger } from "@/utils/logger";
+
+const log = createLogger("useDateFormat");
 
 /**
  * In-memory cache for date-fns locales (max 4 entries: de, fr, it, en).
@@ -47,10 +49,7 @@ async function loadDateLocale(locale: string): Promise<DateFnsLocale> {
     localeCache.set(locale, loadedLocale);
     return loadedLocale;
   } catch (error) {
-    logger.error(
-      "[useDateFormat] Failed to load locale, falling back to English:",
-      error,
-    );
+    log.error("Failed to load locale, falling back to English:", error);
     return enUS;
   }
 }

--- a/web-app/src/hooks/useExchangeActions.ts
+++ b/web-app/src/hooks/useExchangeActions.ts
@@ -4,13 +4,15 @@ import {
   useApplyForExchange,
   useWithdrawFromExchange,
 } from "./useConvocations";
-import { logger } from "@/utils/logger";
+import { createLogger } from "@/utils/logger";
 import { checkSafeMode } from "@/utils/safe-mode-guard";
 import { useAuthStore } from "@/stores/auth";
 import { toast } from "@/stores/toast";
 import { useSettingsStore } from "@/stores/settings";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useModalState } from "./useModalState";
+
+const log = createLogger("useExchangeActions");
 
 interface UseExchangeActionsResult {
   takeOverModal: {
@@ -52,7 +54,8 @@ export function useExchangeActions(): UseExchangeActionsResult {
         checkSafeMode({
           isDemoMode,
           isSafeModeEnabled,
-          context: "[useExchangeActions] taking exchange",
+          context: "useExchangeActions",
+          action: "taking exchange",
         })
       ) {
         return;
@@ -65,19 +68,13 @@ export function useExchangeActions(): UseExchangeActionsResult {
         await applyMutation.mutateAsync(exchange.__identity);
         takeOverModal.close();
 
-        logger.debug(
-          "[useExchangeActions] Successfully applied for exchange:",
-          exchange.__identity,
-        );
+        log.debug("Successfully applied for exchange:", exchange.__identity);
 
         if (!isDemoMode) {
           toast.success(t("exchange.applySuccess"));
         }
       } catch (error) {
-        logger.error(
-          "[useExchangeActions] Failed to apply for exchange:",
-          error,
-        );
+        log.error("Failed to apply for exchange:", error);
 
         toast.error(t("exchange.applyError"));
       } finally {
@@ -93,7 +90,8 @@ export function useExchangeActions(): UseExchangeActionsResult {
         checkSafeMode({
           isDemoMode,
           isSafeModeEnabled,
-          context: "[useExchangeActions] withdrawing from exchange",
+          context: "useExchangeActions",
+          action: "withdrawing from exchange",
         })
       ) {
         return;
@@ -106,19 +104,13 @@ export function useExchangeActions(): UseExchangeActionsResult {
         await withdrawMutation.mutateAsync(exchange.__identity);
         removeFromExchangeModal.close();
 
-        logger.debug(
-          "[useExchangeActions] Successfully withdrawn from exchange:",
-          exchange.__identity,
-        );
+        log.debug("Successfully withdrawn from exchange:", exchange.__identity);
 
         if (!isDemoMode) {
           toast.success(t("exchange.withdrawSuccess"));
         }
       } catch (error) {
-        logger.error(
-          "[useExchangeActions] Failed to withdraw from exchange:",
-          error,
-        );
+        log.error("Failed to withdraw from exchange:", error);
 
         toast.error(t("exchange.withdrawError"));
       } finally {

--- a/web-app/src/hooks/usePreloadLocales.test.ts
+++ b/web-app/src/hooks/usePreloadLocales.test.ts
@@ -23,11 +23,18 @@ vi.mock("@/hooks/useDateFormat", () => ({
   preloadDateLocales: vi.fn(),
 }));
 
-vi.mock("@/utils/logger", () => ({
-  logger: {
-    error: vi.fn(),
-  },
-}));
+const mockLogError = vi.fn();
+
+vi.mock("@/utils/logger", () => {
+  return {
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: (...args: unknown[]) => mockLogError(...args),
+    }),
+  };
+});
 
 describe("usePreloadLocales", () => {
   beforeEach(() => {
@@ -141,7 +148,6 @@ describe("usePreloadLocales", () => {
     it("handles preloadTranslations errors gracefully", async () => {
       const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
       const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
-      const { logger } = await import("@/utils/logger");
 
       const testError = new Error("Translation load failed");
       mockPreloadTranslations.mockRejectedValue(testError);
@@ -157,8 +163,8 @@ describe("usePreloadLocales", () => {
       renderHook(() => usePreloadLocales());
 
       await vi.waitFor(() => {
-        expect(logger.error).toHaveBeenCalledWith(
-          "[usePreloadLocales] Failed to preload locales:",
+        expect(mockLogError).toHaveBeenCalledWith(
+          "Failed to preload locales:",
           testError,
         );
       });
@@ -167,7 +173,6 @@ describe("usePreloadLocales", () => {
     it("handles preloadDateLocales errors gracefully", async () => {
       const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
       const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
-      const { logger } = await import("@/utils/logger");
 
       const testError = new Error("Date locale load failed");
       mockPreloadTranslations.mockResolvedValue();
@@ -183,8 +188,8 @@ describe("usePreloadLocales", () => {
       renderHook(() => usePreloadLocales());
 
       await vi.waitFor(() => {
-        expect(logger.error).toHaveBeenCalledWith(
-          "[usePreloadLocales] Failed to preload locales:",
+        expect(mockLogError).toHaveBeenCalledWith(
+          "Failed to preload locales:",
           testError,
         );
       });
@@ -193,7 +198,6 @@ describe("usePreloadLocales", () => {
     it("handles both preload functions failing", async () => {
       const mockPreloadTranslations = vi.mocked(i18n.preloadTranslations);
       const mockPreloadDateLocales = vi.mocked(useDateFormat.preloadDateLocales);
-      const { logger } = await import("@/utils/logger");
 
       const testError = new Error("All preloads failed");
       mockPreloadTranslations.mockRejectedValue(testError);
@@ -209,8 +213,8 @@ describe("usePreloadLocales", () => {
       renderHook(() => usePreloadLocales());
 
       await vi.waitFor(() => {
-        expect(logger.error).toHaveBeenCalledWith(
-          "[usePreloadLocales] Failed to preload locales:",
+        expect(mockLogError).toHaveBeenCalledWith(
+          "Failed to preload locales:",
           testError,
         );
       });

--- a/web-app/src/hooks/usePreloadLocales.ts
+++ b/web-app/src/hooks/usePreloadLocales.ts
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 import { preloadTranslations } from "@/i18n";
 import { preloadDateLocales } from "@/hooks/useDateFormat";
-import { logger } from "@/utils/logger";
+import { createLogger } from "@/utils/logger";
+
+const log = createLogger("usePreloadLocales");
 
 const PRELOAD_IDLE_TIMEOUT_MS = 1000;
 
@@ -15,7 +17,7 @@ export function usePreloadLocales(): void {
     const handlePreload = () => {
       Promise.all([preloadTranslations(), preloadDateLocales()]).catch(
         (error) => {
-          logger.error("[usePreloadLocales] Failed to preload locales:", error);
+          log.error("Failed to preload locales:", error);
         },
       );
     };

--- a/web-app/src/stores/auth.test.ts
+++ b/web-app/src/stores/auth.test.ts
@@ -366,7 +366,7 @@ describe("useAuthStore", () => {
 
       expect(result).toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(
-        "[VolleyKit]",
+        "[VolleyKit][App]",
         "Session check failed:",
         expect.any(Error),
       );
@@ -449,7 +449,7 @@ describe("useAuthStore", () => {
       expect(useAuthStore.getState().status).toBe("idle");
       expect(useAuthStore.getState().user).toBeNull();
       expect(consoleSpy).toHaveBeenCalledWith(
-        "[VolleyKit]",
+        "[VolleyKit][App]",
         "Session check timed out",
       );
 

--- a/web-app/src/utils/logger.test.ts
+++ b/web-app/src/utils/logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { logger } from "./logger";
+import { logger, createLogger } from "./logger";
 
 describe("logger", () => {
   beforeEach(() => {
@@ -31,5 +31,81 @@ describe("logger", () => {
   it("should have error method", () => {
     expect(typeof logger.error).toBe("function");
     logger.error("error message");
+  });
+});
+
+describe("createLogger", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should create a logger with context prefix", () => {
+    const log = createLogger("TestContext");
+    expect(typeof log.debug).toBe("function");
+    expect(typeof log.info).toBe("function");
+    expect(typeof log.warn).toBe("function");
+    expect(typeof log.error).toBe("function");
+  });
+
+  it("should include context in debug calls", () => {
+    const log = createLogger("TestContext");
+    log.debug("test message", { data: 123 });
+    expect(console.log).toHaveBeenCalledWith(
+      "[VolleyKit][TestContext]",
+      "test message",
+      { data: 123 },
+    );
+  });
+
+  it("should include context in info calls", () => {
+    const log = createLogger("TestContext");
+    log.info("info message");
+    expect(console.info).toHaveBeenCalledWith(
+      "[VolleyKit][TestContext]",
+      "info message",
+    );
+  });
+
+  it("should include context in warn calls", () => {
+    const log = createLogger("TestContext");
+    log.warn("warning message");
+    expect(console.warn).toHaveBeenCalledWith(
+      "[VolleyKit][TestContext]",
+      "warning message",
+    );
+  });
+
+  it("should include context in error calls", () => {
+    const log = createLogger("TestContext");
+    log.error("error message", new Error("test"));
+    expect(console.error).toHaveBeenCalledWith(
+      "[VolleyKit][TestContext]",
+      "error message",
+      expect.any(Error),
+    );
+  });
+
+  it("should create independent loggers with different contexts", () => {
+    const logA = createLogger("ContextA");
+    const logB = createLogger("ContextB");
+
+    logA.debug("message A");
+    logB.debug("message B");
+
+    expect(console.log).toHaveBeenCalledWith(
+      "[VolleyKit][ContextA]",
+      "message A",
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      "[VolleyKit][ContextB]",
+      "message B",
+    );
   });
 });

--- a/web-app/src/utils/logger.ts
+++ b/web-app/src/utils/logger.ts
@@ -3,28 +3,47 @@
  * All logs are disabled in production builds.
  */
 
-export const logger = {
-  debug: (...args: unknown[]): void => {
-    if (import.meta.env.DEV) {
-      console.log("[VolleyKit]", ...args);
-    }
-  },
+export interface Logger {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
 
-  info: (...args: unknown[]): void => {
-    if (import.meta.env.DEV) {
-      console.info("[VolleyKit]", ...args);
-    }
-  },
+/**
+ * Creates a logger with a context prefix.
+ * Usage: const log = createLogger("useAssignmentActions");
+ *        log.debug("Something happened"); // [VolleyKit][useAssignmentActions] Something happened
+ */
+export function createLogger(context: string): Logger {
+  const prefix = `[VolleyKit][${context}]`;
 
-  warn: (...args: unknown[]): void => {
-    if (import.meta.env.DEV) {
-      console.warn("[VolleyKit]", ...args);
-    }
-  },
+  return {
+    debug: (...args: unknown[]): void => {
+      if (import.meta.env.DEV) {
+        console.log(prefix, ...args);
+      }
+    },
 
-  error: (...args: unknown[]): void => {
-    if (import.meta.env.DEV) {
-      console.error("[VolleyKit]", ...args);
-    }
-  },
-};
+    info: (...args: unknown[]): void => {
+      if (import.meta.env.DEV) {
+        console.info(prefix, ...args);
+      }
+    },
+
+    warn: (...args: unknown[]): void => {
+      if (import.meta.env.DEV) {
+        console.warn(prefix, ...args);
+      }
+    },
+
+    error: (...args: unknown[]): void => {
+      if (import.meta.env.DEV) {
+        console.error(prefix, ...args);
+      }
+    },
+  };
+}
+
+/** Default logger without context prefix */
+export const logger = createLogger("App");

--- a/web-app/src/utils/safe-mode-guard.test.ts
+++ b/web-app/src/utils/safe-mode-guard.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { checkSafeMode } from "./safe-mode-guard";
-import { logger } from "@/utils/logger";
 import { toast } from "@/stores/toast";
 
+const mockLogDebug = vi.fn();
+
 vi.mock("@/utils/logger", () => ({
-  logger: {
-    debug: vi.fn(),
+  createLogger: () => ({
+    debug: (...args: unknown[]) => mockLogDebug(...args),
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
-  },
+  }),
 }));
 
 vi.mock("@/stores/toast", () => ({
@@ -39,11 +40,12 @@ describe("checkSafeMode", () => {
       const result = checkSafeMode({
         isDemoMode: true,
         isSafeModeEnabled: true,
-        context: "[test] operation",
+        context: "test",
+        action: "operation",
       });
 
       expect(result).toBe(false);
-      expect(logger.debug).not.toHaveBeenCalled();
+      expect(mockLogDebug).not.toHaveBeenCalled();
       expect(toast.warning).not.toHaveBeenCalled();
     });
 
@@ -51,11 +53,12 @@ describe("checkSafeMode", () => {
       const result = checkSafeMode({
         isDemoMode: true,
         isSafeModeEnabled: false,
-        context: "[test] operation",
+        context: "test",
+        action: "operation",
       });
 
       expect(result).toBe(false);
-      expect(logger.debug).not.toHaveBeenCalled();
+      expect(mockLogDebug).not.toHaveBeenCalled();
       expect(toast.warning).not.toHaveBeenCalled();
     });
   });
@@ -65,11 +68,12 @@ describe("checkSafeMode", () => {
       const result = checkSafeMode({
         isDemoMode: false,
         isSafeModeEnabled: false,
-        context: "[test] operation",
+        context: "test",
+        action: "operation",
       });
 
       expect(result).toBe(false);
-      expect(logger.debug).not.toHaveBeenCalled();
+      expect(mockLogDebug).not.toHaveBeenCalled();
       expect(toast.warning).not.toHaveBeenCalled();
     });
   });
@@ -79,24 +83,26 @@ describe("checkSafeMode", () => {
       const result = checkSafeMode({
         isDemoMode: false,
         isSafeModeEnabled: true,
-        context: "[useAssignmentActions] game validation",
+        context: "useAssignmentActions",
+        action: "game validation",
       });
 
       expect(result).toBe(true);
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(mockLogDebug).toHaveBeenCalledWith(
         "[useAssignmentActions] game validation blocked by safe mode",
       );
       expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
     });
 
-    it("should use provided context in log message", () => {
+    it("should use provided context and action in log message", () => {
       checkSafeMode({
         isDemoMode: false,
         isSafeModeEnabled: true,
-        context: "[useExchangeActions] take over",
+        context: "useExchangeActions",
+        action: "take over",
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(mockLogDebug).toHaveBeenCalledWith(
         "[useExchangeActions] take over blocked by safe mode",
       );
     });
@@ -107,11 +113,12 @@ describe("checkSafeMode", () => {
       checkSafeMode({
         isDemoMode: false,
         isSafeModeEnabled: true,
-        context: "[custom] my action",
+        context: "custom",
+        action: "my action",
       });
 
-      expect(logger.debug).toHaveBeenCalledTimes(1);
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(mockLogDebug).toHaveBeenCalledTimes(1);
+      expect(mockLogDebug).toHaveBeenCalledWith(
         "[custom] my action blocked by safe mode",
       );
     });
@@ -120,10 +127,11 @@ describe("checkSafeMode", () => {
       checkSafeMode({
         isDemoMode: false,
         isSafeModeEnabled: false,
-        context: "[test] allowed operation",
+        context: "test",
+        action: "allowed operation",
       });
 
-      expect(logger.debug).not.toHaveBeenCalled();
+      expect(mockLogDebug).not.toHaveBeenCalled();
     });
   });
 
@@ -132,7 +140,8 @@ describe("checkSafeMode", () => {
       checkSafeMode({
         isDemoMode: false,
         isSafeModeEnabled: true,
-        context: "[test] blocked",
+        context: "test",
+        action: "blocked",
       });
 
       expect(toast.warning).toHaveBeenCalledTimes(1);
@@ -143,7 +152,8 @@ describe("checkSafeMode", () => {
       checkSafeMode({
         isDemoMode: true,
         isSafeModeEnabled: true,
-        context: "[test] allowed",
+        context: "test",
+        action: "allowed",
       });
 
       expect(toast.warning).not.toHaveBeenCalled();
@@ -155,7 +165,8 @@ describe("checkSafeMode", () => {
       const result = checkSafeMode({
         isDemoMode: false,
         isSafeModeEnabled: true,
-        context: "[test]",
+        context: "test",
+        action: "blocked",
       });
 
       expect(result).toBe(true);
@@ -165,7 +176,8 @@ describe("checkSafeMode", () => {
       const result = checkSafeMode({
         isDemoMode: false,
         isSafeModeEnabled: false,
-        context: "[test]",
+        context: "test",
+        action: "allowed",
       });
 
       expect(result).toBe(false);

--- a/web-app/src/utils/safe-mode-guard.ts
+++ b/web-app/src/utils/safe-mode-guard.ts
@@ -1,11 +1,14 @@
-import { logger } from "@/utils/logger";
+import { createLogger } from "@/utils/logger";
 import { toast } from "@/stores/toast";
 import { t } from "@/i18n";
+
+const log = createLogger("SafeModeGuard");
 
 interface SafeModeGuardOptions {
   isDemoMode: boolean;
   isSafeModeEnabled: boolean;
   context: string;
+  action: string;
 }
 
 /**
@@ -20,15 +23,16 @@ interface SafeModeGuardOptions {
  * const isBlocked = checkSafeMode({
  *   isDemoMode: false,
  *   isSafeModeEnabled: true,
- *   context: "[useAssignmentActions] game validation",
+ *   context: "useAssignmentActions",
+ *   action: "game validation",
  * });
  * if (isBlocked) return;
  */
 export function checkSafeMode(options: SafeModeGuardOptions): boolean {
-  const { isDemoMode, isSafeModeEnabled, context } = options;
+  const { isDemoMode, isSafeModeEnabled, context, action } = options;
 
   if (!isDemoMode && isSafeModeEnabled) {
-    logger.debug(`${context} blocked by safe mode`);
+    log.debug(`[${context}] ${action} blocked by safe mode`);
     toast.warning(t("settings.safeModeBlocked"));
     return true;
   }


### PR DESCRIPTION
Replace manual string prefixes like "[useAssignmentActions]" with a
createLogger factory that automatically adds context to log messages.

Changes:
- Add createLogger(context) factory to logger.ts
- Export Logger interface for type safety
- Refactor 6 hooks to use context-aware loggers
- Update tests to match new log format [VolleyKit][Context]