### PR TITLE
feat(transport): use train icon and apostrophe for travel time display

### DIFF
--- a/web-app/src/components/features/TravelTimeBadge.tsx
+++ b/web-app/src/components/features/TravelTimeBadge.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { formatTravelTime } from "@/hooks/useTravelTime";
 import { Badge } from "@/components/ui/Badge";
+import { TrainFront } from "@/components/ui/icons";
 
 interface TravelTimeBadgeProps {
   /** Travel time in minutes */
@@ -26,20 +27,7 @@ function TravelTimeBadgeComponent({
     return (
       <Badge variant="neutral" className={`animate-pulse ${className}`}>
         <span className="flex items-center gap-1">
-          <svg
-            className="w-3 h-3"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
-            />
-          </svg>
+          <TrainFront className="w-3 h-3" aria-hidden="true" />
           <span>...</span>
         </span>
       </Badge>
@@ -57,20 +45,7 @@ function TravelTimeBadgeComponent({
       title={t("exchange.travelTime")}
     >
       <span className="flex items-center gap-1">
-        <svg
-          className="w-3 h-3"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
-          />
-        </svg>
+        <TrainFront className="w-3 h-3" aria-hidden="true" />
         <span>{formatTravelTime(durationMinutes)}</span>
       </span>
     </Badge>

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -32,6 +32,7 @@ export { X } from "lucide-react";
 export { Plus } from "lucide-react";
 export { MapPin } from "lucide-react";
 export { Home } from "lucide-react";
+export { TrainFront } from "lucide-react";
 
 // Status icons
 export { CheckCircle } from "lucide-react";

--- a/web-app/src/hooks/useTravelTime.test.tsx
+++ b/web-app/src/hooks/useTravelTime.test.tsx
@@ -297,9 +297,9 @@ describe("useTravelTime", () => {
 
 describe("formatTravelTime", () => {
   it("formats minutes less than 60", () => {
-    expect(formatTravelTime(15)).toBe("15m");
-    expect(formatTravelTime(45)).toBe("45m");
-    expect(formatTravelTime(59)).toBe("59m");
+    expect(formatTravelTime(15)).toBe("15'");
+    expect(formatTravelTime(45)).toBe("45'");
+    expect(formatTravelTime(59)).toBe("59'");
   });
 
   it("formats exact hours", () => {
@@ -309,15 +309,15 @@ describe("formatTravelTime", () => {
   });
 
   it("formats hours and minutes", () => {
-    expect(formatTravelTime(75)).toBe("1h 15m");
-    expect(formatTravelTime(90)).toBe("1h 30m");
-    expect(formatTravelTime(145)).toBe("2h 25m");
+    expect(formatTravelTime(75)).toBe("1h15'");
+    expect(formatTravelTime(90)).toBe("1h30'");
+    expect(formatTravelTime(145)).toBe("2h25'");
   });
 
   it("handles edge cases", () => {
-    expect(formatTravelTime(0)).toBe("0m");
-    expect(formatTravelTime(1)).toBe("1m");
-    expect(formatTravelTime(61)).toBe("1h 1m");
+    expect(formatTravelTime(0)).toBe("0'");
+    expect(formatTravelTime(1)).toBe("1'");
+    expect(formatTravelTime(61)).toBe("1h1'");
   });
 });
 

--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -81,11 +81,11 @@ export function useTravelTime(
  * Format travel time duration for display.
  *
  * @param minutes Travel time in minutes
- * @returns Formatted string like "45m" or "1h 15m"
+ * @returns Formatted string like "45'" or "1h15'"
  */
 export function formatTravelTime(minutes: number): string {
   if (minutes < 60) {
-    return `${minutes}m`;
+    return `${minutes}'`;
   }
 
   const hours = Math.floor(minutes / 60);
@@ -95,7 +95,7 @@ export function formatTravelTime(minutes: number): string {
     return `${hours}h`;
   }
 
-  return `${hours}h ${remainingMinutes}m`;
+  return `${hours}h${remainingMinutes}'`;
 }
 
 /**

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -138,7 +138,7 @@ const de: Translations = {
     unknownDate: "Datum?",
     currencyChf: "CHF",
     distanceUnit: "km",
-    minutesUnit: "min",
+    minutesUnit: "'",
     hoursUnit: "h",
     dismissNotification: "Benachrichtigung schliessen",
     notifications: "Benachrichtigungen",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -138,7 +138,7 @@ const en: Translations = {
     unknownDate: "Date?",
     currencyChf: "CHF",
     distanceUnit: "km",
-    minutesUnit: "min",
+    minutesUnit: "'",
     hoursUnit: "h",
     dismissNotification: "Dismiss notification",
     notifications: "Notifications",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -138,7 +138,7 @@ const fr: Translations = {
     unknownDate: "Date ?",
     currencyChf: "CHF",
     distanceUnit: "km",
-    minutesUnit: "min",
+    minutesUnit: "'",
     hoursUnit: "h",
     dismissNotification: "Ignorer la notification",
     notifications: "Notifications",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -138,7 +138,7 @@ const it: Translations = {
     unknownDate: "Data?",
     currencyChf: "CHF",
     distanceUnit: "km",
-    minutesUnit: "min",
+    minutesUnit: "'",
     hoursUnit: "h",
     dismissNotification: "Ignora notifica",
     notifications: "Notifiche",


### PR DESCRIPTION
- Replace custom SVG arrows with TrainFront icon from lucide-react
- Update formatTravelTime to use ' (apostrophe) instead of 'm' for minutes
- Update minutesUnit translations from "min" to "'" in all 4 languages
- Loading state now shows train icon with pulsing animation