### PR TITLE
feat(demo): add restricted compensation editing for regional associations

### DIFF
--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -1,11 +1,12 @@
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { Badge } from "@/components/ui/Badge";
-import { Check, Circle } from "@/components/ui/icons";
+import { Check, Circle, Lock } from "@/components/ui/icons";
 import type { CompensationRecord } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateLocale } from "@/hooks/useDateFormat";
 import { formatDistanceKm } from "@/utils/distance";
+import { isCompensationEditable } from "@/utils/compensation-actions";
 
 interface CompensationCardProps {
   compensation: CompensationRecord;
@@ -33,6 +34,9 @@ export function CompensationCard({
 
   const total = (comp?.gameCompensation || 0) + (comp?.travelExpenses || 0);
   const isPaid = comp?.paymentDone;
+  const canEdit = isCompensationEditable(compensation);
+  // Show restriction notice when not editable due to on-site payout (not just paid status)
+  const showEditRestriction = !canEdit && !isPaid;
 
   return (
     <ExpandableCard
@@ -135,6 +139,12 @@ export function CompensationCard({
                   : t("compensations.pending")}
               </span>
             </div>
+            {showEditRestriction && (
+              <div className="flex items-center gap-1.5 text-xs pt-2 text-text-muted dark:text-text-muted-dark">
+                <Lock className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                <span>{t("compensations.editingRestrictedByRegion")}</span>
+              </div>
+            )}
           </div>
         )
       }

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -119,6 +119,8 @@ const de: Translations = {
     pdfNotAvailableDemo: "PDF-Downloads sind im Demo-Modus nicht verfügbar",
     pdfDownloadFailed:
       "PDF konnte nicht heruntergeladen werden. Bitte versuchen Sie es später erneut.",
+    editingRestrictedByRegion:
+      "Bearbeitung ist für diese Region nicht verfügbar. Die Entschädigung wird vor Ort ausgezahlt.",
   },
   exchange: {
     title: "Tauschbörse",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -119,6 +119,8 @@ const en: Translations = {
     pdfNotAvailableDemo: "PDF downloads are not available in demo mode",
     pdfDownloadFailed:
       "Failed to download compensation PDF. Please try again later.",
+    editingRestrictedByRegion:
+      "Editing is not available for this region. Compensation is paid on-site.",
   },
   exchange: {
     title: "Exchange",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -119,6 +119,8 @@ const fr: Translations = {
       "Les téléchargements PDF ne sont pas disponibles en mode démo",
     pdfDownloadFailed:
       "Échec du téléchargement du PDF. Veuillez réessayer plus tard.",
+    editingRestrictedByRegion:
+      "La modification n'est pas disponible pour cette région. L'indemnité est payée sur place.",
   },
   exchange: {
     title: "Bourse aux échanges",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -117,6 +117,8 @@ const it: Translations = {
     errorLoading: "Impossibile caricare i compensi",
     pdfNotAvailableDemo: "I download PDF non sono disponibili in modalità demo",
     pdfDownloadFailed: "Impossibile scaricare il PDF. Riprova più tardi.",
+    editingRestrictedByRegion:
+      "La modifica non è disponibile per questa regione. Il compenso viene pagato sul posto.",
   },
   exchange: {
     title: "Borsa scambi",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -117,6 +117,7 @@ export interface Translations {
     errorLoading: string;
     pdfNotAvailableDemo: string;
     pdfDownloadFailed: string;
+    editingRestrictedByRegion: string;
   };
   exchange: {
     title: string;

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/components/ui/LoadingSpinner";
 import { Tabs, TabPanel } from "@/components/ui/Tabs";
 import { useCompensationActions } from "@/hooks/useCompensationActions";
-import { createCompensationActions } from "@/utils/compensation-actions";
+import {
+  createCompensationActions,
+  isCompensationEditable,
+} from "@/utils/compensation-actions";
 import type { CompensationRecord } from "@/api/client";
 import type { SwipeConfig } from "@/types/swipe";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -57,12 +60,12 @@ export function CompensationsPage() {
         onGeneratePDF: handleGeneratePDF,
       });
 
-      const isPaid = compensation.convocationCompensation?.paymentDone;
+      const canEdit = isCompensationEditable(compensation);
 
       return {
-        left: isPaid
-          ? [actions.generatePDF]
-          : [actions.editCompensation, actions.generatePDF],
+        left: canEdit
+          ? [actions.editCompensation, actions.generatePDF]
+          : [actions.generatePDF],
       };
     },
     [editCompensationModal.open, handleGeneratePDF],

--- a/web-app/src/stores/demo-generators.ts
+++ b/web-app/src/stores/demo-generators.ts
@@ -437,6 +437,8 @@ interface CompensationConfig {
   paymentDaysAgo?: number;
   transportationMode?: "car" | "train";
   correctionReason?: string | null;
+  /** Override the default lock behavior for this specific compensation */
+  lockPayoutOnSiteCompensation?: boolean;
 }
 
 function createCompensationRecord(
@@ -445,6 +447,12 @@ function createCompensationRecord(
   now: Date,
   isSV: boolean,
 ): CompensationRecord {
+  // Regional associations use on-site payout, which locks compensation editing
+  // unless explicitly overridden in config
+  const useOnSitePayout = !isSV;
+  const lockPayoutOnSiteCompensation =
+    config.lockPayoutOnSiteCompensation ?? useOnSitePayout;
+
   return {
     __identity: generateDemoUuid(`demo-comp-${config.index}`),
     refereeConvocationStatus: "active",
@@ -473,6 +481,8 @@ function createCompensationRecord(
         }),
         transportationMode: config.transportationMode,
         correctionReason: config.correctionReason,
+        lockPayoutOnSiteCompensation,
+        methodOfDisbursement: useOnSitePayout ? "payout_on_site" : "central_payout",
       }),
     },
   };

--- a/web-app/src/utils/compensation-actions.test.ts
+++ b/web-app/src/utils/compensation-actions.test.ts
@@ -3,6 +3,7 @@ import { isValidElement } from "react";
 import {
   createCompensationActions,
   downloadCompensationPDF,
+  isCompensationEditable,
 } from "./compensation-actions";
 import type { CompensationRecord } from "@/api/client";
 
@@ -302,5 +303,68 @@ describe("downloadCompensationPDF", () => {
 
     const fetchCall = mockFetch.mock.calls[0]?.[0] as string;
     expect(fetchCall).toContain(encodeURIComponent("   "));
+  });
+});
+
+describe("isCompensationEditable", () => {
+  it("returns true for unpaid compensation with central payout", () => {
+    const compensation = {
+      __identity: "test-1",
+      convocationCompensation: {
+        paymentDone: false,
+        lockPayoutOnSiteCompensation: false,
+      },
+      refereeGame: {},
+    } as unknown as CompensationRecord;
+
+    expect(isCompensationEditable(compensation)).toBe(true);
+  });
+
+  it("returns false for paid compensation", () => {
+    const compensation = {
+      __identity: "test-1",
+      convocationCompensation: {
+        paymentDone: true,
+        lockPayoutOnSiteCompensation: false,
+      },
+      refereeGame: {},
+    } as unknown as CompensationRecord;
+
+    expect(isCompensationEditable(compensation)).toBe(false);
+  });
+
+  it("returns false when on-site payout is locked (regional association)", () => {
+    const compensation = {
+      __identity: "test-1",
+      convocationCompensation: {
+        paymentDone: false,
+        lockPayoutOnSiteCompensation: true,
+      },
+      refereeGame: {},
+    } as unknown as CompensationRecord;
+
+    expect(isCompensationEditable(compensation)).toBe(false);
+  });
+
+  it("returns false when convocationCompensation is undefined", () => {
+    const compensation = {
+      __identity: "test-1",
+      refereeGame: {},
+    } as unknown as CompensationRecord;
+
+    expect(isCompensationEditable(compensation)).toBe(false);
+  });
+
+  it("returns true when lockPayoutOnSiteCompensation is undefined (defaults to editable)", () => {
+    const compensation = {
+      __identity: "test-1",
+      convocationCompensation: {
+        paymentDone: false,
+        // lockPayoutOnSiteCompensation not set
+      },
+      refereeGame: {},
+    } as unknown as CompensationRecord;
+
+    expect(isCompensationEditable(compensation)).toBe(true);
   });
 });

--- a/web-app/src/utils/compensation-actions.ts
+++ b/web-app/src/utils/compensation-actions.ts
@@ -4,6 +4,16 @@ import { type SwipeAction, SWIPE_ACTION_ICON_SIZE } from "@/types/swipe";
 import { Wallet, FileText } from "@/components/ui/icons";
 
 /**
+ * Extended compensation type that includes lock flags.
+ * The API returns these fields in ConvocationCompensationDetailed,
+ * and demo mode generates them for testing regional association behavior.
+ */
+interface ConvocationCompensationWithLockFlags {
+  paymentDone?: boolean;
+  lockPayoutOnSiteCompensation?: boolean;
+}
+
+/**
  * Checks if a compensation record can be edited.
  *
  * Editability rules:
@@ -12,16 +22,16 @@ import { Wallet, FileText } from "@/components/ui/icons";
  * - Editable: lockPayoutOnSiteCompensation=false AND paymentDone=false
  */
 export function isCompensationEditable(compensation: CompensationRecord): boolean {
-  const cc = compensation.convocationCompensation;
+  const cc = compensation.convocationCompensation as
+    | ConvocationCompensationWithLockFlags
+    | undefined;
   if (!cc) return false;
 
   // Already paid - not editable
   if (cc.paymentDone) return false;
 
-  // On-site payout locked - not editable
-  // Access the property dynamically since it's not in the base type
-  const lockOnSite = (cc as Record<string, unknown>).lockPayoutOnSiteCompensation;
-  if (lockOnSite === true) return false;
+  // On-site payout locked - not editable (regional associations)
+  if (cc.lockPayoutOnSiteCompensation === true) return false;
 
   return true;
 }

--- a/web-app/src/utils/compensation-actions.ts
+++ b/web-app/src/utils/compensation-actions.ts
@@ -3,6 +3,29 @@ import type { CompensationRecord } from "@/api/client";
 import { type SwipeAction, SWIPE_ACTION_ICON_SIZE } from "@/types/swipe";
 import { Wallet, FileText } from "@/components/ui/icons";
 
+/**
+ * Checks if a compensation record can be edited.
+ *
+ * Editability rules:
+ * - Non-editable: lockPayoutOnSiteCompensation=true AND paymentDone=false (on-site payout locked)
+ * - Non-editable: paymentDone=true (already paid)
+ * - Editable: lockPayoutOnSiteCompensation=false AND paymentDone=false
+ */
+export function isCompensationEditable(compensation: CompensationRecord): boolean {
+  const cc = compensation.convocationCompensation;
+  if (!cc) return false;
+
+  // Already paid - not editable
+  if (cc.paymentDone) return false;
+
+  // On-site payout locked - not editable
+  // Access the property dynamically since it's not in the base type
+  const lockOnSite = (cc as Record<string, unknown>).lockPayoutOnSiteCompensation;
+  if (lockOnSite === true) return false;
+
+  return true;
+}
+
 // Pre-created icon elements to avoid recreating on each function call
 const ICON_WALLET = createElement(Wallet, { size: SWIPE_ACTION_ICON_SIZE });
 const ICON_FILE_TEXT = createElement(FileText, { size: SWIPE_ACTION_ICON_SIZE });

--- a/web-app/src/utils/demo-compensation.ts
+++ b/web-app/src/utils/demo-compensation.ts
@@ -76,6 +76,10 @@ export interface CompensationParams {
   paymentValueDate?: string;
   transportationMode?: "car" | "train";
   correctionReason?: string | null;
+  /** When true, compensation is locked for on-site payout (non-editable) */
+  lockPayoutOnSiteCompensation?: boolean;
+  /** Disbursement method: payout_on_site or central_payout */
+  methodOfDisbursement?: "payout_on_site" | "central_payout";
 }
 
 export function createCompensationData({
@@ -86,6 +90,8 @@ export function createCompensationData({
   paymentValueDate,
   transportationMode = "car",
   correctionReason = null,
+  lockPayoutOnSiteCompensation = false,
+  methodOfDisbursement = "central_payout",
 }: CompensationParams) {
   const gameCompensation = getCompensationForPosition(position, isSV);
   const travelExpenses = calculateTravelExpenses(distanceInMetres);
@@ -108,5 +114,11 @@ export function createCompensationData({
     hasFlexibleCateringExpenses: false,
     overnightStayExpensesFormatted: "0.00",
     cateringExpensesFormatted: "0.00",
+    // Lock flags for editability
+    lockPayoutOnSiteCompensation,
+    lockPayoutCentralPayoutCompensation: paymentDone,
+    // Disbursement methods
+    methodOfDisbursementArbitration: methodOfDisbursement,
+    methodOfDisbursementTravelCompensation: methodOfDisbursement,
   };
 }


### PR DESCRIPTION
Regional associations (SVRBA, SVRZ) use on-site payout for referee
compensations, which means referees cannot edit their distance/correction
after the game. This change adds demo mode support for this scenario:

- Add lockPayoutOnSiteCompensation and methodOfDisbursement fields to
  demo compensation data generation
- Regional associations now generate compensations with on-site payout
  locked, preventing editing
- Update CompensationsPage to check isCompensationEditable() before
  showing the edit action in the swipe menu
- Add translations for the restricted editing message in all 4 languages
- Add unit tests for isCompensationEditable function

This allows users to see and test the behavior difference between SV
(national) and regional associations in demo mode.