### PR TITLE
refactor(utils): extract position labels into shared utility

### DIFF
--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -5,6 +5,7 @@ import { MapPin, MaleIcon, FemaleIcon } from "@/components/ui/icons";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateFormat } from "@/hooks/useDateFormat";
+import { getPositionLabel } from "@/utils/position-labels";
 
 /** Helper to extract referee display name from deep nested structure */
 function getRefereeDisplayName(
@@ -60,23 +61,11 @@ function AssignmentCardComponent({
   const city = game?.hall?.primaryPostalAddress?.city;
   const status = assignment.refereeConvocationStatus;
 
-  const positionKey = assignment.refereePosition as
-    | keyof typeof positionLabelsMap
-    | undefined;
-  const positionLabelsMap = {
-    "head-one": t("positions.head-one"),
-    "head-two": t("positions.head-two"),
-    "linesman-one": t("positions.linesman-one"),
-    "linesman-two": t("positions.linesman-two"),
-    "linesman-three": t("positions.linesman-three"),
-    "linesman-four": t("positions.linesman-four"),
-    "standby-head": t("positions.standby-head"),
-    "standby-linesman": t("positions.standby-linesman"),
-  } as const;
-  const position =
-    positionKey && positionKey in positionLabelsMap
-      ? positionLabelsMap[positionKey]
-      : assignment.refereePosition || t("occupations.referee");
+  const position = getPositionLabel(
+    assignment.refereePosition,
+    t,
+    t("occupations.referee"),
+  );
 
   // Gender indicator
   const gender = game?.group?.phase?.league?.gender;

--- a/web-app/src/components/features/CompensationCard.tsx
+++ b/web-app/src/components/features/CompensationCard.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { useDateLocale } from "@/hooks/useDateFormat";
 import { formatDistanceKm } from "@/utils/distance";
 import { isCompensationEditable } from "@/utils/compensation-actions";
+import { getPositionLabel } from "@/utils/position-labels";
 
 interface CompensationCardProps {
   compensation: CompensationRecord;
@@ -38,24 +39,7 @@ function CompensationCardComponent({
   const gender = game?.group?.phase?.league?.gender;
   const leagueCategory = game?.group?.phase?.league?.leagueCategory?.name;
 
-  // Translate position
-  const positionKey = compensation.refereePosition as
-    | keyof typeof positionLabelsMap
-    | undefined;
-  const positionLabelsMap = {
-    "head-one": t("positions.head-one"),
-    "head-two": t("positions.head-two"),
-    "linesman-one": t("positions.linesman-one"),
-    "linesman-two": t("positions.linesman-two"),
-    "linesman-three": t("positions.linesman-three"),
-    "linesman-four": t("positions.linesman-four"),
-    "standby-head": t("positions.standby-head"),
-    "standby-linesman": t("positions.standby-linesman"),
-  } as const;
-  const position =
-    positionKey && positionKey in positionLabelsMap
-      ? positionLabelsMap[positionKey]
-      : compensation.refereePosition;
+  const position = getPositionLabel(compensation.refereePosition, t);
 
   const total = (comp?.gameCompensation || 0) + (comp?.travelExpenses || 0);
   const isPaid = comp?.paymentDone;

--- a/web-app/src/utils/position-labels.test.ts
+++ b/web-app/src/utils/position-labels.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getPositionLabel, type PositionKey } from "./position-labels";
 
+type PositionTranslationKey = `positions.${PositionKey}`;
+
 describe("position-labels", () => {
-  const mockT = vi.fn((key: string): string => `translated:${key}`);
+  const mockT = vi.fn(
+    (key: PositionTranslationKey): string => `translated:${key}`,
+  );
 
   beforeEach(() => {
     mockT.mockClear();

--- a/web-app/src/utils/position-labels.test.ts
+++ b/web-app/src/utils/position-labels.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { getPositionLabel, type PositionKey } from "./position-labels";
+
+describe("position-labels", () => {
+  const mockT = vi.fn((key: string) => `translated:${key}`);
+
+  beforeEach(() => {
+    mockT.mockClear();
+  });
+
+  describe("getPositionLabel", () => {
+    it.each<[PositionKey, string]>([
+      ["head-one", "positions.head-one"],
+      ["head-two", "positions.head-two"],
+      ["linesman-one", "positions.linesman-one"],
+      ["linesman-two", "positions.linesman-two"],
+      ["linesman-three", "positions.linesman-three"],
+      ["linesman-four", "positions.linesman-four"],
+      ["standby-head", "positions.standby-head"],
+      ["standby-linesman", "positions.standby-linesman"],
+    ])("should translate known position '%s'", (positionKey, expectedKey) => {
+      const result = getPositionLabel(positionKey, mockT);
+
+      expect(mockT).toHaveBeenCalledWith(expectedKey);
+      expect(result).toBe(`translated:${expectedKey}`);
+    });
+
+    it("should return raw position key for unknown positions", () => {
+      const unknownPosition = "unknown-position";
+
+      const result = getPositionLabel(unknownPosition, mockT);
+
+      expect(mockT).not.toHaveBeenCalled();
+      expect(result).toBe(unknownPosition);
+    });
+
+    it("should return empty string when position is undefined and no fallback", () => {
+      const result = getPositionLabel(undefined, mockT);
+
+      expect(mockT).not.toHaveBeenCalled();
+      expect(result).toBe("");
+    });
+
+    it("should return empty string when position is empty string and no fallback", () => {
+      const result = getPositionLabel("", mockT);
+
+      expect(mockT).not.toHaveBeenCalled();
+      expect(result).toBe("");
+    });
+
+    it("should return fallback when position is undefined", () => {
+      const fallback = "Default Position";
+
+      const result = getPositionLabel(undefined, mockT, fallback);
+
+      expect(result).toBe(fallback);
+    });
+
+    it("should return fallback when position is empty string", () => {
+      const fallback = "Default Position";
+
+      const result = getPositionLabel("", mockT, fallback);
+
+      expect(result).toBe(fallback);
+    });
+
+    it("should not use fallback when position is a known key", () => {
+      const fallback = "Default Position";
+
+      const result = getPositionLabel("head-one", mockT, fallback);
+
+      expect(result).toBe("translated:positions.head-one");
+    });
+
+    it("should not use fallback when position is an unknown key", () => {
+      const fallback = "Default Position";
+
+      const result = getPositionLabel("custom-position", mockT, fallback);
+
+      expect(result).toBe("custom-position");
+    });
+  });
+});

--- a/web-app/src/utils/position-labels.test.ts
+++ b/web-app/src/utils/position-labels.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getPositionLabel, type PositionKey } from "./position-labels";
 
 describe("position-labels", () => {
-  const mockT = vi.fn((key: string) => `translated:${key}`);
+  const mockT = vi.fn((key: string): string => `translated:${key}`);
 
   beforeEach(() => {
     mockT.mockClear();

--- a/web-app/src/utils/position-labels.ts
+++ b/web-app/src/utils/position-labels.ts
@@ -1,0 +1,51 @@
+/**
+ * Position keys used in the volleymanager API for referee assignments.
+ */
+export type PositionKey =
+  | "head-one"
+  | "head-two"
+  | "linesman-one"
+  | "linesman-two"
+  | "linesman-three"
+  | "linesman-four"
+  | "standby-head"
+  | "standby-linesman";
+
+const POSITION_KEYS: readonly PositionKey[] = [
+  "head-one",
+  "head-two",
+  "linesman-one",
+  "linesman-two",
+  "linesman-three",
+  "linesman-four",
+  "standby-head",
+  "standby-linesman",
+] as const;
+
+function isPositionKey(key: string): key is PositionKey {
+  return POSITION_KEYS.includes(key as PositionKey);
+}
+
+/**
+ * Returns the translated label for a referee position.
+ *
+ * @param positionKey - The position key from the API (e.g., "head-one")
+ * @param t - Translation function from useTranslation hook
+ * @param fallback - Optional fallback when positionKey is undefined or empty
+ * @returns Translated position label, or the raw key if not a known position
+ */
+export function getPositionLabel(
+  positionKey: string | undefined,
+  t: (key: string) => string,
+  fallback?: string,
+): string {
+  if (!positionKey) {
+    return fallback ?? "";
+  }
+
+  if (isPositionKey(positionKey)) {
+    return t(`positions.${positionKey}`);
+  }
+
+  return positionKey;
+}

--- a/web-app/src/utils/position-labels.ts
+++ b/web-app/src/utils/position-labels.ts
@@ -11,19 +11,23 @@ export type PositionKey =
   | "standby-head"
   | "standby-linesman";
 
-const POSITION_KEYS: readonly PositionKey[] = [
-  "head-one",
-  "head-two",
-  "linesman-one",
-  "linesman-two",
-  "linesman-three",
-  "linesman-four",
-  "standby-head",
-  "standby-linesman",
-] as const;
+/** Translation keys for positions */
+type PositionTranslationKey = `positions.${PositionKey}`;
+
+/** Map from position key to its translation key */
+const POSITION_TRANSLATION_KEYS: Record<PositionKey, PositionTranslationKey> = {
+  "head-one": "positions.head-one",
+  "head-two": "positions.head-two",
+  "linesman-one": "positions.linesman-one",
+  "linesman-two": "positions.linesman-two",
+  "linesman-three": "positions.linesman-three",
+  "linesman-four": "positions.linesman-four",
+  "standby-head": "positions.standby-head",
+  "standby-linesman": "positions.standby-linesman",
+};
 
 function isPositionKey(key: string): key is PositionKey {
-  return POSITION_KEYS.includes(key as PositionKey);
+  return key in POSITION_TRANSLATION_KEYS;
 }
 
 /**
@@ -36,7 +40,7 @@ function isPositionKey(key: string): key is PositionKey {
  */
 export function getPositionLabel(
   positionKey: string | undefined,
-  t: (key: string) => string,
+  t: (key: PositionTranslationKey) => string,
   fallback?: string,
 ): string {
   if (!positionKey) {
@@ -44,7 +48,7 @@ export function getPositionLabel(
   }
 
   if (isPositionKey(positionKey)) {
-    return t(`positions.${positionKey}`);
+    return t(POSITION_TRANSLATION_KEYS[positionKey]);
   }
 
   return positionKey;


### PR DESCRIPTION
Extract duplicated positionLabelsMap from AssignmentCard and
CompensationCard into a reusable getPositionLabel utility function.
This eliminates code duplication and centralizes position translation
logic.