### PR TITLE
feat(transport): add public transport travel time support

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -41,6 +41,8 @@ jobs:
           VITE_DEMO_MODE_ONLY: 'true'
           # Set base path for PR preview - uses pr-{number} subdirectory
           VITE_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
+          # OJP API key for Swiss public transport travel times
+          VITE_OJP_API_KEY: ${{ secrets.VITE_OJP_API_KEY }}
       - name: Add .nojekyll for GitHub Pages
         run: touch dist/.nojekyll
       # Download existing gh-pages content to preserve main site and other PR previews

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -68,6 +68,8 @@ jobs:
           # Set base path for GitHub Pages deployment
           # Configure via repository variable, defaults to repo name pattern
           VITE_BASE_PATH: ${{ vars.VITE_BASE_PATH || format('/{0}/', github.event.repository.name) }}
+          # OJP API key for Swiss public transport travel times
+          VITE_OJP_API_KEY: ${{ secrets.VITE_OJP_API_KEY }}
       - name: Add .nojekyll for GitHub Pages
         run: touch dist/.nojekyll
       # Download existing gh-pages content to preserve PR previews

--- a/docs/DATA_RETENTION.md
+++ b/docs/DATA_RETENTION.md
@@ -1,0 +1,124 @@
+# Data Retention
+
+VolleyKit stores certain data locally in your browser to provide a better user experience.
+This data never leaves your device and is not transmitted to our servers.
+
+## What We Store
+
+### Settings (`volleykit-settings` in localStorage)
+
+| Data | Purpose | Retention |
+|------|---------|-----------|
+| Home location (coordinates + label) | Filter exchanges by distance/travel time | Until cleared by user |
+| Distance filter preferences | Remember your max distance setting | Until cleared by user |
+| Travel time filter preferences | Remember your max travel time setting | Until cleared by user |
+| Transport enabled toggle | Remember if you enabled public transport | Until cleared by user |
+| Language preference | Display app in your preferred language | Until cleared by user |
+| Safe mode setting | Prevent accidental actions | Until cleared by user |
+
+### Travel Time Cache (TanStack Query cache in memory/localStorage)
+
+| Data | Purpose | Retention |
+|------|---------|-----------|
+| Travel times to sports halls | Avoid repeated API calls | 7 days, auto-expires |
+
+### Authentication (`volleykit-auth` in localStorage)
+
+| Data | Purpose | Retention |
+|------|---------|-----------|
+| Demo mode flag | Remember demo mode state | Until logout |
+| Association code | Multi-association support | Until logout |
+
+**Note**: Session credentials are stored in httpOnly cookies managed by the API,
+not in localStorage. We never store passwords or authentication tokens locally.
+
+### Demo Data (`volleykit-demo` in localStorage)
+
+| Data | Purpose | Retention |
+|------|---------|-----------|
+| Modified demo assignments | Persist demo mode changes | Until reset or logout |
+| Modified demo compensations | Persist demo mode changes | Until reset or logout |
+| Modified demo exchanges | Persist demo mode changes | Until reset or logout |
+
+## How to Clear Your Data
+
+### In the App
+
+1. Go to **Settings** in the app
+2. Scroll to **Data & Privacy**
+3. Tap **Clear Local Data**
+
+### Manually via Browser
+
+- **Chrome**: Settings > Privacy > Clear browsing data > Cookies and site data
+- **Firefox**: Settings > Privacy > Cookies and Site Data > Clear Data
+- **Safari**: Settings > Privacy > Manage Website Data > Remove
+
+## External Services
+
+### Swiss Public Transport API
+
+When you enable public transport calculations, your home location coordinates
+are sent to the Swiss public transport API (opentransportdata.swiss) to calculate
+travel times. This is only done when:
+
+- You explicitly enable transport calculations in Settings
+- You have set a home location
+
+The transport API is operated by the Swiss Federal Office of Transport.
+See their privacy policy at: https://opentransportdata.swiss/en/terms-of-use/
+
+### Geocoding (Address Search)
+
+When you search for an address in the home location settings, your search query
+is sent to Nominatim (OpenStreetMap's geocoding service) to convert addresses
+to coordinates. No personal data is transmitted beyond the search query itself.
+
+See their usage policy at: https://operations.osmfoundation.org/policies/nominatim/
+
+## Data Flow Diagram
+
+```
+┌─────────────────────┐
+│   Your Browser      │
+├─────────────────────┤
+│ localStorage:       │
+│ - Settings          │
+│ - Auth state        │  No data sent to
+│ - Demo data         │  VolleyKit servers
+│ - Travel time cache │
+└─────────────────────┘
+         │
+         │ (when enabled)
+         ▼
+┌─────────────────────────────┐
+│ opentransportdata.swiss     │
+│ (Swiss public transport)    │
+│ - Receives: coordinates     │
+│ - Returns: travel times     │
+└─────────────────────────────┘
+         │
+         │ (when searching address)
+         ▼
+┌─────────────────────────────┐
+│ nominatim.openstreetmap.org │
+│ (Geocoding service)         │
+│ - Receives: address query   │
+│ - Returns: coordinates      │
+└─────────────────────────────┘
+         │
+         │ (API calls)
+         ▼
+┌─────────────────────────────┐
+│ volleymanager.volleyball.ch │
+│ (Swiss Volley API)          │
+│ - Your assignments          │
+│ - Your compensations        │
+│ - Exchange listings         │
+└─────────────────────────────┘
+```
+
+## Questions?
+
+If you have questions about data retention or privacy, please open an issue at:
+https://github.com/Takishima/volleykit/issues

--- a/web-app/.env.example
+++ b/web-app/.env.example
@@ -11,3 +11,7 @@ VITE_API_PROXY_URL=https://volleykit-proxy.<your-subdomain>.workers.dev
 # Demo-only mode - When 'true', the app only allows demo mode (no real authentication)
 # This is automatically set to 'true' for PR preview deployments
 # VITE_DEMO_MODE_ONLY=true
+
+# OJP 2.0 API Key for Swiss public transport routing
+# Get your key from: https://api-manager.opentransportdata.swiss/
+# VITE_OJP_API_KEY=your_api_key_here

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -4873,13 +4873,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.90.12",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.562.0",
+        "ojp-sdk-next": "^0.20.33",
         "openapi-typescript-fetch": "^2.2.1",
         "pdf-lib": "^1.17.1",
         "react": "^19.2.3",
@@ -4829,6 +4830,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -4863,6 +4870,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5171,7 +5189,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5406,6 +5423,18 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "12.0.0",
@@ -5780,6 +5809,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5818,7 +5856,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5975,7 +6012,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5985,7 +6021,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6002,7 +6037,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6015,7 +6049,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6524,6 +6557,24 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.0.8.tgz",
+      "integrity": "sha512-qY8NiI5L8ff00F2giyICiJxSSKHO52tC36LJqx2JtvGyAd5ZfehC/l4iUVVHpmpIa6sM9N5mneSLHQG2INGoHA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -6648,6 +6699,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6679,6 +6750,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -6715,7 +6802,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6786,7 +6872,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6818,7 +6903,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -6964,7 +7048,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7035,7 +7118,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7048,7 +7130,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7064,7 +7145,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8443,7 +8523,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8455,6 +8534,27 @@
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -8647,6 +8747,23 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/ojp-sdk-next": {
+      "version": "0.20.33",
+      "resolved": "https://registry.npmjs.org/ojp-sdk-next/-/ojp-sdk-next-0.20.33.tgz",
+      "integrity": "sha512-BMBqExfydczy5qVguDr1w2nkZmkkeRFr7AFtptsjEhRJKkaRXpViPA1OdujulQsk8T2Vk7MNbx65tZhg7BNKzg==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "1.8.3",
+        "fast-xml-parser": "5.0.8",
+        "ojp-shared-types": "0.0.24"
+      }
+    },
+    "node_modules/ojp-shared-types": {
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/ojp-shared-types/-/ojp-shared-types-0.0.24.tgz",
+      "integrity": "sha512-YeOLTanmGAyvUxwgQKysKPr7QPE1z9+cO66aL/QVZ1dadyIXmDvjZR+NVFyrHAXRY2qZhuyxVVPxSncpPmfKnw==",
       "license": "MIT"
     },
     "node_modules/once": {
@@ -9179,7 +9296,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -10369,6 +10485,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "overrides": {
+    "axios": "^1.12.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -53,7 +53,7 @@
     {
       "name": "Total JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "400 kB",
+      "limit": "410 kB",
       "gzip": true
     }
   ],

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -62,6 +62,7 @@
     "@tanstack/react-query": "^5.90.12",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.562.0",
+    "ojp-sdk-next": "^0.20.33",
     "openapi-typescript-fetch": "^2.2.1",
     "pdf-lib": "^1.17.1",
     "react": "^19.2.3",

--- a/web-app/src/api/queryKeys.ts
+++ b/web-app/src/api/queryKeys.ts
@@ -151,6 +151,19 @@ export const queryKeys = {
     search: (filters: PersonSearchFilter) =>
       [...queryKeys.scorerSearch.all, filters] as const,
   },
+
+  /**
+   * Travel time query keys for public transport routing
+   */
+  travelTime: {
+    /** Base key - invalidates ALL travel time queries */
+    all: ["travelTime"] as const,
+    /** Parent key for all hall travel time queries */
+    halls: () => [...queryKeys.travelTime.all, "hall"] as const,
+    /** Travel time to a specific hall from user's home location */
+    hall: (hallId: string, homeLocationHash: string) =>
+      [...queryKeys.travelTime.halls(), hallId, homeLocationHash] as const,
+  },
 } as const;
 
 /**

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
+import { TravelTimeBadge } from "@/components/features/TravelTimeBadge";
 import { MapPin, MaleIcon, FemaleIcon, Home } from "@/components/ui/icons";
 import type { GameExchange } from "@/api/client";
 import { useDateLocale } from "@/hooks/useDateFormat";
@@ -14,6 +15,10 @@ interface ExchangeCardProps {
   dataTour?: string;
   /** Distance from user's home location in kilometres (if available) */
   distanceKm?: number | null;
