### PR TITLE
fix(e2e): eliminate Firefox flakiness in tab switching and demo mode navigation

### DIFF
--- a/web-app/e2e/pages/assignments.page.ts
+++ b/web-app/e2e/pages/assignments.page.ts
@@ -37,29 +37,23 @@ export class AssignmentsPage {
   }
 
   async switchToUpcomingTab() {
-    await this.upcomingTab.waitFor({ state: "visible" });
+    await expect(this.upcomingTab).toBeVisible();
     await this.upcomingTab.click();
-    // Wait for the "upcoming" tab to become selected using its stable ID (locale-independent)
-    await this.page.waitForFunction(
-      () => {
-        const tab = document.querySelector("#tab-upcoming");
-        return tab?.getAttribute("aria-selected") === "true";
-      },
-      { timeout: TAB_SWITCH_TIMEOUT_MS },
-    );
+    // Wait for tab to become selected using Playwright's built-in assertion
+    await expect(this.upcomingTab).toHaveAttribute("aria-selected", "true", {
+      timeout: TAB_SWITCH_TIMEOUT_MS,
+    });
     // Wait for tab panel content to stabilize
     await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
   }
 
   async switchToValidationClosedTab() {
-    await this.validationClosedTab.waitFor({ state: "visible" });
+    await expect(this.validationClosedTab).toBeVisible();
     await this.validationClosedTab.click();
-    // Wait for the "validationClosed" tab to become selected using its stable ID (locale-independent)
-    await this.page.waitForFunction(
-      () => {
-        const tab = document.querySelector("#tab-validationClosed");
-        return tab?.getAttribute("aria-selected") === "true";
-      },
+    // Wait for tab to become selected using Playwright's built-in assertion
+    await expect(this.validationClosedTab).toHaveAttribute(
+      "aria-selected",
+      "true",
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
     // Wait for tab panel content to stabilize

--- a/web-app/e2e/pages/compensations.page.ts
+++ b/web-app/e2e/pages/compensations.page.ts
@@ -38,46 +38,34 @@ export class CompensationsPage {
   }
 
   async switchToPendingTab() {
-    await this.pendingTab.waitFor({ state: "visible" });
+    await expect(this.pendingTab).toBeVisible();
     await this.pendingTab.click();
-    // Wait for the "unpaid" tab to become selected using its stable ID (locale-independent)
-    await this.page.waitForFunction(
-      () => {
-        const tab = document.querySelector("#tab-unpaid");
-        return tab?.getAttribute("aria-selected") === "true";
-      },
-      { timeout: TAB_SWITCH_TIMEOUT_MS },
-    );
+    // Wait for tab to become selected using Playwright's built-in assertion
+    await expect(this.pendingTab).toHaveAttribute("aria-selected", "true", {
+      timeout: TAB_SWITCH_TIMEOUT_MS,
+    });
     // Wait for tab panel content to stabilize
     await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
   }
 
   async switchToPaidTab() {
-    await this.paidTab.waitFor({ state: "visible" });
+    await expect(this.paidTab).toBeVisible();
     await this.paidTab.click();
-    // Wait for the "paid" tab to become selected using its stable ID (locale-independent)
-    await this.page.waitForFunction(
-      () => {
-        const tab = document.querySelector("#tab-paid");
-        return tab?.getAttribute("aria-selected") === "true";
-      },
-      { timeout: TAB_SWITCH_TIMEOUT_MS },
-    );
+    // Wait for tab to become selected using Playwright's built-in assertion
+    await expect(this.paidTab).toHaveAttribute("aria-selected", "true", {
+      timeout: TAB_SWITCH_TIMEOUT_MS,
+    });
     // Wait for tab panel content to stabilize
     await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
   }
 
   async switchToAllTab() {
-    await this.allTab.waitFor({ state: "visible" });
+    await expect(this.allTab).toBeVisible();
     await this.allTab.click();
-    // Wait for the "all" tab to become selected using its stable ID (locale-independent)
-    await this.page.waitForFunction(
-      () => {
-        const tab = document.querySelector("#tab-all");
-        return tab?.getAttribute("aria-selected") === "true";
-      },
-      { timeout: TAB_SWITCH_TIMEOUT_MS },
-    );
+    // Wait for tab to become selected using Playwright's built-in assertion
+    await expect(this.allTab).toHaveAttribute("aria-selected", "true", {
+      timeout: TAB_SWITCH_TIMEOUT_MS,
+    });
     // Wait for tab panel content to stabilize
     await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
   }

--- a/web-app/e2e/pages/exchanges.page.ts
+++ b/web-app/e2e/pages/exchanges.page.ts
@@ -39,29 +39,23 @@ export class ExchangesPage {
   }
 
   async switchToOpenTab() {
-    await this.openTab.waitFor({ state: "visible" });
+    await expect(this.openTab).toBeVisible();
     await this.openTab.click();
-    // Wait for the "open" tab to become selected using its stable ID (locale-independent)
-    await this.page.waitForFunction(
-      () => {
-        const tab = document.querySelector('#tab-open');
-        return tab?.getAttribute("aria-selected") === "true";
-      },
-      { timeout: TAB_SWITCH_TIMEOUT_MS },
-    );
+    // Wait for tab to become selected using Playwright's built-in assertion
+    await expect(this.openTab).toHaveAttribute("aria-selected", "true", {
+      timeout: TAB_SWITCH_TIMEOUT_MS,
+    });
     // Wait for tab panel content to stabilize
     await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
   }
 
   async switchToMyApplicationsTab() {
-    await this.myApplicationsTab.waitFor({ state: "visible" });
+    await expect(this.myApplicationsTab).toBeVisible();
     await this.myApplicationsTab.click();
-    // Wait for the "applied" tab to become selected using its stable ID (locale-independent)
-    await this.page.waitForFunction(
-      () => {
-        const tab = document.querySelector('#tab-applied');
-        return tab?.getAttribute("aria-selected") === "true";
-      },
+    // Wait for tab to become selected using Playwright's built-in assertion
+    await expect(this.myApplicationsTab).toHaveAttribute(
+      "aria-selected",
+      "true",
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
     // Wait for tab panel content to stabilize

--- a/web-app/e2e/pages/login.page.ts
+++ b/web-app/e2e/pages/login.page.ts
@@ -40,13 +40,19 @@ export class LoginPage {
    * Demo mode provides consistent mock data for reliable testing.
    */
   async enterDemoMode() {
-    // Ensure button is clickable before clicking
+    // Ensure button is visible and enabled before clicking
     await expect(this.demoButton).toBeVisible();
-    await this.demoButton.click();
-    // Wait for navigation away from login with explicit timeout
-    await expect(this.page).not.toHaveURL(/login/, {
-      timeout: PAGE_LOAD_TIMEOUT_MS,
-    });
+    await expect(this.demoButton).toBeEnabled();
+
+    // Click and wait for navigation simultaneously for reliability
+    // This ensures we capture the navigation even if it starts immediately
+    await Promise.all([
+      this.page.waitForURL((url) => !url.pathname.includes("/login"), {
+        timeout: PAGE_LOAD_TIMEOUT_MS,
+      }),
+      this.demoButton.click(),
+    ]);
+
     // Wait for main content to load
     await expect(this.page.getByRole("main")).toBeVisible({
       timeout: PAGE_LOAD_TIMEOUT_MS,


### PR DESCRIPTION
Replace page.waitForFunction() with Playwright's built-in toHaveAttribute()
assertion for tab selection detection. The native assertion has better
auto-waiting and retry logic, making it more reliable across browsers.

For demo mode navigation, use Promise.all with waitForURL to ensure the
navigation event is captured even if it starts immediately after the click.

Changes:
- login.page.ts: Use Promise.all pattern for click + navigation wait
- assignments.page.ts: Replace waitForFunction with toHaveAttribute
- compensations.page.ts: Replace waitForFunction with toHaveAttribute
- exchanges.page.ts: Replace waitForFunction with toHaveAttribute