### PR TITLE
fix(tests): wrap async state updates in act() for SwipeableCard tests

### DIFF
--- a/web-app/src/components/ui/SwipeableCard.test.tsx
+++ b/web-app/src/components/ui/SwipeableCard.test.tsx
@@ -217,7 +217,7 @@ describe("SwipeableCard", () => {
       };
     }
 
-    it("calls onSwipeRight when swiping right past threshold", () => {
+    it("calls onSwipeRight when swiping right past threshold", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -228,19 +228,21 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      // Start touch
-      fireEvent.touchStart(content, createTouchEvent(0, 0));
+      await act(async () => {
+        // Start touch
+        fireEvent.touchStart(content, createTouchEvent(0, 0));
 
-      // Move past threshold (270px * 2 for resistance = 540px movement needed)
-      fireEvent.touchMove(content, createTouchEvent(600, 0));
+        // Move past threshold (270px * 2 for resistance = 540px movement needed)
+        fireEvent.touchMove(content, createTouchEvent(600, 0));
 
-      // End touch
-      fireEvent.touchEnd(content);
+        // End touch
+        fireEvent.touchEnd(content);
+      });
 
       expect(onSwipeRight).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onSwipeLeft when swiping left past threshold", () => {
+    it("calls onSwipeLeft when swiping left past threshold", async () => {
       const onSwipeLeft = vi.fn();
       render(
         <SwipeableCard onSwipeLeft={onSwipeLeft}>
@@ -251,14 +253,16 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.touchStart(content, createTouchEvent(600, 0));
-      fireEvent.touchMove(content, createTouchEvent(0, 0));
-      fireEvent.touchEnd(content);
+      await act(async () => {
+        fireEvent.touchStart(content, createTouchEvent(600, 0));
+        fireEvent.touchMove(content, createTouchEvent(0, 0));
+        fireEvent.touchEnd(content);
+      });
 
       expect(onSwipeLeft).toHaveBeenCalledTimes(1);
     });
 
-    it("does not call action when swipe does not reach threshold", () => {
+    it("does not call action when swipe does not reach threshold", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -269,9 +273,11 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.touchStart(content, createTouchEvent(0, 0));
-      fireEvent.touchMove(content, createTouchEvent(50, 0)); // Less than threshold
-      fireEvent.touchEnd(content);
+      await act(async () => {
+        fireEvent.touchStart(content, createTouchEvent(0, 0));
+        fireEvent.touchMove(content, createTouchEvent(50, 0)); // Less than threshold
+        fireEvent.touchEnd(content);
+      });
 
       expect(onSwipeRight).not.toHaveBeenCalled();
     });
@@ -297,7 +303,7 @@ describe("SwipeableCard", () => {
       expect(onSwipeRight).not.toHaveBeenCalled();
     });
 
-    it("locks direction to horizontal when moving horizontally first", () => {
+    it("locks direction to horizontal when moving horizontally first", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -308,19 +314,21 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.touchStart(content, createTouchEvent(0, 0));
-      // First move is horizontal
-      fireEvent.touchMove(content, createTouchEvent(20, 5));
-      // Continue horizontal past threshold
-      fireEvent.touchMove(content, createTouchEvent(600, 10));
-      fireEvent.touchEnd(content);
+      await act(async () => {
+        fireEvent.touchStart(content, createTouchEvent(0, 0));
+        // First move is horizontal
+        fireEvent.touchMove(content, createTouchEvent(20, 5));
+        // Continue horizontal past threshold
+        fireEvent.touchMove(content, createTouchEvent(600, 10));
+        fireEvent.touchEnd(content);
+      });
 
       expect(onSwipeRight).toHaveBeenCalled();
     });
   });
 
   describe("mouse interactions", () => {
-    it("calls onSwipeRight when dragging right past threshold with mouse", () => {
+    it("calls onSwipeRight when dragging right past threshold with mouse", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -331,19 +339,21 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      // Start mouse drag
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+      await act(async () => {
+        // Start mouse drag
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
 
-      // Move past threshold (270px * 2 for resistance = 540px movement needed)
-      fireEvent.mouseMove(content, { clientX: 600, clientY: 0 });
+        // Move past threshold (270px * 2 for resistance = 540px movement needed)
+        fireEvent.mouseMove(content, { clientX: 600, clientY: 0 });
 
-      // Release mouse
-      fireEvent.mouseUp(content);
+        // Release mouse
+        fireEvent.mouseUp(content);
+      });
 
       expect(onSwipeRight).toHaveBeenCalledTimes(1);
     });
 
-    it("calls onSwipeLeft when dragging left past threshold with mouse", () => {
+    it("calls onSwipeLeft when dragging left past threshold with mouse", async () => {
       const onSwipeLeft = vi.fn();
       render(
         <SwipeableCard onSwipeLeft={onSwipeLeft}>
@@ -354,14 +364,16 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.mouseDown(content, { clientX: 600, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 600, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseUp(content);
+      });
 
       expect(onSwipeLeft).toHaveBeenCalledTimes(1);
     });
 
-    it("does not call action when mouse drag does not reach threshold", () => {
+    it("does not call action when mouse drag does not reach threshold", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -372,14 +384,16 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
+        fireEvent.mouseUp(content);
+      });
 
       expect(onSwipeRight).not.toHaveBeenCalled();
     });
 
-    it("handles mouse leave during drag", () => {
+    it("handles mouse leave during drag", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -390,9 +404,11 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 600, clientY: 0 });
-      fireEvent.mouseLeave(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 600, clientY: 0 });
+        fireEvent.mouseLeave(content);
+      });
 
       expect(onSwipeRight).toHaveBeenCalledTimes(1);
     });
@@ -416,7 +432,7 @@ describe("SwipeableCard", () => {
       expect(onSwipeRight).not.toHaveBeenCalled();
     });
 
-    it("locks direction to horizontal when moving horizontally first with mouse", () => {
+    it("locks direction to horizontal when moving horizontally first with mouse", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -427,10 +443,12 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 20, clientY: 5 });
-      fireEvent.mouseMove(content, { clientX: 600, clientY: 10 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 20, clientY: 5 });
+        fireEvent.mouseMove(content, { clientX: 600, clientY: 10 });
+        fireEvent.mouseUp(content);
+      });
 
       expect(onSwipeRight).toHaveBeenCalled();
     });
@@ -468,7 +486,7 @@ describe("SwipeableCard", () => {
   });
 
   describe("SwipeConfig API", () => {
-    it("accepts single action via swipeConfig", () => {
+    it("accepts single action via swipeConfig", async () => {
       const onAction = vi.fn();
       const swipeConfig: SwipeConfig = {
         left: {
@@ -488,15 +506,17 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 600, clientY: 0 }],
-        preventDefault: vi.fn(),
+      await act(async () => {
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 600, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       expect(onAction).toHaveBeenCalledTimes(1);
     });
@@ -530,7 +550,7 @@ describe("SwipeableCard", () => {
       expect(screen.getByText("Content")).toBeInTheDocument();
     });
 
-    it("executes primary action on full swipe with multiple actions", () => {
+    it("executes primary action on full swipe with multiple actions", async () => {
       const onEdit = vi.fn();
       const onArchive = vi.fn();
       const swipeConfig: SwipeConfig = {
@@ -559,21 +579,23 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 600, clientY: 0 }],
-        preventDefault: vi.fn(),
+      await act(async () => {
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 600, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       expect(onEdit).toHaveBeenCalledTimes(1);
       expect(onArchive).not.toHaveBeenCalled();
     });
 
-    it("does not allow swipe when no action defined for direction", () => {
+    it("does not allow swipe when no action defined for direction", async () => {
       const onRight = vi.fn();
       const swipeConfig: SwipeConfig = {
         right: {
@@ -593,15 +615,17 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 200, clientY: 0 }],
-        preventDefault: vi.fn(),
+      await act(async () => {
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 200, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       expect(onRight).not.toHaveBeenCalled();
     });
@@ -619,7 +643,7 @@ describe("SwipeableCard", () => {
       expect(wrapper).not.toHaveAttribute("role");
     });
 
-    it("maintains backward compatibility with old API", () => {
+    it("maintains backward compatibility with old API", async () => {
       const onSwipeLeft = vi.fn();
       const onSwipeRight = vi.fn();
 
@@ -637,15 +661,17 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 600, clientY: 0 }],
-        preventDefault: vi.fn(),
+      await act(async () => {
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 600, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       expect(onSwipeLeft).toHaveBeenCalledTimes(1);
     });
@@ -660,7 +686,7 @@ describe("SwipeableCard", () => {
       vi.useRealTimers();
     });
 
-    it("blocks clicks immediately after a drag gesture with mouse", () => {
+    it("blocks clicks immediately after a drag gesture with mouse", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -672,15 +698,17 @@ describe("SwipeableCard", () => {
         .parentElement as HTMLElement;
 
       // Perform a drag that doesn't trigger action (below threshold)
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
+        fireEvent.mouseUp(content);
+      });
 
       // Verify pointer-events is set to 'none'
       expect(content).toHaveStyle({ pointerEvents: "none" });
     });
 
-    it("unblocks clicks after delay", () => {
+    it("unblocks clicks after delay", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -691,15 +719,17 @@ describe("SwipeableCard", () => {
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
+        fireEvent.mouseUp(content);
+      });
 
       // Blocked immediately
       expect(content).toHaveStyle({ pointerEvents: "none" });
 
       // Advance timers past the delay (150ms)
-      act(() => {
+      await act(async () => {
         vi.advanceTimersByTime(150);
       });
 
@@ -707,7 +737,7 @@ describe("SwipeableCard", () => {
       expect(content).toHaveStyle({ pointerEvents: "auto" });
     });
 
-    it("does not block clicks when no drag occurred", () => {
+    it("does not block clicks when no drag occurred", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -719,14 +749,16 @@ describe("SwipeableCard", () => {
         .parentElement as HTMLElement;
 
       // Click without dragging (no move event)
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseUp(content);
+      });
 
       // Should not be blocked
       expect(content).toHaveStyle({ pointerEvents: "auto" });
     });
 
-    it("does not block clicks for vertical swipes", () => {
+    it("does not block clicks for vertical swipes", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -738,15 +770,17 @@ describe("SwipeableCard", () => {
         .parentElement as HTMLElement;
 
       // Vertical swipe (should be ignored)
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 5, clientY: 50 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 5, clientY: 50 });
+        fireEvent.mouseUp(content);
+      });
 
       // Should not be blocked because no horizontal drag occurred
       expect(content).toHaveStyle({ pointerEvents: "auto" });
     });
 
-    it("resets timeout when dragging multiple times rapidly", () => {
+    it("resets timeout when dragging multiple times rapidly", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -758,14 +792,16 @@ describe("SwipeableCard", () => {
         .parentElement as HTMLElement;
 
       // First drag
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
+        fireEvent.mouseUp(content);
+      });
 
       expect(content).toHaveStyle({ pointerEvents: "none" });
 
       // Advance time partially
-      act(() => {
+      await act(async () => {
         vi.advanceTimersByTime(50);
       });
 
@@ -773,15 +809,17 @@ describe("SwipeableCard", () => {
       expect(content).toHaveStyle({ pointerEvents: "none" });
 
       // Second drag before first timeout completes
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 50, clientY: 0 });
+        fireEvent.mouseUp(content);
+      });
 
       // Still blocked
       expect(content).toHaveStyle({ pointerEvents: "none" });
 
       // Advance 150ms from second drag
-      act(() => {
+      await act(async () => {
         vi.advanceTimersByTime(150);
       });
 
@@ -789,7 +827,7 @@ describe("SwipeableCard", () => {
       expect(content).toHaveStyle({ pointerEvents: "auto" });
     });
 
-    it("blocks clicks after touch drag gesture", () => {
+    it("blocks clicks after touch drag gesture", async () => {
       const onSwipeRight = vi.fn();
       render(
         <SwipeableCard onSwipeRight={onSwipeRight}>
@@ -801,21 +839,23 @@ describe("SwipeableCard", () => {
         .parentElement as HTMLElement;
 
       // Perform a touch drag below threshold
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
+      await act(async () => {
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 50, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 50, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       // Should be blocked
       expect(content).toHaveStyle({ pointerEvents: "none" });
 
       // Advance timers (150ms)
-      act(() => {
+      await act(async () => {
         vi.advanceTimersByTime(150);
       });
 
@@ -823,7 +863,7 @@ describe("SwipeableCard", () => {
       expect(content).toHaveStyle({ pointerEvents: "auto" });
     });
 
-    it("blocks clicks when drawer is open via onClickCapture", () => {
+    it("blocks clicks when drawer is open via onClickCapture", async () => {
       const onSwipeRight = vi.fn();
       const childClickHandler = vi.fn();
 
@@ -839,12 +879,14 @@ describe("SwipeableCard", () => {
         .parentElement as HTMLElement;
 
       // Open the drawer by swiping past drawer threshold but not full swipe
-      fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
-      fireEvent.mouseMove(content, { clientX: 150, clientY: 0 });
-      fireEvent.mouseUp(content);
+      await act(async () => {
+        fireEvent.mouseDown(content, { clientX: 0, clientY: 0 });
+        fireEvent.mouseMove(content, { clientX: 150, clientY: 0 });
+        fireEvent.mouseUp(content);
+      });
 
       // Wait for click block to clear
-      act(() => {
+      await act(async () => {
         vi.advanceTimersByTime(150);
       });
 
@@ -866,28 +908,28 @@ describe("SwipeableCard", () => {
         value: 300,
       });
 
-      render(
-        <SwipeableCard onSwipeRight={onSwipeRight}>
-          <div data-testid="content">Content</div>
-        </SwipeableCard>,
-      );
+      await act(async () => {
+        render(
+          <SwipeableCard onSwipeRight={onSwipeRight}>
+            <div data-testid="content">Content</div>
+          </SwipeableCard>,
+        );
+      });
 
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 450, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 450, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       expect(onSwipeRight).toHaveBeenCalledTimes(1);
     });
@@ -900,28 +942,28 @@ describe("SwipeableCard", () => {
         value: 200,
       });
 
-      render(
-        <SwipeableCard onSwipeRight={onSwipeRight}>
-          <div data-testid="content">Content</div>
-        </SwipeableCard>,
-      );
+      await act(async () => {
+        render(
+          <SwipeableCard onSwipeRight={onSwipeRight}>
+            <div data-testid="content">Content</div>
+          </SwipeableCard>,
+        );
+      });
 
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 300, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 300, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       expect(onSwipeRight).toHaveBeenCalledTimes(1);
     });
@@ -934,28 +976,28 @@ describe("SwipeableCard", () => {
         value: 600,
       });
 
-      render(
-        <SwipeableCard onSwipeRight={onSwipeRight}>
-          <div data-testid="content">Content</div>
-        </SwipeableCard>,
-      );
+      await act(async () => {
+        render(
+          <SwipeableCard onSwipeRight={onSwipeRight}>
+            <div data-testid="content">Content</div>
+          </SwipeableCard>,
+        );
+      });
 
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 900, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 900, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       expect(onSwipeRight).toHaveBeenCalledTimes(1);
     });
@@ -968,28 +1010,28 @@ describe("SwipeableCard", () => {
         value: 0,
       });
 
-      render(
-        <SwipeableCard onSwipeRight={onSwipeRight}>
-          <div data-testid="content">Content</div>
-        </SwipeableCard>,
-      );
+      await act(async () => {
+        render(
+          <SwipeableCard onSwipeRight={onSwipeRight}>
+            <div data-testid="content">Content</div>
+          </SwipeableCard>,
+        );
+      });
 
       const content = screen.getByTestId("content")
         .parentElement as HTMLElement;
 
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        fireEvent.touchStart(content, {
+          touches: [{ clientX: 0, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchMove(content, {
+          touches: [{ clientX: 600, clientY: 0 }],
+          preventDefault: vi.fn(),
+        });
+        fireEvent.touchEnd(content);
       });
-
-      fireEvent.touchStart(content, {
-        touches: [{ clientX: 0, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchMove(content, {
-        touches: [{ clientX: 600, clientY: 0 }],
-        preventDefault: vi.fn(),
-      });
-      fireEvent.touchEnd(content);
 
       expect(onSwipeRight).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
The SwipeableCard tests were showing React act() warnings because state
updates from the async handleDragEnd callback were happening after the
synchronous act() blocks completed. This change wraps all gesture event
sequences in `await act(async () => {...})` to properly handle the async
state updates from the useSwipeGesture hook.