### PR TITLE
fix(test): stabilize flaky Escape key test in EditCompensationModal

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.test.tsx
+++ b/web-app/src/components/features/EditCompensationModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { EditCompensationModal } from "./EditCompensationModal";
 import type { CompensationRecord, Assignment } from "@/api/client";
@@ -449,10 +449,13 @@ describe("EditCompensationModal", () => {
 
       await waitForFormToLoad();
 
-      fireEvent.keyDown(document, { key: "Escape" });
-      await waitFor(() => {
-        expect(mockOnClose).toHaveBeenCalledTimes(1);
+      // Wrap in act to ensure React has finished processing state updates
+      // and effect cleanup/re-registration before firing the event
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "Escape" });
       });
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
     });
 
     it("submits form with valid data and closes modal", async () => {


### PR DESCRIPTION
The Escape key test was failing intermittently in CI due to a race
condition between React's effect cleanup/re-registration cycle and
the fireEvent.keyDown call. After the async data fetch completed,
state updates triggered re-renders which could cause the keydown
event to be missed during effect re-registration.

Wrap the fireEvent in act() to ensure React has fully processed
all pending state updates before the keyboard event is fired.