### PR TITLE
refactor(ui): extract reusable Modal wrapper component

### DIFF
--- a/web-app/src/components/features/ExchangeConfirmationModal.tsx
+++ b/web-app/src/components/features/ExchangeConfirmationModal.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { GameExchange } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
-import { useModalDismissal } from "@/hooks/useModalDismissal";
 import { logger } from "@/utils/logger";
 import { formatDateTime } from "@/utils/date-helpers";
+import { Modal } from "@/components/ui/Modal";
+import { ModalHeader } from "@/components/ui/ModalHeader";
+import { ModalFooter } from "@/components/ui/ModalFooter";
 import { ModalErrorBoundary } from "@/components/ui/ModalErrorBoundary";
 import { ModalButton } from "@/components/ui/ModalButton";
 
@@ -23,11 +25,6 @@ export function ExchangeConfirmationModal({
   variant,
 }: ExchangeConfirmationModalProps) {
   const { t } = useTranslation();
-
-  const { handleBackdropClick } = useModalDismissal({
-    isOpen,
-    onClose,
-  });
 
   const isSubmittingRef = useRef(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -66,8 +63,6 @@ export function ExchangeConfirmationModal({
     }
   }, [onConfirm, onClose]);
 
-  if (!isOpen) return null;
-
   const game = exchange.refereeGame?.game;
   const homeTeam = game?.encounter?.teamHome?.name || t("common.tbd");
   const awayTeam = game?.encounter?.teamAway?.name || t("common.tbd");
@@ -90,107 +85,91 @@ export function ExchangeConfirmationModal({
   const modalTitleId = `${variant}-exchange-title`;
 
   return (
-    <div
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-      onClick={handleBackdropClick}
-      aria-hidden="true"
-    >
-      <div
-        className="bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-xl max-w-md w-full p-6"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={modalTitleId}
-      >
-        <ModalErrorBoundary modalName="ExchangeConfirmationModal" onClose={onClose}>
-          <h2
-            id={modalTitleId}
-            className="text-xl font-semibold text-text-primary dark:text-text-primary-dark mb-4"
-          >
-            {t(titleKey)}
-          </h2>
+    <Modal isOpen={isOpen} onClose={onClose} titleId={modalTitleId} size="md">
+      <ModalErrorBoundary modalName="ExchangeConfirmationModal" onClose={onClose}>
+        <ModalHeader title={t(titleKey)} titleId={modalTitleId} />
 
-          <div className="mb-6 space-y-3">
+        <div className="mb-6 space-y-3">
+          <div>
+            <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+              {t("common.match")}
+            </div>
+            <div className="text-base text-text-primary dark:text-text-primary-dark font-medium">
+              {homeTeam} {t("common.vs")} {awayTeam}
+            </div>
+          </div>
+
+          {dateTime && (
             <div>
               <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                {t("common.match")}
+                {t("common.dateTime")}
               </div>
-              <div className="text-base text-text-primary dark:text-text-primary-dark font-medium">
-                {homeTeam} {t("common.vs")} {awayTeam}
+              <div className="text-base text-text-primary dark:text-text-primary-dark">
+                {formatDateTime(dateTime)}
               </div>
             </div>
+          )}
 
-            {dateTime && (
-              <div>
-                <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                  {t("common.dateTime")}
-                </div>
-                <div className="text-base text-text-primary dark:text-text-primary-dark">
-                  {formatDateTime(dateTime)}
-                </div>
+          {location && (
+            <div>
+              <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+                {t("common.location")}
               </div>
-            )}
-
-            {location && (
-              <div>
-                <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                  {t("common.location")}
-                </div>
-                <div className="text-base text-text-primary dark:text-text-primary-dark">
-                  {location}
-                </div>
+              <div className="text-base text-text-primary dark:text-text-primary-dark">
+                {location}
               </div>
-            )}
-
-            {position && (
-              <div>
-                <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                  {t("common.position")}
-                </div>
-                <div className="text-base text-text-primary dark:text-text-primary-dark">
-                  {position}
-                </div>
-              </div>
-            )}
-
-            {level && (
-              <div>
-                <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
-                  {t("common.requiredLevel")}
-                </div>
-                <div className="text-base text-text-primary dark:text-text-primary-dark">
-                  {level}
-                </div>
-              </div>
-            )}
-          </div>
-
-          <div className="border-t border-border-default dark:border-border-default-dark pt-4">
-            <p className="text-sm text-text-muted dark:text-text-muted-dark mb-4">
-              {t(confirmKey)}
-            </p>
-
-            <div className="flex gap-3">
-              <ModalButton
-                variant="secondary"
-                fullWidth
-                onClick={onClose}
-                disabled={isSubmitting}
-              >
-                {t("common.cancel")}
-              </ModalButton>
-              <ModalButton
-                variant={confirmVariant}
-                fullWidth
-                onClick={handleConfirm}
-                disabled={isSubmitting}
-                aria-busy={isSubmitting}
-              >
-                {isSubmitting ? t("common.loading") : t(buttonKey)}
-              </ModalButton>
             </div>
-          </div>
-        </ModalErrorBoundary>
-      </div>
-    </div>
+          )}
+
+          {position && (
+            <div>
+              <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+                {t("common.position")}
+              </div>
+              <div className="text-base text-text-primary dark:text-text-primary-dark">
+                {position}
+              </div>
+            </div>
+          )}
+
+          {level && (
+            <div>
+              <div className="text-sm font-medium text-text-muted dark:text-text-muted-dark">
+                {t("common.requiredLevel")}
+              </div>
+              <div className="text-base text-text-primary dark:text-text-primary-dark">
+                {level}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-border-default dark:border-border-default-dark pt-4">
+          <p className="text-sm text-text-muted dark:text-text-muted-dark mb-4">
+            {t(confirmKey)}
+          </p>
+
+          <ModalFooter>
+            <ModalButton
+              variant="secondary"
+              fullWidth
+              onClick={onClose}
+              disabled={isSubmitting}
+            >
+              {t("common.cancel")}
+            </ModalButton>
+            <ModalButton
+              variant={confirmVariant}
+              fullWidth
+              onClick={handleConfirm}
+              disabled={isSubmitting}
+              aria-busy={isSubmitting}
+            >
+              {isSubmitting ? t("common.loading") : t(buttonKey)}
+            </ModalButton>
+          </ModalFooter>
+        </div>
+      </ModalErrorBoundary>
+    </Modal>
   );
 }

--- a/web-app/src/components/features/PdfLanguageModal.tsx
+++ b/web-app/src/components/features/PdfLanguageModal.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from '@/hooks/useTranslation';
-import { useModalDismissal } from '@/hooks/useModalDismissal';
 import { FileText } from 'lucide-react';
 import type { Language } from '@/utils/pdf-form-filler';
+import { Modal } from '@/components/ui/Modal';
+import { ModalHeader } from '@/components/ui/ModalHeader';
+import { ModalFooter } from '@/components/ui/ModalFooter';
 import { ModalButton } from '@/components/ui/ModalButton';
+
+const MODAL_TITLE_ID = 'pdf-lang-title';
 
 interface PdfLanguageModalProps {
   isOpen: boolean;
@@ -32,90 +36,76 @@ export function PdfLanguageModal({
     if (isOpen) setSelected(defaultLanguage); // eslint-disable-line react-hooks/set-state-in-effect
   }, [isOpen, defaultLanguage]);
 
-  const { handleBackdropClick } = useModalDismissal({
-    isOpen,
-    onClose,
-    isLoading,
-  });
-
-  if (!isOpen) return null;
+  const pdfIcon = (
+    <div className="flex-shrink-0 w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
+      <FileText className="w-5 h-5 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+    </div>
+  );
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-      onClick={handleBackdropClick}
-      aria-hidden="true"
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      titleId={MODAL_TITLE_ID}
+      size="sm"
+      isLoading={isLoading}
     >
-      <div
-        className="bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-xl max-w-sm w-full p-6"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="pdf-lang-title"
-      >
-        <div className="flex items-center gap-3 mb-4">
-          <div className="flex-shrink-0 w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
-            <FileText className="w-5 h-5 text-blue-600 dark:text-blue-400" aria-hidden="true" />
-          </div>
-          <h2
-            id="pdf-lang-title"
-            className="text-lg font-semibold text-text-primary dark:text-text-primary-dark"
-          >
-            {t('pdf.exportTitle')}
-          </h2>
-        </div>
-        <p className="text-sm text-text-secondary dark:text-text-secondary-dark mb-4">
-          {t('pdf.selectLanguage')}
-        </p>
+      <ModalHeader
+        title={t('pdf.exportTitle')}
+        titleId={MODAL_TITLE_ID}
+        titleSize="lg"
+        icon={pdfIcon}
+      />
 
-        <div className="space-y-2 mb-6">
-          {LANGUAGES.map(({ code, name }) => (
-            <label
-              key={code}
-              className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                selected === code
-                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
-                  : 'border-border-default dark:border-border-default-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark'
-              }`}
-            >
-              <input
-                type="radio"
-                name="pdf-lang"
-                value={code}
-                checked={selected === code}
-                onChange={() => setSelected(code)}
-                className="w-4 h-4 text-blue-600"
-                disabled={isLoading}
-              />
-              <span className="text-text-primary dark:text-text-primary-dark">{name}</span>
-            </label>
-          ))}
-        </div>
+      <p className="text-sm text-text-secondary dark:text-text-secondary-dark mb-4">
+        {t('pdf.selectLanguage')}
+      </p>
 
-        <div className="flex gap-3">
-          <ModalButton variant="secondary" fullWidth onClick={onClose} disabled={isLoading}>
-            {t('common.cancel')}
-          </ModalButton>
-          <ModalButton
-            variant="blue"
-            fullWidth
-            onClick={() => onConfirm(selected)}
-            disabled={isLoading}
-            className="flex items-center justify-center gap-2"
+      <div className="space-y-2 mb-6">
+        {LANGUAGES.map(({ code, name }) => (
+          <label
+            key={code}
+            className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+              selected === code
+                ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                : 'border-border-default dark:border-border-default-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark'
+            }`}
           >
-            {isLoading ? (
-              <>
-                <span
-                  className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"
-                  aria-hidden="true"
-                />
-                {t('pdf.generating')}
-              </>
-            ) : (
-              t('pdf.export')
-            )}
-          </ModalButton>
-        </div>
+            <input
+              type="radio"
+              name="pdf-lang"
+              value={code}
+              checked={selected === code}
+              onChange={() => setSelected(code)}
+              className="w-4 h-4 text-blue-600"
+              disabled={isLoading}
+            />
+            <span className="text-text-primary dark:text-text-primary-dark">{name}</span>
+          </label>
+        ))}
       </div>
-    </div>
+
+      <ModalFooter>
+        <ModalButton variant="secondary" fullWidth onClick={onClose} disabled={isLoading}>
+          {t('common.cancel')}
+        </ModalButton>
+        <ModalButton
+          variant="blue"
+          fullWidth
+          onClick={() => onConfirm(selected)}
+          disabled={isLoading}
+          className="flex items-center justify-center gap-2"
+        >
+          {isLoading ? (
+            <>
+              <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              {t('pdf.generating')}
+            </>
+          ) : (
+            t('pdf.export')
+          )}
+        </ModalButton>
+      </ModalFooter>
+    </Modal>
   );
 }

--- a/web-app/src/components/features/SafeModeWarningModal.tsx
+++ b/web-app/src/components/features/SafeModeWarningModal.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useRef } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
-import { useModalDismissal } from "@/hooks/useModalDismissal";
+import { Modal } from "@/components/ui/Modal";
+import { ModalHeader } from "@/components/ui/ModalHeader";
+import { ModalFooter } from "@/components/ui/ModalFooter";
 import { ModalButton } from "@/components/ui/ModalButton";
