### PR TITLE
fix(a11y): improve SwipeableCard modal overlay accessibility

### DIFF
--- a/web-app/src/components/ui/SwipeableCard.test.tsx
+++ b/web-app/src/components/ui/SwipeableCard.test.tsx
@@ -185,6 +185,28 @@ describe("SwipeableCard", () => {
       expect(screen.getByText("Left")).toBeInTheDocument();
       expect(screen.getByText("Right")).toBeInTheDocument();
     });
+
+    it("hides action buttons when clicking the backdrop", () => {
+      const { container } = render(
+        <SwipeableCard onSwipeLeft={() => {}} leftActionLabel="Decline">
+          <div>Content</div>
+        </SwipeableCard>,
+      );
+
+      const wrapper = container.firstChild as HTMLElement;
+
+      // Show actions
+      fireEvent.keyDown(wrapper, { key: "Enter" });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      // Click the backdrop (element with aria-hidden="true")
+      const backdrop = wrapper.querySelector('[aria-hidden="true"]');
+      expect(backdrop).toBeInTheDocument();
+      fireEvent.click(backdrop!);
+
+      // Dialog should be dismissed
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
   });
 
   describe("touch interactions", () => {

--- a/web-app/src/components/ui/SwipeableCard.tsx
+++ b/web-app/src/components/ui/SwipeableCard.tsx
@@ -438,45 +438,44 @@ export function SwipeableCard({
 
       {showActions && hasAnyAction && (
         // Modal overlay with action buttons - backdrop dismisses on click
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-        <div
-          onClick={() => setShowActions(false)}
-          className="absolute inset-0 z-20 bg-black/50 rounded-xl flex items-center justify-center gap-2 p-4"
-        >
+        <>
+          {/* Backdrop - click to dismiss, aria-hidden since it's purely visual/interactive */}
+          <div
+            onClick={() => setShowActions(false)}
+            aria-hidden="true"
+            className="absolute inset-0 z-20 bg-black/50 rounded-xl"
+          />
+          {/* Dialog content - positioned above backdrop */}
           <div
             role="dialog"
             aria-label={t("common.cardActions")}
             aria-modal="true"
-            className="flex items-center justify-center gap-2"
+            className="absolute inset-0 z-20 flex items-center justify-center gap-2 p-4 pointer-events-none"
           >
-            {rightActions?.[0] && (
-              <button
-                ref={(el) => el?.focus()}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleRightAction();
-                }}
-                className={`${rightActions[0].color} text-white px-4 py-2 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white`}
-              >
-                {rightActions[0].label}
-              </button>
-            )}
-            {leftActions?.[0] && (
-              <button
-                ref={(el) => {
-                  if (!rightActions?.[0]) el?.focus();
-                }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleLeftAction();
-                }}
-                className={`${leftActions[0].color} text-white px-4 py-2 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white ml-2`}
-              >
-                {leftActions[0].label}
-              </button>
-            )}
+            <div className="flex items-center justify-center gap-2 pointer-events-auto">
+              {rightActions?.[0] && (
+                <button
+                  ref={(el) => el?.focus()}
+                  onClick={handleRightAction}
+                  className={`${rightActions[0].color} text-white px-4 py-2 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white`}
+                >
+                  {rightActions[0].label}
+                </button>
+              )}
+              {leftActions?.[0] && (
+                <button
+                  ref={(el) => {
+                    if (!rightActions?.[0]) el?.focus();
+                  }}
+                  onClick={handleLeftAction}
+                  className={`${leftActions[0].color} text-white px-4 py-2 rounded-lg font-medium text-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-white ml-2`}
+                >
+                  {leftActions[0].label}
+                </button>
+              )}
+            </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
Remove eslint-disable for jsx-a11y rules by restructuring the modal
overlay to separate the backdrop from dialog content. The backdrop
now uses aria-hidden="true" since it's purely visual and interactive
but not semantic. This properly addresses the click-to-dismiss pattern
while maintaining accessibility standards.

- Separate backdrop and dialog as sibling elements
- Use pointer-events to allow clicks through dialog to backdrop
- Add test for backdrop click dismiss behavior