### PR TITLE
feat(transport): optimize OJP cache with day type and localStorage persistence

### DIFF
--- a/web-app/src/api/queryKeys.ts
+++ b/web-app/src/api/queryKeys.ts
@@ -153,16 +153,27 @@ export const queryKeys = {
   },
 
   /**
-   * Travel time query keys for public transport routing
+   * Travel time query keys for public transport routing.
+   * Includes day type (weekday/saturday/sunday) since Swiss transport
+   * schedules differ between these day types.
    */
   travelTime: {
     /** Base key - invalidates ALL travel time queries */
     all: ["travelTime"] as const,
     /** Parent key for all hall travel time queries */
     halls: () => [...queryKeys.travelTime.all, "hall"] as const,
-    /** Travel time to a specific hall from user's home location */
-    hall: (hallId: string, homeLocationHash: string) =>
-      [...queryKeys.travelTime.halls(), hallId, homeLocationHash] as const,
+    /** Travel time to a specific hall from user's home location for a day type */
+    hall: (
+      hallId: string,
+      homeLocationHash: string,
+      dayType: "weekday" | "saturday" | "sunday",
+    ) =>
+      [
+        ...queryKeys.travelTime.halls(),
+        hallId,
+        homeLocationHash,
+        dayType,
+      ] as const,
   },
 } as const;
 

--- a/web-app/src/components/features/settings/TransportSection.tsx
+++ b/web-app/src/components/features/settings/TransportSection.tsx
@@ -38,11 +38,12 @@ function TransportSectionComponent() {
   );
 
   // Calculate cache entry count - recalculates when cacheVersion changes
-  const cacheEntryCount = useMemo(() => {
-    // cacheVersion is used to trigger recalculation after clearing cache
-    void cacheVersion;
-    return transportEnabled ? getTravelTimeCacheStats().entryCount : 0;
-  }, [transportEnabled, cacheVersion]);
+  const cacheEntryCount = useMemo(
+    () => (transportEnabled ? getTravelTimeCacheStats().entryCount : 0),
+    // cacheVersion triggers recalculation after clearing cache
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [transportEnabled, cacheVersion],
+  );
 
   const handleToggleTransport = useCallback(() => {
     setTransportEnabled(!transportEnabled);

--- a/web-app/src/components/features/settings/TransportSection.tsx
+++ b/web-app/src/components/features/settings/TransportSection.tsx
@@ -1,16 +1,25 @@
-import { useCallback, memo } from "react";
+import { useCallback, memo, useState, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
+import { useQueryClient } from "@tanstack/react-query";
 import { useSettingsStore } from "@/stores/settings";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTravelTimeAvailable } from "@/hooks/useTravelTime";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import { queryKeys } from "@/api/queryKeys";
+import {
+  clearTravelTimeCache,
+  getTravelTimeCacheStats,
+} from "@/services/transport";
 
 /** Travel time presets for the slider (in minutes) */
 const TRAVEL_TIME_PRESETS = [30, 45, 60, 90, 120];
 
 function TransportSectionComponent() {
-  const { t } = useTranslation();
+  const { t, tInterpolate } = useTranslation();
   const isAvailable = useTravelTimeAvailable();
+  const queryClient = useQueryClient();
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [cacheVersion, setCacheVersion] = useState(0);
 
   const {
     homeLocation,
@@ -28,6 +37,13 @@ function TransportSectionComponent() {
     })),
   );
 
+  // Calculate cache entry count - recalculates when cacheVersion changes
+  const cacheEntryCount = useMemo(() => {
+    // cacheVersion is used to trigger recalculation after clearing cache
+    void cacheVersion;
+    return transportEnabled ? getTravelTimeCacheStats().entryCount : 0;
+  }, [transportEnabled, cacheVersion]);
+
   const handleToggleTransport = useCallback(() => {
     setTransportEnabled(!transportEnabled);
   }, [transportEnabled, setTransportEnabled]);
@@ -38,6 +54,16 @@ function TransportSectionComponent() {
     },
     [setMaxTravelTimeMinutes],
   );
+
+  const handleClearCache = useCallback(() => {
+    // Clear localStorage cache
+    clearTravelTimeCache();
+    // Invalidate TanStack Query cache
+    queryClient.invalidateQueries({ queryKey: queryKeys.travelTime.all });
+    // Trigger recalculation of cache stats
+    setCacheVersion((v) => v + 1);
+    setShowClearConfirm(false);
+  }, [queryClient]);
 
   const hasHomeLocation = Boolean(homeLocation);
   const canEnable = hasHomeLocation && isAvailable;
