### PR TITLE
feat(demo): set default home location for distance filtering

### DIFF
--- a/web-app/e2e/pages/exchanges.page.ts
+++ b/web-app/e2e/pages/exchanges.page.ts
@@ -26,7 +26,8 @@ export class ExchangesPage {
     this.myApplicationsTab = page.locator('#tab-applied');
     this.tabPanel = page.getByRole("tabpanel");
     this.exchangeCards = this.tabPanel.getByRole("button");
-    this.levelFilterToggle = page.getByRole("checkbox");
+    // Use data-tour attribute to distinguish from distance filter checkbox
+    this.levelFilterToggle = page.locator('[data-tour="exchange-filter"]');
   }
 
   async goto() {

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
-import { MapPin, MaleIcon, FemaleIcon } from "@/components/ui/icons";
+import { MapPin, MaleIcon, FemaleIcon, Home } from "@/components/ui/icons";
 import type { GameExchange } from "@/api/client";
 import { useDateLocale } from "@/hooks/useDateFormat";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -93,7 +93,8 @@ function ExchangeCardComponent({
           {/* Distance badge */}
           {distanceKm != null && (
             <div className="flex items-center shrink-0">
-              <span className="text-xs font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 px-2 py-0.5 rounded-full">
+              <span className="text-xs font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 px-2 py-0.5 rounded-full flex items-center gap-1">
+                <Home className="w-3 h-3" aria-hidden="true" />
                 {distanceKm.toFixed(0)} {t("common.distanceUnit")}
               </span>
             </div>

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -31,6 +31,7 @@ export { Circle } from "lucide-react";
 export { X } from "lucide-react";
 export { Plus } from "lucide-react";
 export { MapPin } from "lucide-react";
+export { Home } from "lucide-react";
 
 // Status icons
 export { CheckCircle } from "lucide-react";

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -9,6 +9,7 @@ import {
   submitLoginCredentials,
 } from "@/utils/auth-parsers";
 import { useDemoStore } from "./demo";
+import { useSettingsStore, DEMO_HOME_LOCATION } from "./settings";
 
 export type AuthStatus = "idle" | "loading" | "authenticated" | "error";
 
@@ -259,6 +260,9 @@ export const useAuthStore = create<AuthState>()(
         ];
 
         const demoOccupations = filterRefereeOccupations(rawDemoOccupations);
+
+        // Set demo home location for distance filtering showcase
+        useSettingsStore.getState().setHomeLocation(DEMO_HOME_LOCATION);
 
         set({
           status: "authenticated",

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -47,6 +47,17 @@ interface SettingsState {
 /** Default max distance in kilometers */
 const DEFAULT_MAX_DISTANCE_KM = 50;
 
+/**
+ * Demo mode default location: Zurich main station area.
+ * Provides a central location in Switzerland to showcase distance filtering.
+ */
+export const DEMO_HOME_LOCATION: UserLocation = {
+  latitude: 47.3769,
+  longitude: 8.5417,
+  label: "Zürich HB",
+  source: "geocoded",
+};
+
 export const useSettingsStore = create<SettingsState>()(
   persist(
     (set) => ({


### PR DESCRIPTION
Add a default Zurich HB location when entering demo mode so that:
- Distance badges appear on exchange cards
- Distance filter toggle becomes visible
- Users can showcase the distance-based filtering feature

The filter remains disabled by default, allowing users to see all
exchanges while having the option to enable filtering.