### PR TITLE
refactor(hooks): extract safe mode checking pattern to useSafeModeGuard hook

### DIFF
--- a/web-app/src/hooks/useAssignmentActions.ts
+++ b/web-app/src/hooks/useAssignmentActions.ts
@@ -2,14 +2,12 @@ import { useState, useCallback } from "react";
 import type { Assignment } from "@/api/client";
 import { createLogger } from "@/utils/logger";
 import { getTeamNames, isGameReportEligible } from "@/utils/assignment-helpers";
-import { checkSafeMode } from "@/utils/safe-mode-guard";
-import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { useLanguageStore } from "@/stores/language";
-import { useSettingsStore } from "@/stores/settings";
 import { toast } from "@/stores/toast";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useModalState } from "./useModalState";
+import { useSafeModeGuard } from "./useSafeModeGuard";
 
 const log = createLogger("useAssignmentActions");
 
@@ -47,11 +45,8 @@ interface UseAssignmentActionsResult {
 
 export function useAssignmentActions(): UseAssignmentActionsResult {
   const { t } = useTranslation();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const { guard, isDemoMode } = useSafeModeGuard();
   const locale = useLanguageStore((state) => state.locale);
-  const isSafeModeEnabled = useSettingsStore(
-    (state) => state.isSafeModeEnabled,
-  );
   const addAssignmentToExchange = useDemoStore(
     (state) => state.addAssignmentToExchange,
   );
@@ -64,9 +59,7 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
   const openValidateGame = useCallback(
     (assignment: Assignment) => {
       if (
-        checkSafeMode({
-          isDemoMode,
-          isSafeModeEnabled,
+        guard({
           context: "useAssignmentActions",
           action: "game validation",
         })
@@ -76,7 +69,7 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
 
       validateGameModal.open(assignment);
     },
-    [isDemoMode, isSafeModeEnabled, validateGameModal],
+    [guard, validateGameModal],
   );
 
   const openPdfReport = useCallback(
@@ -154,9 +147,7 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
       const { homeTeam, awayTeam } = getTeamNames(assignment);
 
       if (
-        checkSafeMode({
-          isDemoMode,
-          isSafeModeEnabled,
+        guard({
           context: "useAssignmentActions",
           action: "adding to exchange",
         })
@@ -181,7 +172,7 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
 
       toast.success(t("exchange.addedToExchangeSuccess"));
     },
-    [isDemoMode, isSafeModeEnabled, addAssignmentToExchange, t],
+    [guard, isDemoMode, addAssignmentToExchange, t],
   );
 
   return {

--- a/web-app/src/hooks/useCompensationActions.ts
+++ b/web-app/src/hooks/useCompensationActions.ts
@@ -2,12 +2,10 @@ import { useCallback, useRef } from "react";
 import type { CompensationRecord } from "@/api/client";
 import { downloadCompensationPDF } from "@/utils/compensation-actions";
 import { createLogger } from "@/utils/logger";
-import { checkSafeMode } from "@/utils/safe-mode-guard";
-import { useAuthStore } from "@/stores/auth";
-import { useSettingsStore } from "@/stores/settings";
 import { toast } from "@/stores/toast";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useModalState } from "./useModalState";
+import { useSafeModeGuard } from "./useSafeModeGuard";
 
 const log = createLogger("useCompensationActions");
 
@@ -23,19 +21,14 @@ interface UseCompensationActionsResult {
 
 export function useCompensationActions(): UseCompensationActionsResult {
   const { t } = useTranslation();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const isSafeModeEnabled = useSettingsStore(
-    (state) => state.isSafeModeEnabled,
-  );
+  const { guard, isDemoMode } = useSafeModeGuard();
   const editCompensationModal = useModalState<CompensationRecord>();
   const isDownloadingRef = useRef(false);
 
   const openEditCompensation = useCallback(
     (compensation: CompensationRecord) => {
       if (
-        checkSafeMode({
-          isDemoMode,
-          isSafeModeEnabled,
+        guard({
           context: "useCompensationActions",
           action: "editing compensation",
         })
@@ -45,7 +38,7 @@ export function useCompensationActions(): UseCompensationActionsResult {
 
       editCompensationModal.open(compensation);
     },
-    [isDemoMode, isSafeModeEnabled, editCompensationModal],
+    [guard, editCompensationModal],
   );
 
   const handleGeneratePDF = useCallback(

--- a/web-app/src/hooks/useExchangeActions.ts
+++ b/web-app/src/hooks/useExchangeActions.ts
@@ -5,12 +5,10 @@ import {
   useWithdrawFromExchange,
 } from "./useConvocations";
 import { createLogger } from "@/utils/logger";
-import { checkSafeMode } from "@/utils/safe-mode-guard";
-import { useAuthStore } from "@/stores/auth";
 import { toast } from "@/stores/toast";
-import { useSettingsStore } from "@/stores/settings";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useModalState } from "./useModalState";
+import { useSafeModeGuard } from "./useSafeModeGuard";
 
 const log = createLogger("useExchangeActions");
 
@@ -33,10 +31,7 @@ interface UseExchangeActionsResult {
 
 export function useExchangeActions(): UseExchangeActionsResult {
   const { t } = useTranslation();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const isSafeModeEnabled = useSettingsStore(
-    (state) => state.isSafeModeEnabled,
-  );
+  const { guard, isDemoMode } = useSafeModeGuard();
 
   const takeOverModal = useModalState<GameExchange>();
   const removeFromExchangeModal = useModalState<GameExchange>();
@@ -51,9 +46,7 @@ export function useExchangeActions(): UseExchangeActionsResult {
   const handleTakeOver = useCallback(
     async (exchange: GameExchange) => {
       if (
-        checkSafeMode({
-          isDemoMode,
-          isSafeModeEnabled,
+        guard({
           context: "useExchangeActions",
           action: "taking exchange",
         })
@@ -81,15 +74,13 @@ export function useExchangeActions(): UseExchangeActionsResult {
         isTakingOverRef.current = false;
       }
     },
-    [isDemoMode, isSafeModeEnabled, applyMutation, takeOverModal, t],
+    [guard, isDemoMode, applyMutation, takeOverModal, t],
   );
 
   const handleRemoveFromExchange = useCallback(
     async (exchange: GameExchange) => {
       if (
-        checkSafeMode({
-          isDemoMode,
-          isSafeModeEnabled,
+        guard({
           context: "useExchangeActions",
           action: "withdrawing from exchange",
         })
@@ -117,7 +108,7 @@ export function useExchangeActions(): UseExchangeActionsResult {
         isRemovingRef.current = false;
       }
     },
-    [isDemoMode, isSafeModeEnabled, withdrawMutation, removeFromExchangeModal, t],
+    [guard, isDemoMode, withdrawMutation, removeFromExchangeModal, t],
   );
 
   return {

--- a/web-app/src/hooks/useSafeModeGuard.test.ts
+++ b/web-app/src/hooks/useSafeModeGuard.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSafeModeGuard } from "./useSafeModeGuard";
+import * as authStore from "@/stores/auth";
+import * as settingsStore from "@/stores/settings";
+import { toast } from "@/stores/toast";
+
+vi.mock("@/stores/auth");
+vi.mock("@/stores/settings");
+vi.mock("@/stores/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+vi.mock("@/i18n", () => ({
+  t: (key: string) => key,
+}));
+
+describe("useSafeModeGuard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: not in demo mode, safe mode disabled
+    vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+      selector({ isDemoMode: false } as ReturnType<
+        typeof authStore.useAuthStore.getState
+      >),
+    );
+
+    vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
+      selector({ isSafeModeEnabled: false } as ReturnType<
+        typeof settingsStore.useSettingsStore.getState
+      >),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("guard function", () => {
+    it("should return false when safe mode is disabled", () => {
+      const { result } = renderHook(() => useSafeModeGuard());
+
+      let isBlocked: boolean;
+      act(() => {
+        isBlocked = result.current.guard({
+          context: "test",
+          action: "test action",
+        });
+      });
+
+      expect(isBlocked!).toBe(false);
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
+
+    it("should return false when in demo mode, even with safe mode enabled", () => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
+        selector({ isSafeModeEnabled: true } as ReturnType<
+          typeof settingsStore.useSettingsStore.getState
+        >),
+      );
+
+      const { result } = renderHook(() => useSafeModeGuard());
+
+      let isBlocked: boolean;
+      act(() => {
+        isBlocked = result.current.guard({
+          context: "test",
+          action: "test action",
+        });
+      });
+
+      expect(isBlocked!).toBe(false);
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
+
+    it("should return true and show warning when safe mode is active", () => {
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
+        selector({ isSafeModeEnabled: true } as ReturnType<
+          typeof settingsStore.useSettingsStore.getState
+        >),
+      );
+
+      const { result } = renderHook(() => useSafeModeGuard());
+
+      let isBlocked: boolean;
+      act(() => {
+        isBlocked = result.current.guard({
+          context: "useAssignmentActions",
+          action: "game validation",
+        });
+      });
+
+      expect(isBlocked!).toBe(true);
+      expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
+    });
+
+    it("should call onBlocked callback when blocked", () => {
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
+        selector({ isSafeModeEnabled: true } as ReturnType<
+          typeof settingsStore.useSettingsStore.getState
+        >),
+      );
+
+      const onBlocked = vi.fn();
+      const { result } = renderHook(() => useSafeModeGuard());
+
+      act(() => {
+        result.current.guard({
+          context: "test",
+          action: "test action",
+          onBlocked,
+        });
+      });
+
+      expect(onBlocked).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call onBlocked callback when not blocked", () => {
+      const onBlocked = vi.fn();
+      const { result } = renderHook(() => useSafeModeGuard());
+
+      act(() => {
+        result.current.guard({
+          context: "test",
+          action: "test action",
+          onBlocked,
+        });
+      });
+
+      expect(onBlocked).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("state exposure", () => {
+    it("should expose isDemoMode state", () => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      const { result } = renderHook(() => useSafeModeGuard());
+
+      expect(result.current.isDemoMode).toBe(true);
+    });
+
+    it("should expose isSafeModeEnabled state", () => {
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
+        selector({ isSafeModeEnabled: true } as ReturnType<
+          typeof settingsStore.useSettingsStore.getState
+        >),
+      );
+
+      const { result } = renderHook(() => useSafeModeGuard());
+
+      expect(result.current.isSafeModeEnabled).toBe(true);
+    });
+  });
+
+  describe("guard function stability", () => {
+    it("should return stable guard function reference", () => {
+      const { result, rerender } = renderHook(() => useSafeModeGuard());
+
+      const firstGuard = result.current.guard;
+      rerender();
+      const secondGuard = result.current.guard;
+
+      expect(firstGuard).toBe(secondGuard);
+    });
+
+    it("should update guard function when isDemoMode changes", () => {
+      const { result, rerender } = renderHook(() => useSafeModeGuard());
+
+      const firstGuard = result.current.guard;
+
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      rerender();
+      const secondGuard = result.current.guard;
+
+      expect(firstGuard).not.toBe(secondGuard);
+    });
+
+    it("should update guard function when isSafeModeEnabled changes", () => {
+      const { result, rerender } = renderHook(() => useSafeModeGuard());
+
+      const firstGuard = result.current.guard;
+
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
+        selector({ isSafeModeEnabled: true } as ReturnType<
+          typeof settingsStore.useSettingsStore.getState
+        >),
+      );
+
+      rerender();
+      const secondGuard = result.current.guard;
+
+      expect(firstGuard).not.toBe(secondGuard);
+    });
+  });
+});

--- a/web-app/src/hooks/useSafeModeGuard.ts
+++ b/web-app/src/hooks/useSafeModeGuard.ts
@@ -1,0 +1,68 @@
+import { useCallback } from "react";
+import { checkSafeMode } from "@/utils/safe-mode-guard";
+import { useAuthStore } from "@/stores/auth";
+import { useSettingsStore } from "@/stores/settings";
+
+interface SafeModeGuardParams {
+  context: string;
+  action: string;
+  onBlocked?: () => void;
+}
+
+interface UseSafeModeGuardResult {
+  /**
+   * Checks if an operation should be blocked due to safe mode.
+   * Returns true if blocked, false if allowed.
+   *
+   * @example
+   * const { guard } = useSafeModeGuard();
+   * if (guard({ context: "useAssignmentActions", action: "game validation" })) {
+   *   return; // Operation blocked
+   * }
+   */
+  guard: (params: SafeModeGuardParams) => boolean;
+  isDemoMode: boolean;
+  isSafeModeEnabled: boolean;
+}
+
+/**
+ * Hook that encapsulates the safe mode checking pattern.
+ * Extracts state from auth and settings stores and provides a guard function
+ * that can be used to check if an operation should be blocked.
+ *
+ * @example
+ * const { guard } = useSafeModeGuard();
+ *
+ * const handleAction = useCallback(() => {
+ *   if (guard({ context: "MyComponent", action: "my action" })) {
+ *     return;
+ *   }
+ *   // Proceed with action...
+ * }, [guard]);
+ */
+export function useSafeModeGuard(): UseSafeModeGuardResult {
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const isSafeModeEnabled = useSettingsStore(
+    (state) => state.isSafeModeEnabled,
+  );
+
+  const guard = useCallback(
+    ({ context, action, onBlocked }: SafeModeGuardParams): boolean => {
+      const isBlocked = checkSafeMode({
+        isDemoMode,
+        isSafeModeEnabled,
+        context,
+        action,
+      });
+
+      if (isBlocked && onBlocked) {
+        onBlocked();
+      }
+
+      return isBlocked;
+    },
+    [isDemoMode, isSafeModeEnabled],
+  );
+
+  return { guard, isDemoMode, isSafeModeEnabled };
+}


### PR DESCRIPTION
Create a reusable useSafeModeGuard hook that encapsulates the common pattern
of checking safe mode before performing mutations. This follows the DRY
principle by centralizing the logic that was previously duplicated across
multiple action hooks.

The new hook:
- Extracts isDemoMode and isSafeModeEnabled state from stores
- Provides a guard() function for consistent safe mode checking
- Supports optional onBlocked callback for custom behavior

Refactored consumers:
- useAssignmentActions
- useExchangeActions
- useCompensationActions

Closes #282