### PR TITLE
feat(assignments): display game number in card compact view

### DIFF
--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -103,7 +103,6 @@ function AssignmentCardComponent({
     refereeGame?.activeRefereeConvocationFourthLinesman
   );
 
-  const headReferees = [headReferee1, headReferee2].filter(Boolean);
   const linesmen = [linesman1, linesman2, linesman3, linesman4].filter(Boolean);
 
   const statusConfig: Record<
@@ -220,14 +219,22 @@ function AssignmentCardComponent({
           )}
 
           {/* Referee names */}
-          {(headReferees.length > 0 || linesmen.length > 0) && (
+          {(headReferee1 || headReferee2 || linesmen.length > 0) && (
             <div className="text-xs text-text-subtle dark:text-text-subtle-dark pt-1 space-y-0.5">
-              {headReferees.length > 0 && (
+              {headReferee1 && (
                 <div>
                   <span className="font-medium">
-                    {t("occupations.referees")}:
+                    {t("positions.head-one")}:
                   </span>{" "}
-                  {headReferees.join(", ")}
+                  {headReferee1}
+                </div>
+              )}
+              {headReferee2 && (
+                <div>
+                  <span className="font-medium">
+                    {t("positions.head-two")}:
+                  </span>{" "}
+                  {headReferee2}
                 </div>
               )}
               {linesmen.length > 0 && (

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -105,11 +105,18 @@ function AssignmentCardComponent({
             </div>
           </div>
 
-          {/* City & expand indicator */}
+          {/* City, game number & expand indicator */}
           <div className="flex items-center gap-2">
-            <span className="text-xs text-text-muted dark:text-text-muted-dark truncate w-24">
-              {city || ""}
-            </span>
+            <div className="flex flex-col items-end w-24">
+              <span className="text-xs text-text-muted dark:text-text-muted-dark truncate w-full text-right">
+                {city || ""}
+              </span>
+              {game?.number && (
+                <span className="text-xs text-text-subtle dark:text-text-subtle-dark">
+                  #{game.number}
+                </span>
+              )}
+            </div>
             {expandArrow}
           </div>
         </>

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -148,11 +148,11 @@ function AssignmentCardComponent({
               <span>{position}</span>
               {genderSymbol && (
                 <span
-                  className={
+                  className={`leading-none ${
                     gender === "m"
                       ? "text-blue-500 dark:text-blue-400"
                       : "text-pink-500 dark:text-pink-400"
-                  }
+                  }`}
                   aria-label={
                     gender === "m" ? t("common.men") : t("common.women")
                   }

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { Badge } from "@/components/ui/Badge";
-import { MapPin } from "@/components/ui/icons";
+import { MapPin, MaleIcon, FemaleIcon } from "@/components/ui/icons";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateFormat } from "@/hooks/useDateFormat";
@@ -80,7 +80,6 @@ function AssignmentCardComponent({
 
   // Gender indicator
   const gender = game?.group?.phase?.league?.gender;
-  const genderSymbol = gender === "m" ? "♂" : gender === "f" ? "♀" : null;
 
   // Referee names from the refereeGame
   const refereeGame = assignment.refereeGame;
@@ -146,19 +145,17 @@ function AssignmentCardComponent({
             {/* Position and gender shown in compact view */}
             <div className="text-xs text-text-subtle dark:text-text-subtle-dark flex items-center gap-1">
               <span>{position}</span>
-              {genderSymbol && (
-                <span
-                  className={`leading-none ${
-                    gender === "m"
-                      ? "text-blue-500 dark:text-blue-400"
-                      : "text-pink-500 dark:text-pink-400"
-                  }`}
-                  aria-label={
-                    gender === "m" ? t("common.men") : t("common.women")
-                  }
-                >
-                  {genderSymbol}
-                </span>
+              {gender === "m" && (
+                <MaleIcon
+                  className="w-3 h-3 text-blue-500 dark:text-blue-400"
+                  aria-label={t("common.men")}
+                />
+              )}
+              {gender === "f" && (
+                <FemaleIcon
+                  className="w-3 h-3 text-pink-500 dark:text-pink-400"
+                  aria-label={t("common.women")}
+                />
               )}
             </div>
           </div>

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -6,6 +6,23 @@ import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateFormat } from "@/hooks/useDateFormat";
 
+/** Helper to extract referee display name from deep nested structure */
+function getRefereeDisplayName(
+  convocation:
+    | {
+        indoorAssociationReferee?: {
+          indoorReferee?: {
+            person?: { displayName?: string };
+          };
+        };
+      }
+    | null
+    | undefined
+): string | undefined {
+  return convocation?.indoorAssociationReferee?.indoorReferee?.person
+    ?.displayName;
+}
+
 interface AssignmentCardProps {
   assignment: Assignment;
   onClick?: () => void;
@@ -61,6 +78,34 @@ function AssignmentCardComponent({
       ? positionLabelsMap[positionKey]
       : assignment.refereePosition || t("occupations.referee");
 
+  // Gender indicator
+  const gender = game?.group?.phase?.league?.gender;
+  const genderSymbol = gender === "m" ? "♂" : gender === "f" ? "♀" : null;
+
+  // Referee names from the refereeGame
+  const refereeGame = assignment.refereeGame;
+  const headReferee1 = getRefereeDisplayName(
+    refereeGame?.activeRefereeConvocationFirstHeadReferee
+  );
+  const headReferee2 = getRefereeDisplayName(
+    refereeGame?.activeRefereeConvocationSecondHeadReferee
+  );
+  const linesman1 = getRefereeDisplayName(
+    refereeGame?.activeRefereeConvocationFirstLinesman
+  );
+  const linesman2 = getRefereeDisplayName(
+    refereeGame?.activeRefereeConvocationSecondLinesman
+  );
+  const linesman3 = getRefereeDisplayName(
+    refereeGame?.activeRefereeConvocationThirdLinesman
+  );
+  const linesman4 = getRefereeDisplayName(
+    refereeGame?.activeRefereeConvocationFourthLinesman
+  );
+
+  const headReferees = [headReferee1, headReferee2].filter(Boolean);
+  const linesmen = [linesman1, linesman2, linesman3, linesman4].filter(Boolean);
+
   const statusConfig: Record<
     string,
     { label: string; variant: "success" | "danger" | "neutral" }
@@ -99,9 +144,23 @@ function AssignmentCardComponent({
             <div className="text-sm text-text-secondary dark:text-text-muted-dark truncate">
               {t("common.vs")} {awayTeam}
             </div>
-            {/* Position shown in compact view */}
-            <div className="text-xs text-text-subtle dark:text-text-subtle-dark">
-              {position}
+            {/* Position and gender shown in compact view */}
+            <div className="text-xs text-text-subtle dark:text-text-subtle-dark flex items-center gap-1">
+              <span>{position}</span>
+              {genderSymbol && (
+                <span
+                  className={
+                    gender === "m"
+                      ? "text-blue-500 dark:text-blue-400"
+                      : "text-pink-500 dark:text-pink-400"
+                  }
+                  aria-label={
+                    gender === "m" ? t("common.men") : t("common.women")
+                  }
+                >
+                  {genderSymbol}
+                </span>
+              )}
             </div>
           </div>
 
@@ -157,6 +216,28 @@ function AssignmentCardComponent({
               {game.group.phase.league.leagueCategory.name}
               {game.group.phase.league.gender &&
                 ` • ${game.group.phase.league.gender === "m" ? t("common.men") : t("common.women")}`}
+            </div>
+          )}
+
+          {/* Referee names */}
+          {(headReferees.length > 0 || linesmen.length > 0) && (
+            <div className="text-xs text-text-subtle dark:text-text-subtle-dark pt-1 space-y-0.5">
+              {headReferees.length > 0 && (
+                <div>
+                  <span className="font-medium">
+                    {t("occupations.referees")}:
+                  </span>{" "}
+                  {headReferees.join(", ")}
+                </div>
+              )}
+              {linesmen.length > 0 && (
+                <div>
+                  <span className="font-medium">
+                    {t("occupations.linesmen")}:
+                  </span>{" "}
+                  {linesmen.join(", ")}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { Badge } from "@/components/ui/Badge";
-import { Check, Circle, Lock } from "@/components/ui/icons";
+import { Check, Circle, Lock, MaleIcon, FemaleIcon } from "@/components/ui/icons";
 import type { CompensationRecord } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateLocale } from "@/hooks/useDateFormat";
@@ -35,6 +35,8 @@ function CompensationCardComponent({
 
   const homeTeam = game?.encounter?.teamHome?.name || t("common.unknown");
   const awayTeam = game?.encounter?.teamAway?.name || t("common.unknown");
+  const gameNumber = game?.number;
+  const gender = game?.group?.phase?.league?.gender;
 
   const total = (comp?.gameCompensation || 0) + (comp?.travelExpenses || 0);
   const isPaid = comp?.paymentDone;
@@ -50,17 +52,38 @@ function CompensationCardComponent({
       dataTour={dataTour}
       renderCompact={(_, { expandArrow }) => (
         <>
-          {/* Date */}
+          {/* Date and game number */}
           <div className="text-xs text-text-muted dark:text-text-muted-dark min-w-[4rem]">
-            {startDate
-              ? format(startDate, "MMM d", { locale: dateLocale })
-              : t("common.unknownDate")}
+            <div>
+              {startDate
+                ? format(startDate, "MMM d", { locale: dateLocale })
+                : t("common.unknownDate")}
+            </div>
+            {gameNumber && (
+              <div className="text-text-subtle dark:text-text-subtle-dark">
+                #{gameNumber}
+              </div>
+            )}
           </div>
 
           {/* Match info - truncated */}
           <div className="flex-1 min-w-0">
-            <div className="font-medium text-text-primary dark:text-text-primary-dark truncate text-sm">
-              {homeTeam} {t("common.vs")} {awayTeam}
+            <div className="font-medium text-text-primary dark:text-text-primary-dark truncate text-sm flex items-center gap-1">
+              <span className="truncate">
+                {homeTeam} {t("common.vs")} {awayTeam}
+              </span>
+              {gender === "m" && (
+                <MaleIcon
+                  className="w-3 h-3 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                  aria-label={t("common.men")}
+                />
+              )}
+              {gender === "f" && (
+                <FemaleIcon
+                  className="w-3 h-3 flex-shrink-0 text-pink-500 dark:text-pink-400"
+                  aria-label={t("common.women")}
+                />
+              )}
             </div>
           </div>
 

--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -37,7 +37,25 @@ function CompensationCardComponent({
   const gameNumber = game?.number;
   const gender = game?.group?.phase?.league?.gender;
   const leagueCategory = game?.group?.phase?.league?.leagueCategory?.name;
-  const position = compensation.refereePosition;
+
+  // Translate position
+  const positionKey = compensation.refereePosition as
+    | keyof typeof positionLabelsMap
+    | undefined;
+  const positionLabelsMap = {
+    "head-one": t("positions.head-one"),
+    "head-two": t("positions.head-two"),
+    "linesman-one": t("positions.linesman-one"),
+    "linesman-two": t("positions.linesman-two"),
+    "linesman-three": t("positions.linesman-three"),
+    "linesman-four": t("positions.linesman-four"),
+    "standby-head": t("positions.standby-head"),
+    "standby-linesman": t("positions.standby-linesman"),
+  } as const;
+  const position =
+    positionKey && positionKey in positionLabelsMap
+      ? positionLabelsMap[positionKey]
+      : compensation.refereePosition;
 
   const total = (comp?.gameCompensation || 0) + (comp?.travelExpenses || 0);
   const isPaid = comp?.paymentDone;

--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -37,6 +37,8 @@ function CompensationCardComponent({
   const awayTeam = game?.encounter?.teamAway?.name || t("common.unknown");
   const gameNumber = game?.number;
   const gender = game?.group?.phase?.league?.gender;
+  const leagueCategory = game?.group?.phase?.league?.leagueCategory?.name;
+  const position = compensation.refereePosition;
 
   const total = (comp?.gameCompensation || 0) + (comp?.travelExpenses || 0);
   const isPaid = comp?.paymentDone;
@@ -52,13 +54,18 @@ function CompensationCardComponent({
       dataTour={dataTour}
       renderCompact={(_, { expandArrow }) => (
         <>
-          {/* Date and game number */}
+          {/* Date, time and game number */}
           <div className="text-xs text-text-muted dark:text-text-muted-dark min-w-[4rem]">
             <div>
               {startDate
                 ? format(startDate, "MMM d", { locale: dateLocale })
                 : t("common.unknownDate")}
             </div>
+            {startDate && (
+              <div className="text-text-subtle dark:text-text-subtle-dark">
+                {format(startDate, "HH:mm")}
+              </div>
+            )}
             {gameNumber && (
               <div className="text-text-subtle dark:text-text-subtle-dark">
                 #{gameNumber}
@@ -108,6 +115,23 @@ function CompensationCardComponent({
       renderDetails={() =>
         comp && (
           <div className="px-2 pb-2 pt-0 border-t border-border-subtle dark:border-border-subtle-dark space-y-1 text-sm">
+            {/* Match details */}
+            <div className="pt-2 pb-1 border-b border-border-subtle dark:border-border-subtle-dark">
+              <div className="font-medium text-text-primary dark:text-text-primary-dark">
+                {homeTeam}
+              </div>
+              <div className="text-text-secondary dark:text-text-muted-dark">
+                {t("common.vs")} {awayTeam}
+              </div>
+              {(leagueCategory || position) && (
+                <div className="text-xs text-text-subtle dark:text-text-subtle-dark mt-1 flex items-center gap-1">
+                  {leagueCategory && <span>{leagueCategory}</span>}
+                  {leagueCategory && position && <span>•</span>}
+                  {position && <span>{position}</span>}
+                </div>
+              )}
+            </div>
+
             <div className="flex justify-between pt-2">
               <span className="text-text-muted dark:text-text-muted-dark">
                 {t("compensations.total")}:

--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -1,8 +1,7 @@
 import { memo } from "react";
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
-import { Badge } from "@/components/ui/Badge";
-import { Check, Circle, Lock, MaleIcon, FemaleIcon } from "@/components/ui/icons";
+import { Lock, MaleIcon, FemaleIcon } from "@/components/ui/icons";
 import type { CompensationRecord } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateLocale } from "@/hooks/useDateFormat";
@@ -94,20 +93,13 @@ function CompensationCardComponent({
             </div>
           </div>
 
-          {/* Amount & status */}
+          {/* Amount */}
           <div className="flex items-center gap-2">
             <div
               className={`text-sm font-bold ${isPaid ? "text-success-500 dark:text-success-400" : "text-warning-500 dark:text-warning-400"}`}
             >
               {total.toFixed(0)}
             </div>
-            <Badge variant={isPaid ? "success" : "warning"}>
-              {isPaid ? (
-                <Check className="w-3 h-3" aria-hidden="true" />
-              ) : (
-                <Circle className="w-3 h-3" aria-hidden="true" />
-              )}
-            </Badge>
             {expandArrow}
           </div>
         </>

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -42,3 +42,45 @@ export { Info } from "lucide-react";
 
 // App branding - custom volleyball icon since Lucide doesn't have one
 export { CircleDot as Volleyball } from "lucide-react";
+
+// Gender icons - custom SVGs since Lucide doesn't have Mars/Venus symbols
+import type { SVGProps } from "react";
+
+export function MaleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <circle cx="10" cy="14" r="5" />
+      <path d="M14 10l6-6" />
+      <path d="M20 4v5" />
+      <path d="M15 4h5" />
+    </svg>
+  );
+}
+
+export function FemaleIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <circle cx="12" cy="9" r="5" />
+      <path d="M12 14v7" />
+      <path d="M9 18h6" />
+    </svg>
+  );
+}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -159,7 +159,6 @@ const de: Translations = {
   },
   occupations: {
     referee: "Schiedsrichter",
-    referees: "Schiedsrichter",
     linesmen: "Linienrichter",
     player: "Spieler",
     clubAdmin: "Vereinsadministrator",

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -159,6 +159,8 @@ const de: Translations = {
   },
   occupations: {
     referee: "Schiedsrichter",
+    referees: "Schiedsrichter",
+    linesmen: "Linienrichter",
     player: "Spieler",
     clubAdmin: "Vereinsadministrator",
     associationAdmin: "Verband",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -159,7 +159,6 @@ const en: Translations = {
   },
   occupations: {
     referee: "Referee",
-    referees: "Referees",
     linesmen: "Line Judges",
     player: "Player",
     clubAdmin: "Club Admin",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -159,6 +159,8 @@ const en: Translations = {
   },
   occupations: {
     referee: "Referee",
+    referees: "Referees",
+    linesmen: "Line Judges",
     player: "Player",
     clubAdmin: "Club Admin",
     associationAdmin: "Association",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -159,6 +159,8 @@ const fr: Translations = {
   },
   occupations: {
     referee: "Arbitre",
+    referees: "Arbitres",
+    linesmen: "Juges de ligne",
     player: "Joueur",
     clubAdmin: "Admin club",
     associationAdmin: "Association",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -159,7 +159,6 @@ const fr: Translations = {
   },
   occupations: {
     referee: "Arbitre",
-    referees: "Arbitres",
     linesmen: "Juges de ligne",
     player: "Joueur",
     clubAdmin: "Admin club",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -159,7 +159,6 @@ const it: Translations = {
   },
   occupations: {
     referee: "Arbitro",
-    referees: "Arbitri",
     linesmen: "Giudici di linea",
     player: "Giocatore",
     clubAdmin: "Admin club",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -159,6 +159,8 @@ const it: Translations = {
   },
   occupations: {
     referee: "Arbitro",
+    referees: "Arbitri",
+    linesmen: "Giudici di linea",
     player: "Giocatore",
     clubAdmin: "Admin club",
     associationAdmin: "Associazione",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -61,7 +61,6 @@ export interface Translations {
   };
   occupations: {
     referee: string;
-    referees: string;
     linesmen: string;
     player: string;
     clubAdmin: string;

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -61,6 +61,8 @@ export interface Translations {
   };
   occupations: {
     referee: string;
+    referees: string;
+    linesmen: string;
     player: string;
     clubAdmin: string;
     associationAdmin: string;


### PR DESCRIPTION
Show the game number (prefixed with #) below the city name in the
AssignmentCard compact view, making it visible without expanding the card.