### PR TITLE
fix(assignments): reflect compensation editability on assignment tab

### DIFF
--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -1552,6 +1552,18 @@ components:
         linkedDoubleConvocationGameNumberAndRefereePosition:
           type: string
           nullable: true
+        convocationCompensation:
+          type: object
+          description: |
+            Compensation lock flags for editability check.
+            Only populated when convocationCompensation properties are requested.
+          properties:
+            paymentDone:
+              type: boolean
+              description: Whether payment has been processed
+            lockPayoutOnSiteCompensation:
+              type: boolean
+              description: Whether on-site payout is locked (regional associations)
         _permissions:
           $ref: '#/components/schemas/Permissions'
     CompensationsResponse:

--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -42,6 +42,9 @@ export const ASSIGNMENT_PROPERTIES = [
   "refereeGame.game.lastPostponement.activeRefereeConvocationsAtTimeOfAcceptedPostponement.*.indoorAssociationReferee.indoorReferee.person",
   "refereeGame.game.lastPostponement.createdAt",
   "refereeGame.isGameInFuture",
+  // Compensation lock flags for editability check
+  "convocationCompensation.paymentDone",
+  "convocationCompensation.lockPayoutOnSiteCompensation",
 ];
 
 /**
@@ -131,6 +134,7 @@ export const COMPENSATION_PROPERTIES = [
   "convocationCompensation.distanceFormatted",
   "convocationCompensation.transportationMode",
   "convocationCompensation.paymentDone",
+  "convocationCompensation.lockPayoutOnSiteCompensation",
   "convocationCompensation.paymentValueDate",
   "convocationCompensation.paymentUpdatedByAssociation.name",
   "indoorAssociationReferee.indoorReferee.person.associationId",

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -669,7 +669,7 @@ export interface paths {
          * Finalize scoresheet
          * @description Finalizes and closes a scoresheet after the game.
          *     Once finalized, the scoresheet becomes read-only.
-         *     A PDF file must be attached before finalization.
+         *     A scoresheet file (JPEG, PNG, or PDF) must be attached before finalization.
          */
         post: operations["finalizeScoresheet"];
         delete?: never;
