### PR TITLE
feat(validation): support optional scoresheet upload for certain groups

### DIFF
--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -3131,6 +3131,12 @@ components:
             displayName:
               type: string
               example: "#27106 | Herren 2. Liga"
+            isTournamentGroup:
+              type: boolean
+              description: Whether this is a tournament group (affects nomination workflow)
+            hasNoScoresheet:
+              type: boolean
+              description: Whether games in this group require no scoresheet upload
             phase:
               type: object
               properties:

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -513,12 +513,25 @@ export const mockApi = {
     const validatedData = store.validatedGames[gameId];
     const pendingScorer = store.getPendingScorer(gameId);
 
+    // Find the assignment with this game to get group info
+    const assignment = store.assignments.find(
+      (a) => a.refereeGame?.game?.__identity === gameId,
+    );
+    const group = assignment?.refereeGame?.game?.group;
+
     // Determine the scorer to show: validated scorer takes precedence, then pending
     const scorerToShow = validatedData?.scorer ?? pendingScorer;
 
     // Build mock game details with scoresheet and nomination lists
     const gameDetails: GameDetails = {
       __identity: gameId,
+      // Include group info for scoresheet requirements
+      ...(group && {
+        group: {
+          isTournamentGroup: group.isTournamentGroup ?? false,
+          hasNoScoresheet: group.hasNoScoresheet ?? false,
+        },
+      }),
       scoresheet: {
         __identity: `scoresheet-${gameId}`,
         game: { __identity: gameId },

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -2088,6 +2088,10 @@ export interface components {
                 __identity?: string;
                 /** @example #27106 | Herren 2. Liga */
                 displayName?: string;
+                /** @description Whether this is a tournament group (affects nomination workflow) */
+                isTournamentGroup?: boolean;
+                /** @description Whether games in this group require no scoresheet upload */
+                hasNoScoresheet?: boolean;
                 phase?: {
                     /** Format: uuid */
                     __identity?: string;

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -99,6 +99,7 @@ describe("ValidateGameModal", () => {
       isValidated: false,
       validatedInfo: null,
       pendingScorer: null,
+      scoresheetNotRequired: false,
       setHomeRosterModifications: vi.fn(),
       setAwayRosterModifications: vi.fn(),
       setScorer: vi.fn(),

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -58,6 +58,7 @@ export function ValidateGameModal({
     isValidated,
     validatedInfo,
     pendingScorer,
+    scoresheetNotRequired,
     setHomeRosterModifications,
     setAwayRosterModifications,
     setScorer,
@@ -374,6 +375,7 @@ export function ValidateGameModal({
                       onScoresheetChange={setScoresheet}
                       readOnly={isValidated}
                       hasScoresheet={validatedInfo?.hasScoresheet}
+                      scoresheetNotRequired={scoresheetNotRequired}
                     />
                   )}
                 </ModalErrorBoundary>

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle,
   FileText,
   AlertCircle,
+  Info,
 } from "@/components/ui/icons";
 
 interface ScoresheetPanelProps {
@@ -16,6 +17,8 @@ interface ScoresheetPanelProps {
   readOnly?: boolean;
   /** Whether a scoresheet was uploaded (for read-only mode) */
   hasScoresheet?: boolean;
+  /** Whether scoresheet upload is not required for this game's group */
+  scoresheetNotRequired?: boolean;
 }
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
@@ -44,6 +47,7 @@ export function ScoresheetPanel({
   onScoresheetChange,
   readOnly = false,
   hasScoresheet = false,
+  scoresheetNotRequired = false,
 }: ScoresheetPanelProps) {
   const { t } = useTranslation();
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
@@ -203,6 +207,23 @@ export function ScoresheetPanel({
 
   const tKey = (key: string) =>
     t(`validation.scoresheetUpload.${key}` as Parameters<typeof t>[0]);
+
+  // When scoresheet is not required for this group, show informational message
+  if (scoresheetNotRequired) {
+    return (
+      <div className="py-4">
+        <div className="border border-info-200 dark:border-info-800 bg-info-50 dark:bg-info-900/20 rounded-lg p-4 text-center">
+          <Info className="w-12 h-12 mx-auto text-info-500 mb-3" aria-hidden="true" />
+          <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-1">
+            {t("validation.scoresheetUpload.notRequired")}
+          </h3>
+          <p className="text-sm text-text-muted dark:text-text-muted-dark">
+            {t("validation.scoresheetUpload.notRequiredDescription")}
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   // In read-only mode, show a simple status display
   if (readOnly) {

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -38,6 +38,7 @@ export { AlertTriangle } from "lucide-react";
 export { Calendar } from "lucide-react";
 export { Lock } from "lucide-react";
 export { Inbox } from "lucide-react";
+export { Info } from "lucide-react";
 
 // App branding - custom volleyball icon since Lucide doesn't have one
 export { CircleDot as Volleyball } from "lucide-react";

--- a/web-app/src/hooks/useValidationState.ts
+++ b/web-app/src/hooks/useValidationState.ts
@@ -115,6 +115,11 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     };
   }, [gameDetailsQuery.data, isValidated]);
 
+  const scoresheetNotRequired = useMemo(
+    () => gameDetailsQuery.data?.group?.hasNoScoresheet ?? false,
+    [gameDetailsQuery.data],
+  );
+
   const isDirty = useMemo(() => {
     return (
       hasRosterModifications(state.homeRoster.modifications) ||
@@ -225,6 +230,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     isValidated,
     validatedInfo,
     pendingScorer,
+    scoresheetNotRequired,
     setHomeRosterModifications,
     setAwayRosterModifications,
     setScorer,

--- a/web-app/src/hooks/validation/types.ts
+++ b/web-app/src/hooks/validation/types.ts
@@ -88,6 +88,8 @@ export interface UseValidationStateResult {
   validatedInfo: ValidatedGameInfo | null;
   /** Pending scorer from previous save (if any) */
   pendingScorer: PendingScorerData | null;
+  /** Whether scoresheet upload is not required for this game's group */
+  scoresheetNotRequired: boolean;
   /** Update home roster modifications (auto-marks roster as reviewed) */
   setHomeRosterModifications: (modifications: RosterModifications) => void;
   /** Update away roster modifications (auto-marks roster as reviewed) */

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -431,6 +431,9 @@ const de: Translations = {
       previewAlt: "Spielbericht-Vorschau",
       scoresheetUploaded: "Spielbericht hochgeladen",
       noScoresheet: "Kein Spielbericht hochgeladen",
+      notRequired: "Spielbericht nicht erforderlich",
+      notRequiredDescription:
+        "Für diesen Wettbewerb ist kein Spielbericht erforderlich.",
     },
     state: {
       unsavedChangesTitle: "Ungespeicherte Änderungen",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -426,6 +426,9 @@ const en: Translations = {
       previewAlt: "Scoresheet preview",
       scoresheetUploaded: "Scoresheet uploaded",
       noScoresheet: "No scoresheet uploaded",
+      notRequired: "Scoresheet not required",
+      notRequiredDescription:
+        "This competition does not require a scoresheet upload.",
     },
     state: {
       unsavedChangesTitle: "Unsaved Changes",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -430,6 +430,9 @@ const fr: Translations = {
       previewAlt: "Aperçu de la feuille de match",
       scoresheetUploaded: "Feuille de match téléchargée",
       noScoresheet: "Aucune feuille de match téléchargée",
+      notRequired: "Feuille de match non requise",
+      notRequiredDescription:
+        "Cette compétition ne nécessite pas de téléchargement de feuille de match.",
     },
     state: {
       unsavedChangesTitle: "Modifications non enregistrées",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -425,6 +425,9 @@ const it: Translations = {
       previewAlt: "Anteprima referto",
       scoresheetUploaded: "Referto caricato",
       noScoresheet: "Nessun referto caricato",
+      notRequired: "Referto non richiesto",
+      notRequiredDescription:
+        "Questa competizione non richiede il caricamento del referto.",
     },
     state: {
       unsavedChangesTitle: "Modifiche non salvate",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -303,6 +303,8 @@ export interface Translations {
       previewAlt: string;
       scoresheetUploaded: string;
       noScoresheet: string;
+      notRequired: string;
+      notRequiredDescription: string;
     };
     state: {
       unsavedChangesTitle: string;

--- a/web-app/src/stores/demo-generators.ts
+++ b/web-app/src/stores/demo-generators.ts
@@ -430,7 +430,7 @@ export function generateAssignments(
 ): Assignment[] {
   const configs: AssignmentConfig[] = [
     { index: 1, status: "active", position: "head-one", confirmationStatus: "confirmed", confirmationDaysAgo: 5, gameDate: addDays(now, 2), venueIndex: 0, leagueIndex: 0, gender: "m", isGameInFuture: true },
-    { index: 2, status: "active", position: "linesman-one", confirmationStatus: "confirmed", confirmationDaysAgo: 3, gameDate: addHours(now, 3), venueIndex: 1, leagueIndex: 1, gender: "m", isGameInFuture: true, hasMessage: true, hasNoScoresheet: true },
+    { index: 2, status: "active", position: "linesman-one", confirmationStatus: "confirmed", confirmationDaysAgo: 3, gameDate: addHours(now, 3), venueIndex: 1, leagueIndex: 1, gender: "m", isGameInFuture: true, hasMessage: true, hasNoScoresheet: associationCode !== "SV" },
     { index: 3, status: "active", position: "head-two", confirmationStatus: "pending", confirmationDaysAgo: null, gameDate: addDays(now, 5), venueIndex: 2, leagueIndex: 0, gender: "f", isGameInFuture: true, linkedDouble: "382420 / ARB 1" },
     { index: 4, status: "cancelled", position: "head-one", confirmationStatus: "confirmed", confirmationDaysAgo: 10, gameDate: addDays(now, 7), venueIndex: 3, leagueIndex: 1, gender: "f", isGameInFuture: true, isOpenInExchange: true },
     { index: 5, status: "archived", position: "linesman-two", confirmationStatus: "confirmed", confirmationDaysAgo: 14, gameDate: subDays(now, 3), venueIndex: 4, leagueIndex: associationCode === "SV" ? 1 : 2, gender: "m", isGameInFuture: false },

--- a/web-app/src/stores/demo-generators.ts
+++ b/web-app/src/stores/demo-generators.ts
@@ -284,6 +284,10 @@ interface RefereeGameParams {
   isGameInFuture: boolean;
   associationCode: DemoAssociationCode;
   idPrefix: string;
+  /** Whether games in this group require no scoresheet upload */
+  hasNoScoresheet?: boolean;
+  /** Whether this is a tournament group */
+  isTournamentGroup?: boolean;
 }
 
 function createRefereeGame({
@@ -296,6 +300,8 @@ function createRefereeGame({
   isGameInFuture,
   associationCode,
   idPrefix,
+  hasNoScoresheet = false,
+  isTournamentGroup = false,
 }: RefereeGameParams): RefereeGame {
   const venues = getVenuesForAssociation(associationCode);
   const leagues = getLeaguesForAssociation(associationCode);
@@ -348,6 +354,8 @@ function createRefereeGame({
       group: {
         name: "Quali",
         managingAssociationShortName: associationCode,
+        isTournamentGroup,
+        hasNoScoresheet,
         phase: {
           name: "Phase 1",
           league: {
@@ -374,6 +382,10 @@ interface AssignmentConfig {
   isOpenInExchange?: boolean;
   hasMessage?: boolean;
   linkedDouble?: string;
+  /** Whether games in this group require no scoresheet upload */
+  hasNoScoresheet?: boolean;
+  /** Whether this is a tournament group */
+  isTournamentGroup?: boolean;
 }
 
 function createAssignment(
@@ -406,6 +418,8 @@ function createAssignment(
       isGameInFuture: config.isGameInFuture,
       associationCode,
       idPrefix: "demo",
+      hasNoScoresheet: config.hasNoScoresheet,
+      isTournamentGroup: config.isTournamentGroup,
     }),
   };
 }
@@ -416,7 +430,7 @@ export function generateAssignments(
 ): Assignment[] {
   const configs: AssignmentConfig[] = [
     { index: 1, status: "active", position: "head-one", confirmationStatus: "confirmed", confirmationDaysAgo: 5, gameDate: addDays(now, 2), venueIndex: 0, leagueIndex: 0, gender: "m", isGameInFuture: true },
-    { index: 2, status: "active", position: "linesman-one", confirmationStatus: "confirmed", confirmationDaysAgo: 3, gameDate: addHours(now, 3), venueIndex: 1, leagueIndex: 1, gender: "m", isGameInFuture: true, hasMessage: true },
+    { index: 2, status: "active", position: "linesman-one", confirmationStatus: "confirmed", confirmationDaysAgo: 3, gameDate: addHours(now, 3), venueIndex: 1, leagueIndex: 1, gender: "m", isGameInFuture: true, hasMessage: true, hasNoScoresheet: true },
     { index: 3, status: "active", position: "head-two", confirmationStatus: "pending", confirmationDaysAgo: null, gameDate: addDays(now, 5), venueIndex: 2, leagueIndex: 0, gender: "f", isGameInFuture: true, linkedDouble: "382420 / ARB 1" },
     { index: 4, status: "cancelled", position: "head-one", confirmationStatus: "confirmed", confirmationDaysAgo: 10, gameDate: addDays(now, 7), venueIndex: 3, leagueIndex: 1, gender: "f", isGameInFuture: true, isOpenInExchange: true },
     { index: 5, status: "archived", position: "linesman-two", confirmationStatus: "confirmed", confirmationDaysAgo: 14, gameDate: subDays(now, 3), venueIndex: 4, leagueIndex: associationCode === "SV" ? 1 : 2, gender: "m", isGameInFuture: false },


### PR DESCRIPTION
Add support for the `hasNoScoresheet` group property, which indicates
that games in a specific group do not require scoresheet uploads.

Changes:
- Add `isTournamentGroup` and `hasNoScoresheet` to demo data generators
- Update mock API to include group info in GameDetails response
- Add `scoresheetNotRequired` flag to validation state hook
- Display informational message in ScoresheetPanel when upload not required
- Add translations for the new messages in all 4 languages (de, en, fr, it)
- Update OpenAPI spec with new group properties for GameDetails

One demo assignment (index 2) now has `hasNoScoresheet: true` for testing.