### PR TITLE
perf(stores): optimize Zustand selectors to prevent unnecessary re-renders

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -7,6 +7,7 @@ import {
   useNavigate,
 } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { AppShell } from "@/components/layout/AppShell";
@@ -85,9 +86,21 @@ const queryClient = new QueryClient({
 });
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { status, checkSession, isDemoMode } = useAuthStore();
+  const { status, checkSession, isDemoMode } = useAuthStore(
+    useShallow((state) => ({
+      status: state.status,
+      checkSession: state.checkSession,
+      isDemoMode: state.isDemoMode,
+    })),
+  );
   const { assignments, activeAssociationCode, initializeDemoData } =
-    useDemoStore();
+    useDemoStore(
+      useShallow((state) => ({
+        assignments: state.assignments,
+        activeAssociationCode: state.activeAssociationCode,
+        initializeDemoData: state.initializeDemoData,
+      })),
+    );
   const { t } = useTranslation();
   const shouldVerifySession = status === "authenticated" && !isDemoMode;
   const [isVerifying, setIsVerifying] = useState(() => shouldVerifySession);
@@ -153,7 +166,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 }
 
 function PublicRoute({ children }: { children: React.ReactNode }) {
-  const { status } = useAuthStore();
+  const status = useAuthStore((state) => state.status);
 
   if (status === "authenticated") {
     return <Navigate to="/" replace />;

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Outlet, NavLink, useLocation } from "react-router-dom";
+import { useShallow } from "zustand/react/shallow";
 import { useAuthStore, type Occupation } from "@/stores/auth";
 import { useDemoStore, type DemoAssociationCode } from "@/stores/demo";
 import { useTourStore } from "@/stores/tour";
@@ -49,8 +50,17 @@ export function AppShell() {
     activeOccupationId,
     setActiveOccupation,
     isDemoMode,
-  } = useAuthStore();
-  const { setActiveAssociation } = useDemoStore();
+  } = useAuthStore(
+    useShallow((state) => ({
+      status: state.status,
+      user: state.user,
+      logout: state.logout,
+      activeOccupationId: state.activeOccupationId,
+      setActiveOccupation: state.setActiveOccupation,
+      isDemoMode: state.isDemoMode,
+    })),
+  );
+  const setActiveAssociation = useDemoStore((state) => state.setActiveAssociation);
   const activeTour = useTourStore((state) => state.activeTour);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useGameExchanges, type ExchangeStatus } from "@/hooks/useConvocations";
 import { useExchangeActions } from "@/hooks/useExchangeActions";
 import { useDemoStore } from "@/stores/demo";