@@ -192,6 +218,49 @@ function TransportSectionComponent() {
                   {preset < 60 ? `${preset}m` : `${preset / 60}h`}
                 </span>
               ))}
+            </div>
+
+            {/* Cache management */}
+            <div className="mt-4 pt-3 border-t border-border-subtle dark:border-border-subtle-dark">
+              <p className="text-xs text-text-muted dark:text-text-muted-dark mb-2">
+                {t("settings.transport.cacheInfo")}
+              </p>
+
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                  {tInterpolate("settings.transport.cacheEntries", {
+                    count: cacheEntryCount,
+                  })}
+                </span>
+
+                {!showClearConfirm ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowClearConfirm(true)}
+                    disabled={cacheEntryCount === 0}
+                    className="text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {t("settings.transport.refreshCache")}
+                  </button>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowClearConfirm(false)}
+                      className="text-sm text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
+                    >
+                      {t("common.cancel")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleClearCache}
+                      className="text-sm text-error-600 dark:text-error-400 hover:text-error-700 dark:hover:text-error-300"
+                    >
+                      {t("common.confirm")}
+                    </button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         )}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -324,6 +324,13 @@ const de: Translations = {
       requiresHomeLocation: "Legen Sie zuerst Ihren Heimatstandort fest",
       apiNotConfigured: "Transport-API ist nicht konfiguriert",
       maxTravelTime: "Maximale Reisezeit",
+      cacheInfo:
+        "Reisezeiten werden nach Tagestyp (Werktag/Samstag/Sonntag) für 30 Tage zwischengespeichert.",
+      cacheEntries: "{count} gespeicherte Routen",
+      refreshCache: "Cache leeren",
+      refreshCacheConfirm:
+        "Alle gespeicherten Reisezeiten löschen? Neue Berechnungen werden von der API abgerufen.",
+      cacheCleared: "Reisezeit-Cache geleert",
     },
     dataRetention: {
       title: "Daten & Datenschutz",
@@ -331,7 +338,7 @@ const de: Translations = {
         "Diese App speichert bestimmte Daten lokal in Ihrem Browser. Diese Daten verlassen Ihr Gerät nie und werden nicht an unsere Server übertragen.",
       homeLocation: "Ihr Heimatstandort (für Distanzfilterung)",
       filterPreferences: "Filtereinstellungen",
-      travelTimeCache: "Zwischengespeicherte Reisezeiten (läuft nach 7 Tagen ab)",
+      travelTimeCache: "Zwischengespeicherte Reisezeiten (läuft nach 30 Tagen ab)",
       languagePreference: "Spracheinstellung",
       clearData: "Lokale Daten löschen",
       clearDataConfirm:

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -322,6 +322,13 @@ const en: Translations = {
       requiresHomeLocation: "Set your home location first",
       apiNotConfigured: "Transport API is not configured",
       maxTravelTime: "Maximum travel time",
+      cacheInfo:
+        "Travel times are cached by day type (weekday/Saturday/Sunday) for 30 days.",
+      cacheEntries: "{count} cached routes",
+      refreshCache: "Clear Cache",
+      refreshCacheConfirm:
+        "Clear all cached travel times? New calculations will be fetched from the API.",
+      cacheCleared: "Travel time cache cleared",
     },
     dataRetention: {
       title: "Data & Privacy",
@@ -329,7 +336,7 @@ const en: Translations = {
         "This app stores certain data locally in your browser. This data never leaves your device and is not transmitted to our servers.",
       homeLocation: "Your home location (for distance filtering)",
       filterPreferences: "Filter preferences",
-      travelTimeCache: "Cached travel times (expires after 7 days)",
+      travelTimeCache: "Cached travel times (expires after 30 days)",
       languagePreference: "Language preference",
       clearData: "Clear Local Data",
       clearDataConfirm:

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -323,6 +323,13 @@ const fr: Translations = {
       requiresHomeLocation: "Définissez d'abord votre emplacement domicile",
       apiNotConfigured: "L'API de transport n'est pas configurée",
       maxTravelTime: "Temps de trajet maximum",
+      cacheInfo:
+        "Les temps de trajet sont mis en cache par type de jour (semaine/samedi/dimanche) pendant 30 jours.",
+      cacheEntries: "{count} trajets en cache",
+      refreshCache: "Vider le cache",
+      refreshCacheConfirm:
+        "Effacer tous les temps de trajet en cache ? Les nouveaux calculs seront récupérés depuis l'API.",
+      cacheCleared: "Cache des temps de trajet vidé",
     },
     dataRetention: {
       title: "Données et confidentialité",
@@ -330,7 +337,7 @@ const fr: Translations = {
         "Cette application stocke certaines données localement dans votre navigateur. Ces données ne quittent jamais votre appareil et ne sont pas transmises à nos serveurs.",
       homeLocation: "Votre emplacement domicile (pour le filtrage par distance)",
       filterPreferences: "Préférences de filtre",
-      travelTimeCache: "Temps de trajet en cache (expire après 7 jours)",
+      travelTimeCache: "Temps de trajet en cache (expire après 30 jours)",
       languagePreference: "Préférence de langue",
       clearData: "Effacer les données locales",
       clearDataConfirm:

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -321,6 +321,13 @@ const it: Translations = {
       requiresHomeLocation: "Imposta prima la tua posizione casa",
       apiNotConfigured: "API trasporti non configurata",
       maxTravelTime: "Tempo di viaggio massimo",
+      cacheInfo:
+        "I tempi di viaggio sono memorizzati in cache per tipo di giorno (feriale/sabato/domenica) per 30 giorni.",
+      cacheEntries: "{count} percorsi in cache",
+      refreshCache: "Svuota cache",
+      refreshCacheConfirm:
+        "Cancellare tutti i tempi di viaggio in cache? I nuovi calcoli verranno recuperati dall'API.",
+      cacheCleared: "Cache tempi di viaggio svuotata",
     },
     dataRetention: {
       title: "Dati e privacy",
@@ -328,7 +335,7 @@ const it: Translations = {
         "Questa app memorizza alcuni dati localmente nel tuo browser. Questi dati non lasciano mai il tuo dispositivo e non vengono trasmessi ai nostri server.",
       homeLocation: "La tua posizione casa (per il filtraggio per distanza)",
       filterPreferences: "Preferenze di filtro",
-      travelTimeCache: "Tempi di viaggio in cache (scadono dopo 7 giorni)",
+      travelTimeCache: "Tempi di viaggio in cache (scadono dopo 30 giorni)",
       languagePreference: "Preferenza di lingua",
       clearData: "Cancella dati locali",
       clearDataConfirm:

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -206,6 +206,11 @@ export interface Translations {
       requiresHomeLocation: string;
       apiNotConfigured: string;
       maxTravelTime: string;
+      cacheInfo: string;
+      cacheEntries: string;
+      refreshCache: string;
+      refreshCacheConfirm: string;
+      cacheCleared: string;
     };
     dataRetention: {
       title: string;

--- a/web-app/src/services/transport/cache.test.ts
+++ b/web-app/src/services/transport/cache.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { getDayType, hashLocation, getHallCacheKey } from "./cache";
+
+describe("getDayType", () => {
+  it("returns 'weekday' for Monday", () => {
+    const monday = new Date("2024-01-15"); // Monday
+    expect(getDayType(monday)).toBe("weekday");
+  });
+
+  it("returns 'weekday' for Friday", () => {
+    const friday = new Date("2024-01-19"); // Friday
+    expect(getDayType(friday)).toBe("weekday");
+  });
+
+  it("returns 'saturday' for Saturday", () => {
+    const saturday = new Date("2024-01-20"); // Saturday
+    expect(getDayType(saturday)).toBe("saturday");
+  });
+
+  it("returns 'sunday' for Sunday", () => {
+    const sunday = new Date("2024-01-21"); // Sunday
+    expect(getDayType(sunday)).toBe("sunday");
+  });
+
+  it("returns weekday for all weekdays (Mon-Fri)", () => {
+    // Jan 15-19, 2024 are Mon-Fri
+    const weekdays = [
+      new Date("2024-01-15"), // Mon
+      new Date("2024-01-16"), // Tue
+      new Date("2024-01-17"), // Wed
+      new Date("2024-01-18"), // Thu
+      new Date("2024-01-19"), // Fri
+    ];
+
+    weekdays.forEach((day) => {
+      expect(getDayType(day)).toBe("weekday");
+    });
+  });
+});
+
+describe("hashLocation", () => {
+  it("rounds coordinates to 3 decimal places", () => {
+    const coords = { latitude: 47.37686, longitude: 8.541694 };
+    const hash = hashLocation(coords);
+    expect(hash).toBe("47.377,8.542");
+  });
+
+  it("handles negative coordinates", () => {
+    const coords = { latitude: -33.8688, longitude: 151.2093 };
+    const hash = hashLocation(coords);
+    expect(hash).toBe("-33.869,151.209");
+  });
+
+  it("produces same hash for nearby locations (~100m precision)", () => {
+    const location1 = { latitude: 47.3768, longitude: 8.5416 };
+    const location2 = { latitude: 47.3769, longitude: 8.5417 }; // ~10m away
+
+    expect(hashLocation(location1)).toBe(hashLocation(location2));
+  });
+
+  it("produces different hashes for distant locations", () => {
+    const zurich = { latitude: 47.3769, longitude: 8.5417 };
+    const bern = { latitude: 46.948, longitude: 7.4474 };
+
+    expect(hashLocation(zurich)).not.toBe(hashLocation(bern));
+  });
+});
+
+describe("getHallCacheKey", () => {
+  it("returns hallId when provided", () => {
+    const result = getHallCacheKey("hall-123", {
+      latitude: 47.3769,
+      longitude: 8.5417,
+    });
+    expect(result).toBe("hall-123");
+  });
+
+  it("returns coordinate hash when no hallId", () => {
+    const coords = { latitude: 47.3769, longitude: 8.5417 };
+    const result = getHallCacheKey(undefined, coords);
+    expect(result).toBe("coords:47.377,8.542");
+  });
+
+  it("returns null when neither hallId nor coords provided", () => {
+    const result = getHallCacheKey(undefined, null);
+    expect(result).toBeNull();
+  });
+
+  it("prefers hallId over coordinates", () => {
+    const coords = { latitude: 47.3769, longitude: 8.5417 };
+    const result = getHallCacheKey("hall-456", coords);
+    expect(result).toBe("hall-456");
+  });
+});

--- a/web-app/src/services/transport/cache.ts
+++ b/web-app/src/services/transport/cache.ts
@@ -1,17 +1,47 @@
 /**
  * Travel time cache utilities.
+ *
+ * Swiss public transport schedules are stable within day types:
+ * - Weekdays (Mon-Fri): Same schedule
+ * - Saturday: Different schedule
+ * - Sunday/holidays: Different schedule
+ *
+ * We use day type in cache keys to reuse calculations across similar days.
  */
 
 import type { Coordinates } from "./types";
 
-/** Cache TTL: 7 days in milliseconds */
-export const TRAVEL_TIME_CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
+/** Day types for Swiss public transport schedules */
+export type DayType = "weekday" | "saturday" | "sunday";
 
-/** Cache stale time: 7 days (TanStack Query config) */
+/** Cache TTL: 30 days in milliseconds */
+export const TRAVEL_TIME_CACHE_TTL = 30 * 24 * 60 * 60 * 1000;
+
+/** Cache stale time: 30 days (TanStack Query config) */
 export const TRAVEL_TIME_STALE_TIME = TRAVEL_TIME_CACHE_TTL;
 
 /** Garbage collection time: same as TTL */
 export const TRAVEL_TIME_GC_TIME = TRAVEL_TIME_CACHE_TTL;
+
+/** LocalStorage key for persisted travel time cache */
+export const TRAVEL_TIME_STORAGE_KEY = "volleykit-travel-time-cache";
+
+/**
+ * Get the day type for a given date.
+ * Swiss public transport uses the same schedules for:
+ * - Weekdays (Monday-Friday)
+ * - Saturday
+ * - Sunday (and holidays, though we don't track holidays)
+ *
+ * @param date Date to check (defaults to today)
+ * @returns Day type: "weekday", "saturday", or "sunday"
+ */
+export function getDayType(date: Date = new Date()): DayType {
+  const day = date.getDay();
+  if (day === 0) return "sunday";
+  if (day === 6) return "saturday";
+  return "weekday";
+}
 
 /**
  * Hash a location to create a cache key component.

--- a/web-app/src/services/transport/index.ts
+++ b/web-app/src/services/transport/index.ts
@@ -16,10 +16,23 @@ export { calculateTravelTime, isOjpConfigured } from "./ojp-client";
 
 export { calculateMockTravelTime, mockTransportApi } from "./mock-transport";
 
+export type { DayType } from "./cache";
+
 export {
   TRAVEL_TIME_CACHE_TTL,
   TRAVEL_TIME_STALE_TIME,
   TRAVEL_TIME_GC_TIME,
+  TRAVEL_TIME_STORAGE_KEY,
   getHallCacheKey,
   hashLocation,
+  getDayType,
 } from "./cache";
+
+export {
+  getCachedTravelTime,
+  setCachedTravelTime,
+  removeCachedTravelTime,
+  clearTravelTimeCache,
+  getTravelTimeCacheStats,
+  buildCacheKey,
+} from "./persistence";

--- a/web-app/src/services/transport/persistence.test.ts
+++ b/web-app/src/services/transport/persistence.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  getCachedTravelTime,
+  setCachedTravelTime,
+  removeCachedTravelTime,
+  clearTravelTimeCache,
+  getTravelTimeCacheStats,
+  buildCacheKey,
+} from "./persistence";
+import { TRAVEL_TIME_STORAGE_KEY, TRAVEL_TIME_CACHE_TTL } from "./cache";
+import type { TravelTimeResult } from "./types";
+
+describe("persistence", () => {
+  const mockResult: TravelTimeResult = {
+    durationMinutes: 45,
+    departureTime: "2024-01-15T09:00:00Z",
+    arrivalTime: "2024-01-15T09:45:00Z",
+    transfers: 1,
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T10:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("buildCacheKey", () => {
+    it("builds key from hallId, homeLocationHash, and dayType", () => {
+      const key = buildCacheKey("hall-123", "47.377,8.542", "weekday");
+      expect(key).toBe("hall-123:47.377,8.542:weekday");
+    });
+
+    it("builds different keys for different day types", () => {
+      const weekdayKey = buildCacheKey("hall-123", "47.377,8.542", "weekday");
+      const saturdayKey = buildCacheKey("hall-123", "47.377,8.542", "saturday");
+      const sundayKey = buildCacheKey("hall-123", "47.377,8.542", "sunday");
+
+      expect(weekdayKey).not.toBe(saturdayKey);
+      expect(saturdayKey).not.toBe(sundayKey);
+      expect(weekdayKey).not.toBe(sundayKey);
+    });
+  });
+
+  describe("setCachedTravelTime and getCachedTravelTime", () => {
+    it("stores and retrieves travel time result", () => {
+      setCachedTravelTime("hall-123", "47.377,8.542", "weekday", mockResult);
+      const cached = getCachedTravelTime("hall-123", "47.377,8.542", "weekday");
+
+      expect(cached).toEqual(mockResult);
+    });
+
+    it("returns null for non-existent entries", () => {
+      const cached = getCachedTravelTime("nonexistent", "47.377,8.542", "weekday");
+      expect(cached).toBeNull();
+    });
+
+    it("stores different results for different day types", () => {
+      const weekdayResult = { ...mockResult, durationMinutes: 45 };
+      const saturdayResult = { ...mockResult, durationMinutes: 60 };
+
+      setCachedTravelTime("hall-123", "47.377,8.542", "weekday", weekdayResult);
+      setCachedTravelTime("hall-123", "47.377,8.542", "saturday", saturdayResult);
+
+      expect(
+        getCachedTravelTime("hall-123", "47.377,8.542", "weekday")?.durationMinutes,
+      ).toBe(45);
+      expect(
+        getCachedTravelTime("hall-123", "47.377,8.542", "saturday")?.durationMinutes,
+      ).toBe(60);
+    });
+
+    it("returns null for expired entries", () => {
+      setCachedTravelTime("hall-123", "47.377,8.542", "weekday", mockResult);
+
+      // Advance time past TTL
+      vi.advanceTimersByTime(TRAVEL_TIME_CACHE_TTL + 1000);
+
+      const cached = getCachedTravelTime("hall-123", "47.377,8.542", "weekday");
+      expect(cached).toBeNull();
+    });
+
+    it("returns valid entries before TTL expires", () => {
+      setCachedTravelTime("hall-123", "47.377,8.542", "weekday", mockResult);
+
+      // Advance time to just before TTL
+      vi.advanceTimersByTime(TRAVEL_TIME_CACHE_TTL - 1000);
+
+      const cached = getCachedTravelTime("hall-123", "47.377,8.542", "weekday");
+      expect(cached).toEqual(mockResult);
+    });
+  });
+
+  describe("removeCachedTravelTime", () => {
+    it("removes a specific cached entry", () => {
+      setCachedTravelTime("hall-123", "47.377,8.542", "weekday", mockResult);
+      setCachedTravelTime("hall-456", "47.377,8.542", "weekday", mockResult);
+
+      removeCachedTravelTime("hall-123", "47.377,8.542", "weekday");
+
+      expect(getCachedTravelTime("hall-123", "47.377,8.542", "weekday")).toBeNull();
+      expect(getCachedTravelTime("hall-456", "47.377,8.542", "weekday")).toEqual(
+        mockResult,
+      );
+    });
+  });
+
+  describe("clearTravelTimeCache", () => {
+    it("removes all cached entries", () => {
+      setCachedTravelTime("hall-123", "47.377,8.542", "weekday", mockResult);
+      setCachedTravelTime("hall-456", "47.377,8.542", "saturday", mockResult);
+
+      clearTravelTimeCache();
+
+      expect(getCachedTravelTime("hall-123", "47.377,8.542", "weekday")).toBeNull();
+      expect(getCachedTravelTime("hall-456", "47.377,8.542", "saturday")).toBeNull();
+    });
+  });
+
+  describe("getTravelTimeCacheStats", () => {
+    it("returns zero entries for empty cache", () => {
+      const stats = getTravelTimeCacheStats();
+      expect(stats.entryCount).toBe(0);
+      expect(stats.oldestEntryAge).toBeNull();
+    });
+
+    it("returns correct entry count", () => {
+      setCachedTravelTime("hall-123", "47.377,8.542", "weekday", mockResult);
+      setCachedTravelTime("hall-456", "47.377,8.542", "saturday", mockResult);
+      setCachedTravelTime("hall-789", "47.377,8.542", "sunday", mockResult);
+
+      const stats = getTravelTimeCacheStats();
+      expect(stats.entryCount).toBe(3);
+    });
+
+    it("returns oldest entry age", () => {
+      setCachedTravelTime("hall-123", "47.377,8.542", "weekday", mockResult);
+
+      vi.advanceTimersByTime(5000);
+
+      setCachedTravelTime("hall-456", "47.377,8.542", "saturday", mockResult);
+
+      const stats = getTravelTimeCacheStats();
+      expect(stats.oldestEntryAge).toBe(5000);
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles corrupted localStorage data gracefully", () => {
+      localStorage.setItem(TRAVEL_TIME_STORAGE_KEY, "invalid json");
+
+      const cached = getCachedTravelTime("hall-123", "47.377,8.542", "weekday");
+      expect(cached).toBeNull();
+    });
+
+    it("handles invalid cache structure gracefully", () => {
+      localStorage.setItem(
+        TRAVEL_TIME_STORAGE_KEY,
+        JSON.stringify({ invalid: "structure" }),
+      );
+
+      const cached = getCachedTravelTime("hall-123", "47.377,8.542", "weekday");
+      expect(cached).toBeNull();
+    });
+  });
+});

--- a/web-app/src/services/transport/persistence.ts
+++ b/web-app/src/services/transport/persistence.ts
@@ -1,0 +1,183 @@
+/**
+ * Travel time cache persistence to localStorage.
+ *
+ * Persists travel time results to survive browser sessions.
+ * Uses a dedicated storage key to avoid polluting other cached data.
+ */
+
+import { TRAVEL_TIME_STORAGE_KEY, TRAVEL_TIME_CACHE_TTL } from "./cache";
+import type { TravelTimeResult } from "./types";
+import type { DayType } from "./cache";
+
+interface CachedTravelTime {
+  result: TravelTimeResult;
+  timestamp: number;
+}
+
+interface TravelTimeCache {
+  version: 1;
+  entries: Record<string, CachedTravelTime>;
+}
+
+/**
+ * Build a cache key from the route parameters.
+ */
+export function buildCacheKey(
+  hallId: string,
+  homeLocationHash: string,
+  dayType: DayType,
+): string {
+  return `${hallId}:${homeLocationHash}:${dayType}`;
+}
+
+/**
+ * Load the travel time cache from localStorage.
+ */
+function loadCache(): TravelTimeCache {
+  try {
+    const stored = localStorage.getItem(TRAVEL_TIME_STORAGE_KEY);
+    if (!stored) {
+      return { version: 1, entries: {} };
+    }
+
+    const parsed = JSON.parse(stored) as TravelTimeCache;
+
+    // Validate structure
+    if (parsed.version !== 1 || typeof parsed.entries !== "object") {
+      return { version: 1, entries: {} };
+    }
+
+    return parsed;
+  } catch {
+    return { version: 1, entries: {} };
+  }
+}
+
+/**
+ * Save the travel time cache to localStorage.
+ */
+function saveCache(cache: TravelTimeCache): void {
+  try {
+    localStorage.setItem(TRAVEL_TIME_STORAGE_KEY, JSON.stringify(cache));
+  } catch {
+    // localStorage might be full or disabled - ignore
+  }
+}
+
+/**
+ * Get a cached travel time result.
+ *
+ * @param hallId Sports hall ID
+ * @param homeLocationHash Hashed home location coordinates
+ * @param dayType Day type (weekday/saturday/sunday)
+ * @returns Cached result if valid, null otherwise
+ */
+export function getCachedTravelTime(
+  hallId: string,
+  homeLocationHash: string,
+  dayType: DayType,
+): TravelTimeResult | null {
+  const cache = loadCache();
+  const key = buildCacheKey(hallId, homeLocationHash, dayType);
+  const entry = cache.entries[key];
+
+  if (!entry) {
+    return null;
+  }
+
+  // Check if entry has expired
+  const age = Date.now() - entry.timestamp;
+  if (age > TRAVEL_TIME_CACHE_TTL) {
+    // Entry expired, remove it
+    delete cache.entries[key];
+    saveCache(cache);
+    return null;
+  }
+
+  return entry.result;
+}
+
+/**
+ * Store a travel time result in the persistent cache.
+ *
+ * @param hallId Sports hall ID
+ * @param homeLocationHash Hashed home location coordinates
+ * @param dayType Day type (weekday/saturday/sunday)
+ * @param result Travel time result to cache
+ */
+export function setCachedTravelTime(
+  hallId: string,
+  homeLocationHash: string,
+  dayType: DayType,
+  result: TravelTimeResult,
+): void {
+  const cache = loadCache();
+  const key = buildCacheKey(hallId, homeLocationHash, dayType);
+
+  cache.entries[key] = {
+    result,
+    timestamp: Date.now(),
+  };
+
+  // Clean up expired entries while we're at it
+  const now = Date.now();
+  for (const [entryKey, entry] of Object.entries(cache.entries)) {
+    if (now - entry.timestamp > TRAVEL_TIME_CACHE_TTL) {
+      delete cache.entries[entryKey];
+    }
+  }
+
+  saveCache(cache);
+}
+
+/**
+ * Remove a specific travel time from the cache.
+ *
+ * @param hallId Sports hall ID
+ * @param homeLocationHash Hashed home location coordinates
+ * @param dayType Day type (weekday/saturday/sunday)
+ */
+export function removeCachedTravelTime(
+  hallId: string,
+  homeLocationHash: string,
+  dayType: DayType,
+): void {
+  const cache = loadCache();
+  const key = buildCacheKey(hallId, homeLocationHash, dayType);
+  delete cache.entries[key];
+  saveCache(cache);
+}
+
+/**
+ * Clear all cached travel times.
+ */
+export function clearTravelTimeCache(): void {
+  try {
+    localStorage.removeItem(TRAVEL_TIME_STORAGE_KEY);
+  } catch {
+    // Ignore errors
+  }
+}
+
+/**
+ * Get cache statistics for display in settings.
+ */
+export function getTravelTimeCacheStats(): {
+  entryCount: number;
+  oldestEntryAge: number | null;
+} {
+  const cache = loadCache();
+  const entries = Object.values(cache.entries);
+
+  if (entries.length === 0) {
+    return { entryCount: 0, oldestEntryAge: null };
+  }
+
+  const now = Date.now();
+  const oldestTimestamp = Math.min(...entries.map((e) => e.timestamp));
+
+  return {
+    entryCount: entries.length,
+    oldestEntryAge: now - oldestTimestamp,
+  };
+}


### PR DESCRIPTION
Cache travel times by day type (weekday/saturday/sunday) since Swiss
public transport schedules are stable within each day type. This reduces
API calls by reusing calculations across similar days.

Changes:
- Add day type (weekday/saturday/sunday) to cache key
- Extend cache TTL from 7 days to 30 days
- Persist travel time cache to localStorage (survives browser sessions)
- Add UI to view cache stats and manually clear cached routes
- Add translations for cache management in all 4 languages