### PR TITLE
perf(cards): add React.memo to card components in lists

### DIFF
--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { Badge } from "@/components/ui/Badge";
 import { MapPin } from "@/components/ui/icons";
@@ -14,7 +15,7 @@ interface AssignmentCardProps {
   dataTour?: string;
 }
 
-export function AssignmentCard({
+function AssignmentCardComponent({
   assignment,
   onClick,
   disableExpansion,
@@ -156,3 +157,5 @@ export function AssignmentCard({
     />
   );
 }
+
+export const AssignmentCard = memo(AssignmentCardComponent);

--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { Badge } from "@/components/ui/Badge";
@@ -17,7 +18,7 @@ interface CompensationCardProps {
   dataTour?: string;
 }
 
-export function CompensationCard({
+function CompensationCardComponent({
   compensation,
   onClick,
   disableExpansion,
@@ -155,3 +156,5 @@ export function CompensationCard({
     />
   );
 }
+
+export const CompensationCard = memo(CompensationCardComponent);

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { Badge } from "@/components/ui/Badge";
@@ -14,7 +15,7 @@ interface ExchangeCardProps {
   dataTour?: string;
 }
 
-export function ExchangeCard({
+function ExchangeCardComponent({
   exchange,
   disableExpansion,
   dataTour,
@@ -117,3 +118,5 @@ export function ExchangeCard({
     />
   );
 }
+
+export const ExchangeCard = memo(ExchangeCardComponent);


### PR DESCRIPTION
Wrap AssignmentCard, CompensationCard, and ExchangeCard with React.memo
to prevent unnecessary re-renders when one card updates in a list.

Props passed to these cards (data objects from TanStack Query cache and
stable primitive values) are suitable for shallow comparison. Parent
components already properly memoize callbacks with useCallback.

Closes #280