### PR TITLE
perf: lazy load modal components to reduce main bundle size

### DIFF
--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -16,8 +16,6 @@ import {
   isGameReportEligible,
   isValidationEligible,
 } from "@/utils/assignment-helpers";
-import { EditCompensationModal } from "@/components/features/EditCompensationModal";
-import { ValidateGameModal } from "@/components/features/ValidateGameModal";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTour } from "@/hooks/useTour";
@@ -26,6 +24,20 @@ const PdfLanguageModal = lazy(
   () =>
     import("@/components/features/PdfLanguageModal").then((m) => ({
       default: m.PdfLanguageModal,
+    })),
+);
+
+const EditCompensationModal = lazy(
+  () =>
+    import("@/components/features/EditCompensationModal").then((m) => ({
+      default: m.EditCompensationModal,
+    })),
+);
+
+const ValidateGameModal = lazy(
+  () =>
+    import("@/components/features/ValidateGameModal").then((m) => ({
+      default: m.ValidateGameModal,
     })),
 );
 
@@ -228,20 +240,24 @@ export function AssignmentsPage() {
 
       {/* Modals */}
       {editCompensationModal.assignment && (
-        <EditCompensationModal
-          assignment={editCompensationModal.assignment}
-          isOpen={editCompensationModal.isOpen}
-          onClose={editCompensationModal.close}
-        />
+        <Suspense fallback={null}>
+          <EditCompensationModal
+            assignment={editCompensationModal.assignment}
+            isOpen={editCompensationModal.isOpen}
+            onClose={editCompensationModal.close}
+          />
+        </Suspense>
       )}
 
       {validateGameModal.assignment && (
-        <ValidateGameModal
-          key={validateGameModal.assignment.__identity}
-          assignment={validateGameModal.assignment}
-          isOpen={validateGameModal.isOpen}
-          onClose={validateGameModal.close}
-        />
+        <Suspense fallback={null}>
+          <ValidateGameModal
+            key={validateGameModal.assignment.__identity}
+            assignment={validateGameModal.assignment}
+            isOpen={validateGameModal.isOpen}
+            onClose={validateGameModal.close}
+          />
+        </Suspense>
       )}
 
       {pdfReportModal.isOpen && (

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -1,7 +1,6 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, lazy, Suspense } from "react";
 import { useCompensations, useCompensationTotals } from "@/hooks/useConvocations";
 import { CompensationCard } from "@/components/features/CompensationCard";
-import { EditCompensationModal } from "@/components/features/EditCompensationModal";
 import { SwipeableCard } from "@/components/ui/SwipeableCard";
 import {
   LoadingState,
@@ -18,6 +17,13 @@ import type { CompensationRecord } from "@/api/client";
 import type { SwipeConfig } from "@/types/swipe";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTour } from "@/hooks/useTour";
+
+const EditCompensationModal = lazy(
+  () =>
+    import("@/components/features/EditCompensationModal").then((m) => ({
+      default: m.EditCompensationModal,
+    })),
+);
 
 type FilterType = "all" | "paid" | "unpaid";
 
@@ -177,11 +183,13 @@ export function CompensationsPage() {
 
       {/* Edit Compensation Modal - compensation is guaranteed non-null by conditional render */}
       {editCompensationModal.compensation && (
-        <EditCompensationModal
-          isOpen={editCompensationModal.isOpen}
-          onClose={editCompensationModal.close}
-          compensation={editCompensationModal.compensation}
-        />
+        <Suspense fallback={null}>
+          <EditCompensationModal
+            isOpen={editCompensationModal.isOpen}
+            onClose={editCompensationModal.close}
+            compensation={editCompensationModal.compensation}
+          />
+        </Suspense>
       )}
     </div>
   );

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, lazy, Suspense } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useGameExchanges, type ExchangeStatus } from "@/hooks/useConvocations";
 import { useExchangeActions } from "@/hooks/useExchangeActions";
@@ -14,12 +14,24 @@ import {
   EmptyState,
 } from "@/components/ui/LoadingSpinner";
 import { Tabs, TabPanel } from "@/components/ui/Tabs";
