### PR TITLE
feat(api): allow JPEG and PNG uploads for scoresheets

### DIFF
--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -969,7 +969,7 @@ paths:
       description: |
         Finalizes and closes a scoresheet after the game.
         Once finalized, the scoresheet becomes read-only.
-        A PDF file must be attached before finalization.
+        A scoresheet file (JPEG, PNG, or PDF) must be attached before finalization.
       operationId: finalizeScoresheet
       requestBody:
         required: true
@@ -1184,8 +1184,9 @@ paths:
       tags: [Resources]
       summary: Upload file
       description: |
-        Uploads a file (e.g., scoresheet PDF) and returns a resource reference.
+        Uploads a file (scoresheet image or PDF) and returns a resource reference.
         The returned resource can be attached to entities like scoresheets.
+        Supported formats: JPEG, PNG, PDF. Maximum file size: 10 MB.
       operationId: uploadResource
       requestBody:
         required: true
@@ -5232,7 +5233,7 @@ components:
           nullable: true
         hasFile:
           type: boolean
-          description: Whether a PDF file is attached
+          description: Whether a scoresheet file is attached
         closedAt:
           type: string
           format: date-time
@@ -5292,7 +5293,7 @@ components:
         "scoresheet[file][__identity]":
           type: string
           format: uuid
-          description: Reference to uploaded PDF file
+          description: Reference to uploaded file (JPEG, PNG, or PDF)
         "scoresheet[hasFile]":
           type: string
           enum: ["true", "false"]
@@ -5357,7 +5358,7 @@ components:
         "scoresheet[file][__identity]":
           type: string
           format: uuid
-          description: Reference to uploaded PDF file (required for finalization)
+          description: Reference to uploaded file (required for finalization)
         "scoresheet[hasFile]":
           type: string
           enum: ["true"]
@@ -5807,10 +5808,11 @@ components:
               format: uuid
             filename:
               type: string
-              example: "scoresheet.pdf"
+              example: "scoresheet.jpg"
             mediaType:
               type: string
-              example: "application/pdf"
+              description: "MIME type (image/jpeg, image/png, or application/pdf)"
+              example: "image/jpeg"
             fileSize:
               type: integer
               description: File size in bytes

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -31,7 +31,7 @@ if (!import.meta.env.DEV && !API_BASE) {
 
 const DEFAULT_SEARCH_RESULTS_LIMIT = 50;
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-const ALLOWED_FILE_TYPES = ["application/pdf"];
+const ALLOWED_FILE_TYPES = ["application/pdf", "image/jpeg", "image/png"];
 
 // Re-export schema types
 export type Schemas = components["schemas"];
@@ -556,7 +556,7 @@ export const api = {
   async uploadResource(file: File): Promise<FileResource[]> {
     if (!ALLOWED_FILE_TYPES.includes(file.type)) {
       throw new Error(
-        `Invalid file type: ${file.type || "unknown"}. Only PDF files are allowed.`,
+        `Invalid file type: ${file.type || "unknown"}. Only JPEG, PNG, or PDF files are allowed.`,
       );
     }
 

--- a/web-app/src/api/contract.test.ts
+++ b/web-app/src/api/contract.test.ts
@@ -680,6 +680,36 @@ describe("File upload endpoint", () => {
     expect(result[0]?.persistentResource?.filename).toBe("test.pdf");
     expect(result[0]?.persistentResource?.mediaType).toBe("application/pdf");
   });
+
+  it("uploadResource accepts valid JPEG files", async () => {
+    const validFile = new File(["test content"], "scoresheet.jpg", {
+      type: "image/jpeg",
+    });
+
+    const result = await mockApi.uploadResource(validFile);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(1);
+    expect(result[0]).toHaveProperty("__identity");
+    expect(result[0]).toHaveProperty("persistentResource");
+    expect(result[0]?.persistentResource?.filename).toBe("scoresheet.jpg");
+    expect(result[0]?.persistentResource?.mediaType).toBe("image/jpeg");
+  });
+
+  it("uploadResource accepts valid PNG files", async () => {
+    const validFile = new File(["test content"], "scoresheet.png", {
+      type: "image/png",
+    });
+
+    const result = await mockApi.uploadResource(validFile);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(1);
+    expect(result[0]).toHaveProperty("__identity");
+    expect(result[0]).toHaveProperty("persistentResource");
+    expect(result[0]?.persistentResource?.filename).toBe("scoresheet.png");
+    expect(result[0]?.persistentResource?.mediaType).toBe("image/png");
+  });
 });
 
 describe("Filtering and pagination", () => {

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -50,7 +50,7 @@ const DEFAULT_PERSON_SEARCH_LIMIT = 50;
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
 /** Allowed MIME types for scoresheet uploads. */
-const ALLOWED_FILE_TYPES = ["application/pdf"];
+const ALLOWED_FILE_TYPES = ["application/pdf", "image/jpeg", "image/png"];
 
 /**
  * Extended compensation data type for demo mode.
@@ -684,7 +684,7 @@ export const mockApi = {
     // Validate file type
     if (!ALLOWED_FILE_TYPES.includes(file.type)) {
       throw new Error(
-        `Invalid file type: ${file.type || "unknown"}. Only PDF files are allowed.`,
+        `Invalid file type: ${file.type || "unknown"}. Only JPEG, PNG, or PDF files are allowed.`,
       );
     }
 


### PR DESCRIPTION
Mobile users taking photos with their camera get JPEG files, which
were being rejected by the API despite the UI accepting them. This
aligns the API client and mock API with the existing UI file type
validation to accept JPEG, PNG, and PDF files.