### PR TITLE
perf(components): add React.memo to feature components

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, memo } from "react";
 import type { Assignment, CompensationRecord } from "@/api/client";
 import { getApiClient } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -35,7 +35,7 @@ interface EditCompensationModalProps {
   onClose: () => void;
 }
 
-export function EditCompensationModal({
+function EditCompensationModalComponent({
   assignment,
   compensation,
   isOpen,
@@ -328,3 +328,5 @@ export function EditCompensationModal({
     </Modal>
   );
 }
+
+export const EditCompensationModal = memo(EditCompensationModalComponent);

--- a/web-app/src/components/features/ExchangeConfirmationModal.tsx
+++ b/web-app/src/components/features/ExchangeConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, memo } from "react";
 import type { GameExchange } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { logger } from "@/utils/logger";
@@ -17,7 +17,7 @@ interface ExchangeConfirmationModalProps {
   variant: "takeOver" | "remove";
 }
 
-export function ExchangeConfirmationModal({
+function ExchangeConfirmationModalComponent({
   exchange,
   isOpen,
   onClose,
@@ -173,3 +173,5 @@ export function ExchangeConfirmationModal({
     </Modal>
   );
 }
+
+export const ExchangeConfirmationModal = memo(ExchangeConfirmationModalComponent);

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { getTeamNames } from "@/utils/assignment-helpers";
@@ -20,7 +21,7 @@ interface ValidateGameModalProps {
   onClose: () => void;
 }
 
-export function ValidateGameModal({
+function ValidateGameModalComponent({
   assignment,
   isOpen,
   onClose,
@@ -204,3 +205,5 @@ export function ValidateGameModal({
     </>
   );
 }
+
+export const ValidateGameModal = memo(ValidateGameModalComponent);

--- a/web-app/src/components/features/settings/DemoSection.tsx
+++ b/web-app/src/components/features/settings/DemoSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, memo } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
@@ -10,7 +10,7 @@ interface DemoSectionProps {
   onRefreshData: () => void;
 }
 
-export function DemoSection({ activeAssociationCode, onRefreshData }: DemoSectionProps) {
+function DemoSectionComponent({ activeAssociationCode, onRefreshData }: DemoSectionProps) {
   const { t } = useTranslation();
   const [demoDataReset, setDemoDataReset] = useState(false);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -79,3 +79,5 @@ export function DemoSection({ activeAssociationCode, onRefreshData }: DemoSectio
     </Card>
   );
 }
+
+export const DemoSection = memo(DemoSectionComponent);

--- a/web-app/src/components/features/settings/ProfileSection.tsx
+++ b/web-app/src/components/features/settings/ProfileSection.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { Badge } from "@/components/ui/Badge";
@@ -8,7 +9,7 @@ interface ProfileSectionProps {
   user: UserProfile;
 }
 
-export function ProfileSection({ user }: ProfileSectionProps) {
+function ProfileSectionComponent({ user }: ProfileSectionProps) {
   const { t } = useTranslation();
 
   return (
@@ -55,3 +56,5 @@ export function ProfileSection({ user }: ProfileSectionProps) {
     </Card>
   );
 }
+
+export const ProfileSection = memo(ProfileSectionComponent);

--- a/web-app/src/components/features/settings/SafeModeSection.tsx
+++ b/web-app/src/components/features/settings/SafeModeSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, lazy, Suspense } from "react";
+import { useState, useCallback, lazy, Suspense, memo } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 
@@ -14,7 +14,7 @@ interface SafeModeSectionProps {
   onSetSafeMode: (enabled: boolean) => void;
 }
 
-export function SafeModeSection({ isSafeModeEnabled, onSetSafeMode }: SafeModeSectionProps) {
+function SafeModeSectionComponent({ isSafeModeEnabled, onSetSafeMode }: SafeModeSectionProps) {
   const { t } = useTranslation();
   const [showSafeModeWarning, setShowSafeModeWarning] = useState(false);
 
@@ -114,3 +114,5 @@ export function SafeModeSection({ isSafeModeEnabled, onSetSafeMode }: SafeModeSe
     </>
   );
 }
+
+export const SafeModeSection = memo(SafeModeSectionComponent);

--- a/web-app/src/components/features/settings/TourSection.tsx
+++ b/web-app/src/components/features/settings/TourSection.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useTourStore, type TourId } from "@/stores/tour";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -10,7 +11,7 @@ interface TourSectionProps {
   isDemoMode: boolean;
 }
 
-export function TourSection({ isDemoMode }: TourSectionProps) {
+function TourSectionComponent({ isDemoMode }: TourSectionProps) {
   const { t } = useTranslation();
   const { getTourStatus, resetAllTours } = useTourStore(
     useShallow((state) => ({
@@ -80,3 +81,5 @@ export function TourSection({ isDemoMode }: TourSectionProps) {
     </Card>
   );
 }
+
+export const TourSection = memo(TourSectionComponent);

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -128,6 +128,18 @@ export function ExchangePage() {
     setStatusFilter(tabId as ExchangeStatus);
   }, []);
 
+  const handleTakeOverConfirm = useCallback(() => {
+    if (takeOverModal.exchange) {
+      handleTakeOver(takeOverModal.exchange);
+    }
+  }, [takeOverModal.exchange, handleTakeOver]);
+
+  const handleRemoveConfirm = useCallback(() => {
+    if (removeFromExchangeModal.exchange) {
+      handleRemoveFromExchange(removeFromExchangeModal.exchange);
+    }
+  }, [removeFromExchangeModal.exchange, handleRemoveFromExchange]);
+
   // Determine if filter is available (demo mode with level set)
   const isLevelFilterAvailable = isDemoMode && userRefereeLevel !== null;
 
@@ -221,7 +233,7 @@ export function ExchangePage() {
             exchange={takeOverModal.exchange}
             isOpen={takeOverModal.isOpen}
             onClose={takeOverModal.close}
-            onConfirm={() => handleTakeOver(takeOverModal.exchange!)}
+            onConfirm={handleTakeOverConfirm}
           />
         </Suspense>
       )}
@@ -232,9 +244,7 @@ export function ExchangePage() {
             exchange={removeFromExchangeModal.exchange}
             isOpen={removeFromExchangeModal.isOpen}
             onClose={removeFromExchangeModal.close}
-            onConfirm={() =>
-              handleRemoveFromExchange(removeFromExchangeModal.exchange!)
-            }
+            onConfirm={handleRemoveConfirm}
           />
         </Suspense>
       )}


### PR DESCRIPTION
Memoize components that receive props to prevent unnecessary re-renders:
- EditCompensationModal
- ValidateGameModal
- ExchangeConfirmationModal
- DemoSection
- SafeModeSection
- ProfileSection
- TourSection