### PR TITLE
feat(tour): add safe mode note to guided tours section

### DIFF
--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -88,6 +88,8 @@ const de: Translations = {
         title: "Einführungstouren",
         description:
           "Interaktive Tipps, die Sie mit Beispieldaten durch jeden Bereich der App führen.",
+        safeModeNote:
+          "Hinweis: Der Sicherheitsmodus ist standardmässig aktiviert und blockiert bestimmte Aktionen. Um Spiele zu validieren oder Börsenaktionen durchzuführen, deaktivieren Sie den Sicherheitsmodus im Abschnitt unten.",
         restart: "Touren neu starten",
         statusCompleted: "Abgeschlossen",
         statusSkipped: "Übersprungen",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -88,6 +88,8 @@ const en: Translations = {
         title: "Guided Tours",
         description:
           "Interactive tips that guide you through each section of the app using example data.",
+        safeModeNote:
+          "Note: Safe mode is enabled by default, which blocks certain operations. To perform actions like validating games or managing exchanges, disable safe mode in the Safe Mode section below.",
         restart: "Restart Tours",
         statusCompleted: "Completed",
         statusSkipped: "Skipped",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -88,6 +88,8 @@ const fr: Translations = {
         title: "Visites guidées",
         description:
           "Conseils interactifs qui vous guident à travers chaque section de l'application avec des données d'exemple.",
+        safeModeNote:
+          "Remarque : Le mode sécurisé est activé par défaut, ce qui bloque certaines opérations. Pour valider des matchs ou gérer les échanges, désactivez le mode sécurisé dans la section ci-dessous.",
         restart: "Recommencer les visites",
         statusCompleted: "Terminé",
         statusSkipped: "Ignoré",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -88,6 +88,8 @@ const it: Translations = {
         title: "Tour guidati",
         description:
           "Suggerimenti interattivi che ti guidano attraverso ogni sezione dell'app usando dati di esempio.",
+        safeModeNote:
+          "Nota: La modalità sicura è attiva per impostazione predefinita e blocca alcune operazioni. Per validare partite o gestire gli scambi, disattiva la modalità sicura nella sezione sottostante.",
         restart: "Riavvia tour",
         statusCompleted: "Completato",
         statusSkipped: "Saltato",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -403,6 +403,7 @@ export interface Translations {
       tourSection: {
         title: string;
         description: string;
+        safeModeNote: string;
         restart: string;
         statusCompleted: string;
         statusSkipped: string;

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -173,6 +173,13 @@ export function SettingsPage() {
             {t("tour.settings.tourSection.description")}
           </p>
 
+          {/* Safe mode note - only show outside demo mode */}
+          {!isDemoMode && (
+            <p className="text-sm text-warning-600 dark:text-warning-400">
+              {t("tour.settings.tourSection.safeModeNote")}
+            </p>
+          )}
+
           {/* Tour status list */}
           <div className="space-y-2">
             {TOUR_IDS.map((tourId) => {


### PR DESCRIPTION
Add a note in the Guided Tours section explaining that safe mode is
enabled by default, blocking certain operations. Directs users to
disable safe mode in the Safe Mode section to perform actions like
validating games or managing exchanges.

The note is only shown outside demo mode since the Safe Mode section
itself is only visible when not in demo mode.