### PR TITLE
refactor(api): centralize query key generation (#284)

### DIFF
--- a/web-app/src/api/queryKeys.ts
+++ b/web-app/src/api/queryKeys.ts
@@ -1,0 +1,159 @@
+/**
+ * Centralized Query Key Factory
+ *
+ * This module provides a single source of truth for all TanStack Query keys.
+ * Using a hierarchical structure enables:
+ * - Type-safe key generation with autocomplete
+ * - Hierarchical invalidation (invalidating parent keys invalidates all children)
+ * - Consistency across useQuery, useMutation, and cache invalidation calls
+ *
+ * Pattern:
+ * - `.all` - Base key for the entity, used for bulk invalidation
+ * - `.lists()` - Parent key for all list queries
+ * - `.list(params)` - Specific list query with parameters
+ * - `.details()` - Parent key for all detail queries
+ * - `.detail(id)` - Specific detail query
+ *
+ * @example
+ * // Invalidate all assignments (lists and details)
+ * queryClient.invalidateQueries({ queryKey: queryKeys.assignments.all })
+ *
+ * // Invalidate only assignment lists (not details)
+ * queryClient.invalidateQueries({ queryKey: queryKeys.assignments.lists() })
+ *
+ * // Query a specific assignment list
+ * useQuery({ queryKey: queryKeys.assignments.list(config, demoCode) })
+ */
+
+import type { SearchConfiguration, PersonSearchFilter } from "./client";
+
+export const queryKeys = {
+  /**
+   * Assignment query keys
+   */
+  assignments: {
+    /** Base key - invalidates ALL assignment queries */
+    all: ["assignments"] as const,
+    /** Parent key for all list queries */
+    lists: () => [...queryKeys.assignments.all, "list"] as const,
+    /** Specific list query with search configuration */
+    list: (
+      config?: SearchConfiguration,
+      demoAssociationCode?: string | null,
+    ) => [...queryKeys.assignments.lists(), config, demoAssociationCode] as const,
+    /** Parent key for all detail queries */
+    details: () => [...queryKeys.assignments.all, "detail"] as const,
+    /** Specific assignment detail query */
+    detail: (id: string) => [...queryKeys.assignments.details(), id] as const,
+    /** Validation-closed assignments query */
+    validationClosed: (
+      fromDate: string,
+      toDate: string,
+      deadlineHours: number,
+    ) =>
+      [
+        ...queryKeys.assignments.all,
+        "validationClosed",
+        fromDate,
+        toDate,
+        deadlineHours,
+      ] as const,
+  },
+
+  /**
+   * Compensation query keys
+   */
+  compensations: {
+    /** Base key - invalidates ALL compensation queries */
+    all: ["compensations"] as const,
+    /** Parent key for all list queries */
+    lists: () => [...queryKeys.compensations.all, "list"] as const,
+    /** Specific list query with search configuration */
+    list: (
+      config?: SearchConfiguration,
+      demoAssociationCode?: string | null,
+    ) => [...queryKeys.compensations.lists(), config, demoAssociationCode] as const,
+  },
+
+  /**
+   * Exchange query keys
+   */
+  exchanges: {
+    /** Base key - invalidates ALL exchange queries */
+    all: ["exchanges"] as const,
+    /** Parent key for all list queries */
+    lists: () => [...queryKeys.exchanges.all, "list"] as const,
+    /** Specific list query with search configuration */
+    list: (
+      config?: SearchConfiguration,
+      demoAssociationCode?: string | null,
+    ) => [...queryKeys.exchanges.lists(), config, demoAssociationCode] as const,
+  },
+
+  /**
+   * Season query keys
+   */
+  seasons: {
+    /** Base key - invalidates ALL season queries */
+    all: ["seasons"] as const,
+    /** Active season query */
+    active: () => [...queryKeys.seasons.all, "active"] as const,
+  },
+
+  /**
+   * Association settings query keys
+   */
+  settings: {
+    /** Base key - invalidates ALL settings queries */
+    all: ["settings"] as const,
+    /** Association settings query */
+    association: () => [...queryKeys.settings.all, "association"] as const,
+  },
+
+  /**
+   * Nomination query keys
+   */
+  nominations: {
+    /** Base key - invalidates ALL nomination queries */
+    all: ["nominations"] as const,
+    /** Parent key for nomination list queries */
+    lists: () => [...queryKeys.nominations.all, "list"] as const,
+    /** Specific nomination list for a game and team */
+    list: (gameId: string, team: "home" | "away") =>
+      [...queryKeys.nominations.lists(), gameId, team] as const,
+    /** Parent key for possible nomination queries */
+    possibles: () => [...queryKeys.nominations.all, "possible"] as const,
+    /** Possible nominations for a nomination list */
+    possible: (nominationListId: string) =>
+      [...queryKeys.nominations.possibles(), nominationListId] as const,
+  },
+
+  /**
+   * Validation/game details query keys
+   */
+  validation: {
+    /** Base key - invalidates ALL validation queries */
+    all: ["validation"] as const,
+    /** Parent key for game detail queries */
+    gameDetails: () => [...queryKeys.validation.all, "gameDetails"] as const,
+    /** Specific game details with scoresheet */
+    gameDetail: (gameId: string) =>
+      [...queryKeys.validation.gameDetails(), gameId] as const,
+  },
+
+  /**
+   * Scorer search query keys
+   */
+  scorerSearch: {
+    /** Base key - invalidates ALL scorer search queries */
+    all: ["scorerSearch"] as const,
+    /** Specific search query with filters */
+    search: (filters: PersonSearchFilter) =>
+      [...queryKeys.scorerSearch.all, filters] as const,
+  },
+} as const;
+
+/**
+ * Type helper to extract query key types
+ */
+export type QueryKeys = typeof queryKeys;

--- a/web-app/src/hooks/useConvocations.test.tsx
+++ b/web-app/src/hooks/useConvocations.test.tsx
@@ -742,10 +742,11 @@ describe("useConvocations - Demo Association Switching", () => {
     const svQueryData = queryClient.getQueriesData({ queryKey: ["assignments"] });
     expect(svQueryData.length).toBeGreaterThan(0);
 
-    // The query key should include "SV" as the third element
+    // The query key should include "SV" as the fourth element
+    // (query key format: ["assignments", "list", config, demoAssociationCode])
     const svQueryKey = svQueryData[0]?.[0];
     expect(svQueryKey).toBeDefined();
-    expect(svQueryKey?.[2]).toBe("SV");
+    expect(svQueryKey?.[3]).toBe("SV");
 
     // Now test with SVRBA association in a fresh query client
     const queryClient2 = new QueryClient({
@@ -777,11 +778,12 @@ describe("useConvocations - Demo Association Switching", () => {
       expect(result2.current.isSuccess).toBe(true);
     });
 
-    // The query key should include "SVRBA" as the third element
+    // The query key should include "SVRBA" as the fourth element
+    // (query key format: ["assignments", "list", config, demoAssociationCode])
     const svrbaQueryData = queryClient2.getQueriesData({ queryKey: ["assignments"] });
     const svrbaQueryKey = svrbaQueryData[0]?.[0];
     expect(svrbaQueryKey).toBeDefined();
-    expect(svrbaQueryKey?.[2]).toBe("SVRBA");
+    expect(svrbaQueryKey?.[3]).toBe("SVRBA");
   });
 
   it("should use null association code for non-demo mode", async () => {

--- a/web-app/src/hooks/useNominationList.ts
+++ b/web-app/src/hooks/useNominationList.ts
@@ -4,6 +4,7 @@ import type { NominationList, IndoorPlayerNomination } from "@/api/client";
 import { getApiClient } from "@/api/client";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
+import { queryKeys } from "@/api/queryKeys";
 
 const NOMINATION_LIST_STALE_TIME_MINUTES = 5;
 const MS_PER_MINUTE = 60 * 1000;
@@ -116,7 +117,7 @@ export function useNominationList({
   const apiClient = getApiClient(isDemoMode);
 
   const query = useQuery({
-    queryKey: ["nominationList", gameId, team],
+    queryKey: queryKeys.nominations.list(gameId, team),
     queryFn: async (): Promise<NominationList | null> => {
       return apiClient.getNominationList(gameId, team);
     },

--- a/web-app/src/hooks/usePlayerNominations.ts
+++ b/web-app/src/hooks/usePlayerNominations.ts
@@ -5,7 +5,7 @@ import {
   type PossibleNominationsResponse,
 } from "@/api/client";
 import { useAuthStore } from "@/stores/auth";
-import { queryKeys } from "./useConvocations";
+import { queryKeys } from "@/api/queryKeys";
 
 interface UsePossiblePlayerNominationsOptions {
   nominationListId: string;
@@ -30,7 +30,7 @@ export function usePossiblePlayerNominations({
   const apiClient = getApiClient(isDemoMode);
 
   return useQuery({
-    queryKey: queryKeys.possibleNominations(nominationListId),
+    queryKey: queryKeys.nominations.possible(nominationListId),
     queryFn: async () => {
       const response: PossibleNominationsResponse =
         await apiClient.getPossiblePlayerNominations(nominationListId);

--- a/web-app/src/hooks/useScorerSearch.ts
+++ b/web-app/src/hooks/useScorerSearch.ts
@@ -6,13 +6,7 @@ import {
   type ValidatedPersonSearchResult,
 } from "@/api/validation";
 import { useAuthStore } from "@/stores/auth";
-
-// Query key factory for scorer search
-const scorerSearchKeys = {
-  all: ["scorerSearch"] as const,
-  search: (filters: PersonSearchFilter) =>
-    [...scorerSearchKeys.all, filters] as const,
-};
+import { queryKeys } from "@/api/queryKeys";
 
 /**
  * Cache duration for search results.
@@ -102,7 +96,7 @@ export function useScorerSearch(
   );
 
   const query = useQuery({
-    queryKey: scorerSearchKeys.search(filters),
+    queryKey: queryKeys.scorerSearch.search(filters),
     queryFn: async () => {
       const response = await apiClient.searchPersons(filters);
       const validated = validateResponse(

--- a/web-app/src/hooks/useValidationState.ts
+++ b/web-app/src/hooks/useValidationState.ts
@@ -20,6 +20,7 @@ import {
   finalizeRoster,
   finalizeScoresheetWithFile,
 } from "./validation/api-helpers";
+import { queryKeys } from "@/api/queryKeys";
 
 // Re-export types for consumers
 export type {
@@ -66,7 +67,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
 
   // Fetch game details (scoresheet and nomination list IDs)
   const gameDetailsQuery = useQuery({
-    queryKey: ["gameWithScoresheet", gameId],
+    queryKey: queryKeys.validation.gameDetail(gameId ?? ""),
     queryFn: async () => {
       if (!gameId) return null;
       return apiClient.getGameWithScoresheet(gameId);
@@ -211,7 +212,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
       await finalizeRoster(apiClient, gameId, gameDetails.nominationListOfTeamAway, state.awayRoster.modifications);
       await finalizeScoresheetWithFile(apiClient, gameId, gameDetails.scoresheet, state.scorer.selected?.__identity, fileResourceId);
 
-      await queryClient.invalidateQueries({ queryKey: ["gameWithScoresheet", gameId] });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.validation.gameDetail(gameId!) });
       logger.debug("[VS] finalize done");
     } catch (error) {
       logger.error("[VS] finalize failed:", error);


### PR DESCRIPTION
Create a single source of truth for all TanStack Query keys in
web-app/src/api/queryKeys.ts with a hierarchical structure that
enables:

- Type-safe key generation with autocomplete
- Hierarchical invalidation (invalidating parent keys invalidates
  all children)
- Consistency across useQuery, useMutation, and cache invalidation

Changes:
- Add centralized queryKeys.ts with hierarchical factory pattern
- Update useConvocations.ts to use centralized keys and re-export
  for backwards compatibility
- Update useValidationState.ts, useNominationList.ts, useScorerSearch.ts,
  and usePlayerNominations.ts to use centralized keys
- Update tests to reflect new query key structure

Closes #284