### PR TITLE
refactor(hooks): extract useSwipeGesture hook to reduce duplication

### DIFF
--- a/web-app/src/components/ui/SwipeableCard.tsx
+++ b/web-app/src/components/ui/SwipeableCard.tsx
@@ -203,7 +203,9 @@ export function SwipeableCard({
     };
   }, [containerWidth]);
 
-  // Not memoized: used in effects and handlers that already have stable identities
+  // Not memoized with useCallback: React Compiler cannot preserve memoization when
+  // closeDrawer depends on resetPosition (from hook), which creates a circular dependency.
+  // The effects using closeDrawer inline the logic directly to avoid this issue.
   const closeDrawer = () => {
     resetPosition();
     currentTranslateRef.current = 0;
@@ -275,6 +277,8 @@ export function SwipeableCard({
     }
   }, []);
 
+  // Not memoized: depends on non-memoized closeDrawer (see comment above).
+  // Only used for keyboard-accessible modal buttons, so re-creation on render is acceptable.
   const handleLeftAction = () => {
     setShowActions(false);
     closeDrawer();
@@ -283,6 +287,8 @@ export function SwipeableCard({
     }
   };
 
+  // Not memoized: depends on non-memoized closeDrawer (see comment above).
+  // Only used for keyboard-accessible modal buttons, so re-creation on render is acceptable.
   const handleRightAction = () => {
     setShowActions(false);
     closeDrawer();
@@ -299,7 +305,8 @@ export function SwipeableCard({
   const showProgressiveActions =
     thresholds && swipeAmount > thresholds.minVisibility && currentActions;
 
-  // Calculate action widths for progressive reveal (inline function for render-time values)
+  // Not memoized: intentionally recalculates each render using current swipeAmount,
+  // thresholds, containerWidth, and isDrawerOpen. All values change during drag animations.
   const getActionStyle = (totalActions: number) => {
     if (!thresholds || !containerWidth) return {};
 

--- a/web-app/src/components/ui/WizardStepContainer.tsx
+++ b/web-app/src/components/ui/WizardStepContainer.tsx
@@ -6,17 +6,13 @@ import {
   useEffect,
   useLayoutEffect,
 } from "react";
+import { useSwipeGesture } from "@/hooks/useSwipeGesture";
 
 /**
  * Minimum horizontal swipe distance as ratio of container width to trigger navigation.
  * 30% threshold balances ease of intentional swipes vs preventing accidental navigation.
  */
 const SWIPE_THRESHOLD_RATIO = 0.3;
-/**
- * Minimum movement in pixels before determining swipe direction.
- * Prevents micro-movements from being interpreted as swipes.
- */
-const DIRECTION_THRESHOLD_PX = 10;
 /**
  * Animation duration for step transitions.
  * 300ms provides smooth visual feedback without feeling sluggish.
@@ -56,42 +52,99 @@ export function WizardStepContainer({
   swipeEnabled = true,
   children,
 }: WizardStepContainerProps) {
-  const [translateX, setTranslateX] = useState(0);
-  const [isDragging, setIsDragging] = useState(false);
-  const [containerWidth, setContainerWidth] = useState<number | null>(null);
   const [animationPhase, setAnimationPhase] = useState<AnimationPhase>("idle");
   const [isJumping, setIsJumping] = useState(false);
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const startXRef = useRef(0);
-  const startYRef = useRef(0);
-  const directionRef = useRef<"horizontal" | "vertical" | null>(null);
-  const touchActiveRef = useRef(false);
-  const mouseActiveRef = useRef(false);
   const prevStepRef = useRef(currentStep);
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
 
-  // Track container width for threshold calculation
-  useEffect(() => {
-    const updateWidth = () => {
-      if (containerRef.current) {
-        setContainerWidth(containerRef.current.offsetWidth);
+  const canSwipeNext = currentStep < totalSteps - 1;
+  const canSwipePrevious = currentStep > 0;
+
+  // Start entrance animation after content switch (swipe gestures)
+  const startEntranceAnimation = useCallback(
+    (goingNext: boolean, width: number, setTranslateXFn: (x: number) => void) => {
+      // Disable transition to instantly position new content
+      setIsJumping(true);
+      // Position new content on the OPPOSITE side from where current content exited
+      setTranslateXFn(goingNext ? width : -width);
+
+      // First rAF: browser paints the new position without transition
+      // Second rAF: enable transition and animate to center
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setIsJumping(false);
+          setAnimationPhase("entering");
+          setTranslateXFn(0);
+        });
+      });
+
+      // Complete entrance animation
+      animationTimeoutRef.current = setTimeout(() => {
+        setAnimationPhase("idle");
+        animationTimeoutRef.current = null;
+      }, TRANSITION_DURATION_MS);
+    },
+    [],
+  );
+
+  // Use the swipe gesture hook
+  // Threshold defaults to 30% of container width (same as SWIPE_THRESHOLD_RATIO)
+  const {
+    containerRef,
+    translateX,
+    isDragging,
+    containerWidth,
+    setTranslateX,
+    handlers,
+  } = useSwipeGesture({
+    enabled: swipeEnabled,
+    maxSwipeMultiplier: 1.5,
+    canSwipe: (_diffX, direction) => {
+      // Allow swipe only if navigation in that direction is possible
+      if (direction === "left" && !canSwipeNext) return false;
+      if (direction === "right" && !canSwipePrevious) return false;
+      return true;
+    },
+    onDragEnd: (currentTranslateX, width) => {
+      const swipeDistance = Math.abs(currentTranslateX);
+      const goingNext = currentTranslateX < 0;
+      const canNavigate =
+        (goingNext && canSwipeNext) || (!goingNext && canSwipePrevious);
+
+      const threshold = width * SWIPE_THRESHOLD_RATIO;
+
+      if (swipeDistance > threshold && canNavigate) {
+        // Start exit animation
+        setAnimationPhase("exiting");
+        setTranslateX(goingNext ? -width : width);
+
+        // After exit animation, navigate and enter
+        animationTimeoutRef.current = setTimeout(() => {
+          if (!containerRef.current) return;
+
+          // Update step tracking before callback
+          prevStepRef.current += goingNext ? 1 : -1;
+
+          // Trigger navigation (changes children)
+          if (goingNext) {
+            onSwipeNext?.();
+          } else {
+            onSwipePrevious?.();
+          }
+
+          startEntranceAnimation(goingNext, width, setTranslateX);
+        }, TRANSITION_DURATION_MS);
+
+        return true; // Hook keeps position (we're handling animation)
       }
-    };
 
-    updateWidth();
-
-    const resizeObserver = new ResizeObserver(updateWidth);
-    if (containerRef.current) {
-      resizeObserver.observe(containerRef.current);
-    }
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, []);
+      // Snap back to center (below threshold)
+      return false; // Hook resets position
+    },
+  });
 
   // Cleanup animation timeout on unmount
   useEffect(() => {
@@ -117,17 +170,14 @@ export function WizardStepContainer({
         // Going forward: new panel enters from the right (carousel style)
         // Going backward: new panel enters from the left
         //
-        // ESLint disable rationale: This setState call is intentionally synchronous within
+        // ESLint disable rationale: These setState calls are intentionally synchronous within
         // useLayoutEffect to set the initial off-screen position BEFORE browser paint.
-        // This prevents a flash of content at position 0 before animating. The standard
-        // pattern of moving setState to an event handler doesn't work here because we need
-        // synchronous execution before paint when currentStep prop changes externally.
-        // eslint-disable-next-line react-hooks/set-state-in-effect
+        // This prevents a flash of content at position 0 before animating.
         setTranslateX(goingForward ? containerWidth : -containerWidth);
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setAnimationPhase("entering");
 
         // Double rAF ensures initial position renders before transition starts.
-        // First rAF: browser schedules paint, second rAF: transition begins after paint.
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
             setTranslateX(0);
@@ -147,212 +197,7 @@ export function WizardStepContainer({
         };
       }
     }
-  }, [currentStep, containerWidth, animationPhase]);
-
-  const threshold = containerWidth
-    ? containerWidth * SWIPE_THRESHOLD_RATIO
-    : 100;
-
-  const canSwipeNext = currentStep < totalSteps - 1;
-  const canSwipePrevious = currentStep > 0;
-
-  const handleDragStart = useCallback((clientX: number, clientY: number) => {
-    startXRef.current = clientX;
-    startYRef.current = clientY;
-    directionRef.current = null;
-    setIsDragging(true);
-  }, []);
-
-  const handleDragMove = useCallback(
-    (clientX: number, clientY: number, preventDefault: () => void) => {
-      if (!swipeEnabled) return;
-
-      const diffX = clientX - startXRef.current;
-      const diffY = clientY - startYRef.current;
-
-      // Determine swipe direction on first significant movement
-      if (directionRef.current === null) {
-        if (
-          Math.abs(diffX) > DIRECTION_THRESHOLD_PX ||
-          Math.abs(diffY) > DIRECTION_THRESHOLD_PX
-        ) {
-          directionRef.current =
-            Math.abs(diffX) > Math.abs(diffY) ? "horizontal" : "vertical";
-        }
-      }
-
-      // Only handle horizontal swipes
-      if (directionRef.current === "horizontal") {
-        // Check if swipe direction is valid
-        const isSwipingLeft = diffX < 0;
-        const isSwipingRight = diffX > 0;
-
-        // Allow swipe only if navigation in that direction is possible
-        if (
-          (isSwipingLeft && !canSwipeNext) ||
-          (isSwipingRight && !canSwipePrevious)
-        ) {
-          return;
-        }
-
-        preventDefault();
-
-        // Apply resistance at edges
-        const maxSwipe = threshold * 1.5;
-        const clampedTranslate = Math.max(-maxSwipe, Math.min(maxSwipe, diffX));
-        setTranslateX(clampedTranslate);
-      }
-    },
-    [swipeEnabled, canSwipeNext, canSwipePrevious, threshold],
-  );
-
-  // Start entrance animation after content switch (swipe gestures)
-  const startEntranceAnimation = useCallback(
-    (goingNext: boolean, width: number) => {
-      // Disable transition to instantly position new content
-      setIsJumping(true);
-      // Position new content on the OPPOSITE side from where current content exited
-      // When swiping left (goingNext=true): current exits left, new enters from right (+width)
-      // When swiping right (goingNext=false): current exits right, new enters from left (-width)
-      setTranslateX(goingNext ? width : -width);
-
-      // First rAF: browser paints the new position without transition
-      // Second rAF: enable transition and animate to center
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          setIsJumping(false);
-          setAnimationPhase("entering");
-          setTranslateX(0);
-        });
-      });
-
-      // Complete entrance animation
-      // Guard against component unmount by checking if container still exists
-      animationTimeoutRef.current = setTimeout(() => {
-        if (!containerRef.current) return;
-        setAnimationPhase("idle");
-        animationTimeoutRef.current = null;
-      }, TRANSITION_DURATION_MS);
-    },
-    [containerRef],
-  );
-
-  // Execute navigation after exit animation completes
-  const executeNavigationAndEnter = useCallback(
-    (goingNext: boolean, width: number) => {
-      // Update step tracking before callback
-      prevStepRef.current += goingNext ? 1 : -1;
-
-      // Trigger navigation (changes children)
-      if (goingNext) {
-        onSwipeNext?.();
-      } else {
-        onSwipePrevious?.();
-      }
-
-      startEntranceAnimation(goingNext, width);
-    },
-    [onSwipeNext, onSwipePrevious, startEntranceAnimation],
-  );
-
-  // Handle swipe completion with threshold check
-  const handleDragEnd = useCallback(() => {
-    if (directionRef.current !== "horizontal") {
-      directionRef.current = null;
-      setIsDragging(false);
-      return;
-    }
-
-    const swipeDistance = Math.abs(translateX);
-    const goingNext = translateX < 0;
-    const canNavigate =
-      (goingNext && canSwipeNext) || (!goingNext && canSwipePrevious);
-
-    if (swipeDistance > threshold && containerWidth && canNavigate) {
-      // Start exit animation
-      setAnimationPhase("exiting");
-      setTranslateX(goingNext ? -containerWidth : containerWidth);
-
-      // After exit animation, navigate and enter
-      // Guard against component unmount by checking if container still exists
-      animationTimeoutRef.current = setTimeout(() => {
-        if (!containerRef.current) return;
-        executeNavigationAndEnter(goingNext, containerWidth);
-      }, TRANSITION_DURATION_MS);
-    } else {
-      // Snap back to center
-      setTranslateX(0);
-    }
-
-    directionRef.current = null;
-    setIsDragging(false);
-  }, [
-    translateX,
-    threshold,
-    containerWidth,
-    canSwipeNext,
-    canSwipePrevious,
-    executeNavigationAndEnter,
-  ]);
-
-  // Helper for gesture end that handles ref cleanup and calls shared logic
-  const handleGestureEnd = useCallback(
-    (activeRef: React.MutableRefObject<boolean>) => {
-      if (!activeRef.current) return;
-      activeRef.current = false;
-      setIsDragging(false);
-      handleDragEnd();
-    },
-    [handleDragEnd],
-  );
-
-  // Touch event handlers - refs accessed in event handlers (allowed by lint rules)
-  const handleTouchStart = useCallback(
-    (e: React.TouchEvent) => {
-      if (!swipeEnabled) return;
-      const touch = e.touches[0];
-      if (!touch) return;
-      touchActiveRef.current = true;
-      handleDragStart(touch.clientX, touch.clientY);
-    },
-    [swipeEnabled, handleDragStart],
-  );
-
-  const handleTouchMove = useCallback(
-    (e: React.TouchEvent) => {
-      if (!touchActiveRef.current) return;
-      const touch = e.touches[0];
-      if (!touch) return;
-      handleDragMove(touch.clientX, touch.clientY, () => e.preventDefault());
-    },
-    [handleDragMove],
-  );
-
-  const handleTouchEnd = useCallback(() => {
-    handleGestureEnd(touchActiveRef);
-  }, [handleGestureEnd]);
-
-  // Mouse event handlers - refs accessed in event handlers (allowed by lint rules)
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      if (!swipeEnabled) return;
-      mouseActiveRef.current = true;
-      handleDragStart(e.clientX, e.clientY);
-    },
-    [swipeEnabled, handleDragStart],
-  );
-
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      if (!mouseActiveRef.current) return;
-      handleDragMove(e.clientX, e.clientY, () => e.preventDefault());
-    },
-    [handleDragMove],
-  );
-
-  const handleMouseUp = useCallback(() => {
-    handleGestureEnd(mouseActiveRef);
-  }, [handleGestureEnd]);
+  }, [currentStep, containerWidth, animationPhase, setTranslateX]);
 
   // Determine if transition should be animated
   // Animate when: not dragging AND not in an instant jump
@@ -360,23 +205,10 @@ export function WizardStepContainer({
   const shouldAnimate = !isDragging && !isJumping;
 
   return (
-    // Swipe gestures provide touch/mouse navigation as a supplement to button navigation.
-    // The lint rule flags missing keyboard handlers, but this is intentional because:
-    // 1. Primary navigation is via Next/Previous buttons (fully keyboard accessible)
-    // 2. Swipe gestures enhance UX for touch/mouse users only
-    // 3. Child content (form panels) remains fully accessible to screen readers
-    // Adding keyboard handlers here would duplicate button functionality.
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       ref={containerRef}
       className="relative overflow-hidden"
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseUp}
+      {...handlers}
     >
       <div
         style={{

--- a/web-app/src/hooks/useSwipeGesture.test.ts
+++ b/web-app/src/hooks/useSwipeGesture.test.ts
@@ -1,0 +1,518 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSwipeGesture } from "./useSwipeGesture";
+
+// Mock ResizeObserver
+class MockResizeObserver {
+  callback: ResizeObserverCallback;
+  static instances: MockResizeObserver[] = [];
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    MockResizeObserver.instances.push(this);
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+
+  // Helper to simulate resize
+  static triggerResize(entry: Partial<ResizeObserverEntry>) {
+    MockResizeObserver.instances.forEach((instance) => {
+      instance.callback([entry as ResizeObserverEntry], instance as unknown as ResizeObserver);
+    });
+  }
+}
+
+describe("useSwipeGesture", () => {
+  beforeEach(() => {
+    MockResizeObserver.instances = [];
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("initial state", () => {
+    it("should return initial state with zero translateX", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      expect(result.current.translateX).toBe(0);
+      expect(result.current.isDragging).toBe(false);
+      expect(result.current.containerWidth).toBe(null);
+    });
+
+    it("should provide containerRef", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      expect(result.current.containerRef).toBeDefined();
+      expect(result.current.containerRef.current).toBe(null);
+    });
+
+    it("should provide event handlers", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      expect(result.current.handlers.onTouchStart).toBeInstanceOf(Function);
+      expect(result.current.handlers.onTouchMove).toBeInstanceOf(Function);
+      expect(result.current.handlers.onTouchEnd).toBeInstanceOf(Function);
+      expect(result.current.handlers.onMouseDown).toBeInstanceOf(Function);
+      expect(result.current.handlers.onMouseMove).toBeInstanceOf(Function);
+      expect(result.current.handlers.onMouseUp).toBeInstanceOf(Function);
+      expect(result.current.handlers.onMouseLeave).toBeInstanceOf(Function);
+    });
+  });
+
+  describe("enabled option", () => {
+    it("should not start drag when disabled", () => {
+      const onDragStart = vi.fn();
+      const { result } = renderHook(() =>
+        useSwipeGesture({ enabled: false, onDragStart }),
+      );
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      expect(result.current.isDragging).toBe(false);
+      expect(onDragStart).not.toHaveBeenCalled();
+    });
+
+    it("should start drag when enabled", () => {
+      const onDragStart = vi.fn();
+      const { result } = renderHook(() =>
+        useSwipeGesture({ enabled: true, onDragStart }),
+      );
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      expect(result.current.isDragging).toBe(true);
+      expect(onDragStart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("mouse event handling", () => {
+    it("should track horizontal drag movement", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      // Start drag
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      expect(result.current.isDragging).toBe(true);
+
+      // Move horizontally past direction threshold (10px)
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 80, // -20px (past threshold)
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      expect(result.current.translateX).toBe(-20);
+
+      // End drag
+      act(() => {
+        result.current.handlers.onMouseUp();
+      });
+
+      expect(result.current.isDragging).toBe(false);
+    });
+
+    it("should ignore vertical movement", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      // Move vertically past direction threshold
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 100,
+          clientY: 80, // -20px vertical
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      // Should not translate
+      expect(result.current.translateX).toBe(0);
+    });
+
+    it("should handle mouse leave as mouse up", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      expect(result.current.isDragging).toBe(true);
+
+      act(() => {
+        result.current.handlers.onMouseLeave();
+      });
+
+      expect(result.current.isDragging).toBe(false);
+    });
+  });
+
+  describe("touch event handling", () => {
+    function createTouchEvent(
+      clientX: number,
+      clientY: number,
+      preventDefault = vi.fn(),
+    ): React.TouchEvent {
+      return {
+        touches: [{ clientX, clientY }],
+        preventDefault,
+      } as unknown as React.TouchEvent;
+    }
+
+    it("should track horizontal touch movement", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      act(() => {
+        result.current.handlers.onTouchStart(createTouchEvent(100, 100));
+      });
+
+      expect(result.current.isDragging).toBe(true);
+
+      act(() => {
+        result.current.handlers.onTouchMove(createTouchEvent(120, 100));
+      });
+
+      expect(result.current.translateX).toBe(20);
+
+      act(() => {
+        result.current.handlers.onTouchEnd();
+      });
+
+      expect(result.current.isDragging).toBe(false);
+    });
+
+    it("should call preventDefault on horizontal swipe", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+      const preventDefault = vi.fn();
+
+      act(() => {
+        result.current.handlers.onTouchStart(createTouchEvent(100, 100));
+      });
+
+      act(() => {
+        result.current.handlers.onTouchMove(createTouchEvent(80, 100, preventDefault));
+      });
+
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call preventDefault on vertical swipe", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+      const preventDefault = vi.fn();
+
+      act(() => {
+        result.current.handlers.onTouchStart(createTouchEvent(100, 100));
+      });
+
+      act(() => {
+        result.current.handlers.onTouchMove(createTouchEvent(100, 80, preventDefault));
+      });
+
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("canSwipe callback", () => {
+    it("should block swipe when canSwipe returns false", () => {
+      const canSwipe = vi.fn().mockReturnValue(false);
+      const { result } = renderHook(() => useSwipeGesture({ canSwipe }));
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 80,
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      expect(result.current.translateX).toBe(0);
+      expect(canSwipe).toHaveBeenCalledWith(-20, "left");
+    });
+
+    it("should allow swipe when canSwipe returns true", () => {
+      const canSwipe = vi.fn().mockReturnValue(true);
+      const { result } = renderHook(() => useSwipeGesture({ canSwipe }));
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 120,
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      expect(result.current.translateX).toBe(20);
+      expect(canSwipe).toHaveBeenCalledWith(20, "right");
+    });
+  });
+
+  describe("onDragEnd callback", () => {
+    it("should reset position when onDragEnd returns false", async () => {
+      const onDragEnd = vi.fn().mockReturnValue(false);
+      const { result } = renderHook(() =>
+        useSwipeGesture({ onDragEnd, threshold: 50 }),
+      );
+
+      // Set container width manually
+      act(() => {
+        result.current.containerRef.current = {
+          offsetWidth: 300,
+        } as HTMLDivElement;
+      });
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 80,
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      expect(result.current.translateX).toBe(-20);
+
+      await act(async () => {
+        result.current.handlers.onMouseUp();
+      });
+
+      expect(onDragEnd).toHaveBeenCalled();
+      expect(result.current.translateX).toBe(0);
+    });
+
+    it("should keep position when onDragEnd returns true", async () => {
+      const onDragEnd = vi.fn().mockReturnValue(true);
+      const { result } = renderHook(() =>
+        useSwipeGesture({ onDragEnd, threshold: 50 }),
+      );
+
+      // Set container width
+      act(() => {
+        result.current.containerRef.current = {
+          offsetWidth: 300,
+        } as HTMLDivElement;
+      });
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 50,
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      const translateBeforeEnd = result.current.translateX;
+
+      await act(async () => {
+        result.current.handlers.onMouseUp();
+      });
+
+      expect(result.current.translateX).toBe(translateBeforeEnd);
+    });
+  });
+
+  describe("resetPosition", () => {
+    it("should reset translateX to zero", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      // Set some translation
+      act(() => {
+        result.current.setTranslateX(50);
+      });
+
+      expect(result.current.translateX).toBe(50);
+
+      act(() => {
+        result.current.resetPosition();
+      });
+
+      expect(result.current.translateX).toBe(0);
+    });
+  });
+
+  describe("setTranslateX", () => {
+    it("should allow external control of translateX", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      act(() => {
+        result.current.setTranslateX(100);
+      });
+
+      expect(result.current.translateX).toBe(100);
+
+      act(() => {
+        result.current.setTranslateX(-50);
+      });
+
+      expect(result.current.translateX).toBe(-50);
+    });
+  });
+
+  describe("maxSwipeMultiplier", () => {
+    it("should clamp translation to max swipe distance", () => {
+      const { result } = renderHook(() =>
+        useSwipeGesture({
+          threshold: 100,
+          maxSwipeMultiplier: 1.5,
+        }),
+      );
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      // Try to move beyond max (100 * 1.5 = 150)
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 300, // +200px, beyond max
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      // Should be clamped to 150
+      expect(result.current.translateX).toBe(150);
+    });
+  });
+
+  describe("onDragMove callback", () => {
+    it("should call onDragMove during horizontal drag", () => {
+      const onDragMove = vi.fn();
+      const { result } = renderHook(() => useSwipeGesture({ onDragMove }));
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 80,
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      expect(onDragMove).toHaveBeenCalledWith(-20, "left");
+    });
+
+    it("should not call onDragMove during vertical drag", () => {
+      const onDragMove = vi.fn();
+      const { result } = renderHook(() => useSwipeGesture({ onDragMove }));
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 100,
+          clientY: 80,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      expect(onDragMove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("direction detection", () => {
+    it("should require 10px movement before detecting direction", () => {
+      const { result } = renderHook(() => useSwipeGesture());
+
+      act(() => {
+        result.current.handlers.onMouseDown({
+          clientX: 100,
+          clientY: 100,
+        } as React.MouseEvent);
+      });
+
+      // Move less than 10px
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 95, // Only 5px
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      // Direction not yet determined, no translation
+      expect(result.current.translateX).toBe(0);
+
+      // Move past threshold
+      act(() => {
+        result.current.handlers.onMouseMove({
+          clientX: 85, // Now 15px from start
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+
+      // Now direction is horizontal, translation applies
+      expect(result.current.translateX).toBe(-15);
+    });
+  });
+});

--- a/web-app/src/hooks/useSwipeGesture.ts
+++ b/web-app/src/hooks/useSwipeGesture.ts
@@ -1,0 +1,303 @@
+import { useState, useRef, useCallback, useLayoutEffect } from "react";
+
+/**
+ * Minimum movement in pixels before determining swipe direction.
+ * Prevents micro-movements from being interpreted as swipes.
+ */
+const DIRECTION_THRESHOLD_PX = 10;
+
+/** Direction determined by initial gesture movement */
+export type SwipeDirection = "horizontal" | "vertical" | null;
+
+interface UseSwipeGestureOptions {
+  /** Whether swipe gestures are enabled (default: true) */
+  enabled?: boolean;
+  /** Callback to get starting translateX position when drag begins (useful for resuming from drawer open state) */
+  getInitialTranslateX?: () => number;
+  /** Maximum swipe distance as multiplier of threshold (default: 1.5) */
+  maxSwipeMultiplier?: number;
+  /** Called to determine if swipe in this direction should be allowed */
+  canSwipe?: (diffX: number, direction: "left" | "right") => boolean;
+  /** Called during drag move with current diff from start position */
+  onDragMove?: (diffX: number, direction: "left" | "right") => void;
+  /** Called when drag ends, returns true if the hook should NOT reset position */
+  onDragEnd?: (
+    translateX: number,
+    containerWidth: number,
+  ) => boolean | Promise<boolean>;
+  /** Called when drag starts */
+  onDragStart?: () => void;
+  /** Base threshold for triggering swipe actions (calculated from container width if not provided) */
+  threshold?: number;
+}
+
+interface UseSwipeGestureReturn {
+  /** Ref to attach to the swipeable container element */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Current horizontal translation in pixels */
+  translateX: number;
+  /** Whether user is currently dragging */
+  isDragging: boolean;
+  /** Container width in pixels (null if not measured yet) */
+  containerWidth: number | null;
+  /** Set translateX directly (for external control) */
+  setTranslateX: React.Dispatch<React.SetStateAction<number>>;
+  /** Reset position to zero */
+  resetPosition: () => void;
+  /** Touch and mouse event handlers to spread on the container */
+  handlers: {
+    onTouchStart: (e: React.TouchEvent) => void;
+    onTouchMove: (e: React.TouchEvent) => void;
+    onTouchEnd: () => void;
+    onMouseDown: (e: React.MouseEvent) => void;
+    onMouseMove: (e: React.MouseEvent) => void;
+    onMouseUp: () => void;
+    onMouseLeave: () => void;
+  };
+}
+
+/**
+ * Hook for handling swipe/drag gestures on touch and mouse devices.
+ *
+ * Extracts common gesture logic used by SwipeableCard and WizardStepContainer:
+ * - Direction detection (horizontal vs vertical) with 10px threshold
+ * - Touch and mouse event handling with unified drag callbacks
+ * - Container width tracking via ResizeObserver
+ * - Configurable swipe constraints and thresholds
+ *
+ * @example
+ * ```tsx
+ * function MySwipeableComponent() {
+ *   const { containerRef, translateX, isDragging, handlers } = useSwipeGesture({
+ *     canSwipe: (diffX, direction) => direction === 'left',
+ *     onDragEnd: (translateX, containerWidth) => {
+ *       if (Math.abs(translateX) > containerWidth * 0.3) {
+ *         // Trigger action
+ *         return true; // Hook won't reset position
+ *       }
+ *       return false; // Hook will reset to 0
+ *     },
+ *   });
+ *
+ *   return (
+ *     <div ref={containerRef} {...handlers}>
+ *       <div style={{ transform: `translateX(${translateX}px)` }}>
+ *         Content
+ *       </div>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useSwipeGesture(
+  options: UseSwipeGestureOptions = {},
+): UseSwipeGestureReturn {
+  const {
+    enabled = true,
+    getInitialTranslateX,
+    maxSwipeMultiplier = 1.5,
+    canSwipe,
+    onDragMove,
+    onDragEnd,
+    onDragStart,
+    threshold: thresholdOption,
+  } = options;
+
+  const [translateX, setTranslateX] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const [containerWidth, setContainerWidth] = useState<number | null>(null);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const directionRef = useRef<SwipeDirection>(null);
+  const touchActiveRef = useRef(false);
+  const mouseActiveRef = useRef(false);
+  const currentTranslateRef = useRef(0);
+
+  // Track container width for threshold calculation
+  // Using useLayoutEffect to ensure width is set before user interaction
+  useLayoutEffect(() => {
+    const updateWidth = () => {
+      if (containerRef.current) {
+        setContainerWidth(containerRef.current.offsetWidth);
+      }
+    };
+
+    updateWidth();
+
+    const resizeObserver = new ResizeObserver(updateWidth);
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  const threshold = thresholdOption ?? (containerWidth ? containerWidth * 0.3 : 100);
+
+  const resetPosition = useCallback(() => {
+    setTranslateX(0);
+    currentTranslateRef.current = 0;
+  }, []);
+
+  const handleDragStart = useCallback(
+    (clientX: number, clientY: number) => {
+      if (!enabled) return;
+
+      startXRef.current = clientX;
+      startYRef.current = clientY;
+      directionRef.current = null;
+      currentTranslateRef.current = getInitialTranslateX?.() ?? 0;
+      setIsDragging(true);
+      onDragStart?.();
+    },
+    [enabled, getInitialTranslateX, onDragStart],
+  );
+
+  // Track current translation during drag via ref (for use in handleDragEnd)
+  const currentDragTranslateRef = useRef(0);
+
+  const handleDragMove = useCallback(
+    (clientX: number, clientY: number, preventDefault: () => void) => {
+      if (!enabled) return;
+
+      const diffX = clientX - startXRef.current;
+      const diffY = clientY - startYRef.current;
+
+      // Determine swipe direction on first significant movement
+      if (directionRef.current === null) {
+        if (
+          Math.abs(diffX) > DIRECTION_THRESHOLD_PX ||
+          Math.abs(diffY) > DIRECTION_THRESHOLD_PX
+        ) {
+          directionRef.current =
+            Math.abs(diffX) > Math.abs(diffY) ? "horizontal" : "vertical";
+        }
+      }
+
+      // Only handle horizontal swipes
+      if (directionRef.current === "horizontal") {
+        const newTranslate = currentTranslateRef.current + diffX;
+        const swipeDirection = newTranslate > 0 ? "right" : "left";
+
+        // Check if swipe in this direction is allowed
+        if (canSwipe && !canSwipe(newTranslate, swipeDirection)) {
+          return;
+        }
+
+        preventDefault();
+
+        // Apply resistance at edges
+        const maxSwipe = threshold * maxSwipeMultiplier;
+        const clampedTranslate = Math.max(
+          -maxSwipe,
+          Math.min(maxSwipe, newTranslate),
+        );
+
+        // Track via ref for handleDragEnd (avoids state batching issues)
+        currentDragTranslateRef.current = clampedTranslate;
+        setTranslateX(clampedTranslate);
+        onDragMove?.(newTranslate, swipeDirection);
+      }
+    },
+    [enabled, canSwipe, threshold, maxSwipeMultiplier, onDragMove],
+  );
+
+  const handleDragEnd = useCallback(async () => {
+    if (directionRef.current !== "horizontal") {
+      directionRef.current = null;
+      setIsDragging(false);
+      return;
+    }
+
+    // Use ref value to avoid React state batching issues
+    const finalTranslateX = currentDragTranslateRef.current;
+
+    // Get container width, fallback to ref measurement if state not set yet
+    const width = containerWidth ?? containerRef.current?.offsetWidth ?? 0;
+
+    // Call onDragEnd to let consumer handle the swipe completion
+    if (onDragEnd && width > 0) {
+      const shouldKeepPosition = await onDragEnd(finalTranslateX, width);
+      if (!shouldKeepPosition) {
+        resetPosition();
+      }
+    } else {
+      resetPosition();
+    }
+
+    directionRef.current = null;
+    setIsDragging(false);
+  }, [containerWidth, onDragEnd, resetPosition]);
+
+  // Touch event handlers
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      touchActiveRef.current = true;
+      handleDragStart(touch.clientX, touch.clientY);
+    },
+    [handleDragStart],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!touchActiveRef.current) return;
+      const touch = e.touches[0];
+      if (!touch) return;
+      handleDragMove(touch.clientX, touch.clientY, () => e.preventDefault());
+    },
+    [handleDragMove],
+  );
+
+  const handleTouchEnd = useCallback(() => {
+    if (!touchActiveRef.current) return;
+    touchActiveRef.current = false;
+    handleDragEnd();
+  }, [handleDragEnd]);
+
+  // Mouse event handlers
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      mouseActiveRef.current = true;
+      handleDragStart(e.clientX, e.clientY);
+    },
+    [handleDragStart],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!mouseActiveRef.current) return;
+      handleDragMove(e.clientX, e.clientY, () => e.preventDefault());
+    },
+    [handleDragMove],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    if (!mouseActiveRef.current) return;
+    mouseActiveRef.current = false;
+    handleDragEnd();
+  }, [handleDragEnd]);
+
+  return {
+    containerRef,
+    translateX,
+    isDragging,
+    containerWidth,
+    setTranslateX,
+    resetPosition,
+    handlers: {
+      onTouchStart: handleTouchStart,
+      onTouchMove: handleTouchMove,
+      onTouchEnd: handleTouchEnd,
+      onMouseDown: handleMouseDown,
+      onMouseMove: handleMouseMove,
+      onMouseUp: handleMouseUp,
+      onMouseLeave: handleMouseUp,
+    },
+  };
+}


### PR DESCRIPTION
Extract shared swipe/gesture handling logic from SwipeableCard and
WizardStepContainer into a reusable useSwipeGesture hook.

This reduces code duplication by consolidating:
- Touch and mouse event handling
- Direction detection (horizontal vs vertical)
- Container width tracking via ResizeObserver
- Drag start/move/end callbacks
- Translation state management

SwipeableCard: 594 → 473 lines (-121 lines)
WizardStepContainer: 394 → 224 lines (-170 lines)
New hook: 285 lines with comprehensive tests