### PR TITLE
fix(e2e): eliminate flaky tests by replacing hardcoded timeouts with state-based waits

### DIFF
--- a/web-app/e2e/assignments.spec.ts
+++ b/web-app/e2e/assignments.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 import { LoginPage, AssignmentsPage, NavigationPage } from "./pages";
-import { ANIMATION_DELAY_MS } from "./constants";
 
 test.describe("Assignments Journey", () => {
   let loginPage: LoginPage;
@@ -86,13 +85,14 @@ test.describe("Assignments Journey", () => {
       expect(cardText!.length).toBeGreaterThan(0);
     });
 
-    test("can expand assignment card for details", async ({ page }) => {
+    test("can expand assignment card for details", async () => {
       await assignmentsPage.waitForAssignmentsLoaded();
 
       const firstCard = assignmentsPage.assignmentCards.first();
+      // Ensure card is visible before clicking
+      await expect(firstCard).toBeVisible();
       await firstCard.click();
-      await page.waitForTimeout(ANIMATION_DELAY_MS);
-
+      // Verify card remains visible after click (Playwright auto-waits)
       await expect(firstCard).toBeVisible();
     });
   });

--- a/web-app/e2e/compensations.spec.ts
+++ b/web-app/e2e/compensations.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 import { LoginPage, CompensationsPage, NavigationPage } from "./pages";
-import { ANIMATION_DELAY_MS } from "./constants";
 
 test.describe("Compensations Journey", () => {
   let loginPage: LoginPage;
@@ -80,14 +79,16 @@ test.describe("Compensations Journey", () => {
       }
     });
 
-    test("can expand compensation card for details", async ({ page }) => {
+    test("can expand compensation card for details", async () => {
       await compensationsPage.waitForCompensationsLoaded();
       const count = await compensationsPage.getCompensationCount();
 
       if (count > 0) {
         const firstCard = compensationsPage.compensationCards.first();
+        // Ensure card is visible before clicking
+        await expect(firstCard).toBeVisible();
         await firstCard.click();
-        await page.waitForTimeout(ANIMATION_DELAY_MS);
+        // Verify card remains visible after click (Playwright auto-waits)
         await expect(firstCard).toBeVisible();
       }
     });

--- a/web-app/e2e/constants.ts
+++ b/web-app/e2e/constants.ts
@@ -1,13 +1,12 @@
 /**
  * Shared constants for E2E tests.
  * Centralizes timing values to avoid magic numbers throughout tests.
+ *
+ * Note: Avoid hardcoded delay waits (waitForTimeout). Instead, use
+ * Playwright's built-in auto-waiting via expect assertions and proper
+ * element state checks. These timeout values are for explicit waitFor
+ * calls when waiting for specific states.
  */
-
-/** Time to wait for UI animations to complete (ms) */
-export const ANIMATION_DELAY_MS = 300;
-
-/** Time to wait for content to render after loading (ms) */
-export const CONTENT_RENDER_DELAY_MS = 500;
 
 /** Timeout for page/component loading (ms) */
 export const PAGE_LOAD_TIMEOUT_MS = 10000;

--- a/web-app/e2e/exchanges.spec.ts
+++ b/web-app/e2e/exchanges.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 import { LoginPage, ExchangesPage, NavigationPage } from "./pages";
-import { ANIMATION_DELAY_MS } from "./constants";
 
 test.describe("Exchanges Journey", () => {
   let loginPage: LoginPage;
@@ -88,14 +87,16 @@ test.describe("Exchanges Journey", () => {
       }
     });
 
-    test("can expand exchange card for details", async ({ page }) => {
+    test("can expand exchange card for details", async () => {
       await exchangesPage.waitForExchangesLoaded();
       const count = await exchangesPage.getExchangeCount();
 
       if (count > 0) {
         const firstCard = exchangesPage.exchangeCards.first();
+        // Ensure card is visible before clicking
+        await expect(firstCard).toBeVisible();
         await firstCard.click();
-        await page.waitForTimeout(ANIMATION_DELAY_MS);
+        // Verify card remains visible after click (Playwright auto-waits)
         await expect(firstCard).toBeVisible();
       }
     });

--- a/web-app/e2e/pages/exchanges.page.ts
+++ b/web-app/e2e/pages/exchanges.page.ts
@@ -3,7 +3,6 @@ import {
   PAGE_LOAD_TIMEOUT_MS,
   TAB_SWITCH_TIMEOUT_MS,
   LOADING_TIMEOUT_MS,
-  CONTENT_RENDER_DELAY_MS,
 } from "../constants";
 
 /**
@@ -50,6 +49,8 @@ export class ExchangesPage {
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
+    // Wait for tab panel content to stabilize
+    await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
   }
 
   async switchToMyApplicationsTab() {
@@ -63,6 +64,8 @@ export class ExchangesPage {
       },
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
+    // Wait for tab panel content to stabilize
+    await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
   }
 
   async getExchangeCount(): Promise<number> {
@@ -84,14 +87,20 @@ export class ExchangesPage {
   async waitForExchangesLoaded() {
     await expect(this.tabPanel).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT_MS });
 
-    // Use stable test ID for loading indicator (locale-independent)
+    // Wait for loading indicator to disappear (if it appears)
     const loadingIndicator = this.page.getByTestId("loading-state");
-    await loadingIndicator
-      .waitFor({ state: "hidden", timeout: LOADING_TIMEOUT_MS })
-      .catch(() => {
-        // Loading may have already finished or not appeared
+    const isLoadingVisible = await loadingIndicator.isVisible();
+    if (isLoadingVisible) {
+      await loadingIndicator.waitFor({
+        state: "hidden",
+        timeout: LOADING_TIMEOUT_MS,
       });
+    }
 
-    await this.page.waitForTimeout(CONTENT_RENDER_DELAY_MS);
+    // Wait for actual content: either cards are present or empty state is shown
+    const emptyState = this.page.getByTestId("empty-state");
+    await expect(this.exchangeCards.first().or(emptyState)).toBeVisible({
+      timeout: LOADING_TIMEOUT_MS,
+    });
   }
 }

--- a/web-app/e2e/pages/login.page.ts
+++ b/web-app/e2e/pages/login.page.ts
@@ -1,4 +1,5 @@
 import { type Page, type Locator, expect } from "@playwright/test";
+import { PAGE_LOAD_TIMEOUT_MS } from "../constants";
 
 /**
  * Page Object Model for the Login page.
@@ -22,6 +23,10 @@ export class LoginPage {
 
   async goto() {
     await this.page.goto("/login");
+    // Wait for login form to be ready
+    await expect(this.loginButton).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
   }
 
   async login(username: string, password: string) {
@@ -35,9 +40,17 @@ export class LoginPage {
    * Demo mode provides consistent mock data for reliable testing.
    */
   async enterDemoMode() {
+    // Ensure button is clickable before clicking
+    await expect(this.demoButton).toBeVisible();
     await this.demoButton.click();
-    // Wait for navigation away from login
-    await expect(this.page).not.toHaveURL(/login/);
+    // Wait for navigation away from login with explicit timeout
+    await expect(this.page).not.toHaveURL(/login/, {
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
+    // Wait for main content to load
+    await expect(this.page.getByRole("main")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
   }
 
   async expectToBeVisible() {

--- a/web-app/e2e/pages/navigation.page.ts
+++ b/web-app/e2e/pages/navigation.page.ts
@@ -1,4 +1,5 @@
 import { type Page, type Locator, expect } from "@playwright/test";
+import { PAGE_LOAD_TIMEOUT_MS } from "../constants";
 
 /**
  * Page Object Model for app navigation.
@@ -28,21 +29,45 @@ export class NavigationPage {
 
   async goToAssignments() {
     await this.assignmentsLink.click();
-    await expect(this.page).toHaveURL("/");
+    await expect(this.page).toHaveURL("/", {
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
+    // Wait for main content area to be visible
+    await expect(this.page.getByRole("main")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
   }
 
   async goToCompensations() {
     await this.compensationsLink.click();
-    await expect(this.page).toHaveURL("/compensations");
+    await expect(this.page).toHaveURL("/compensations", {
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
+    // Wait for main content area to be visible
+    await expect(this.page.getByRole("main")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
   }
 
   async goToExchange() {
     await this.exchangeLink.click();
-    await expect(this.page).toHaveURL("/exchange");
+    await expect(this.page).toHaveURL("/exchange", {
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
+    // Wait for main content area to be visible
+    await expect(this.page.getByRole("main")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
   }
 
   async goToSettings() {
     await this.settingsLink.click();
-    await expect(this.page).toHaveURL("/settings");
+    await expect(this.page).toHaveURL("/settings", {
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
+    // Wait for main content area to be visible
+    await expect(this.page.getByRole("main")).toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
   }
 }

--- a/web-app/playwright.config.ts
+++ b/web-app/playwright.config.ts
@@ -6,12 +6,18 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
+  // Global timeout for each test (prevents hanging tests)
+  timeout: 30000,
+  // Timeout for expect assertions (allows slower browsers like Firefox)
+  expect: {
+    timeout: 10000,
+  },
   // Run tests in parallel
   fullyParallel: true,
   // Fail the build on CI if you accidentally left test.only in the source code
   forbidOnly: !!process.env.CI,
-  // Retry on CI only
-  retries: process.env.CI ? 2 : 0,
+  // Retry on CI only (helps catch flaky tests locally too)
+  retries: process.env.CI ? 2 : 1,
   // Limit parallel workers on CI
   workers: process.env.CI ? 1 : undefined,
   // Reporter to use
@@ -24,6 +30,10 @@ export default defineConfig({
     trace: 'on-first-retry',
     // Take screenshot on failure
     screenshot: 'only-on-failure',
+    // Timeout for actions (click, fill, etc.)
+    actionTimeout: 10000,
+    // Timeout for navigation
+    navigationTimeout: 15000,
   },
 
   // Configure projects for major browsers
@@ -34,7 +44,12 @@ export default defineConfig({
     },
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: {
+        ...devices['Desktop Firefox'],
+        // Firefox is slower, increase timeouts
+        actionTimeout: 15000,
+        navigationTimeout: 20000,
+      },
     },
     {
       name: 'webkit',


### PR DESCRIPTION
- Remove all `page.waitForTimeout()` calls that caused timing-dependent flakiness
- Replace silent `.catch()` blocks on loading indicators with conditional checks
- Add explicit visibility waits before card clicks to prevent race conditions
- Wait for tab panel content after `aria-selected` attribute changes
- Add explicit timeouts to navigation methods with content load verification
- Configure Playwright with proper timeouts:
  - Global test timeout (30s)
  - Expect assertion timeout (10s)
  - Action timeout (10s default, 15s Firefox)
  - Navigation timeout (15s default, 20s Firefox)
- Enable 1 retry locally to catch flaky tests during development
- Remove unused ANIMATION_DELAY_MS and CONTENT_RENDER_DELAY_MS constants

These changes address the root causes of flaky tests:
1. Hardcoded delays don't account for varying browser/system performance
2. Firefox is slower, now has increased timeouts
3. Waiting for actual DOM state is more reliable than arbitrary delays