### PR TITLE
refactor(ui): create unified Button component (#286)

### DIFF
--- a/web-app/src/components/ui/Button.test.tsx
+++ b/web-app/src/components/ui/Button.test.tsx
@@ -1,0 +1,277 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Button } from "./Button";
+
+describe("Button", () => {
+  describe("rendering", () => {
+    it("renders children correctly", () => {
+      render(<Button>Click me</Button>);
+      expect(
+        screen.getByRole("button", { name: "Click me" })
+      ).toBeInTheDocument();
+    });
+
+    it("renders as a button element", () => {
+      render(<Button>Test</Button>);
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("has type='button' by default", () => {
+      render(<Button>Test</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    });
+
+    it("allows type to be overridden", () => {
+      render(<Button type="submit">Submit</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
+    });
+
+    it("applies custom className", () => {
+      render(<Button className="custom-class">Test</Button>);
+      expect(screen.getByRole("button")).toHaveClass("custom-class");
+    });
+
+    it("passes through additional button attributes", () => {
+      render(
+        <Button aria-label="Test label" data-testid="test-btn">
+          Test
+        </Button>
+      );
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-label", "Test label");
+      expect(button).toHaveAttribute("data-testid", "test-btn");
+    });
+  });
+
+  describe("variants", () => {
+    it("applies primary variant by default", () => {
+      render(<Button>Primary</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-primary-500");
+      expect(button).toHaveClass("text-primary-950");
+    });
+
+    it("applies secondary variant styles", () => {
+      render(<Button variant="secondary">Cancel</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-surface-subtle");
+      expect(button).toHaveClass("text-text-secondary");
+    });
+
+    it("applies success variant styles", () => {
+      render(<Button variant="success">Confirm</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-green-600");
+      expect(button).toHaveClass("text-white");
+    });
+
+    it("applies danger variant styles", () => {
+      render(<Button variant="danger">Delete</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-red-600");
+      expect(button).toHaveClass("text-white");
+    });
+
+    it("applies blue variant styles", () => {
+      render(<Button variant="blue">Export</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-blue-600");
+      expect(button).toHaveClass("text-white");
+    });
+
+    it("applies ghost variant styles", () => {
+      render(<Button variant="ghost">Ghost</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("bg-transparent");
+      expect(button).toHaveClass("text-text-secondary");
+    });
+  });
+
+  describe("sizes", () => {
+    it("applies medium size by default", () => {
+      render(<Button>Test</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("px-4");
+      expect(button).toHaveClass("py-2");
+      expect(button).toHaveClass("text-sm");
+    });
+
+    it("applies small size styles", () => {
+      render(<Button size="sm">Small</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("px-3");
+      expect(button).toHaveClass("py-1.5");
+      expect(button).toHaveClass("text-xs");
+    });
+
+    it("applies large size styles", () => {
+      render(<Button size="lg">Large</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("px-6");
+      expect(button).toHaveClass("py-3");
+      expect(button).toHaveClass("text-base");
+    });
+  });
+
+  describe("base styles", () => {
+    it("applies base flexbox and transition styles", () => {
+      render(<Button>Test</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("inline-flex");
+      expect(button).toHaveClass("items-center");
+      expect(button).toHaveClass("justify-center");
+      expect(button).toHaveClass("gap-2");
+      expect(button).toHaveClass("transition-colors");
+    });
+
+    it("applies focus ring styles", () => {
+      render(<Button>Test</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("focus:outline-none");
+      expect(button).toHaveClass("focus:ring-2");
+      expect(button).toHaveClass("focus:ring-offset-2");
+    });
+
+    it("applies rounded corners", () => {
+      render(<Button>Test</Button>);
+      expect(screen.getByRole("button")).toHaveClass("rounded-lg");
+    });
+  });
+
+  describe("fullWidth prop", () => {
+    it("does not apply w-full by default", () => {
+      render(<Button>Test</Button>);
+      expect(screen.getByRole("button")).not.toHaveClass("w-full");
+    });
+
+    it("applies w-full when fullWidth is true", () => {
+      render(<Button fullWidth>Test</Button>);
+      expect(screen.getByRole("button")).toHaveClass("w-full");
+    });
+  });
+
+  describe("disabled state", () => {
+    it("applies disabled attribute when disabled", () => {
+      render(<Button disabled>Test</Button>);
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    it("applies disabled styles", () => {
+      render(<Button disabled>Test</Button>);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("disabled:opacity-50");
+      expect(button).toHaveClass("disabled:cursor-not-allowed");
+    });
+
+    it("does not call onClick when disabled", () => {
+      const handleClick = vi.fn();
+      render(
+        <Button disabled onClick={handleClick}>
+          Test
+        </Button>
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading spinner when loading", () => {
+      render(<Button loading>Loading</Button>);
+      const button = screen.getByRole("button");
+      const spinner = button.querySelector(".animate-spin");
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it("is disabled when loading", () => {
+      render(<Button loading>Loading</Button>);
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    it("has aria-busy when loading", () => {
+      render(<Button loading>Loading</Button>);
+      expect(screen.getByRole("button")).toHaveAttribute("aria-busy", "true");
+    });
+
+    it("does not have aria-busy when not loading", () => {
+      render(<Button>Not Loading</Button>);
+      expect(screen.getByRole("button")).not.toHaveAttribute("aria-busy");
+    });
+
+    it("does not call onClick when loading", () => {
+      const handleClick = vi.fn();
+      render(
+        <Button loading onClick={handleClick}>
+          Test
+        </Button>
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it("hides iconLeft when loading", () => {
+      render(
+        <Button loading iconLeft={<span data-testid="left-icon">L</span>}>
+          Test
+        </Button>
+      );
+      expect(screen.queryByTestId("left-icon")).not.toBeInTheDocument();
+    });
+
+    it("hides iconRight when loading", () => {
+      render(
+        <Button loading iconRight={<span data-testid="right-icon">R</span>}>
+          Test
+        </Button>
+      );
+      expect(screen.queryByTestId("right-icon")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("icon support", () => {
+    it("renders iconLeft before children", () => {
+      render(
+        <Button iconLeft={<span data-testid="left-icon">←</span>}>Back</Button>
+      );
+      const button = screen.getByRole("button");
+      expect(screen.getByTestId("left-icon")).toBeInTheDocument();
+      expect(button.textContent).toBe("←Back");
+    });
+
+    it("renders iconRight after children", () => {
+      render(
+        <Button iconRight={<span data-testid="right-icon">→</span>}>
+          Next
+        </Button>
+      );
+      const button = screen.getByRole("button");
+      expect(screen.getByTestId("right-icon")).toBeInTheDocument();
+      expect(button.textContent).toBe("Next→");
+    });
+
+    it("renders both icons correctly", () => {
+      render(
+        <Button
+          iconLeft={<span data-testid="left-icon">←</span>}
+          iconRight={<span data-testid="right-icon">→</span>}
+        >
+          Middle
+        </Button>
+      );
+      expect(screen.getByTestId("left-icon")).toBeInTheDocument();
+      expect(screen.getByTestId("right-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("interactions", () => {
+    it("calls onClick handler when clicked", () => {
+      const handleClick = vi.fn();
+      render(<Button onClick={handleClick}>Test</Button>);
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/web-app/src/components/ui/Button.tsx
+++ b/web-app/src/components/ui/Button.tsx
@@ -1,0 +1,119 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+export type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "success"
+  | "danger"
+  | "blue"
+  | "ghost";
+
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Visual style variant */
+  variant?: ButtonVariant;
+  /** Button size */
+  size?: ButtonSize;
+  /** Show loading spinner and disable interactions */
+  loading?: boolean;
+  /** Icon to display before the button text */
+  iconLeft?: ReactNode;
+  /** Icon to display after the button text */
+  iconRight?: ReactNode;
+  /** Whether the button should expand to fill available width */
+  fullWidth?: boolean;
+  /** Button content */
+  children: ReactNode;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "text-primary-950 bg-primary-500 hover:bg-primary-600 focus:ring-primary-500",
+  secondary:
+    "text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:ring-border-strong",
+  success: "text-white bg-green-600 hover:bg-green-700 focus:ring-green-500",
+  danger: "text-white bg-red-600 hover:bg-red-700 focus:ring-red-500",
+  blue: "text-white bg-blue-600 hover:bg-blue-700 focus:ring-blue-500",
+  ghost:
+    "text-text-secondary dark:text-text-secondary-dark bg-transparent hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark focus:ring-border-strong",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "px-6 py-3 text-base",
+};
+
+const iconSizeClasses: Record<ButtonSize, string> = {
+  sm: "w-3 h-3",
+  md: "w-4 h-4",
+  lg: "w-5 h-5",
+};
+
+function LoadingSpinner({ size }: { size: ButtonSize }) {
+  const sizeClass = iconSizeClasses[size];
+  return (
+    <span
+      className={`${sizeClass} border-2 border-current border-t-transparent rounded-full animate-spin`}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Unified button component for consistent styling across the application.
+ * Supports multiple variants, sizes, loading states, and icon placement.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * <Button variant="primary" onClick={handleClick}>
+ *   Save
+ * </Button>
+ *
+ * // With loading state
+ * <Button variant="primary" loading={isLoading}>
+ *   {isLoading ? "Saving..." : "Save"}
+ * </Button>
+ *
+ * // With icons
+ * <Button variant="secondary" iconLeft={<ArrowLeftIcon />}>
+ *   Back
+ * </Button>
+ * ```
+ */
+export function Button({
+  variant = "primary",
+  size = "md",
+  loading = false,
+  iconLeft,
+  iconRight,
+  fullWidth = false,
+  children,
+  className = "",
+  disabled,
+  ...props
+}: ButtonProps) {
+  const isDisabled = disabled || loading;
+
+  const baseClasses =
+    "inline-flex items-center justify-center gap-2 font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed";
+  const variantClass = variantClasses[variant];
+  const sizeClass = sizeClasses[size];
+  const widthClass = fullWidth ? "w-full" : "";
+
+  return (
+    <button
+      type="button"
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      className={`${baseClasses} ${variantClass} ${sizeClass} ${widthClass} ${className}`.trim()}
+      {...props}
+    >
+      {loading ? <LoadingSpinner size={size} /> : iconLeft}
+      {children}
+      {!loading && iconRight}
+    </button>
+  );
+}

--- a/web-app/src/components/ui/LoadingSpinner.tsx
+++ b/web-app/src/components/ui/LoadingSpinner.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { AlertTriangle, Calendar, Lock, Inbox, Wallet, ArrowLeftRight } from "@/components/ui/icons";
 import type { LucideIcon } from "lucide-react";
+import { Button } from "@/components/ui/Button";
 import { useTranslation } from "@/hooks/useTranslation";
 
 interface LoadingSpinnerProps {
@@ -81,9 +82,9 @@ export function ErrorState({ message, onRetry }: ErrorStateProps) {
       <AlertTriangle className="w-10 h-10 text-warning-500" aria-hidden="true" />
       <p className="text-danger-600 dark:text-danger-400 text-center">{message}</p>
       {onRetry && (
-        <button onClick={onRetry} className="btn btn-secondary">
+        <Button variant="secondary" onClick={onRetry}>
           {t("common.retry")}
-        </button>
+        </Button>
       )}
     </div>
   );
@@ -140,9 +141,9 @@ export function EmptyState({
         </p>
       )}
       {action && (
-        <button onClick={action.onClick} className="btn btn-primary mt-2">
+        <Button variant="primary" onClick={action.onClick} className="mt-2">
           {action.label}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/web-app/src/components/ui/ModalButton.test.tsx
+++ b/web-app/src/components/ui/ModalButton.test.tsx
@@ -51,8 +51,9 @@ describe("ModalButton", () => {
     it("applies primary variant styles", () => {
       render(<ModalButton variant="primary">Save</ModalButton>);
       const button = screen.getByRole("button");
-      expect(button).toHaveClass("bg-primary-600");
-      expect(button).toHaveClass("text-white");
+      // Uses unified Button styling: primary-500 with dark text
+      expect(button).toHaveClass("bg-primary-500");
+      expect(button).toHaveClass("text-primary-950");
     });
 
     it("applies success variant styles", () => {

--- a/web-app/src/components/ui/ModalButton.tsx
+++ b/web-app/src/components/ui/ModalButton.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { Button, type ButtonVariant } from "./Button";
 
 type ModalButtonVariant = "secondary" | "primary" | "success" | "danger" | "blue";
 
@@ -11,27 +12,22 @@ interface ModalButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
 }
 
-const variantClasses: Record<ModalButtonVariant, string> = {
-  secondary:
-    "text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark focus:ring-border-strong",
-  primary:
-    "text-white bg-primary-600 hover:bg-primary-700 focus:ring-primary-500",
-  success: "text-white bg-green-600 hover:bg-green-700 focus:ring-green-500",
-  danger: "text-white bg-red-600 hover:bg-red-700 focus:ring-red-500",
-  blue: "text-white bg-blue-600 hover:bg-blue-700 focus:ring-blue-500",
-};
-
 /**
+ * @deprecated Use `Button` component instead. ModalButton will be removed in a future version.
+ *
  * Standardized button component for use in modals and dialogs.
- * Provides consistent styling, accessibility, and dark mode support.
+ * This is now a thin wrapper around the unified Button component.
  *
  * @example
  * ```tsx
+ * // Preferred: Use Button directly
+ * <Button variant="secondary" onClick={onClose}>
+ *   Cancel
+ * </Button>
+ *
+ * // Legacy: Still supported but deprecated
  * <ModalButton variant="secondary" onClick={onClose}>
  *   Cancel
- * </ModalButton>
- * <ModalButton variant="success" onClick={onConfirm} disabled={isLoading}>
- *   {isLoading ? "Saving..." : "Save"}
  * </ModalButton>
  * ```
  */
@@ -40,22 +36,18 @@ export function ModalButton({
   fullWidth = false,
   children,
   className = "",
-  disabled,
   ...props
 }: ModalButtonProps) {
-  const baseClasses =
-    "px-4 py-2 text-sm font-medium rounded-md focus:outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed";
-  const widthClass = fullWidth ? "flex-1" : "";
-  const variantClass = variantClasses[variant];
+  // Modal-specific styling: smaller border radius and flex-1 for fullWidth
+  const modalClasses = `rounded-md ${fullWidth ? "flex-1" : ""} ${className}`.trim();
 
   return (
-    <button
-      type="button"
-      disabled={disabled}
-      className={`${baseClasses} ${variantClass} ${widthClass} ${className}`.trim()}
+    <Button
+      variant={variant as ButtonVariant}
+      className={modalClasses}
       {...props}
     >
       {children}
-    </button>
+    </Button>
   );
 }

--- a/web-app/src/components/ui/ModalErrorBoundary.tsx
+++ b/web-app/src/components/ui/ModalErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ReactNode } from "react";
 import { AlertTriangle } from "@/components/ui/icons";
+import { Button } from "@/components/ui/Button";
 import { useTranslation } from "@/hooks/useTranslation";
 import { classifyError, type ErrorType } from "@/utils/error-helpers";
 import { logger } from "../../utils/logger";
@@ -96,19 +97,13 @@ class ModalErrorBoundaryClass extends Component<ModalErrorBoundaryClassProps, St
             </details>
           )}
           <div className="flex gap-3 justify-center">
-            <button
-              onClick={this.handleReset}
-              className="btn btn-secondary"
-            >
+            <Button variant="secondary" onClick={this.handleReset}>
               {translations.tryAgain}
-            </button>
+            </Button>
             {onClose && (
-              <button
-                onClick={this.handleClose}
-                className="btn btn-primary"
-              >
+              <Button variant="primary" onClick={this.handleClose}>
                 {translations.closeModal}
-              </button>
+              </Button>
             )}
           </div>
         </div>

--- a/web-app/src/components/ui/PageErrorBoundary.tsx
+++ b/web-app/src/components/ui/PageErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ReactNode } from "react";
 import { AlertTriangle } from "@/components/ui/icons";
+import { Button } from "@/components/ui/Button";
 import { useTranslation } from "@/hooks/useTranslation";
 import { classifyError, type ErrorType } from "@/utils/error-helpers";
 import { logger } from "../../utils/logger";
@@ -96,18 +97,12 @@ class PageErrorBoundaryClass extends Component<PageErrorBoundaryClassProps, Stat
               </details>
             )}
             <div className="flex gap-3 justify-center">
-              <button
-                onClick={this.handleReset}
-                className="btn btn-secondary flex items-center gap-2"
-              >
+              <Button variant="secondary" onClick={this.handleReset}>
                 {translations.tryAgain}
-              </button>
-              <button
-                onClick={this.handleGoHome}
-                className="btn btn-primary"
-              >
+              </Button>
+              <Button variant="primary" onClick={this.handleGoHome}>
                 {translations.goHome}
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -10,6 +10,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { useTranslation } from "@/hooks/useTranslation";
+import { Button } from "@/components/ui/Button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { LanguageSwitcher } from "@/components/ui/LanguageSwitcher";
 import { Volleyball } from "@/components/ui/icons";
@@ -155,21 +156,15 @@ export function LoginPage() {
               </div>
             )}
 
-            <button
+            <Button
               type="submit"
-              disabled={isLoading}
+              variant="primary"
+              fullWidth
+              loading={isLoading}
               data-testid="login-button"
-              className="btn btn-primary w-full flex items-center justify-center gap-2"
             >
-              {isLoading ? (
-                <>
-                  <LoadingSpinner size="sm" />
-                  <span>{t("auth.loggingIn")}</span>
-                </>
-              ) : (
-                t("auth.loginButton")
-              )}
-            </button>
+              {isLoading ? t("auth.loggingIn") : t("auth.loginButton")}
+            </Button>
 
             <div className="relative my-4">
               <div className="absolute inset-0 flex items-center">
@@ -182,15 +177,15 @@ export function LoginPage() {
               </div>
             </div>
 
-            <button
-              type="button"
+            <Button
+              variant="secondary"
               onClick={handleDemoLogin}
               disabled={isLoading}
+              fullWidth
               data-testid="demo-button"
-              className="btn btn-secondary w-full"
             >
               {t("auth.demoMode")}
-            </button>
+            </Button>
           </form>
         </div>
 

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { useTourStore, type TourId } from "@/stores/tour";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTour } from "@/hooks/useTour";
 import { usePWA } from "@/contexts/PWAContext";
+import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
 import { LanguageSwitcher } from "@/components/ui/LanguageSwitcher";
@@ -242,13 +243,9 @@ export function SettingsPage() {
 
           {/* Reset button */}
           <div className="pt-2">
-            <button
-              type="button"
-              onClick={resetAllTours}
-              className="rounded-md bg-surface-subtle dark:bg-surface-subtle-dark px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark hover:bg-gray-200 dark:hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
-            >
+            <Button variant="secondary" onClick={resetAllTours}>
               {t("tour.settings.tourSection.restart")}
-            </button>
+            </Button>
           </div>
         </CardContent>
       </Card>
@@ -284,14 +281,13 @@ export function SettingsPage() {
                 )}
               </div>
 
-              <button
-                type="button"
+              <Button
+                variant="secondary"
                 onClick={handleResetDemoData}
-                className="rounded-md bg-surface-subtle dark:bg-surface-subtle-dark px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark hover:bg-gray-200 dark:hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
                 aria-label={t("settings.resetDemoData")}
               >
                 {t("settings.resetDemoData")}
-              </button>
+              </Button>
             </div>
           </CardContent>
         </Card>
@@ -413,23 +409,22 @@ export function SettingsPage() {
                 )}
               </div>
               {needRefresh ? (
-                <button
+                <Button
+                  variant="primary"
                   onClick={updateApp}
-                  className="rounded-md bg-primary-500 px-4 py-2 text-sm font-medium text-primary-950 hover:bg-primary-600 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:outline-none"
                   aria-label={t("settings.updateNow")}
                 >
                   {t("settings.updateNow")}
-                </button>
+                </Button>
               ) : (
-                <button
+                <Button
+                  variant="secondary"
                   onClick={checkForUpdate}
-                  disabled={isChecking}
-                  aria-busy={isChecking}
-                  className="rounded-md bg-surface-subtle dark:bg-surface-subtle-dark px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark hover:bg-gray-200 dark:hover:bg-gray-600 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                  loading={isChecking}
                   aria-label={t("settings.checkForUpdates")}
                 >
                   {isChecking ? t("settings.checking") : t("settings.checkForUpdates")}
-                </button>
+                </Button>
               )}
             </div>
           </CardContent>
@@ -479,9 +474,13 @@ export function SettingsPage() {
 
       {/* Logout */}
       <div className="pt-4 border-t border-border-default dark:border-border-default-dark">
-        <button onClick={logout} className="btn btn-secondary w-full sm:w-auto">
+        <Button
+          variant="secondary"
+          onClick={logout}
+          className="w-full sm:w-auto"
+        >
           {t("auth.logout")}
-        </button>
+        </Button>
       </div>
 
       {/* Safe Mode Warning Modal */}


### PR DESCRIPTION
Introduce a reusable Button component supporting:
- Variants: primary, secondary, success, danger, blue, ghost
- Sizes: sm, md, lg
- Loading state with animated spinner
- Icon support (left/right)
- Full accessibility defaults (aria-busy, focus rings)

Migrate all button patterns to use the unified component:
- Update ModalButton to wrap Button (deprecated, kept for compatibility)
- Replace inline Tailwind button styles in SettingsPage
- Replace CSS class patterns (.btn) in LoginPage, error boundaries,
  and LoadingSpinner states