@@ -795,8 +795,9 @@ export interface paths {
         put?: never;
         /**
          * Upload file
-         * @description Uploads a file (e.g., scoresheet PDF) and returns a resource reference.
+         * @description Uploads a file (scoresheet image or PDF) and returns a resource reference.
          *     The returned resource can be attached to entities like scoresheets.
+         *     Supported formats: JPEG, PNG, PDF. Maximum file size: 10 MB.
          */
         post: operations["uploadResource"];
         delete?: never;
@@ -3553,7 +3554,7 @@ export interface components {
             };
             scoresheetValidation?: components["schemas"]["ScoresheetValidation"];
             file?: components["schemas"]["FileResource"];
-            /** @description Whether a PDF file is attached */
+            /** @description Whether a scoresheet file is attached */
             hasFile?: boolean;
             /**
              * Format: date-time
@@ -3593,7 +3594,7 @@ export interface components {
             "scoresheet[writerPerson][__identity]"?: string;
             /**
              * Format: uuid
-             * @description Reference to uploaded PDF file
+             * @description Reference to uploaded file (JPEG, PNG, or PDF)
              */
             "scoresheet[file][__identity]"?: string;
             /** @enum {string} */
@@ -3636,7 +3637,7 @@ export interface components {
             "scoresheet[writerPerson][__identity]"?: string;
             /**
              * Format: uuid
-             * @description Reference to uploaded PDF file (required for finalization)
+             * @description Reference to uploaded file (required for finalization)
              */
             "scoresheet[file][__identity]": string;
             /**
@@ -3915,9 +3916,12 @@ export interface components {
             persistentResource?: {
                 /** Format: uuid */
                 __identity?: string;
-                /** @example scoresheet.pdf */
+                /** @example scoresheet.jpg */
                 filename?: string;
-                /** @example application/pdf */
+                /**
+                 * @description MIME type (image/jpeg, image/png, or application/pdf)
+                 * @example image/jpeg
+                 */
                 mediaType?: string;
                 /** @description File size in bytes */
                 fileSize?: number;

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -1053,6 +1053,16 @@ export interface components {
             hasLastMessageToReferee?: boolean;
             hasLinkedDoubleConvocation?: boolean;
             linkedDoubleConvocationGameNumberAndRefereePosition?: string | null;
+            /**
+             * @description Compensation lock flags for editability check.
+             *     Only populated when convocationCompensation properties are requested.
+             */
+            convocationCompensation?: {
+                /** @description Whether payment has been processed */
+                paymentDone?: boolean;
+                /** @description Whether on-site payout is locked (regional associations) */
+                lockPayoutOnSiteCompensation?: boolean;
+            };
             _permissions?: components["schemas"]["Permissions"];
         };
         CompensationsResponse: {

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -16,6 +16,7 @@ import {
   isGameReportEligible,
   isValidationEligible,
 } from "@/utils/assignment-helpers";
+import { isAssignmentCompensationEditable } from "@/utils/compensation-actions";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTour } from "@/hooks/useTour";
@@ -92,14 +93,17 @@ export function AssignmentsPage() {
       const isGameInFuture = assignment.refereeGame?.isGameInFuture === "1";
       const canValidateGame = isValidationEligible(assignment);
       const canGenerateReport = isGameReportEligible(assignment);
+      const canEditCompensation = isAssignmentCompensationEditable(assignment);
 
       // Action array ordering: first item = furthest from card = full swipe default
       // When swiping left, actions appear right-to-left from the card edge
       // Validate action only shown for first referee (head-one position)
       // Report action only shown for NLA/NLB games where user is first referee
-      const leftActions = canValidateGame
-        ? [actions.validateGame, actions.editCompensation]
-        : [actions.editCompensation];
+      // Edit compensation action only shown if compensation is editable
+      const leftActions = canValidateGame ? [actions.validateGame] : [];
+      if (canEditCompensation) {
+        leftActions.push(actions.editCompensation);
+      }
       if (canGenerateReport) {
         leftActions.push(actions.generateReport);
       }

--- a/web-app/src/stores/demo-generators.ts
+++ b/web-app/src/stores/demo-generators.ts
@@ -393,6 +393,9 @@ function createAssignment(
   associationCode: DemoAssociationCode,
   now: Date,
 ): Assignment {
+  // Regional associations use on-site payout, which locks compensation editing
+  const lockPayoutOnSiteCompensation = associationCode !== "SV";
+
   return {
     __identity: generateDemoUuid(`demo-assignment-${config.index}`),
     refereeConvocationStatus: config.status,
@@ -408,6 +411,11 @@ function createAssignment(
     ...(config.linkedDouble && {
       linkedDoubleConvocationGameNumberAndRefereePosition: config.linkedDouble,
     }),
+    // Compensation lock flags for editability check
+    convocationCompensation: {
+      paymentDone: false,
+      lockPayoutOnSiteCompensation,
+    },
     refereeGame: createRefereeGame({
       gameId: String(config.index),
       gameNumber: DEMO_GAME_NUMBERS.ASSIGNMENTS[config.index - 1]!,

--- a/web-app/src/utils/compensation-actions.test.ts
+++ b/web-app/src/utils/compensation-actions.test.ts
@@ -4,8 +4,9 @@ import {
   createCompensationActions,
   downloadCompensationPDF,
   isCompensationEditable,
+  isAssignmentCompensationEditable,
 } from "./compensation-actions";
-import type { CompensationRecord } from "@/api/client";
+import type { Assignment, CompensationRecord } from "@/api/client";
 
 const mockCompensation: CompensationRecord = {
   __identity: "test-compensation-1",
@@ -366,5 +367,68 @@ describe("isCompensationEditable", () => {
     } as unknown as CompensationRecord;
 
     expect(isCompensationEditable(compensation)).toBe(true);
+  });
+});
+
+describe("isAssignmentCompensationEditable", () => {
+  it("returns true when convocationCompensation is undefined (backwards compatibility)", () => {
+    const assignment = {
+      __identity: "test-1",
+      refereeGame: {},
+    } as unknown as Assignment;
+
+    expect(isAssignmentCompensationEditable(assignment)).toBe(true);
+  });
+
+  it("returns true for unpaid assignment with central payout (SV association)", () => {
+    const assignment = {
+      __identity: "test-1",
+      convocationCompensation: {
+        paymentDone: false,
+        lockPayoutOnSiteCompensation: false,
+      },
+      refereeGame: {},
+    } as unknown as Assignment;
+
+    expect(isAssignmentCompensationEditable(assignment)).toBe(true);
+  });
+
+  it("returns false for paid assignment", () => {
+    const assignment = {
+      __identity: "test-1",
+      convocationCompensation: {
+        paymentDone: true,
+        lockPayoutOnSiteCompensation: false,
+      },
+      refereeGame: {},
+    } as unknown as Assignment;
+
+    expect(isAssignmentCompensationEditable(assignment)).toBe(false);
+  });
+
+  it("returns false when on-site payout is locked (regional association)", () => {
+    const assignment = {
+      __identity: "test-1",
+      convocationCompensation: {
+        paymentDone: false,
+        lockPayoutOnSiteCompensation: true,
+      },
+      refereeGame: {},
+    } as unknown as Assignment;
+
+    expect(isAssignmentCompensationEditable(assignment)).toBe(false);
+  });
+
+  it("returns true when lockPayoutOnSiteCompensation is undefined (defaults to editable)", () => {
+    const assignment = {
+      __identity: "test-1",
+      convocationCompensation: {
+        paymentDone: false,
+        // lockPayoutOnSiteCompensation not set
+      },
+      refereeGame: {},
+    } as unknown as Assignment;
+
+    expect(isAssignmentCompensationEditable(assignment)).toBe(true);
   });
 });

--- a/web-app/src/utils/compensation-actions.ts
+++ b/web-app/src/utils/compensation-actions.ts
@@ -1,5 +1,5 @@
 import { createElement } from "react";
-import type { CompensationRecord } from "@/api/client";
+import type { Assignment, CompensationRecord } from "@/api/client";
 import { type SwipeAction, SWIPE_ACTION_ICON_SIZE } from "@/types/swipe";
 import { Wallet, FileText } from "@/components/ui/icons";
 
@@ -26,6 +26,30 @@ export function isCompensationEditable(compensation: CompensationRecord): boolea
     | ConvocationCompensationWithLockFlags
     | undefined;
   if (!cc) return false;
+
+  // Already paid - not editable
+  if (cc.paymentDone) return false;
+
+  // On-site payout locked - not editable (regional associations)
+  if (cc.lockPayoutOnSiteCompensation === true) return false;
+
+  return true;
+}
+
+/**
+ * Checks if an assignment's compensation can be edited.
+ *
+ * Editability rules (same as isCompensationEditable):
+ * - Non-editable: lockPayoutOnSiteCompensation=true AND paymentDone=false (on-site payout locked)
+ * - Non-editable: paymentDone=true (already paid)
+ * - Editable: lockPayoutOnSiteCompensation=false AND paymentDone=false
+ * - Editable: convocationCompensation not present (defaults to editable for backwards compatibility)
+ */
+export function isAssignmentCompensationEditable(assignment: Assignment): boolean {
+  const cc = assignment.convocationCompensation;
+  // If no compensation data, default to editable (for backwards compatibility
+  // and when the API doesn't return compensation properties)
+  if (!cc) return true;
 
   // Already paid - not editable
   if (cc.paymentDone) return false;


### PR DESCRIPTION
Some associations lock on-site compensation payouts, making the
compensation non-editable. This status was correctly shown on the
compensations tab but not on the assignments tab.

Changes:
- Add lockPayoutOnSiteCompensation to ASSIGNMENT_PROPERTIES and
  COMPENSATION_PROPERTIES to fetch editability flags from API
- Update Assignment type in schema to include convocationCompensation
  with lock flags
- Add isAssignmentCompensationEditable() helper function
- Update AssignmentsPage to conditionally show edit compensation action
- Update demo mode to include compensation lock flags for assignments
- Add tests for isAssignmentCompensationEditable()