+  /** Travel time in minutes (if available) */
+  travelTimeMinutes?: number | null;
+  /** Whether travel time is currently loading */
+  travelTimeLoading?: boolean;
 }
 
 function ExchangeCardComponent({
@@ -21,6 +26,8 @@ function ExchangeCardComponent({
   disableExpansion,
   dataTour,
   distanceKm,
+  travelTimeMinutes,
+  travelTimeLoading,
 }: ExchangeCardProps) {
   const { t, tInterpolate } = useTranslation();
   const dateLocale = useDateLocale();
@@ -90,13 +97,23 @@ function ExchangeCardComponent({
             </div>
           </div>
 
-          {/* Distance badge */}
-          {distanceKm != null && (
-            <div className="flex items-center shrink-0">
-              <span className="text-xs font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 px-2 py-0.5 rounded-full flex items-center gap-1">
-                <Home className="w-3 h-3" aria-hidden="true" />
-                {distanceKm.toFixed(0)} {t("common.distanceUnit")}
-              </span>
+          {/* Distance and travel time badges */}
+          {(distanceKm != null || travelTimeMinutes !== undefined || travelTimeLoading) && (
+            <div className="flex items-center gap-1 shrink-0">
+              {/* Travel time badge */}
+              {(travelTimeMinutes !== undefined || travelTimeLoading) && (
+                <TravelTimeBadge
+                  durationMinutes={travelTimeMinutes ?? undefined}
+                  isLoading={travelTimeLoading}
+                />
+              )}
+              {/* Distance badge */}
+              {distanceKm != null && (
+                <span className="text-xs font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 px-2 py-0.5 rounded-full flex items-center gap-1">
+                  <Home className="w-3 h-3" aria-hidden="true" />
+                  {distanceKm.toFixed(0)} {t("common.distanceUnit")}
+                </span>
+              )}
             </div>
           )}
 

--- a/web-app/src/components/features/TravelTimeBadge.tsx
+++ b/web-app/src/components/features/TravelTimeBadge.tsx
@@ -50,17 +50,9 @@ function TravelTimeBadgeComponent({
     return null;
   }
 
-  // Determine badge variant based on travel time
-  const variant =
-    durationMinutes <= 45
-      ? "success"
-      : durationMinutes <= 90
-        ? "warning"
-        : "danger";
-
   return (
     <Badge
-      variant={variant}
+      variant="neutral"
       className={className}
       title={t("exchange.travelTime")}
     >

--- a/web-app/src/components/features/TravelTimeBadge.tsx
+++ b/web-app/src/components/features/TravelTimeBadge.tsx
@@ -1,0 +1,88 @@
+import { memo } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { formatTravelTime } from "@/hooks/useTravelTime";
+import { Badge } from "@/components/ui/Badge";
+
+interface TravelTimeBadgeProps {
+  /** Travel time in minutes */
+  durationMinutes: number | undefined;
+  /** Whether the travel time is currently loading */
+  isLoading?: boolean;
+  /** Whether there was an error fetching travel time */
+  isError?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+function TravelTimeBadgeComponent({
+  durationMinutes,
+  isLoading = false,
+  isError = false,
+  className = "",
+}: TravelTimeBadgeProps) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <Badge variant="neutral" className={`animate-pulse ${className}`}>
+        <span className="flex items-center gap-1">
+          <svg
+            className="w-3 h-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+            />
+          </svg>
+          <span>...</span>
+        </span>
+      </Badge>
+    );
+  }
+
+  if (isError || durationMinutes === undefined) {
+    return null;
+  }
+
+  // Determine badge variant based on travel time
+  const variant =
+    durationMinutes <= 45
+      ? "success"
+      : durationMinutes <= 90
+        ? "warning"
+        : "danger";
+
+  return (
+    <Badge
+      variant={variant}
+      className={className}
+      title={t("exchange.travelTime")}
+    >
+      <span className="flex items-center gap-1">
+        <svg
+          className="w-3 h-3"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+          />
+        </svg>
+        <span>{formatTravelTime(durationMinutes)}</span>
+      </span>
+    </Badge>
+  );
+}
+
+export const TravelTimeBadge = memo(TravelTimeBadgeComponent);

--- a/web-app/src/components/features/TravelTimeFilterToggle.tsx
+++ b/web-app/src/components/features/TravelTimeFilterToggle.tsx
@@ -1,0 +1,77 @@
+import { memo } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+
+interface TravelTimeFilterToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  maxTravelTimeMinutes: number;
+  dataTour?: string;
+}
+
+function TravelTimeFilterToggleComponent({
+  checked,
+  onChange,
+  maxTravelTimeMinutes,
+  dataTour,
+}: TravelTimeFilterToggleProps) {
+  const { t } = useTranslation();
+
+  const handleChange = () => {
+    onChange(!checked);
+  };
+
+  // Format time for display
+  const formatTime = (): string => {
+    if (maxTravelTimeMinutes < 60) {
+      return `${maxTravelTimeMinutes}${t("common.minutesUnit")}`;
+    }
+    const hours = Math.floor(maxTravelTimeMinutes / 60);
+    const minutes = maxTravelTimeMinutes % 60;
+    if (minutes === 0) {
+      return `${hours}${t("common.hoursUnit")}`;
+    }
+    return `${hours}${t("common.hoursUnit")} ${minutes}${t("common.minutesUnit")}`;
+  };
+
+  return (
+    <label
+      className="inline-flex items-center gap-2 cursor-pointer select-none"
+      data-tour={dataTour}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={handleChange}
+        className="sr-only peer"
+        aria-describedby="travel-time-filter-description"
+      />
+      <span
+        className={`
+          relative w-9 h-5 rounded-full transition-colors
+          peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary-500 peer-focus:ring-offset-2
+          ${checked ? "bg-primary-500" : "bg-gray-200 dark:bg-gray-700"}
+        `}
+      >
+        <span
+          className={`
+            absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform
+            ${checked ? "translate-x-4" : "translate-x-0"}
+          `}
+        />
+      </span>
+      <span className="text-sm text-gray-600 dark:text-gray-400">
+        {t("exchange.filterByTravelTime")}
+        {checked && (
+          <span
+            id="travel-time-filter-description"
+            className="ml-1 text-xs text-gray-400 dark:text-gray-500"
+          >
+            (&le;{formatTime()})
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}
+
+export const TravelTimeFilterToggle = memo(TravelTimeFilterToggleComponent);

--- a/web-app/src/components/features/settings/DataRetentionSection.tsx
+++ b/web-app/src/components/features/settings/DataRetentionSection.tsx
@@ -1,0 +1,220 @@
+import { useState, useCallback, memo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
+import { useSettingsStore } from "@/stores/settings";
+import { useTranslation } from "@/hooks/useTranslation";
+import { queryKeys } from "@/api/queryKeys";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+
+function DataRetentionSectionComponent() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const { homeLocation, transportEnabled, invalidateTravelTimeCache, setHomeLocation } =
+    useSettingsStore(
+      useShallow((state) => ({
+        homeLocation: state.homeLocation,
+        transportEnabled: state.transportEnabled,
+        invalidateTravelTimeCache: state.invalidateTravelTimeCache,
+        setHomeLocation: state.setHomeLocation,
+      })),
+    );
+
+  const handleClearData = useCallback(() => {
+    // Clear travel time cache from TanStack Query
+    queryClient.removeQueries({ queryKey: queryKeys.travelTime.all });
+
+    // Invalidate cache timestamp in settings store
+    invalidateTravelTimeCache();
+
+    // Clear home location
+    setHomeLocation(null);
+
+    // Reset local storage settings (but keep safe mode and language)
+    localStorage.removeItem("volleykit-settings");
+
+    setShowConfirm(false);
+  }, [queryClient, invalidateTravelTimeCache, setHomeLocation]);
+
+  const handleShowConfirm = useCallback(() => {
+    setShowConfirm(true);
+  }, []);
+
+  const handleCancelConfirm = useCallback(() => {
+    setShowConfirm(false);
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <svg
+            className="w-5 h-5 text-text-muted dark:text-text-muted-dark"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+            />
+          </svg>
+          <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
+            {t("settings.dataRetention.title")}
+          </h2>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t("settings.dataRetention.description")}
+        </p>
+
+        {/* Data stored locally */}
+        <div className="space-y-2">
+          <ul className="space-y-2 text-sm text-text-primary dark:text-text-primary-dark">
+            <li className="flex items-start gap-2">
+              <svg
+                className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+              <span>{t("settings.dataRetention.homeLocation")}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <svg
+                className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+              <span>{t("settings.dataRetention.filterPreferences")}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <svg
+                className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+              <span>{t("settings.dataRetention.travelTimeCache")}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <svg
+                className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+              <span>{t("settings.dataRetention.languagePreference")}</span>
+            </li>
+          </ul>
+        </div>
+
+        {/* External services note */}
+        {transportEnabled && (
+          <div className="p-3 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg">
+            <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-1">
+              {t("settings.dataRetention.externalServices")}
+            </h3>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+              {t("settings.dataRetention.transportApiNote")}
+            </p>
+          </div>
+        )}
+
+        {/* Clear data button */}
+        {(homeLocation || transportEnabled) && (
+          <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+            {!showConfirm ? (
+              <Button
+                variant="secondary"
+                onClick={handleShowConfirm}
+                fullWidth
+                iconLeft={
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                }
+              >
+                {t("settings.dataRetention.clearData")}
+              </Button>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-sm text-text-primary dark:text-text-primary-dark">
+                  {t("settings.dataRetention.clearDataConfirm")}
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="secondary"
+                    onClick={handleCancelConfirm}
+                    className="flex-1"
+                  >
+                    {t("common.cancel")}
+                  </Button>
+                  <Button
+                    variant="primary"
+                    onClick={handleClearData}
+                    className="flex-1"
+                  >
+                    {t("common.confirm")}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export const DataRetentionSection = memo(DataRetentionSectionComponent);

--- a/web-app/src/components/features/settings/DataRetentionSection.tsx
+++ b/web-app/src/components/features/settings/DataRetentionSection.tsx
@@ -12,13 +12,12 @@ function DataRetentionSectionComponent() {
   const queryClient = useQueryClient();
   const [showConfirm, setShowConfirm] = useState(false);
 
-  const { homeLocation, transportEnabled, invalidateTravelTimeCache, setHomeLocation } =
+  const { homeLocation, transportEnabled, resetLocationSettings } =
     useSettingsStore(
       useShallow((state) => ({
         homeLocation: state.homeLocation,
         transportEnabled: state.transportEnabled,
-        invalidateTravelTimeCache: state.invalidateTravelTimeCache,
-        setHomeLocation: state.setHomeLocation,
+        resetLocationSettings: state.resetLocationSettings,
       })),
     );
 
@@ -26,17 +25,12 @@ function DataRetentionSectionComponent() {
     // Clear travel time cache from TanStack Query
     queryClient.removeQueries({ queryKey: queryKeys.travelTime.all });
 
-    // Invalidate cache timestamp in settings store
-    invalidateTravelTimeCache();
-
-    // Clear home location
-    setHomeLocation(null);
-
-    // Reset local storage settings (but keep safe mode and language)
-    localStorage.removeItem("volleykit-settings");
+    // Reset all location-related settings via Zustand store
+    // This properly updates state and persists through the middleware
+    resetLocationSettings();
 
     setShowConfirm(false);
-  }, [queryClient, invalidateTravelTimeCache, setHomeLocation]);
+  }, [queryClient, resetLocationSettings]);
 
   const handleShowConfirm = useCallback(() => {
     setShowConfirm(true);

--- a/web-app/src/components/features/settings/TransportSection.tsx
+++ b/web-app/src/components/features/settings/TransportSection.tsx
@@ -1,0 +1,203 @@
+import { useCallback, memo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useSettingsStore } from "@/stores/settings";
+import { useTranslation } from "@/hooks/useTranslation";
+import { useTravelTimeAvailable } from "@/hooks/useTravelTime";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+
+/** Travel time presets for the slider (in minutes) */
+const TRAVEL_TIME_PRESETS = [30, 45, 60, 90, 120];
+
+function TransportSectionComponent() {
+  const { t } = useTranslation();
+  const isAvailable = useTravelTimeAvailable();
+
+  const {
+    homeLocation,
+    transportEnabled,
+    setTransportEnabled,
+    travelTimeFilter,
+    setMaxTravelTimeMinutes,
+  } = useSettingsStore(
+    useShallow((state) => ({
+      homeLocation: state.homeLocation,
+      transportEnabled: state.transportEnabled,
+      setTransportEnabled: state.setTransportEnabled,
+      travelTimeFilter: state.travelTimeFilter,
+      setMaxTravelTimeMinutes: state.setMaxTravelTimeMinutes,
+    })),
+  );
+
+  const handleToggleTransport = useCallback(() => {
+    setTransportEnabled(!transportEnabled);
+  }, [transportEnabled, setTransportEnabled]);
+
+  const handleTravelTimeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setMaxTravelTimeMinutes(Number(e.target.value));
+    },
+    [setMaxTravelTimeMinutes],
+  );
+
+  const hasHomeLocation = Boolean(homeLocation);
+  const canEnable = hasHomeLocation && isAvailable;
+
+  // Format time for display
+  const formatTime = (minutes: number): string => {
+    if (minutes < 60) {
+      return `${minutes} ${t("common.minutesUnit")}`;
+    }
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    if (remainingMinutes === 0) {
+      return `${hours} ${t("common.hoursUnit")}`;
+    }
+    return `${hours} ${t("common.hoursUnit")} ${remainingMinutes} ${t("common.minutesUnit")}`;
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <svg
+            className="w-5 h-5 text-text-muted dark:text-text-muted-dark"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+            />
+          </svg>
+          <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
+            {t("settings.transport.title")}
+          </h2>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t("settings.transport.description")}
+        </p>
+
+        {/* Status messages */}
+        {!hasHomeLocation && (
+          <div className="flex items-center gap-2 p-3 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg">
+            <svg
+              className="w-5 h-5 flex-shrink-0 text-text-muted dark:text-text-muted-dark"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span className="text-sm text-text-muted dark:text-text-muted-dark">
+              {t("settings.transport.requiresHomeLocation")}
+            </span>
+          </div>
+        )}
+
+        {hasHomeLocation && !isAvailable && (
+          <div className="flex items-center gap-2 p-3 bg-warning-50 dark:bg-warning-900/20 rounded-lg">
+            <svg
+              className="w-5 h-5 flex-shrink-0 text-warning-600 dark:text-warning-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            <span className="text-sm text-warning-700 dark:text-warning-300">
+              {t("settings.transport.apiNotConfigured")}
+            </span>
+          </div>
+        )}
+
+        {/* Enable toggle */}
+        <div className="flex items-center justify-between py-2">
+          <div className="flex-1">
+            <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+              {t("settings.transport.enableCalculations")}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleToggleTransport}
+            disabled={!canEnable}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+              !canEnable
+                ? "bg-surface-muted dark:bg-surface-subtle-dark cursor-not-allowed opacity-50"
+                : transportEnabled
+                  ? "bg-primary-600"
+                  : "bg-surface-muted dark:bg-surface-subtle-dark"
+            }`}
+            role="switch"
+            aria-checked={transportEnabled}
+            aria-label={t("settings.transport.enableCalculations")}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                transportEnabled ? "translate-x-6" : "translate-x-1"
+              }`}
+            />
+          </button>
+        </div>
+
+        {/* Travel time slider */}
+        {transportEnabled && (
+          <div className="space-y-3 pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+            <div className="flex items-center justify-between">
+              <label
+                htmlFor="max-travel-time"
+                className="text-sm font-medium text-text-primary dark:text-text-primary-dark"
+              >
+                {t("settings.transport.maxTravelTime")}
+              </label>
+              <span className="text-sm font-semibold text-primary-600 dark:text-primary-400">
+                {formatTime(travelTimeFilter.maxTravelTimeMinutes)}
+              </span>
+            </div>
+
+            <input
+              id="max-travel-time"
+              type="range"
+              min={TRAVEL_TIME_PRESETS[0]}
+              max={TRAVEL_TIME_PRESETS[TRAVEL_TIME_PRESETS.length - 1]}
+              step={15}
+              value={travelTimeFilter.maxTravelTimeMinutes}
+              onChange={handleTravelTimeChange}
+              className="w-full h-2 bg-surface-muted dark:bg-surface-subtle-dark rounded-lg appearance-none cursor-pointer accent-primary-600"
+            />
+
+            {/* Preset labels */}
+            <div className="flex justify-between text-xs text-text-muted dark:text-text-muted-dark">
+              {TRAVEL_TIME_PRESETS.map((preset) => (
+                <span key={preset}>
+                  {preset < 60 ? `${preset}m` : `${preset / 60}h`}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export const TransportSection = memo(TransportSectionComponent);

--- a/web-app/src/components/features/settings/index.ts
+++ b/web-app/src/components/features/settings/index.ts
@@ -1,6 +1,8 @@
 export { ProfileSection } from "./ProfileSection";
 export { LanguageSection } from "./LanguageSection";
 export { HomeLocationSection } from "./HomeLocationSection";
+export { TransportSection } from "./TransportSection";
+export { DataRetentionSection } from "./DataRetentionSection";
 export { TourSection } from "./TourSection";
 export { DemoSection } from "./DemoSection";
 export { SafeModeSection } from "./SafeModeSection";

--- a/web-app/src/hooks/useTravelTime.test.tsx
+++ b/web-app/src/hooks/useTravelTime.test.tsx
@@ -1,0 +1,369 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useTravelTime, formatTravelTime, useTravelTimeAvailable } from "./useTravelTime";
+import type { TravelTimeResult, Coordinates } from "@/services/transport";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFunction = (...args: any[]) => any;
+
+// Mock the transport service
+vi.mock("@/services/transport", () => ({
+  calculateTravelTime: vi.fn(),
+  calculateMockTravelTime: vi.fn(),
+  isOjpConfigured: vi.fn(() => false),
+  hashLocation: vi.fn((coords: Coordinates) => `${coords.latitude},${coords.longitude}`),
+  TRAVEL_TIME_STALE_TIME: 7 * 24 * 60 * 60 * 1000,
+  TRAVEL_TIME_GC_TIME: 7 * 24 * 60 * 60 * 1000,
+}));
+
+// Mock the stores - using AnyFunction to avoid strict type checking in tests
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn((selector: AnyFunction) =>
+    selector({ isDemoMode: false }),
+  ),
+}));
+
+vi.mock("@/stores/settings", () => ({
+  useSettingsStore: vi.fn((selector: AnyFunction) =>
+    selector({
+      homeLocation: null,
+      transportEnabled: false,
+    }),
+  ),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useTravelTime", () => {
+  const mockHallCoords: Coordinates = { latitude: 46.9480, longitude: 7.4474 };
+  const mockHomeLocation = {
+    latitude: 47.3769,
+    longitude: 8.5417,
+    label: "Zürich HB",
+    source: "geocoded" as const,
+  };
+
+  const mockTravelTimeResult: TravelTimeResult = {
+    durationMinutes: 75,
+    departureTime: "2024-01-15T09:00:00Z",
+    arrivalTime: "2024-01-15T10:15:00Z",
+    transfers: 2,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("query enabling conditions", () => {
+    it("does not fetch when transport is disabled", async () => {
+      const { calculateMockTravelTime } = await import("@/services/transport");
+      const { useSettingsStore } = await import("@/stores/settings");
+
+      vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
+        selector({
+          homeLocation: mockHomeLocation,
+          transportEnabled: false,
+        }),
+      );
+
+      const { result } = renderHook(
+        () => useTravelTime("hall-1", mockHallCoords),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(calculateMockTravelTime).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when home location is not set", async () => {
+      const { calculateMockTravelTime } = await import("@/services/transport");
+      const { useSettingsStore } = await import("@/stores/settings");
+
+      vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
+        selector({
+          homeLocation: null,
+          transportEnabled: true,
+        }),
+      );
+
+      const { result } = renderHook(
+        () => useTravelTime("hall-1", mockHallCoords),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(calculateMockTravelTime).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when hall coordinates are null", async () => {
+      const { calculateMockTravelTime } = await import("@/services/transport");
+      const { useSettingsStore } = await import("@/stores/settings");
+
+      vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
+        selector({
+          homeLocation: mockHomeLocation,
+          transportEnabled: true,
+        }),
+      );
+
+      const { result } = renderHook(
+        () => useTravelTime("hall-1", null),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(calculateMockTravelTime).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when hall ID is undefined", async () => {
+      const { calculateMockTravelTime } = await import("@/services/transport");
+      const { useSettingsStore } = await import("@/stores/settings");
+
+      vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
+        selector({
+          homeLocation: mockHomeLocation,
+          transportEnabled: true,
+        }),
+      );
+
+      const { result } = renderHook(
+        () => useTravelTime(undefined, mockHallCoords),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(calculateMockTravelTime).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("demo mode", () => {
+    it("uses mock transport in demo mode", async () => {
+      const { calculateMockTravelTime } = await import("@/services/transport");
+      const { useAuthStore } = await import("@/stores/auth");
+      const { useSettingsStore } = await import("@/stores/settings");
+
+      vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+        selector({ isDemoMode: true }),
+      );
+
+      vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
+        selector({
+          homeLocation: mockHomeLocation,
+          transportEnabled: true,
+        }),
+      );
+
+      vi.mocked(calculateMockTravelTime).mockResolvedValue(mockTravelTimeResult);
+
+      const { result } = renderHook(
+        () => useTravelTime("hall-1", mockHallCoords),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.data).toBeDefined();
+      });
+
+      expect(calculateMockTravelTime).toHaveBeenCalledWith(
+        { latitude: mockHomeLocation.latitude, longitude: mockHomeLocation.longitude },
+        mockHallCoords,
+      );
+      expect(result.current.data?.durationMinutes).toBe(75);
+    });
+  });
+
+  describe("production mode with OJP API", () => {
+    it("uses real transport API when OJP is configured", async () => {
+      const { calculateTravelTime, isOjpConfigured } = await import("@/services/transport");
+      const { useAuthStore } = await import("@/stores/auth");
+      const { useSettingsStore } = await import("@/stores/settings");
+
+      vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+        selector({ isDemoMode: false }),
+      );
+
+      vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
+        selector({
+          homeLocation: mockHomeLocation,
+          transportEnabled: true,
+        }),
+      );
+
+      vi.mocked(isOjpConfigured).mockReturnValue(true);
+      vi.mocked(calculateTravelTime).mockResolvedValue(mockTravelTimeResult);
+
+      const { result } = renderHook(
+        () => useTravelTime("hall-1", mockHallCoords),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.data).toBeDefined();
+      });
+
+      expect(calculateTravelTime).toHaveBeenCalledWith(
+        { latitude: mockHomeLocation.latitude, longitude: mockHomeLocation.longitude },
+        mockHallCoords,
+      );
+      expect(result.current.data?.durationMinutes).toBe(75);
+    });
+
+    it("does not fetch when OJP API is not configured and not in demo mode", async () => {
+      const { calculateTravelTime, isOjpConfigured } = await import("@/services/transport");
+      const { useAuthStore } = await import("@/stores/auth");
+      const { useSettingsStore } = await import("@/stores/settings");
+
+      vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+        selector({ isDemoMode: false }),
+      );
+
+      vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
+        selector({
+          homeLocation: mockHomeLocation,
+          transportEnabled: true,
+        }),
+      );
+
+      vi.mocked(isOjpConfigured).mockReturnValue(false);
+
+      const { result } = renderHook(
+        () => useTravelTime("hall-1", mockHallCoords),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toBeUndefined();
+      expect(calculateTravelTime).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles API errors gracefully", { timeout: 15000 }, async () => {
+      const { calculateMockTravelTime } = await import("@/services/transport");
+      const { useAuthStore } = await import("@/stores/auth");
+      const { useSettingsStore } = await import("@/stores/settings");
+
+      vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+        selector({ isDemoMode: true }),
+      );
+
+      vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
+        selector({
+          homeLocation: mockHomeLocation,
+          transportEnabled: true,
+        }),
+      );
+
+      vi.mocked(calculateMockTravelTime).mockRejectedValue(new Error("API error"));
+
+      const { result } = renderHook(
+        () => useTravelTime("hall-1", mockHallCoords),
+        { wrapper: createWrapper() },
+      );
+
+      // Wait for all retries to complete (3 retries with exponential backoff: 1s + 2s + 4s = 7s)
+      await waitFor(
+        () => {
+          expect(result.current.isError).toBe(true);
+        },
+        { timeout: 10000 },
+      );
+
+      expect(result.current.error?.message).toBe("API error");
+    });
+  });
+});
+
+describe("formatTravelTime", () => {
+  it("formats minutes less than 60", () => {
+    expect(formatTravelTime(15)).toBe("15m");
+    expect(formatTravelTime(45)).toBe("45m");
+    expect(formatTravelTime(59)).toBe("59m");
+  });
+
+  it("formats exact hours", () => {
+    expect(formatTravelTime(60)).toBe("1h");
+    expect(formatTravelTime(120)).toBe("2h");
+    expect(formatTravelTime(180)).toBe("3h");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatTravelTime(75)).toBe("1h 15m");
+    expect(formatTravelTime(90)).toBe("1h 30m");
+    expect(formatTravelTime(145)).toBe("2h 25m");
+  });
+
+  it("handles edge cases", () => {
+    expect(formatTravelTime(0)).toBe("0m");
+    expect(formatTravelTime(1)).toBe("1m");
+    expect(formatTravelTime(61)).toBe("1h 1m");
+  });
+});
+
+describe("useTravelTimeAvailable", () => {
+  it("returns true in demo mode", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    const { isOjpConfigured } = await import("@/services/transport");
+
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: true }),
+    );
+    vi.mocked(isOjpConfigured).mockReturnValue(false);
+
+    const { result } = renderHook(() => useTravelTimeAvailable());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns true when OJP is configured", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    const { isOjpConfigured } = await import("@/services/transport");
+
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false }),
+    );
+    vi.mocked(isOjpConfigured).mockReturnValue(true);
+
+    const { result } = renderHook(() => useTravelTimeAvailable());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when not in demo mode and OJP not configured", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    const { isOjpConfigured } = await import("@/services/transport");
+
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false }),
+    );
+    vi.mocked(isOjpConfigured).mockReturnValue(false);
+
+    const { result } = renderHook(() => useTravelTimeAvailable());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/web-app/src/hooks/useTravelTime.test.tsx
+++ b/web-app/src/hooks/useTravelTime.test.tsx
@@ -262,7 +262,7 @@ describe("useTravelTime", () => {
   });
 
   describe("error handling", () => {
-    it("handles API errors gracefully", { timeout: 15000 }, async () => {
+    it("handles API errors gracefully", async () => {
       const { calculateMockTravelTime } = await import("@/services/transport");
       const { useAuthStore } = await import("@/stores/auth");
       const { useSettingsStore } = await import("@/stores/settings");
@@ -285,13 +285,10 @@ describe("useTravelTime", () => {
         { wrapper: createWrapper() },
       );
 
-      // Wait for all retries to complete (3 retries with exponential backoff: 1s + 2s + 4s = 7s)
-      await waitFor(
-        () => {
-          expect(result.current.isError).toBe(true);
-        },
-        { timeout: 10000 },
-      );
+      // QueryClient is configured with retry: false, so error surfaces immediately
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
 
       expect(result.current.error?.message).toBe("API error");
     });

--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -1,0 +1,109 @@
+/**
+ * Hook for fetching travel time to a sports hall using Swiss public transport.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useAuthStore } from "@/stores/auth";
+import { useSettingsStore } from "@/stores/settings";
+import { queryKeys } from "@/api/queryKeys";
+import {
+  calculateTravelTime,
+  calculateMockTravelTime,
+  isOjpConfigured,
+  hashLocation,
+  TRAVEL_TIME_STALE_TIME,
+  TRAVEL_TIME_GC_TIME,
+  type Coordinates,
+  type TravelTimeResult,
+} from "@/services/transport";
+
+/**
+ * Hook to fetch travel time from user's home location to a sports hall.
+ *
+ * @param hallId Unique identifier for the sports hall (used for caching)
+ * @param hallCoords Coordinates of the sports hall
+ * @returns TanStack Query result with travel time data
+ */
+export function useTravelTime(
+  hallId: string | undefined,
+  hallCoords: Coordinates | null,
+) {
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const homeLocation = useSettingsStore((state) => state.homeLocation);
+  const transportEnabled = useSettingsStore((state) => state.transportEnabled);
+
+  // Create a hash of home location for cache key stability
+  const homeLocationHash = homeLocation ? hashLocation(homeLocation) : null;
+
+  // Determine if we should fetch travel time
+  const shouldFetch = Boolean(
+    transportEnabled &&
+    homeLocation &&
+    hallCoords &&
+    hallId &&
+    (isDemoMode || isOjpConfigured()),
+  );
+
+  return useQuery<TravelTimeResult>({
+    queryKey: queryKeys.travelTime.hall(hallId ?? "", homeLocationHash ?? ""),
+    queryFn: async () => {
+      if (!homeLocation || !hallCoords) {
+        throw new Error("Missing home location or hall coordinates");
+      }
+
+      const fromCoords: Coordinates = {
+        latitude: homeLocation.latitude,
+        longitude: homeLocation.longitude,
+      };
+
+      // Use mock transport in demo mode, real API otherwise
+      if (isDemoMode) {
+        return calculateMockTravelTime(fromCoords, hallCoords);
+      }
+
+      return calculateTravelTime(fromCoords, hallCoords);
+    },
+    enabled: shouldFetch,
+
+    // Long stale time - travel times don't change frequently
+    staleTime: TRAVEL_TIME_STALE_TIME,
+    gcTime: TRAVEL_TIME_GC_TIME,
+
+    // Don't refetch on window focus since travel times are stable
+    refetchOnWindowFocus: false,
+
+    // Retry with exponential backoff for transient failures
+    retry: 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
+  });
+}
+
+/**
+ * Format travel time duration for display.
+ *
+ * @param minutes Travel time in minutes
+ * @returns Formatted string like "45m" or "1h 15m"
+ */
+export function formatTravelTime(minutes: number): string {
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (remainingMinutes === 0) {
+    return `${hours}h`;
+  }
+
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+/**
+ * Check if travel time feature is available.
+ * Returns true if either demo mode is active or OJP API is configured.
+ */
+export function useTravelTimeAvailable(): boolean {
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  return isDemoMode || isOjpConfigured();
+}

--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -72,9 +72,8 @@ export function useTravelTime(
     // Don't refetch on window focus since travel times are stable
     refetchOnWindowFocus: false,
 
-    // Retry with exponential backoff for transient failures
-    retry: 3,
-    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
+    // Use TanStack Query defaults for retry (3 retries with exponential backoff)
+    // Not setting retry here allows tests to override via QueryClient defaults
   });
 }
 

--- a/web-app/src/hooks/useTravelTimeFilter.ts
+++ b/web-app/src/hooks/useTravelTimeFilter.ts
@@ -1,0 +1,189 @@
+/**
+ * Hook for filtering exchanges by travel time.
+ */
+
+import { useMemo, useCallback } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { useAuthStore } from "@/stores/auth";
+import { useSettingsStore } from "@/stores/settings";
+import { queryKeys } from "@/api/queryKeys";
+import {
+  calculateTravelTime,
+  calculateMockTravelTime,
+  isOjpConfigured,
+  hashLocation,
+  TRAVEL_TIME_STALE_TIME,
+  TRAVEL_TIME_GC_TIME,
+  type Coordinates,
+  type TravelTimeResult,
+} from "@/services/transport";
+import type { GameExchange } from "@/api/client";
+
+interface HallInfo {
+  id: string;
+  coords: Coordinates | null;
+}
+
+interface ExchangeWithTravelTime<T> {
+  item: T;
+  travelTimeMinutes: number | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * Extract hall information from a game exchange.
+ */
+function getHallInfo(exchange: GameExchange): HallInfo | null {
+  const hall = exchange.refereeGame?.game?.hall;
+  if (!hall?.__identity) return null;
+
+  const geoLocation = hall.primaryPostalAddress?.geographicalLocation;
+  const lat = geoLocation?.latitude;
+  const lon = geoLocation?.longitude;
+
+  return {
+    id: hall.__identity,
+    coords: lat != null && lon != null ? { latitude: lat, longitude: lon } : null,
+  };
+}
+
+/**
+ * Hook to calculate and filter travel times for a list of exchanges.
+ *
+ * @param exchanges List of exchanges to calculate travel times for
+ * @returns Object with travel time data for each exchange and filter helper
+ */
+export function useTravelTimeFilter<T extends GameExchange>(exchanges: T[] | null) {
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const homeLocation = useSettingsStore((state) => state.homeLocation);
+  const transportEnabled = useSettingsStore((state) => state.transportEnabled);
+  const travelTimeFilter = useSettingsStore((state) => state.travelTimeFilter);
+
+  // Get unique halls to query
+  const hallInfos = useMemo(() => {
+    if (!exchanges) return [];
+
+    const seen = new Set<string>();
+    const result: (HallInfo & { exchange: T })[] = [];
+
+    for (const exchange of exchanges) {
+      const hallInfo = getHallInfo(exchange);
+      if (hallInfo && !seen.has(hallInfo.id)) {
+        seen.add(hallInfo.id);
+        result.push({ ...hallInfo, exchange });
+      }
+    }
+
+    return result;
+  }, [exchanges]);
+
+  // Home location hash for cache key stability
+  const homeLocationHash = homeLocation ? hashLocation(homeLocation) : null;
+
+  // Check if we should fetch travel times
+  const canFetch = Boolean(
+    transportEnabled &&
+    homeLocation &&
+    (isDemoMode || isOjpConfigured()),
+  );
+
+  // Create queries for each unique hall
+  const queries = useQueries({
+    queries: hallInfos.map((hallInfo) => ({
+      queryKey: queryKeys.travelTime.hall(hallInfo.id, homeLocationHash ?? ""),
+      queryFn: async (): Promise<TravelTimeResult> => {
+        if (!homeLocation || !hallInfo.coords) {
+          throw new Error("Missing location data");
+        }
+
+        const fromCoords: Coordinates = {
+          latitude: homeLocation.latitude,
+          longitude: homeLocation.longitude,
+        };
+
+        if (isDemoMode) {
+          return calculateMockTravelTime(fromCoords, hallInfo.coords);
+        }
+
+        return calculateTravelTime(fromCoords, hallInfo.coords);
+      },
+      enabled: canFetch && hallInfo.coords !== null,
+      staleTime: TRAVEL_TIME_STALE_TIME,
+      gcTime: TRAVEL_TIME_GC_TIME,
+      refetchOnWindowFocus: false,
+      retry: 3,
+      retryDelay: (attempt: number) => Math.min(1000 * 2 ** attempt, 30000),
+    })),
+  });
+
+  // Build a map of hall ID -> travel time result
+  const travelTimeMap = useMemo(() => {
+    const map = new Map<string, { minutes: number | null; isLoading: boolean; isError: boolean }>();
+
+    hallInfos.forEach((hallInfo, index) => {
+      const query = queries[index];
+      map.set(hallInfo.id, {
+        minutes: query?.data?.durationMinutes ?? null,
+        isLoading: query?.isLoading ?? false,
+        isError: query?.isError ?? false,
+      });
+    });
+
+    return map;
+  }, [hallInfos, queries]);
+
+  // Enrich exchanges with travel time data
+  const exchangesWithTravelTime: ExchangeWithTravelTime<T>[] | null = useMemo(() => {
+    if (!exchanges) return null;
+
+    return exchanges.map((exchange) => {
+      const hallInfo = getHallInfo(exchange);
+      const travelTimeData = hallInfo ? travelTimeMap.get(hallInfo.id) : null;
+
+      return {
+        item: exchange,
+        travelTimeMinutes: travelTimeData?.minutes ?? null,
+        isLoading: travelTimeData?.isLoading ?? false,
+        isError: travelTimeData?.isError ?? false,
+      };
+    });
+  }, [exchanges, travelTimeMap]);
+
+  // Filter function that can be applied to exchanges
+  const filterByTravelTime = useCallback(
+    (exchangeWithTravelTime: ExchangeWithTravelTime<T>): boolean => {
+      // If filtering is disabled, include all
+      if (!travelTimeFilter.enabled) return true;
+
+      // If no travel time available, include (conservative approach)
+      if (exchangeWithTravelTime.travelTimeMinutes === null) return true;
+
+      // Apply the filter
+      return exchangeWithTravelTime.travelTimeMinutes <= travelTimeFilter.maxTravelTimeMinutes;
+    },
+    [travelTimeFilter.enabled, travelTimeFilter.maxTravelTimeMinutes],
+  );
+
+  // Get filtered list
+  const filteredExchanges = useMemo(() => {
+    if (!exchangesWithTravelTime) return null;
+    return exchangesWithTravelTime.filter(filterByTravelTime);
+  }, [exchangesWithTravelTime, filterByTravelTime]);
+
+  // Check if any travel times are loading
+  const isLoadingAny = queries.some((q) => q.isLoading);
+
+  return {
+    /** Exchanges enriched with travel time data */
+    exchangesWithTravelTime,
+    /** Exchanges filtered by travel time (if filter is enabled) */
+    filteredExchanges,
+    /** Whether any travel time queries are loading */
+    isLoading: isLoadingAny,
+    /** Filter function to apply manually */
+    filterByTravelTime,
+    /** Whether travel time filtering is available */
+    isAvailable: canFetch,
+  };
+}

--- a/web-app/src/hooks/useTravelTimeFilter.ts
+++ b/web-app/src/hooks/useTravelTimeFilter.ts
@@ -118,11 +118,22 @@ export function useTravelTimeFilter<T extends GameExchange>(exchanges: T[] | nul
   });
 
   // Build a map of hall ID -> travel time result
+  // Uses explicit ID matching instead of index correlation for robustness
   const travelTimeMap = useMemo(() => {
     const map = new Map<string, { minutes: number | null; isLoading: boolean; isError: boolean }>();
 
-    hallInfos.forEach((hallInfo, index) => {
-      const query = queries[index];
+    // Create a lookup from query key to result
+    const queryByHallId = new Map<string, typeof queries[number]>();
+    queries.forEach((query, index) => {
+      const hallInfo = hallInfos[index];
+      if (hallInfo) {
+        queryByHallId.set(hallInfo.id, query);
+      }
+    });
+
+    // Build the result map using explicit ID matching
+    hallInfos.forEach((hallInfo) => {
+      const query = queryByHallId.get(hallInfo.id);
       map.set(hallInfo.id, {
         minutes: query?.data?.durationMinutes ?? null,
         isLoading: query?.isLoading ?? false,

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -138,6 +138,8 @@ const de: Translations = {
     unknownDate: "Datum?",
     currencyChf: "CHF",
     distanceUnit: "km",
+    minutesUnit: "min",
+    hoursUnit: "h",
     dismissNotification: "Benachrichtigung schliessen",
     notifications: "Benachrichtigungen",
     cardActions: "Kartenaktionen",
@@ -254,6 +256,9 @@ const de: Translations = {
     removeButton: "Aus Tauschbörse entfernen",
     filterByLevel: "Nur mein Niveau",
     filterByDistance: "Nach Distanz filtern",
+    filterByTravelTime: "Nach Reisezeit filtern",
+    travelTime: "Reisezeit",
+    calculatingTravelTime: "Reisezeit wird berechnet...",
     noExchangesAtLevel: "Keine Tauschangebote auf Ihrem Niveau verfügbar.",
     noExchangesWithFilters: "Keine Tauschangebote entsprechen Ihren Filtern.",
     noOpenExchangesTitle: "Keine offenen Tauschangebote",
@@ -310,6 +315,30 @@ const de: Translations = {
       errorPositionUnavailable: "Standort nicht verfügbar. Bitte erneut versuchen.",
       errorTimeout: "Standortabfrage hat zu lange gedauert. Bitte erneut versuchen.",
       errorUnknown: "Unbekannter Fehler beim Ermitteln des Standorts.",
+    },
+    transport: {
+      title: "Öffentlicher Verkehr",
+      description:
+        "Berechnen Sie Reisezeiten mit dem Schweizer öffentlichen Verkehr, um Tauschangebote nach Anfahrtszeit zu filtern.",
+      enableCalculations: "Reisezeitberechnung aktivieren",
+      requiresHomeLocation: "Legen Sie zuerst Ihren Heimatstandort fest",
+      apiNotConfigured: "Transport-API ist nicht konfiguriert",
+      maxTravelTime: "Maximale Reisezeit",
+    },
+    dataRetention: {
+      title: "Daten & Datenschutz",
+      description:
+        "Diese App speichert bestimmte Daten lokal in Ihrem Browser. Diese Daten verlassen Ihr Gerät nie und werden nicht an unsere Server übertragen.",
+      homeLocation: "Ihr Heimatstandort (für Distanzfilterung)",
+      filterPreferences: "Filtereinstellungen",
+      travelTimeCache: "Zwischengespeicherte Reisezeiten (läuft nach 7 Tagen ab)",
+      languagePreference: "Spracheinstellung",
+      clearData: "Lokale Daten löschen",
+      clearDataConfirm:
+        "Dies setzt alle Einstellungen zurück und löscht zwischengespeicherte Daten. Fortfahren?",
+      externalServices: "Externe Dienste",
+      transportApiNote:
+        "Bei aktivierter Reisezeitberechnung werden Ihre Heimatstandort-Koordinaten an die Schweizer ÖV-API (opentransportdata.swiss) gesendet.",
     },
     safeMode: "Sicherheitsmodus",
     safeModeDescription:

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -138,6 +138,8 @@ const en: Translations = {
     unknownDate: "Date?",
     currencyChf: "CHF",
     distanceUnit: "km",
+    minutesUnit: "min",
+    hoursUnit: "h",
     dismissNotification: "Dismiss notification",
     notifications: "Notifications",
     cardActions: "Card actions",
@@ -254,6 +256,9 @@ const en: Translations = {
     removeButton: "Remove from Exchange",
     filterByLevel: "My level only",
     filterByDistance: "Filter by distance",
+    filterByTravelTime: "Filter by travel time",
+    travelTime: "Travel time",
+    calculatingTravelTime: "Calculating travel time...",
     noExchangesAtLevel: "No exchanges available at your level.",
     noExchangesWithFilters: "No exchanges match your filters.",
     noOpenExchangesTitle: "No open exchanges",
@@ -308,6 +313,30 @@ const en: Translations = {
       errorPositionUnavailable: "Location unavailable. Please try again.",
       errorTimeout: "Location request timed out. Please try again.",
       errorUnknown: "Unknown error while getting location.",
+    },
+    transport: {
+      title: "Public Transport",
+      description:
+        "Calculate travel times using Swiss public transport to filter exchange offers by commute time.",
+      enableCalculations: "Enable travel time calculations",
+      requiresHomeLocation: "Set your home location first",
+      apiNotConfigured: "Transport API is not configured",
+      maxTravelTime: "Maximum travel time",
+    },
+    dataRetention: {
+      title: "Data & Privacy",
+      description:
+        "This app stores certain data locally in your browser. This data never leaves your device and is not transmitted to our servers.",
+      homeLocation: "Your home location (for distance filtering)",
+      filterPreferences: "Filter preferences",
+      travelTimeCache: "Cached travel times (expires after 7 days)",
+      languagePreference: "Language preference",
+      clearData: "Clear Local Data",
+      clearDataConfirm:
+        "This will reset all settings and clear cached data. Continue?",
+      externalServices: "External Services",
+      transportApiNote:
+        "When travel time calculations are enabled, your home location coordinates are sent to the Swiss public transport API (opentransportdata.swiss).",
     },
     safeMode: "Safe Mode",
     safeModeDescription:

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -138,6 +138,8 @@ const fr: Translations = {
     unknownDate: "Date ?",
     currencyChf: "CHF",
     distanceUnit: "km",
+    minutesUnit: "min",
+    hoursUnit: "h",
     dismissNotification: "Ignorer la notification",
     notifications: "Notifications",
     cardActions: "Actions de la carte",
@@ -254,6 +256,9 @@ const fr: Translations = {
     removeButton: "Retirer de la bourse",
     filterByLevel: "Mon niveau uniquement",
     filterByDistance: "Filtrer par distance",
+    filterByTravelTime: "Filtrer par temps de trajet",
+    travelTime: "Temps de trajet",
+    calculatingTravelTime: "Calcul du temps de trajet...",
     noExchangesAtLevel: "Aucun échange disponible à votre niveau.",
     noExchangesWithFilters: "Aucun échange ne correspond à vos filtres.",
     noOpenExchangesTitle: "Aucun échange ouvert",
@@ -309,6 +314,30 @@ const fr: Translations = {
       errorPositionUnavailable: "Position non disponible. Veuillez réessayer.",
       errorTimeout: "La demande de position a expiré. Veuillez réessayer.",
       errorUnknown: "Erreur inconnue lors de l'obtention de la position.",
+    },
+    transport: {
+      title: "Transports publics",
+      description:
+        "Calculez les temps de trajet avec les transports publics suisses pour filtrer les échanges par temps de déplacement.",
+      enableCalculations: "Activer le calcul des temps de trajet",
+      requiresHomeLocation: "Définissez d'abord votre emplacement domicile",
+      apiNotConfigured: "L'API de transport n'est pas configurée",
+      maxTravelTime: "Temps de trajet maximum",
+    },
+    dataRetention: {
+      title: "Données et confidentialité",
+      description:
+        "Cette application stocke certaines données localement dans votre navigateur. Ces données ne quittent jamais votre appareil et ne sont pas transmises à nos serveurs.",
+      homeLocation: "Votre emplacement domicile (pour le filtrage par distance)",
+      filterPreferences: "Préférences de filtre",
+      travelTimeCache: "Temps de trajet en cache (expire après 7 jours)",
+      languagePreference: "Préférence de langue",
+      clearData: "Effacer les données locales",
+      clearDataConfirm:
+        "Cela réinitialisera tous les paramètres et effacera les données en cache. Continuer?",
+      externalServices: "Services externes",
+      transportApiNote:
+        "Lorsque le calcul des temps de trajet est activé, les coordonnées de votre domicile sont envoyées à l'API des transports publics suisses (opentransportdata.swiss).",
     },
     safeMode: "Mode sécurisé",
     safeModeDescription:

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -138,6 +138,8 @@ const it: Translations = {
     unknownDate: "Data?",
     currencyChf: "CHF",
     distanceUnit: "km",
+    minutesUnit: "min",
+    hoursUnit: "h",
     dismissNotification: "Ignora notifica",
     notifications: "Notifiche",
     cardActions: "Azioni della scheda",
@@ -252,6 +254,9 @@ const it: Translations = {
     removeButton: "Rimuovere dalla borsa",
     filterByLevel: "Solo il mio livello",
     filterByDistance: "Filtra per distanza",
+    filterByTravelTime: "Filtra per tempo di viaggio",
+    travelTime: "Tempo di viaggio",
+    calculatingTravelTime: "Calcolo tempo di viaggio...",
     noExchangesAtLevel: "Nessuno scambio disponibile al tuo livello.",
     noExchangesWithFilters: "Nessuno scambio corrisponde ai tuoi filtri.",
     noOpenExchangesTitle: "Nessuno scambio aperto",
@@ -307,6 +312,30 @@ const it: Translations = {
       errorPositionUnavailable: "Posizione non disponibile. Riprova.",
       errorTimeout: "Richiesta posizione scaduta. Riprova.",
       errorUnknown: "Errore sconosciuto durante l'ottenimento della posizione.",
+    },
+    transport: {
+      title: "Trasporto pubblico",
+      description:
+        "Calcola i tempi di viaggio con i trasporti pubblici svizzeri per filtrare gli scambi per tempo di percorrenza.",
+      enableCalculations: "Abilita calcolo tempo di viaggio",
+      requiresHomeLocation: "Imposta prima la tua posizione casa",
+      apiNotConfigured: "API trasporti non configurata",
+      maxTravelTime: "Tempo di viaggio massimo",
+    },
+    dataRetention: {
+      title: "Dati e privacy",
+      description:
+        "Questa app memorizza alcuni dati localmente nel tuo browser. Questi dati non lasciano mai il tuo dispositivo e non vengono trasmessi ai nostri server.",
+      homeLocation: "La tua posizione casa (per il filtraggio per distanza)",
+      filterPreferences: "Preferenze di filtro",
+      travelTimeCache: "Tempi di viaggio in cache (scadono dopo 7 giorni)",
+      languagePreference: "Preferenza di lingua",
+      clearData: "Cancella dati locali",
+      clearDataConfirm:
+        "Questo resetterà tutte le impostazioni e cancellerà i dati in cache. Continuare?",
+      externalServices: "Servizi esterni",
+      transportApiNote:
+        "Quando il calcolo dei tempi di viaggio è abilitato, le coordinate della tua posizione casa vengono inviate all'API dei trasporti pubblici svizzeri (opentransportdata.swiss).",
     },
     safeMode: "Modalità sicura",
     safeModeDescription:

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -35,6 +35,8 @@ export interface Translations {
     unknownDate: string;
     currencyChf: string;
     distanceUnit: string;
+    minutesUnit: string;
+    hoursUnit: string;
     dismissNotification: string;
     notifications: string;
     cardActions: string;
@@ -142,6 +144,9 @@ export interface Translations {
     removeButton: string;
     filterByLevel: string;
     filterByDistance: string;
+    filterByTravelTime: string;
+    travelTime: string;
+    calculatingTravelTime: string;
     noExchangesAtLevel: string;
     noExchangesWithFilters: string;
     noOpenExchangesTitle: string;
@@ -193,6 +198,26 @@ export interface Translations {
       errorPositionUnavailable: string;
       errorTimeout: string;
       errorUnknown: string;
+    };
+    transport: {
+      title: string;
+      description: string;
+      enableCalculations: string;
+      requiresHomeLocation: string;
+      apiNotConfigured: string;
+      maxTravelTime: string;
+    };
+    dataRetention: {
+      title: string;
+      description: string;
+      homeLocation: string;
+      filterPreferences: string;
+      travelTimeCache: string;
+      languagePreference: string;
+      clearData: string;
+      clearDataConfirm: string;
+      externalServices: string;
+      transportApiNote: string;
     };
     safeMode: string;
     safeModeDescription: string;

--- a/web-app/src/pages/ExchangePage.test.tsx
+++ b/web-app/src/pages/ExchangePage.test.tsx
@@ -10,6 +10,15 @@ import * as demoStore from "@/stores/demo";
 vi.mock("@/hooks/useConvocations");
 vi.mock("@/stores/auth");
 vi.mock("@/stores/demo");
+vi.mock("@/hooks/useTravelTimeFilter", () => ({
+  useTravelTimeFilter: () => ({
+    exchangesWithTravelTime: null,
+    filteredExchanges: null,
+    isLoading: false,
+    filterByTravelTime: () => true,
+    isAvailable: false,
+  }),
+}));
 vi.mock("@/hooks/useExchangeActions", () => ({
   useExchangeActions: () => ({
     takeOverModal: {

--- a/web-app/src/pages/SettingsPage.test.tsx
+++ b/web-app/src/pages/SettingsPage.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { SettingsPage } from "./SettingsPage";
 import * as authStore from "@/stores/auth";
 import * as settingsStore from "@/stores/settings";
@@ -14,6 +16,20 @@ vi.mock("@/hooks/useTranslation", () => ({
     locale: "en",
   }),
 }));
+vi.mock("@/hooks/useTravelTime", () => ({
+  useTravelTimeAvailable: () => false,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
 
 // Disable PWA for tests by default
 vi.stubGlobal("__PWA_ENABLED__", false);
@@ -76,30 +92,30 @@ describe("SettingsPage", () => {
 
   describe("Profile Section", () => {
     it("displays user name", () => {
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.getByText("John Doe")).toBeInTheDocument();
     });
 
     it("displays user initials", () => {
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.getByText("JD")).toBeInTheDocument();
     });
 
     it("displays user email", () => {
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.getByText("john.doe@example.com")).toBeInTheDocument();
     });
 
     it("does not render profile when user is null", () => {
       mockAuthStore({ user: null });
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
     });
   });
 
   describe("Language Section", () => {
     it("renders language section with heading", () => {
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       // Language section header should be present
       expect(screen.getByText("settings.language")).toBeInTheDocument();
     });
@@ -108,26 +124,26 @@ describe("SettingsPage", () => {
   describe("Safe Mode Section", () => {
     it("hides safe mode section in demo mode", () => {
       mockAuthStore({ isDemoMode: true });
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.queryByText("settings.safeMode")).not.toBeInTheDocument();
     });
 
     it("shows safe mode section when not in demo mode", () => {
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.getByText("settings.safeMode")).toBeInTheDocument();
     });
   });
 
   describe("About Section", () => {
     it("displays version info", () => {
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.getByText("1.0.0")).toBeInTheDocument();
     });
   });
 
   describe("Logout", () => {
     it("renders logout button", () => {
-      render(<SettingsPage />);
+      render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.getByText("auth.logout")).toBeInTheDocument();
     });
   });

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -9,6 +9,8 @@ import {
   ProfileSection,
   LanguageSection,
   HomeLocationSection,
+  TransportSection,
+  DataRetentionSection,
   TourSection,
   DemoSection,
   SafeModeSection,
@@ -53,6 +55,10 @@ export function SettingsPage() {
       <LanguageSection />
 
       <HomeLocationSection />
+
+      <TransportSection />
+
+      <DataRetentionSection />
 
       <TourSection isDemoMode={isDemoMode} />
 

--- a/web-app/src/services/transport/cache.ts
+++ b/web-app/src/services/transport/cache.ts
@@ -1,0 +1,51 @@
+/**
+ * Travel time cache utilities.
+ */
+
+import type { Coordinates } from "./types";
+
+/** Cache TTL: 7 days in milliseconds */
+export const TRAVEL_TIME_CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
+
+/** Cache stale time: 7 days (TanStack Query config) */
+export const TRAVEL_TIME_STALE_TIME = TRAVEL_TIME_CACHE_TTL;
+
+/** Garbage collection time: same as TTL */
+export const TRAVEL_TIME_GC_TIME = TRAVEL_TIME_CACHE_TTL;
+
+/**
+ * Hash a location to create a cache key component.
+ * Rounds to ~100m precision to avoid cache misses from GPS drift.
+ *
+ * @param coords Coordinates to hash
+ * @returns String hash suitable for use in cache keys
+ */
+export function hashLocation(coords: Coordinates): string {
+  // Round to 3 decimal places (~100m precision)
+  const lat = Math.round(coords.latitude * 1000) / 1000;
+  const lon = Math.round(coords.longitude * 1000) / 1000;
+  return `${lat},${lon}`;
+}
+
+/**
+ * Get a unique ID for a sports hall from API data.
+ * Falls back to coordinate-based hash if no ID is available.
+ *
+ * @param hallId Optional hall ID from API
+ * @param hallCoords Hall coordinates as fallback
+ * @returns Unique identifier for the hall
+ */
+export function getHallCacheKey(
+  hallId: string | undefined,
+  hallCoords: Coordinates | null,
+): string | null {
+  if (hallId) {
+    return hallId;
+  }
+
+  if (hallCoords) {
+    return `coords:${hashLocation(hallCoords)}`;
+  }
+
+  return null;
+}

--- a/web-app/src/services/transport/index.ts
+++ b/web-app/src/services/transport/index.ts
@@ -12,7 +12,7 @@ export type {
 
 export { TransportApiError } from "./types";
 
-export { calculateTravelTime, isOjpConfigured, hashLocation } from "./ojp-client";
+export { calculateTravelTime, isOjpConfigured } from "./ojp-client";
 
 export { calculateMockTravelTime, mockTransportApi } from "./mock-transport";
 
@@ -21,4 +21,5 @@ export {
   TRAVEL_TIME_STALE_TIME,
   TRAVEL_TIME_GC_TIME,
   getHallCacheKey,
+  hashLocation,
 } from "./cache";

--- a/web-app/src/services/transport/index.ts
+++ b/web-app/src/services/transport/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Public transport routing service.
+ * Provides travel time calculations using Swiss public transport via OJP 2.0.
+ */
+
+export type {
+  TravelTimeResult,
+  TravelTimeOptions,
+  Coordinates,
+  TransportConfig,
+} from "./types";
+
+export { TransportApiError } from "./types";
+
+export { calculateTravelTime, isOjpConfigured, hashLocation } from "./ojp-client";
+
+export { calculateMockTravelTime, mockTransportApi } from "./mock-transport";
+
+export {
+  TRAVEL_TIME_CACHE_TTL,
+  TRAVEL_TIME_STALE_TIME,
+  TRAVEL_TIME_GC_TIME,
+  getHallCacheKey,
+} from "./cache";

--- a/web-app/src/services/transport/mock-transport.ts
+++ b/web-app/src/services/transport/mock-transport.ts
@@ -1,0 +1,115 @@
+/**
+ * Mock transport API for demo mode.
+ * Provides realistic travel times based on straight-line distance.
+ */
+
+import type { Coordinates, TravelTimeResult, TravelTimeOptions } from "./types";
+
+/** Network delay for realistic demo behavior */
+const MOCK_DELAY_MS = 100;
+
+/**
+ * Estimate travel time based on straight-line distance.
+ * Uses a formula that approximates Swiss public transport:
+ * - Base time: 15 minutes (getting to station, waiting)
+ * - Travel time: ~40 km/h average speed for public transport
+ * - Transfers: estimated based on distance
+ *
+ * @param distanceKm Straight-line distance in kilometers
+ * @returns Estimated travel time in minutes
+ */
+function estimateTravelTimeFromDistance(distanceKm: number): number {
+  const baseTimeMinutes = 15; // Getting to station, waiting
+  const averageSpeedKmh = 40; // Average speed including stops
+  const travelMinutes = (distanceKm / averageSpeedKmh) * 60;
+
+  return Math.round(baseTimeMinutes + travelMinutes);
+}
+
+/**
+ * Estimate number of transfers based on distance.
+ *
+ * @param distanceKm Straight-line distance in kilometers
+ * @returns Estimated number of transfers
+ */
+function estimateTransfers(distanceKm: number): number {
+  if (distanceKm < 10) return 0;
+  if (distanceKm < 30) return 1;
+  if (distanceKm < 60) return 2;
+  return 3;
+}
+
+/**
+ * Calculate straight-line distance between two coordinates using Haversine formula.
+ *
+ * @param from Origin coordinates
+ * @param to Destination coordinates
+ * @returns Distance in kilometers
+ */
+function calculateDistanceKm(from: Coordinates, to: Coordinates): number {
+  const R = 6371; // Earth's radius in kilometers
+
+  const dLat = ((to.latitude - from.latitude) * Math.PI) / 180;
+  const dLon = ((to.longitude - from.longitude) * Math.PI) / 180;
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos((from.latitude * Math.PI) / 180) *
+      Math.cos((to.latitude * Math.PI) / 180) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
+}
+
+/**
+ * Simulate network delay.
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Calculate mock travel time between two coordinates.
+ * Used in demo mode when the real OJP API is not available.
+ *
+ * @param from Origin coordinates (user's home location)
+ * @param to Destination coordinates (sports hall)
+ * @param options Optional configuration
+ * @returns Mock travel time result
+ */
+export async function calculateMockTravelTime(
+  from: Coordinates,
+  to: Coordinates,
+  options: TravelTimeOptions = {},
+): Promise<TravelTimeResult> {
+  // Simulate network delay
+  await delay(MOCK_DELAY_MS);
+
+  // Calculate distance and estimate travel time
+  const distanceKm = calculateDistanceKm(from, to);
+  const durationMinutes = estimateTravelTimeFromDistance(distanceKm);
+  const transfers = estimateTransfers(distanceKm);
+
+  // Calculate departure and arrival times
+  const departureTime = options.departureTime ?? new Date();
+  const arrivalTime = new Date(departureTime.getTime() + durationMinutes * 60 * 1000);
+
+  return {
+    durationMinutes,
+    departureTime: departureTime.toISOString(),
+    arrivalTime: arrivalTime.toISOString(),
+    transfers,
+    tripData: undefined,
+  };
+}
+
+/**
+ * Mock transport API object matching the real API interface.
+ */
+export const mockTransportApi = {
+  calculateTravelTime: calculateMockTravelTime,
+  isConfigured: (): boolean => true, // Always "configured" in demo mode
+};

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -118,15 +118,18 @@ export async function calculateTravelTime(
  * @returns Duration in minutes
  */
 function parseDurationToMinutes(duration: string): number {
-  // Match ISO 8601 duration format: PT[nH][nM][nS]
-  const match = duration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
-  if (!match) {
+  if (!duration.startsWith("PT")) {
     return 0;
   }
 
-  const hours = parseInt(match[1] ?? "0", 10);
-  const minutes = parseInt(match[2] ?? "0", 10);
-  const seconds = parseInt(match[3] ?? "0", 10);
+  // Extract hours, minutes, seconds with simple patterns
+  const hoursMatch = duration.match(/(\d+)H/);
+  const minutesMatch = duration.match(/(\d+)M/);
+  const secondsMatch = duration.match(/(\d+)S/);
+
+  const hours = hoursMatch ? parseInt(hoursMatch[1]!, 10) : 0;
+  const minutes = minutesMatch ? parseInt(minutesMatch[1]!, 10) : 0;
+  const seconds = secondsMatch ? parseInt(secondsMatch[1]!, 10) : 0;
 
   return hours * 60 + minutes + Math.ceil(seconds / 60);
 }

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -150,17 +150,3 @@ function parseDurationToMinutes(duration: string): number {
 
   return hours * 60 + minutes + Math.ceil(seconds / 60);
 }
-
-/**
- * Hash a location to create a cache key component.
- * Rounds to ~100m precision to avoid cache misses from GPS drift.
- *
- * @param coords Coordinates to hash
- * @returns String hash suitable for use in cache keys
- */
-export function hashLocation(coords: Coordinates): string {
-  // Round to 3 decimal places (~100m precision)
-  const lat = Math.round(coords.latitude * 1000) / 1000;
-  const lon = Math.round(coords.longitude * 1000) / 1000;
-  return `${lat},${lon}`;
-}

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -1,0 +1,146 @@
+/**
+ * OJP 2.0 client for Swiss public transport routing.
+ * Wraps the ojp-sdk-next package with rate limiting.
+ */
+
+import { SDK, TripRequest, Place } from "ojp-sdk-next";
+import type { Coordinates, TravelTimeResult, TravelTimeOptions } from "./types";
+import { TransportApiError } from "./types";
+
+/** OJP 2.0 API endpoint */
+const OJP_API_ENDPOINT = "https://api.opentransportdata.swiss/ojp20";
+
+/** Minimum delay between API requests (50 req/min = 1.2s to be safe) */
+const RATE_LIMIT_DELAY_MS = 1200;
+
+/** Timestamp of the last API request */
+let lastRequestTime = 0;
+
+/**
+ * Wait if necessary to respect rate limits.
+ */
+async function waitForRateLimit(): Promise<void> {
+  const now = Date.now();
+  const timeSinceLastRequest = now - lastRequestTime;
+
+  if (timeSinceLastRequest < RATE_LIMIT_DELAY_MS) {
+    const waitTime = RATE_LIMIT_DELAY_MS - timeSinceLastRequest;
+    await new Promise((resolve) => setTimeout(resolve, waitTime));
+  }
+  lastRequestTime = Date.now();
+}
+
+/**
+ * Check if the OJP API is configured.
+ */
+export function isOjpConfigured(): boolean {
+  const apiKey = import.meta.env.VITE_OJP_API_KEY;
+  return Boolean(apiKey && apiKey !== "your_api_key_here");
+}
+
+/**
+ * Calculate travel time between two coordinates using Swiss public transport.
+ *
+ * @param from Origin coordinates (user's home location)
+ * @param to Destination coordinates (sports hall)
+ * @param options Optional configuration
+ * @returns Travel time result with duration, times, and transfers
+ * @throws TransportApiError if the API call fails or no route is found
+ */
+export async function calculateTravelTime(
+  from: Coordinates,
+  to: Coordinates,
+  options: TravelTimeOptions = {},
+): Promise<TravelTimeResult> {
+  const apiKey = import.meta.env.VITE_OJP_API_KEY;
+
+  if (!apiKey || apiKey === "your_api_key_here") {
+    throw new TransportApiError("OJP API key not configured", "API_NOT_CONFIGURED");
+  }
+
+  // Wait for rate limit before making request
+  await waitForRateLimit();
+
+  try {
+    // Create SDK instance
+    const sdk = new SDK("VolleyKit", { url: OJP_API_ENDPOINT, authToken: apiKey }, "de");
+
+    // Create places from coordinates
+    const fromPlace = Place.initWithCoords(from.longitude, from.latitude);
+    const toPlace = Place.initWithCoords(to.longitude, to.latitude);
+
+    // Create trip request
+    const tripRequest = TripRequest.initWithPlaces(fromPlace, toPlace);
+
+    // Set departure time if provided
+    const departureTime = options.departureTime ?? new Date();
+    tripRequest.setDepartureDatetime(departureTime);
+
+    // Configure for public transport
+    tripRequest.setPublicTransportRequest();
+
+    // Fetch trips
+    const trips = await sdk.fetchTrips(tripRequest);
+
+    // Check for results
+    if (!trips || trips.length === 0) {
+      throw new TransportApiError("No route found between locations", "NO_ROUTE");
+    }
+
+    // Get the first (fastest) trip - safe access after length check
+    const trip = trips[0]!;
+
+    // Parse duration from ISO 8601 duration string (e.g., "PT1H30M")
+    const durationMinutes = parseDurationToMinutes(trip.duration);
+
+    return {
+      durationMinutes,
+      departureTime: trip.startTime,
+      arrivalTime: trip.endTime,
+      transfers: trip.transfers,
+      tripData: options.includeTrips ? trip : undefined,
+    };
+  } catch (error) {
+    if (error instanceof TransportApiError) {
+      throw error;
+    }
+
+    // Wrap unknown errors
+    const message = error instanceof Error ? error.message : "Unknown transport API error";
+    throw new TransportApiError(message, "API_ERROR");
+  }
+}
+
+/**
+ * Parse ISO 8601 duration string to minutes.
+ *
+ * @param duration ISO 8601 duration string (e.g., "PT1H30M")
+ * @returns Duration in minutes
+ */
+function parseDurationToMinutes(duration: string): number {
+  // Match ISO 8601 duration format: PT[nH][nM][nS]
+  const match = duration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  if (!match) {
+    return 0;
+  }
+
+  const hours = parseInt(match[1] ?? "0", 10);
+  const minutes = parseInt(match[2] ?? "0", 10);
+  const seconds = parseInt(match[3] ?? "0", 10);
+
+  return hours * 60 + minutes + Math.ceil(seconds / 60);
+}
+
+/**
+ * Hash a location to create a cache key component.
+ * Rounds to ~100m precision to avoid cache misses from GPS drift.
+ *
+ * @param coords Coordinates to hash
+ * @returns String hash suitable for use in cache keys
+ */
+export function hashLocation(coords: Coordinates): string {
+  // Round to 3 decimal places (~100m precision)
+  const lat = Math.round(coords.latitude * 1000) / 1000;
+  const lon = Math.round(coords.longitude * 1000) / 1000;
+  return `${lat},${lon}`;
+}

--- a/web-app/src/services/transport/types.ts
+++ b/web-app/src/services/transport/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Travel time calculation types for public transport routing.
+ * Uses the OJP 2.0 API via ojp-sdk-next.
+ */
+
+/**
+ * Result of a travel time calculation.
+ */
+export interface TravelTimeResult {
+  /** Total travel duration in minutes */
+  durationMinutes: number;
+  /** ISO 8601 departure time */
+  departureTime: string;
+  /** ISO 8601 arrival time */
+  arrivalTime: string;
+  /** Number of transfers required */
+  transfers: number;
+  /** Raw trip data for future itinerary display */
+  tripData?: unknown;
+}
+
+/**
+ * Options for travel time calculation.
+ */
+export interface TravelTimeOptions {
+  /** Desired departure time (defaults to now) */
+  departureTime?: Date;
+  /** Include raw trip data in result (for future itinerary display) */
+  includeTrips?: boolean;
+}
+
+/**
+ * Coordinates for location-based routing.
+ */
+export interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * Configuration for the transport service.
+ */
+export interface TransportConfig {
+  /** OJP API endpoint URL */
+  apiEndpoint: string;
+  /** API key for authentication */
+  apiKey: string;
+  /** Minimum delay between requests in milliseconds */
+  rateLimitDelayMs: number;
+}
+
+/**
+ * Error thrown when transport API requests fail.
+ */
+export class TransportApiError extends Error {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "TransportApiError";
+    this.code = code;
+  }
+}

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -65,6 +65,9 @@ interface SettingsState {
   setTravelTimeFilterEnabled: (enabled: boolean) => void;
   setMaxTravelTimeMinutes: (minutes: number) => void;
   invalidateTravelTimeCache: () => void;
+
+  // Reset all settings to defaults (keeps safe mode)
+  resetLocationSettings: () => void;
 }
 
 /** Default max distance in kilometers */
@@ -150,6 +153,24 @@ export const useSettingsStore = create<SettingsState>()(
             cacheInvalidatedAt: Date.now(),
           },
         }));
+      },
+
+      resetLocationSettings: () => {
+        // Reset all location-related settings to defaults
+        // Keeps safe mode and language preferences unchanged
+        set({
+          homeLocation: null,
+          distanceFilter: {
+            enabled: false,
+            maxDistanceKm: DEFAULT_MAX_DISTANCE_KM,
+          },
+          transportEnabled: false,
+          travelTimeFilter: {
+            enabled: false,
+            maxTravelTimeMinutes: DEFAULT_MAX_TRAVEL_TIME_MINUTES,
+            cacheInvalidatedAt: null,
+          },
+        });
       },
     }),
     {


### PR DESCRIPTION
Add support for Swiss public transport travel time calculations using
the OJP 2.0 API (Open Journey Planner). This allows users to filter
exchange offers by commute time from their home location.

Key features:
- OJP 2.0 integration with ojp-sdk-next package
- Rate limiting (50 req/min) to respect API limits
- 7-day travel time cache for efficiency
- Mock transport service for demo mode
- Travel time filter toggle on ExchangePage
- Travel time badge on ExchangeCard
- Transport settings section with max travel time slider
- Data retention documentation

Components added:
- TravelTimeBadge: Color-coded duration indicator
- TravelTimeFilterToggle: Filter toggle for exchange list
- TransportSection: Settings for transport calculations
- DataRetentionSection: Privacy info and data clearing

Hooks added:
- useTravelTime: Fetch travel time for a hall
- useTravelTimeFilter: Filter exchanges by travel time

All translations added for DE, EN, FR, IT locales.