+
+const MODAL_TITLE_ID = "safe-mode-warning-title";
 
 interface SafeModeWarningModalProps {
   isOpen: boolean;
@@ -17,11 +21,6 @@ export function SafeModeWarningModal({
   const { t } = useTranslation();
   const isConfirmingRef = useRef(false);
 
-  const { handleBackdropClick } = useModalDismissal({
-    isOpen,
-    onClose,
-  });
-
   const handleConfirm = useCallback(() => {
     if (isConfirmingRef.current) return;
     isConfirmingRef.current = true;
@@ -33,86 +32,62 @@ export function SafeModeWarningModal({
     }
   }, [onConfirm, onClose]);
 
-  if (!isOpen) return null;
-
-  // Backdrop pattern: aria-hidden="true" hides the backdrop from screen readers since it's
-  // purely decorative. Click-to-close is a convenience feature; keyboard users close via Escape.
-  // See CLAUDE.md Accessibility section for the canonical modal pattern.
-  return (
-    <div
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-      onClick={handleBackdropClick}
-      aria-hidden="true"
-    >
-      <div
-        className="bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-xl max-w-md w-full p-6"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="safe-mode-warning-title"
+  const warningIcon = (
+    <div className="flex-shrink-0 w-12 h-12 rounded-full bg-yellow-100 dark:bg-yellow-900 flex items-center justify-center">
+      <svg
+        className="w-6 h-6 text-yellow-600 dark:text-yellow-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
       >
-        <div className="flex items-center gap-3 mb-4">
-          <div className="flex-shrink-0 w-12 h-12 rounded-full bg-yellow-100 dark:bg-yellow-900 flex items-center justify-center">
-            <svg
-              className="w-6 h-6 text-yellow-600 dark:text-yellow-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
-          </div>
-          <h2
-            id="safe-mode-warning-title"
-            className="text-xl font-semibold text-text-primary dark:text-text-primary-dark"
-          >
-            {t("settings.safeModeWarningTitle")}
-          </h2>
-        </div>
-
-        <div className="mb-6 space-y-3">
-          <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
-            {t("settings.safeModeWarningMessage")}
-          </p>
-
-          <ul className="space-y-2 text-sm text-text-secondary dark:text-text-secondary-dark">
-            <li className="flex items-start">
-              <span className="text-yellow-600 dark:text-yellow-400 mr-2">
-                •
-              </span>
-              <span>{t("settings.safeModeWarningPoint1")}</span>
-            </li>
-            <li className="flex items-start">
-              <span className="text-yellow-600 dark:text-yellow-400 mr-2">
-                •
-              </span>
-              <span>{t("settings.safeModeWarningPoint2")}</span>
-            </li>
-            <li className="flex items-start">
-              <span className="text-yellow-600 dark:text-yellow-400 mr-2">
-                •
-              </span>
-              <span>{t("settings.safeModeWarningPoint3")}</span>
-            </li>
-          </ul>
-        </div>
-
-        <div className="border-t border-border-default dark:border-border-default-dark pt-4">
-          <div className="flex gap-3">
-            <ModalButton variant="secondary" fullWidth onClick={onClose}>
-              {t("common.cancel")}
-            </ModalButton>
-            <ModalButton variant="danger" fullWidth onClick={handleConfirm}>
-              {t("settings.safeModeConfirmButton")}
-            </ModalButton>
-          </div>
-        </div>
-      </div>
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+        />
+      </svg>
     </div>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} titleId={MODAL_TITLE_ID} size="md">
+      <ModalHeader
+        title={t("settings.safeModeWarningTitle")}
+        titleId={MODAL_TITLE_ID}
+        icon={warningIcon}
+      />
+
+      <div className="mb-6 space-y-3">
+        <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+          {t("settings.safeModeWarningMessage")}
+        </p>
+
+        <ul className="space-y-2 text-sm text-text-secondary dark:text-text-secondary-dark">
+          <li className="flex items-start">
+            <span className="text-yellow-600 dark:text-yellow-400 mr-2">•</span>
+            <span>{t("settings.safeModeWarningPoint1")}</span>
+          </li>
+          <li className="flex items-start">
+            <span className="text-yellow-600 dark:text-yellow-400 mr-2">•</span>
+            <span>{t("settings.safeModeWarningPoint2")}</span>
+          </li>
+          <li className="flex items-start">
+            <span className="text-yellow-600 dark:text-yellow-400 mr-2">•</span>
+            <span>{t("settings.safeModeWarningPoint3")}</span>
+          </li>
+        </ul>
+      </div>
+
+      <ModalFooter divider>
+        <ModalButton variant="secondary" fullWidth onClick={onClose}>
+          {t("common.cancel")}
+        </ModalButton>
+        <ModalButton variant="danger" fullWidth onClick={handleConfirm}>
+          {t("settings.safeModeConfirmButton")}
+        </ModalButton>
+      </ModalFooter>
+    </Modal>
   );
 }

--- a/web-app/src/components/ui/Modal.tsx
+++ b/web-app/src/components/ui/Modal.tsx
@@ -3,6 +3,9 @@ import { useModalDismissal } from "@/hooks/useModalDismissal";
 
 export type ModalSize = "sm" | "md" | "lg" | "xl";
 
+/** Default z-index for modal overlays */
+const DEFAULT_Z_INDEX = 50;
+
 const sizeClasses: Record<ModalSize, string> = {
   sm: "max-w-sm",
   md: "max-w-md",
@@ -65,7 +68,7 @@ export function Modal({
   closeOnEscape = true,
   closeOnBackdrop = true,
   isLoading = false,
-  zIndex = 50,
+  zIndex = DEFAULT_Z_INDEX,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);

--- a/web-app/src/components/ui/Modal.tsx
+++ b/web-app/src/components/ui/Modal.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { useModalDismissal } from "@/hooks/useModalDismissal";
+
+export type ModalSize = "sm" | "md" | "lg" | "xl";
+
+const sizeClasses: Record<ModalSize, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+};
+
+interface ModalProps {
+  /** Whether the modal is currently open */
+  isOpen: boolean;
+  /** Callback to close the modal */
+  onClose: () => void;
+  /** Content to render inside the modal */
+  children: ReactNode;
+  /** ID for the modal title element (used for aria-labelledby) */
+  titleId: string;
+  /** Modal width size variant */
+  size?: ModalSize;
+  /** Whether pressing Escape should close the modal */
+  closeOnEscape?: boolean;
+  /** Whether clicking the backdrop should close the modal */
+  closeOnBackdrop?: boolean;
+  /** When true, dismissal is disabled (e.g., during loading/submission) */
+  isLoading?: boolean;
+  /** Custom z-index for the modal (default: 50) */
+  zIndex?: number;
+}
+
+/**
+ * Reusable modal component with accessibility features.
+ *
+ * Features:
+ * - Focus trapping within the modal
+ * - Escape key and backdrop click to close
+ * - ARIA attributes for screen readers
+ *
+ * @example
+ * ```tsx
+ * <Modal
+ *   isOpen={isOpen}
+ *   onClose={handleClose}
+ *   titleId="my-modal-title"
+ *   size="md"
+ * >
+ *   <ModalHeader title="My Modal" titleId="my-modal-title" />
+ *   <div className="mb-6">Modal content here</div>
+ *   <ModalFooter>
+ *     <ModalButton variant="secondary" onClick={handleClose}>Cancel</ModalButton>
+ *     <ModalButton variant="primary" onClick={handleConfirm}>Confirm</ModalButton>
+ *   </ModalFooter>
+ * </Modal>
+ * ```
+ */
+export function Modal({
+  isOpen,
+  onClose,
+  children,
+  titleId,
+  size = "md",
+  closeOnEscape = true,
+  closeOnBackdrop = true,
+  isLoading = false,
+  zIndex = 50,
+}: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const { handleBackdropClick } = useModalDismissal({
+    isOpen,
+    onClose,
+    isLoading,
+    closeOnEscape,
+    closeOnBackdropClick: closeOnBackdrop,
+  });
+
+  // Focus management: save previous focus and restore on close
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      // Focus the dialog container for screen reader announcement
+      dialogRef.current?.focus();
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [isOpen]);
+
+  // Focus trap: keep focus within the modal
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+
+      const focusableElements = dialog.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+
+      if (focusableElements.length === 0) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (e.shiftKey) {
+        // Shift + Tab: if on first element, wrap to last
+        if (document.activeElement === firstElement && lastElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        // Tab: if on last element, wrap to first
+        if (document.activeElement === lastElement && firstElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  // Backdrop pattern: aria-hidden="true" hides the backdrop from screen readers since it's
+  // purely decorative. Click-to-close is a convenience feature; keyboard users close via Escape.
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4"
+      style={{ zIndex }}
+      onClick={handleBackdropClick}
+      aria-hidden="true"
+    >
+      {/* Dialog container */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={`bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-xl w-full ${sizeClasses[size]} p-6 focus:outline-none`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/components/ui/ModalFooter.tsx
+++ b/web-app/src/components/ui/ModalFooter.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+
+interface ModalFooterProps {
+  /** Footer content (typically ModalButton components) */
+  children: ReactNode;
+  /** Whether to show a divider line above the footer */
+  divider?: boolean;
+}
+
+/**
+ * Footer component for modals with consistent styling and optional divider.
+ *
+ * @example
+ * ```tsx
+ * <ModalFooter divider>
+ *   <ModalButton variant="secondary" fullWidth onClick={onClose}>
+ *     Cancel
+ *   </ModalButton>
+ *   <ModalButton variant="primary" fullWidth onClick={onConfirm}>
+ *     Confirm
+ *   </ModalButton>
+ * </ModalFooter>
+ * ```
+ */
+export function ModalFooter({ children, divider = false }: ModalFooterProps) {
+  return (
+    <div
+      className={
+        divider
+          ? "border-t border-border-default dark:border-border-default-dark pt-4"
+          : undefined
+      }
+    >
+      <div className="flex gap-3">{children}</div>
+    </div>
+  );
+}

--- a/web-app/src/components/ui/ModalHeader.tsx
+++ b/web-app/src/components/ui/ModalHeader.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+type TitleSize = "base" | "lg" | "xl";
+
 interface ModalHeaderProps {
   /** Modal title text */
   title: string;
@@ -10,10 +12,10 @@ interface ModalHeaderProps {
   /** Optional subtitle or additional content below the title */
   subtitle?: ReactNode;
   /** Title text size variant */
-  titleSize?: "base" | "lg" | "xl";
+  titleSize?: TitleSize;
 }
 
-const titleSizeClasses: Record<string, string> = {
+const titleSizeClasses: Record<TitleSize, string> = {
   base: "text-base",
   lg: "text-lg",
   xl: "text-xl",

--- a/web-app/src/components/ui/ModalHeader.tsx
+++ b/web-app/src/components/ui/ModalHeader.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+
+interface ModalHeaderProps {
+  /** Modal title text */
+  title: string;
+  /** ID for the title element (must match Modal's titleId) */
+  titleId: string;
+  /** Optional icon to display before the title */
+  icon?: ReactNode;
+  /** Optional subtitle or additional content below the title */
+  subtitle?: ReactNode;
+  /** Title text size variant */
+  titleSize?: "base" | "lg" | "xl";
+}
+
+const titleSizeClasses: Record<string, string> = {
+  base: "text-base",
+  lg: "text-lg",
+  xl: "text-xl",
+};
+
+/**
+ * Header component for modals with title and optional icon.
+ *
+ * @example
+ * ```tsx
+ * // Simple title
+ * <ModalHeader
+ *   title="Edit Settings"
+ *   titleId="edit-settings-title"
+ * />
+ *
+ * // With icon
+ * <ModalHeader
+ *   title="Export PDF"
+ *   titleId="pdf-export-title"
+ *   icon={
+ *     <div className="flex-shrink-0 w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
+ *       <FileText className="w-5 h-5 text-blue-600 dark:text-blue-400" aria-hidden="true" />
+ *     </div>
+ *   }
+ * />
+ *
+ * // With subtitle
+ * <ModalHeader
+ *   title="Confirm Action"
+ *   titleId="confirm-action-title"
+ *   subtitle="Team A vs Team B"
+ * />
+ * ```
+ */
+export function ModalHeader({
+  title,
+  titleId,
+  icon,
+  subtitle,
+  titleSize = "xl",
+}: ModalHeaderProps) {
+  return (
+    <div className="mb-4">
+      <div className={icon ? "flex items-center gap-3" : undefined}>
+        {icon}
+        <h2
+          id={titleId}
+          className={`${titleSizeClasses[titleSize]} font-semibold text-text-primary dark:text-text-primary-dark`}
+        >
+          {title}
+        </h2>
+      </div>
+      {subtitle && (
+        <div className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
+          {subtitle}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Create a unified Modal component to replace duplicated modal patterns:
- Modal.tsx: Main wrapper with focus trap, escape key, backdrop click
- ModalHeader.tsx: Consistent header with title, icon, and subtitle support
- ModalFooter.tsx: Button container with optional divider

Refactor all five modal components to use the new wrapper:
- EditCompensationModal
- ValidateGameModal
- ExchangeConfirmationModal
- SafeModeWarningModal
- PdfLanguageModal

Benefits:
- Single source of truth for modal styling and accessibility
- Centralized ARIA management (role, aria-modal, aria-labelledby)
- Focus trap implementation for keyboard navigation
- Reduced code duplication (~90 lines saved)

Closes #283