### PR TITLE
fix(auth): improve login success/failure detection

### DIFF
--- a/web-app/src/utils/auth-parsers.ts
+++ b/web-app/src/utils/auth-parsers.ts
@@ -6,6 +6,18 @@
 import { logger } from "@/utils/logger";
 
 /**
+ * URL path pattern that indicates successful login redirect to dashboard.
+ * The API redirects to this path after successful authentication.
+ */
+const DASHBOARD_URL_PATTERN = "/sportmanager.volleyball/main/dashboard";
+
+/**
+ * HTML patterns that indicate authentication failure.
+ * The Vuetify snackbar uses these color attributes for error messages.
+ */
+const AUTH_ERROR_INDICATORS = ['color="error"', "color='error'"] as const;
+
+/**
  * Login form fields extracted from the login page HTML.
  * The Neos Flow framework requires these fields for CSRF protection.
  */
@@ -169,8 +181,7 @@ export async function submitLoginCredentials(
   // Check if we were redirected to the dashboard (successful login)
   // The API returns 303 redirect on success, fetch follows it automatically
   const isOnDashboard =
-    response.redirected &&
-    response.url.includes("/sportmanager.volleyball/main/dashboard");
+    response.redirected && response.url.includes(DASHBOARD_URL_PATTERN);
 
   if (isOnDashboard) {
     // Successfully redirected to dashboard - extract CSRF token
@@ -189,8 +200,9 @@ export async function submitLoginCredentials(
 
   // Not redirected - check if we're on the login page with an error
   // The Vuetify snackbar with color="error" indicates authentication failure
-  const hasAuthError =
-    html.includes('color="error"') || html.includes("color='error'");
+  const hasAuthError = AUTH_ERROR_INDICATORS.some((indicator) =>
+    html.includes(indicator),
+  );
 
   if (hasAuthError) {
     return { success: false, error: "Invalid username or password" };

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -256,6 +256,32 @@ export default defineConfig(({ mode }) => {
     server: {
       proxy: {
         // Proxy all API calls during development to bypass CORS
+        // Authentication endpoints
+        '/login': {
+          target: 'https://volleymanager.volleyball.ch',
+          changeOrigin: true,
+          secure: true,
+          cookieDomainRewrite: 'localhost',
+        },
+        '/logout': {
+          target: 'https://volleymanager.volleyball.ch',
+          changeOrigin: true,
+          secure: true,
+          cookieDomainRewrite: 'localhost',
+        },
+        '/sportmanager.security': {
+          target: 'https://volleymanager.volleyball.ch',
+          changeOrigin: true,
+          secure: true,
+          cookieDomainRewrite: 'localhost',
+        },
+        '/sportmanager.volleyball': {
+          target: 'https://volleymanager.volleyball.ch',
+          changeOrigin: true,
+          secure: true,
+          cookieDomainRewrite: 'localhost',
+        },
+        // API endpoints
         '/neos': {
           target: 'https://volleymanager.volleyball.ch',
           changeOrigin: true,

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -57,6 +57,26 @@ function spaFallbackPlugin(basePath: string): Plugin {
   };
 }
 
+// Target API server for development proxy
+const VOLLEYMANAGER_API = 'https://volleymanager.volleyball.ch';
+
+/**
+ * Creates proxy configuration for development server.
+ * All paths are proxied to the VolleyManager API with CORS bypass.
+ */
+function createDevProxy(paths: string[]): Record<string, object> {
+  const proxyConfig: Record<string, object> = {};
+  for (const path of paths) {
+    proxyConfig[path] = {
+      target: VOLLEYMANAGER_API,
+      changeOrigin: true,
+      secure: true,
+      cookieDomainRewrite: 'localhost',
+    };
+  }
+  return proxyConfig;
+}
+
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   // Warn if proxy URL is not configured for production (runtime check in client.ts handles the actual failure)
@@ -254,53 +274,17 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
-      proxy: {
-        // Proxy all API calls during development to bypass CORS
+      proxy: createDevProxy([
         // Authentication endpoints
-        '/login': {
-          target: 'https://volleymanager.volleyball.ch',
-          changeOrigin: true,
-          secure: true,
-          cookieDomainRewrite: 'localhost',
-        },
-        '/logout': {
-          target: 'https://volleymanager.volleyball.ch',
-          changeOrigin: true,
-          secure: true,
-          cookieDomainRewrite: 'localhost',
-        },
-        '/sportmanager.security': {
-          target: 'https://volleymanager.volleyball.ch',
-          changeOrigin: true,
-          secure: true,
-          cookieDomainRewrite: 'localhost',
-        },
-        '/sportmanager.volleyball': {
-          target: 'https://volleymanager.volleyball.ch',
-          changeOrigin: true,
-          secure: true,
-          cookieDomainRewrite: 'localhost',
-        },
+        '/login',
+        '/logout',
+        '/sportmanager.security',
+        '/sportmanager.volleyball',
         // API endpoints
-        '/neos': {
-          target: 'https://volleymanager.volleyball.ch',
-          changeOrigin: true,
-          secure: true,
-          cookieDomainRewrite: 'localhost',
-        },
-        '/indoorvolleyball.refadmin': {
-          target: 'https://volleymanager.volleyball.ch',
-          changeOrigin: true,
-          secure: true,
-          cookieDomainRewrite: 'localhost',
-        },
-        '/sportmanager.indoorvolleyball': {
-          target: 'https://volleymanager.volleyball.ch',
-          changeOrigin: true,
-          secure: true,
-          cookieDomainRewrite: 'localhost',
-        },
-      },
+        '/neos',
+        '/indoorvolleyball.refadmin',
+        '/sportmanager.indoorvolleyball',
+      ]),
     },
   };
 })

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -63,15 +63,33 @@ const VOLLEYMANAGER_API = 'https://volleymanager.volleyball.ch';
 /**
  * Creates proxy configuration for development server.
  * All paths are proxied to the VolleyManager API with CORS bypass.
+ *
+ * Important: Uses a bypass function to skip proxying browser page navigation
+ * (HTML requests). This prevents conflicts with SPA routes like /login that
+ * are also API endpoints. Browser navigation should serve index.html, while
+ * fetch() API calls should be proxied.
  */
 function createDevProxy(paths: string[]): Record<string, object> {
   const proxyConfig: Record<string, object> = {};
-  for (const path of paths) {
-    proxyConfig[path] = {
+  for (const proxyPath of paths) {
+    proxyConfig[proxyPath] = {
       target: VOLLEYMANAGER_API,
       changeOrigin: true,
       secure: true,
       cookieDomainRewrite: 'localhost',
+      // Skip proxying for HTML page navigation - serve SPA's index.html instead.
+      // Browser navigation sends Accept headers starting with "text/html".
+      // API fetch calls send "*/*" or specific content types.
+      // Return a path string to serve that file instead of proxying.
+      bypass(req: { headers: { accept?: string } }) {
+        const accept = req.headers.accept || '';
+        if (accept.startsWith('text/html')) {
+          // Return index.html path to serve SPA for page navigation
+          return '/index.html';
+        }
+        // Return undefined to proceed with proxying for API calls
+        return undefined;
+      },
     };
   }
   return proxyConfig;


### PR DESCRIPTION
Previously, login success was detected solely by the presence of a
CSRF token in the response. This caused false "Invalid username or
password" errors when:
- The redirect flag wasn't preserved by the proxy
- The response URL wasn't set correctly

Changes:
- Check response.redirected and response.url for primary success detection
- Check for error snackbar in HTML for failure detection
- Fall back to CSRF token presence for edge cases
- Add missing dev proxy routes for /login, /logout, /sportmanager.security,
  and /sportmanager.volleyball endpoints
- Add regression test for fallback CSRF token detection scenario