### PR TITLE
perf(hooks): use targeted query invalidation for compensation mutations

### DIFF
--- a/web-app/src/hooks/useConvocations.test.tsx
+++ b/web-app/src/hooks/useConvocations.test.tsx
@@ -637,7 +637,7 @@ describe("useConvocations - Unified API Architecture", () => {
 
     await result.current.mutateAsync("test-exchange-id");
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["exchanges"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["exchanges", "list"] });
   });
 });
 


### PR DESCRIPTION
Replace broad query invalidation with more targeted invalidation to
reduce unnecessary refetches:

- useUpdateCompensation: Invalidate only compensation lists instead of
  all compensation queries
- useUpdateAssignmentCompensation: Invalidate specific assignment
  detail, assignment lists, and compensation lists instead of all
  queries for both entities

This improves performance by avoiding refetching data that wasn't
affected by the mutation (e.g., validation-closed assignments cache).