-import { TakeOverExchangeModal } from "@/components/features/TakeOverExchangeModal";
-import { RemoveFromExchangeModal } from "@/components/features/RemoveFromExchangeModal";
 import type { SwipeConfig } from "@/types/swipe";
 import type { GameExchange } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTour } from "@/hooks/useTour";
+
+const TakeOverExchangeModal = lazy(
+  () =>
+    import("@/components/features/TakeOverExchangeModal").then((m) => ({
+      default: m.TakeOverExchangeModal,
+    })),
+);
+
+const RemoveFromExchangeModal = lazy(
+  () =>
+    import("@/components/features/RemoveFromExchangeModal").then((m) => ({
+      default: m.RemoveFromExchangeModal,
+    })),
+);
 
 export function ExchangePage() {
   const [statusFilter, setStatusFilter] = useState<ExchangeStatus>("open");
@@ -204,23 +216,27 @@ export function ExchangePage() {
 
       {/* Modals - exchange is guaranteed non-null by conditional render */}
       {takeOverModal.exchange && (
-        <TakeOverExchangeModal
-          exchange={takeOverModal.exchange}
-          isOpen={takeOverModal.isOpen}
-          onClose={takeOverModal.close}
-          onConfirm={() => handleTakeOver(takeOverModal.exchange!)}
-        />
+        <Suspense fallback={null}>
+          <TakeOverExchangeModal
+            exchange={takeOverModal.exchange}
+            isOpen={takeOverModal.isOpen}
+            onClose={takeOverModal.close}
+            onConfirm={() => handleTakeOver(takeOverModal.exchange!)}
+          />
+        </Suspense>
       )}
 
       {removeFromExchangeModal.exchange && (
-        <RemoveFromExchangeModal
-          exchange={removeFromExchangeModal.exchange}
-          isOpen={removeFromExchangeModal.isOpen}
-          onClose={removeFromExchangeModal.close}
-          onConfirm={() =>
-            handleRemoveFromExchange(removeFromExchangeModal.exchange!)
-          }
-        />
+        <Suspense fallback={null}>
+          <RemoveFromExchangeModal
+            exchange={removeFromExchangeModal.exchange}
+            isOpen={removeFromExchangeModal.isOpen}
+            onClose={removeFromExchangeModal.close}
+            onConfirm={() =>
+              handleRemoveFromExchange(removeFromExchangeModal.exchange!)
+            }
+          />
+        </Suspense>
       )}
     </div>
   );

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, lazy, Suspense } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
@@ -11,7 +11,13 @@ import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { LanguageSwitcher } from "@/components/ui/LanguageSwitcher";
 import { getOccupationLabelKey } from "@/utils/occupation-labels";
-import { SafeModeWarningModal } from "@/components/features/SafeModeWarningModal";
+
+const SafeModeWarningModal = lazy(
+  () =>
+    import("@/components/features/SafeModeWarningModal").then((m) => ({
+      default: m.SafeModeWarningModal,
+    })),
+);
 
 const DEMO_RESET_MESSAGE_DURATION_MS = 3000;
 
@@ -472,11 +478,15 @@ export function SettingsPage() {
       </div>
 
       {/* Safe Mode Warning Modal */}
-      <SafeModeWarningModal
-        isOpen={showSafeModeWarning}
-        onClose={handleCloseSafeModeWarning}
-        onConfirm={handleConfirmDisableSafeMode}
-      />
+      {showSafeModeWarning && (
+        <Suspense fallback={null}>
+          <SafeModeWarningModal
+            isOpen={showSafeModeWarning}
+            onClose={handleCloseSafeModeWarning}
+            onConfirm={handleConfirmDisableSafeMode}
+          />
+        </Suspense>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Convert 5 modal components from eager to dynamic imports using React's
lazy() and Suspense APIs, following the existing PdfLanguageModal pattern.

This reduces the main bundle from ~123 KB to ~109 KB (gzipped), creating
~14 KB of headroom for future development.

Lazy-loaded modals:
- ValidateGameModal (~13 KB gzip)
- EditCompensationModal (~2 KB gzip)
- TakeOverExchangeModal (~0.3 KB gzip)
- RemoveFromExchangeModal (~0.3 KB gzip)
- SafeModeWarningModal (~1 KB gzip)

Closes #279