### PR TITLE
refactor(hooks): extract useSafeMutation pattern from action hooks

### DIFF
--- a/web-app/src/hooks/useExchangeActions.ts
+++ b/web-app/src/hooks/useExchangeActions.ts
@@ -1,16 +1,11 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import type { GameExchange } from "@/api/client";
 import {
   useApplyForExchange,
   useWithdrawFromExchange,
 } from "./useConvocations";
-import { createLogger } from "@/utils/logger";
-import { toast } from "@/stores/toast";
-import { useTranslation } from "@/hooks/useTranslation";
 import { useModalState } from "./useModalState";
-import { useSafeModeGuard } from "./useSafeModeGuard";
-
-const log = createLogger("useExchangeActions");
+import { useSafeMutation } from "./useSafeMutation";
 
 interface UseExchangeActionsResult {
   takeOverModal: {
@@ -30,85 +25,57 @@ interface UseExchangeActionsResult {
 }
 
 export function useExchangeActions(): UseExchangeActionsResult {
-  const { t } = useTranslation();
-  const { guard, isDemoMode } = useSafeModeGuard();
-
   const takeOverModal = useModalState<GameExchange>();
   const removeFromExchangeModal = useModalState<GameExchange>();
 
   const applyMutation = useApplyForExchange();
   const withdrawMutation = useWithdrawFromExchange();
 
-  // Race condition protection refs for async operations
-  const isTakingOverRef = useRef(false);
-  const isRemovingRef = useRef(false);
+  const takeOverMutation = useSafeMutation(
+    async (exchange: GameExchange, log) => {
+      await applyMutation.mutateAsync(exchange.__identity);
+      log.debug("Successfully applied for exchange:", exchange.__identity);
+    },
+    {
+      logContext: "useExchangeActions",
+      successMessage: "exchange.applySuccess",
+      errorMessage: "exchange.applyError",
+      safeGuard: { context: "useExchangeActions", action: "taking exchange" },
+      skipSuccessToastInDemoMode: true,
+      onSuccess: () => takeOverModal.close(),
+    },
+  );
+
+  const withdrawMutation2 = useSafeMutation(
+    async (exchange: GameExchange, log) => {
+      await withdrawMutation.mutateAsync(exchange.__identity);
+      log.debug("Successfully withdrawn from exchange:", exchange.__identity);
+    },
+    {
+      logContext: "useExchangeActions",
+      successMessage: "exchange.withdrawSuccess",
+      errorMessage: "exchange.withdrawError",
+      safeGuard: {
+        context: "useExchangeActions",
+        action: "withdrawing from exchange",
+      },
+      skipSuccessToastInDemoMode: true,
+      onSuccess: () => removeFromExchangeModal.close(),
+    },
+  );
 
   const handleTakeOver = useCallback(
     async (exchange: GameExchange) => {
-      if (
-        guard({
-          context: "useExchangeActions",
-          action: "taking exchange",
-        })
-      ) {
-        return;
-      }
-
-      if (isTakingOverRef.current) return;
-      isTakingOverRef.current = true;
-
-      try {
-        await applyMutation.mutateAsync(exchange.__identity);
-        takeOverModal.close();
-
-        log.debug("Successfully applied for exchange:", exchange.__identity);
-
-        if (!isDemoMode) {
-          toast.success(t("exchange.applySuccess"));
-        }
-      } catch (error) {
-        log.error("Failed to apply for exchange:", error);
-
-        toast.error(t("exchange.applyError"));
-      } finally {
-        isTakingOverRef.current = false;
-      }
+      await takeOverMutation.execute(exchange);
     },
-    [guard, isDemoMode, applyMutation, takeOverModal, t],
+    [takeOverMutation],
   );
 
   const handleRemoveFromExchange = useCallback(
     async (exchange: GameExchange) => {
-      if (
-        guard({
-          context: "useExchangeActions",
-          action: "withdrawing from exchange",
-        })
-      ) {
-        return;
-      }
-
-      if (isRemovingRef.current) return;
-      isRemovingRef.current = true;
-
-      try {
-        await withdrawMutation.mutateAsync(exchange.__identity);
-        removeFromExchangeModal.close();
-
-        log.debug("Successfully withdrawn from exchange:", exchange.__identity);
-
-        if (!isDemoMode) {
-          toast.success(t("exchange.withdrawSuccess"));
-        }
-      } catch (error) {
-        log.error("Failed to withdraw from exchange:", error);
-
-        toast.error(t("exchange.withdrawError"));
-      } finally {
-        isRemovingRef.current = false;
-      }
+      await withdrawMutation2.execute(exchange);
     },
-    [guard, isDemoMode, withdrawMutation, removeFromExchangeModal, t],
+    [withdrawMutation2],
   );
 
   return {

--- a/web-app/src/hooks/useExchangeActions.ts
+++ b/web-app/src/hooks/useExchangeActions.ts
@@ -46,7 +46,7 @@ export function useExchangeActions(): UseExchangeActionsResult {
     },
   );
 
-  const withdrawMutation2 = useSafeMutation(
+  const withdrawSafeMutation = useSafeMutation(
     async (exchange: GameExchange, log) => {
       await withdrawMutation.mutateAsync(exchange.__identity);
       log.debug("Successfully withdrawn from exchange:", exchange.__identity);
@@ -73,9 +73,9 @@ export function useExchangeActions(): UseExchangeActionsResult {
 
   const handleRemoveFromExchange = useCallback(
     async (exchange: GameExchange) => {
-      await withdrawMutation2.execute(exchange);
+      await withdrawSafeMutation.execute(exchange);
     },
-    [withdrawMutation2],
+    [withdrawSafeMutation],
   );
 
   return {

--- a/web-app/src/hooks/useSafeMutation.test.ts
+++ b/web-app/src/hooks/useSafeMutation.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSafeMutation } from "./useSafeMutation";
+import * as authStore from "@/stores/auth";
+import * as settingsStore from "@/stores/settings";
+import { toast } from "@/stores/toast";
+import type { TranslationKey } from "@/i18n";
+
+// Test translation keys (cast for type safety in tests)
+const TEST_ERROR = "compensations.pdfDownloadFailed" as TranslationKey;
+const TEST_SUCCESS = "exchange.applySuccess" as TranslationKey;
+
+vi.mock("@/stores/auth");
+vi.mock("@/stores/settings");
+vi.mock("@/stores/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    language: "en",
+  }),
+}));
+vi.mock("@/i18n", () => ({
+  t: (key: string) => key,
+  getLocale: () => "en",
+  setLocale: vi.fn(),
+  setLocaleImmediate: vi.fn(),
+}));
+
+describe("useSafeMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: not in demo mode, safe mode disabled
+    vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+      selector({ isDemoMode: false } as ReturnType<
+        typeof authStore.useAuthStore.getState
+      >),
+    );
+
+    vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
+      selector({ isSafeModeEnabled: false } as ReturnType<
+        typeof settingsStore.useSettingsStore.getState
+      >),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should execute mutation successfully", async () => {
+    const mutationFn = vi.fn().mockResolvedValue("result");
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSafeMutation(mutationFn, {
+        logContext: "testContext",
+        errorMessage: TEST_ERROR,
+        onSuccess,
+      }),
+    );
+
+    await act(async () => {
+      const returnValue = await result.current.execute("arg");
+      expect(returnValue).toBe("result");
+    });
+
+    expect(mutationFn).toHaveBeenCalledWith("arg", expect.any(Object));
+    expect(onSuccess).toHaveBeenCalledWith("result");
+  });
+
+  it("should show success toast when successMessage is provided", async () => {
+    const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useSafeMutation(mutationFn, {
+        logContext: "testContext",
+        successMessage: TEST_SUCCESS,
+        errorMessage: TEST_ERROR,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.execute("arg");
+    });
+
+    expect(toast.success).toHaveBeenCalledWith(TEST_SUCCESS);
+  });
+
+  it("should not show success toast when successMessage is not provided", async () => {
+    const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useSafeMutation(mutationFn, {
+        logContext: "testContext",
+        errorMessage: TEST_ERROR,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.execute("arg");
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("should show error toast on failure", async () => {
+    const mutationFn = vi.fn().mockRejectedValue(new Error("Network error"));
+    const onError = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSafeMutation(mutationFn, {
+        logContext: "testContext",
+        errorMessage: TEST_ERROR,
+        onError,
+      }),
+    );
+
+    await act(async () => {
+      const returnValue = await result.current.execute("arg");
+      expect(returnValue).toBeUndefined();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(TEST_ERROR);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("should prevent concurrent executions (race condition protection)", async () => {
+    let resolveFirst: () => void;
+    const firstPromise = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    const mutationFn = vi.fn().mockReturnValue(firstPromise);
+
+    const { result } = renderHook(() =>
+      useSafeMutation(mutationFn, {
+        logContext: "testContext",
+        errorMessage: TEST_ERROR,
+      }),
+    );
+
+    // Start first execution (don't await)
+    const promise1 = result.current.execute("arg1");
+
+    // Try to start second execution immediately
+    const promise2 = result.current.execute("arg2");
+
+    // Resolve first
+    resolveFirst!();
+
+    await Promise.all([promise1, promise2]);
+
+    // Should only be called once
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(mutationFn).toHaveBeenCalledWith("arg1", expect.any(Object));
+  });
+
+  it("should allow new execution after previous completes", async () => {
+    const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useSafeMutation(mutationFn, {
+        logContext: "testContext",
+        errorMessage: TEST_ERROR,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.execute("arg1");
+    });
+
+    await act(async () => {
+      await result.current.execute("arg2");
+    });
+
+    expect(mutationFn).toHaveBeenCalledTimes(2);
+    expect(mutationFn).toHaveBeenNthCalledWith(1, "arg1", expect.any(Object));
+    expect(mutationFn).toHaveBeenNthCalledWith(2, "arg2", expect.any(Object));
+  });
+
+  describe("safe mode guard", () => {
+    beforeEach(() => {
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
+        selector({ isSafeModeEnabled: true } as ReturnType<
+          typeof settingsStore.useSettingsStore.getState
+        >),
+      );
+    });
+
+    it("should block execution when safe mode is enabled", async () => {
+      const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useSafeMutation(mutationFn, {
+          logContext: "testContext",
+          errorMessage: TEST_ERROR,
+          safeGuard: { context: "testContext", action: "test action" },
+        }),
+      );
+
+      await act(async () => {
+        const returnValue = await result.current.execute("arg");
+        expect(returnValue).toBeUndefined();
+      });
+
+      expect(mutationFn).not.toHaveBeenCalled();
+      expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
+    });
+
+    it("should allow execution without safeGuard option", async () => {
+      const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useSafeMutation(mutationFn, {
+          logContext: "testContext",
+          errorMessage: TEST_ERROR,
+          // No safeGuard option
+        }),
+      );
+
+      await act(async () => {
+        await result.current.execute("arg");
+      });
+
+      expect(mutationFn).toHaveBeenCalledWith("arg", expect.any(Object));
+    });
+
+    it("should allow execution in demo mode even with safe mode enabled", async () => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useSafeMutation(mutationFn, {
+          logContext: "testContext",
+          errorMessage: TEST_ERROR,
+          safeGuard: { context: "testContext", action: "test action" },
+        }),
+      );
+
+      await act(async () => {
+        await result.current.execute("arg");
+      });
+
+      // Demo mode bypasses safe mode since changes are local-only
+      expect(mutationFn).toHaveBeenCalledWith("arg", expect.any(Object));
+    });
+  });
+
+  describe("skipSuccessToastInDemoMode", () => {
+    it("should skip success toast in demo mode when configured", async () => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useSafeMutation(mutationFn, {
+          logContext: "testContext",
+          successMessage: TEST_SUCCESS,
+          errorMessage: TEST_ERROR,
+          skipSuccessToastInDemoMode: true,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.execute("arg");
+      });
+
+      expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it("should show success toast in demo mode when not configured to skip", async () => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: true } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useSafeMutation(mutationFn, {
+          logContext: "testContext",
+          successMessage: TEST_SUCCESS,
+          errorMessage: TEST_ERROR,
+          skipSuccessToastInDemoMode: false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.execute("arg");
+      });
+
+      expect(toast.success).toHaveBeenCalledWith(TEST_SUCCESS);
+    });
+
+    it("should show success toast when not in demo mode", async () => {
+      const mutationFn = vi.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useSafeMutation(mutationFn, {
+          logContext: "testContext",
+          successMessage: TEST_SUCCESS,
+          errorMessage: TEST_ERROR,
+          skipSuccessToastInDemoMode: true,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.execute("arg");
+      });
+
+      expect(toast.success).toHaveBeenCalledWith(TEST_SUCCESS);
+    });
+  });
+
+  it("should pass logger to mutation function", async () => {
+    const mutationFn = vi.fn().mockImplementation((_arg, log) => {
+      log.debug("Test log message");
+      return Promise.resolve(undefined);
+    });
+
+    const { result } = renderHook(() =>
+      useSafeMutation(mutationFn, {
+        logContext: "testContext",
+        errorMessage: TEST_ERROR,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.execute("arg");
+    });
+
+    expect(mutationFn).toHaveBeenCalledWith("arg", expect.objectContaining({
+      debug: expect.any(Function),
+      error: expect.any(Function),
+    }));
+  });
+
+  it("should reset executing flag after error", async () => {
+    const mutationFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("First error"))
+      .mockResolvedValueOnce("success");
+
+    const { result } = renderHook(() =>
+      useSafeMutation(mutationFn, {
+        logContext: "testContext",
+        errorMessage: TEST_ERROR,
+      }),
+    );
+
+    // First call fails
+    await act(async () => {
+      await result.current.execute("arg1");
+    });
+
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+
+    // Second call should work (flag was reset)
+    await act(async () => {
+      const returnValue = await result.current.execute("arg2");
+      expect(returnValue).toBe("success");
+    });
+
+    expect(mutationFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web-app/src/hooks/useSafeMutation.ts
+++ b/web-app/src/hooks/useSafeMutation.ts
@@ -1,0 +1,122 @@
+import { useCallback, useRef } from "react";
+import { createLogger, type Logger } from "@/utils/logger";
+import { toast } from "@/stores/toast";
+import { useTranslation } from "@/hooks/useTranslation";
+import { useSafeModeGuard } from "./useSafeModeGuard";
+import type { TranslationKey } from "@/i18n";
+
+interface SafeMutationGuardOptions {
+  /** Context for safe mode logging */
+  context: string;
+  /** Action description for safe mode logging */
+  action: string;
+}
+
+interface UseSafeMutationOptions<TResult> {
+  /** Unique key for logging context */
+  logContext: string;
+
+  /** Translation key for success toast (optional - some mutations don't show success) */
+  successMessage?: TranslationKey;
+
+  /** Translation key for error toast */
+  errorMessage: TranslationKey;
+
+  /** Safe mode guard options (optional - blocks when safe mode is enabled) */
+  safeGuard?: SafeMutationGuardOptions;
+
+  /** Skip success toast in demo mode */
+  skipSuccessToastInDemoMode?: boolean;
+
+  /** Callback on success */
+  onSuccess?: (result: TResult) => void;
+
+  /** Callback on error */
+  onError?: (error: unknown) => void;
+}
+
+interface UseSafeMutationResult<TArg, TResult> {
+  /** Execute the mutation with race condition protection */
+  execute: (arg: TArg) => Promise<TResult | undefined>;
+}
+
+/**
+ * Hook that wraps async mutation functions with common patterns:
+ * - Race condition protection via useRef
+ * - Try-catch with logging
+ * - Toast notifications for success/error
+ * - Optional safe mode guard check
+ *
+ * @example
+ * const { execute } = useSafeMutation(
+ *   async (id: string) => api.deleteItem(id),
+ *   {
+ *     logContext: "useItemActions",
+ *     successMessage: "items.deleteSuccess",
+ *     errorMessage: "items.deleteError",
+ *     safeGuard: { context: "useItemActions", action: "deleting item" },
+ *   }
+ * );
+ *
+ * const handleDelete = useCallback((item) => execute(item.id), [execute]);
+ */
+export function useSafeMutation<TArg, TResult = void>(
+  mutationFn: (arg: TArg, logger: Logger) => Promise<TResult>,
+  options: UseSafeMutationOptions<TResult>,
+): UseSafeMutationResult<TArg, TResult> {
+  const { t } = useTranslation();
+  const { guard, isDemoMode } = useSafeModeGuard();
+  const isExecutingRef = useRef(false);
+  const loggerRef = useRef<Logger | null>(null);
+
+  // Lazy initialize logger to avoid creating on every render
+  if (!loggerRef.current) {
+    loggerRef.current = createLogger(options.logContext);
+  }
+  const log = loggerRef.current;
+
+  const execute = useCallback(
+    async (arg: TArg): Promise<TResult | undefined> => {
+      // Safe mode guard check
+      if (options.safeGuard) {
+        if (guard(options.safeGuard)) {
+          return undefined;
+        }
+      }
+
+      // Race condition protection
+      if (isExecutingRef.current) {
+        log.debug("Operation already in progress, ignoring");
+        return undefined;
+      }
+
+      isExecutingRef.current = true;
+
+      try {
+        const result = await mutationFn(arg, log);
+
+        // Success toast (skip in demo mode if configured)
+        if (options.successMessage) {
+          const shouldShowToast =
+            !options.skipSuccessToastInDemoMode || !isDemoMode;
+          if (shouldShowToast) {
+            toast.success(t(options.successMessage));
+          }
+        }
+
+        options.onSuccess?.(result);
+        return result;
+      } catch (error) {
+        log.error("Operation failed:", error);
+        toast.error(t(options.errorMessage));
+        options.onError?.(error);
+        return undefined;
+      } finally {
+        isExecutingRef.current = false;
+      }
+    },
+    [guard, isDemoMode, mutationFn, options, t, log],
+  );
+
+  return { execute };
+}

--- a/web-app/src/i18n/index.ts
+++ b/web-app/src/i18n/index.ts
@@ -186,7 +186,7 @@ type PathKeys<T, Prefix extends string = ""> = T extends object
     }[keyof T]
   : never;
 
-type TranslationKey = PathKeys<Translations>;
+export type TranslationKey = PathKeys<Translations>;
 
 /**
  * Get translation by dot-notation key.


### PR DESCRIPTION
Create a reusable useSafeMutation hook that encapsulates common async
mutation patterns: race condition protection via useRef, try-catch
with logging, toast notifications, and optional safe mode guard checks.

Refactor useCompensationActions and useExchangeActions to use the new
hook, reducing code duplication and improving consistency across
mutation handlers.