@@ -29,7 +30,12 @@ export function ExchangePage() {
   useTour("exchange");
 
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const { userRefereeLevel, userRefereeLevelGradationValue } = useDemoStore();
+  const { userRefereeLevel, userRefereeLevelGradationValue } = useDemoStore(
+    useShallow((state) => ({
+      userRefereeLevel: state.userRefereeLevel,
+      userRefereeLevelGradationValue: state.userRefereeLevelGradationValue,
+    })),
+  );
 
   const { data, isLoading, error, refetch } = useGameExchanges(statusFilter);
 

--- a/web-app/src/pages/LoginPage.test.tsx
+++ b/web-app/src/pages/LoginPage.test.tsx
@@ -26,20 +26,29 @@ const mockInitializeDemoData = vi.fn();
 function mockAuthStoreState(overrides = {}) {
   const state = {
     login: mockLogin,
-    status: "idle",
+    status: "idle" as const,
     error: null,
     setDemoAuthenticated: mockSetDemoAuthenticated,
     ...overrides,
   };
-  vi.mocked(authStore.useAuthStore).mockReturnValue(
-    state as ReturnType<typeof authStore.useAuthStore>,
-  );
+  vi.mocked(authStore.useAuthStore).mockImplementation((selector?: unknown) => {
+    if (typeof selector === "function") {
+      return selector(state);
+    }
+    return state as ReturnType<typeof authStore.useAuthStore>;
+  });
 }
 
 function mockDemoStoreState() {
-  vi.mocked(demoStore.useDemoStore).mockReturnValue({
+  const state = {
     initializeDemoData: mockInitializeDemoData,
-  } as ReturnType<typeof demoStore.useDemoStore>);
+  };
+  vi.mocked(demoStore.useDemoStore).mockImplementation((selector?: unknown) => {
+    if (typeof selector === "function") {
+      return selector(state);
+    }
+    return state as ReturnType<typeof demoStore.useDemoStore>;
+  });
 }
 
 describe("LoginPage", () => {

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ import {
   type FormEvent,
 } from "react";
 import { useNavigate } from "react-router-dom";
+import { useShallow } from "zustand/react/shallow";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -18,8 +19,15 @@ const DEMO_MODE_ONLY = import.meta.env.VITE_DEMO_MODE_ONLY === "true";
 
 export function LoginPage() {
   const navigate = useNavigate();
-  const { login, status, error, setDemoAuthenticated } = useAuthStore();
-  const { initializeDemoData } = useDemoStore();
+  const { login, status, error, setDemoAuthenticated } = useAuthStore(
+    useShallow((state) => ({
+      login: state.login,
+      status: state.status,
+      error: state.error,
+      setDemoAuthenticated: state.setDemoAuthenticated,
+    })),
+  );
+  const initializeDemoData = useDemoStore((state) => state.initializeDemoData);
   const { t } = useTranslation();
 
   const [username, setUsername] = useState("");

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { useSettingsStore } from "@/stores/settings";
@@ -17,10 +18,31 @@ const DEMO_RESET_MESSAGE_DURATION_MS = 3000;
 const TOUR_IDS: TourId[] = ["assignments", "compensations", "exchange", "settings"];
 
 export function SettingsPage() {
-  const { user, logout, isDemoMode } = useAuthStore();
-  const { activeAssociationCode, refreshData } = useDemoStore();
-  const { isSafeModeEnabled, setSafeMode } = useSettingsStore();
-  const { getTourStatus, resetAllTours } = useTourStore();
+  const { user, logout, isDemoMode } = useAuthStore(
+    useShallow((state) => ({
+      user: state.user,
+      logout: state.logout,
+      isDemoMode: state.isDemoMode,
+    })),
+  );
+  const { activeAssociationCode, refreshData } = useDemoStore(
+    useShallow((state) => ({
+      activeAssociationCode: state.activeAssociationCode,
+      refreshData: state.refreshData,
+    })),
+  );
+  const { isSafeModeEnabled, setSafeMode } = useSettingsStore(
+    useShallow((state) => ({
+      isSafeModeEnabled: state.isSafeModeEnabled,
+      setSafeMode: state.setSafeMode,
+    })),
+  );
+  const { getTourStatus, resetAllTours } = useTourStore(
+    useShallow((state) => ({
+      getTourStatus: state.getTourStatus,
+      resetAllTours: state.resetAllTours,
+    })),
+  );
   const { t, locale } = useTranslation();
 
   // Initialize tour for this page (triggers auto-start on first visit)


### PR DESCRIPTION
Use useShallow from zustand/react/shallow to create granular selectors
in components that previously subscribed to entire stores. This prevents
components from re-rendering when unrelated store state changes.

Affected files:
- AppShell.tsx: Auth store with useShallow, individual selector for demo store
- App.tsx: Both auth and demo stores with useShallow in ProtectedRoute
- LoginPage.tsx: Auth store with useShallow, individual selector for demo store
- SettingsPage.tsx: All four stores (auth, demo, settings, tour) with useShallow
- ExchangePage.tsx: Demo store with useShallow

Also updates LoginPage tests to support the new selector pattern.

Fixes #278