### PR TITLE
refactor(i18n): standardize on useTranslation hook pattern (#287)

### DIFF
--- a/web-app/eslint.config.js
+++ b/web-app/eslint.config.js
@@ -9,6 +9,25 @@ import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
   { ignores: ['dist', 'dev-dist', 'coverage', 'playwright-report'] },
+  // Enforce useTranslation hook in React components (issue #287)
+  {
+    files: ['**/*.tsx'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@/i18n',
+              importNames: ['t', 'tInterpolate'],
+              message:
+                'Use the useTranslation() hook instead of direct imports. Import { useTranslation } from "@/hooks/useTranslation".',
+            },
+          ],
+        },
+      ],
+    },
+  },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/Badge";
 import { MapPin } from "@/components/ui/icons";
 import type { GameExchange } from "@/api/client";
 import { useDateLocale } from "@/hooks/useDateFormat";
-import { t, tInterpolate } from "@/i18n";
+import { useTranslation } from "@/hooks/useTranslation";
 
 interface ExchangeCardProps {
   exchange: GameExchange;
@@ -20,6 +20,7 @@ function ExchangeCardComponent({
   disableExpansion,
   dataTour,
 }: ExchangeCardProps) {
+  const { t, tInterpolate } = useTranslation();
   const dateLocale = useDateLocale();
 
   const game = exchange.refereeGame?.game;


### PR DESCRIPTION
- Update ExchangeCard to use useTranslation() hook instead of direct
  t/tInterpolate imports from @/i18n
- Add ESLint no-restricted-imports rule to enforce hook pattern in
  React components (.tsx files)

This ensures consistent i18n usage across components, improving
testability and React lifecycle integration.