### PR TITLE
feat(transport): select optimal OJP connection based on target arrival time

### DIFF
--- a/web-app/src/hooks/useTravelTime.test.tsx
+++ b/web-app/src/hooks/useTravelTime.test.tsx
@@ -232,6 +232,7 @@ describe("useTravelTime", () => {
       expect(calculateTravelTime).toHaveBeenCalledWith(
         { latitude: mockHomeLocation.latitude, longitude: mockHomeLocation.longitude },
         mockHallCoords,
+        { targetArrivalTime: undefined },
       );
       expect(result.current.data?.durationMinutes).toBe(75);
     });

--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -29,6 +29,8 @@ import {
 interface UseTravelTimeOptions {
   /** Date for the journey (used to determine day type). Defaults to today. */
   date?: Date;
+  /** Target arrival time - selects connection arriving closest to this time without being late */
+  targetArrivalTime?: Date;
 }
 
 /**
@@ -45,7 +47,7 @@ export function useTravelTime(
   hallCoords: Coordinates | null,
   options: UseTravelTimeOptions = {},
 ) {
-  const { date } = options;
+  const { date, targetArrivalTime } = options;
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
   const homeLocation = useSettingsStore((state) => state.homeLocation);
   const transportEnabled = useSettingsStore((state) => state.transportEnabled);
@@ -99,7 +101,9 @@ export function useTravelTime(
       if (isDemoMode) {
         result = await calculateMockTravelTime(fromCoords, hallCoords);
       } else {
-        result = await calculateTravelTime(fromCoords, hallCoords);
+        result = await calculateTravelTime(fromCoords, hallCoords, {
+          targetArrivalTime,
+        });
       }
 
       // Persist successful result to localStorage

--- a/web-app/src/services/transport/index.ts
+++ b/web-app/src/services/transport/index.ts
@@ -12,7 +12,9 @@ export type {
 
 export { TransportApiError } from "./types";
 
-export { calculateTravelTime, isOjpConfigured } from "./ojp-client";
+export { calculateTravelTime, isOjpConfigured, selectBestTrip } from "./ojp-client";
+
+export type { OjpTrip } from "./ojp-client";
 
 export { calculateMockTravelTime, mockTransportApi } from "./mock-transport";
 

--- a/web-app/src/services/transport/ojp-client.test.ts
+++ b/web-app/src/services/transport/ojp-client.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for OJP client functions.
+ */
+
+import { describe, it, expect } from "vitest";
+import { selectBestTrip, type OjpTrip } from "./ojp-client";
+
+describe("selectBestTrip", () => {
+  // Helper to create trip objects
+  const createTrip = (
+    endTime: string,
+    transfers: number,
+    duration = "PT1H",
+    startTime = "2025-01-15T12:00:00Z",
+  ): OjpTrip => ({
+    duration,
+    startTime,
+    endTime,
+    transfers,
+  });
+
+  describe("without target arrival time", () => {
+    it("returns the first trip (earliest departure)", () => {
+      const trips: OjpTrip[] = [
+        createTrip("2025-01-15T13:00:00Z", 1),
+        createTrip("2025-01-15T13:30:00Z", 0),
+        createTrip("2025-01-15T14:00:00Z", 2),
+      ];
+
+      const result = selectBestTrip(trips);
+
+      expect(result).toBe(trips[0]);
+    });
+  });
+
+  describe("with target arrival time", () => {
+    const targetArrivalTime = new Date("2025-01-15T14:00:00Z");
+
+    it("filters out trips that arrive after target", () => {
+      const trips: OjpTrip[] = [
+        createTrip("2025-01-15T14:30:00Z", 0), // Too late
+        createTrip("2025-01-15T13:45:00Z", 1), // On time
+        createTrip("2025-01-15T15:00:00Z", 0), // Too late
+      ];
+
+      const result = selectBestTrip(trips, targetArrivalTime);
+
+      expect(result.endTime).toBe("2025-01-15T13:45:00Z");
+    });
+
+    it("prefers fewer transfers over arrival time proximity", () => {
+      const trips: OjpTrip[] = [
+        createTrip("2025-01-15T13:55:00Z", 2), // On time, 2 transfers, closest to target
+        createTrip("2025-01-15T13:30:00Z", 0), // On time, 0 transfers, further from target
+        createTrip("2025-01-15T13:45:00Z", 1), // On time, 1 transfer
+      ];
+
+      const result = selectBestTrip(trips, targetArrivalTime);
+
+      // Should prefer 0 transfers even though it arrives earlier
+      expect(result.transfers).toBe(0);
+      expect(result.endTime).toBe("2025-01-15T13:30:00Z");
+    });
+
+    it("with equal transfers, prefers arrival closest to target", () => {
+      const trips: OjpTrip[] = [
+        createTrip("2025-01-15T13:00:00Z", 1), // On time, 1 transfer, early
+        createTrip("2025-01-15T13:45:00Z", 1), // On time, 1 transfer, closer to target
+        createTrip("2025-01-15T13:30:00Z", 1), // On time, 1 transfer, in between
+      ];
+
+      const result = selectBestTrip(trips, targetArrivalTime);
+
+      // Should prefer the trip arriving at 13:45 (closest to 14:00 target)
+      expect(result.endTime).toBe("2025-01-15T13:45:00Z");
+    });
+
+    it("returns first trip if no trips arrive on time", () => {
+      const trips: OjpTrip[] = [
+        createTrip("2025-01-15T14:15:00Z", 0), // Late
+        createTrip("2025-01-15T14:30:00Z", 1), // Later
+        createTrip("2025-01-15T15:00:00Z", 0), // Even later
+      ];
+
+      const result = selectBestTrip(trips, targetArrivalTime);
+
+      // Falls back to first trip
+      expect(result).toBe(trips[0]);
+    });
+
+    it("includes trips arriving exactly at target time", () => {
+      const trips: OjpTrip[] = [
+        createTrip("2025-01-15T14:00:00Z", 1), // Exactly on time
+        createTrip("2025-01-15T13:30:00Z", 0), // Early
+      ];
+
+      const result = selectBestTrip(trips, targetArrivalTime);
+
+      // 0 transfers wins
+      expect(result.transfers).toBe(0);
+    });
+
+    it("handles complex scenario with multiple criteria", () => {
+      const trips: OjpTrip[] = [
+        createTrip("2025-01-15T13:00:00Z", 2), // On time, 2 transfers
+        createTrip("2025-01-15T14:30:00Z", 0), // Late, 0 transfers
+        createTrip("2025-01-15T13:50:00Z", 1), // On time, 1 transfer, close to target
+        createTrip("2025-01-15T13:30:00Z", 1), // On time, 1 transfer, earlier
+        createTrip("2025-01-15T13:45:00Z", 0), // On time, 0 transfers
+      ];
+
+      const result = selectBestTrip(trips, targetArrivalTime);
+
+      // Should select: 0 transfers, arrives at 13:45 (only on-time trip with 0 transfers)
+      expect(result.transfers).toBe(0);
+      expect(result.endTime).toBe("2025-01-15T13:45:00Z");
+    });
+  });
+});

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -128,8 +128,12 @@ export async function calculateTravelTime(
   }
 }
 
-/** Trip type from OJP SDK */
-interface OjpTrip {
+/**
+ * Subset of trip properties from ojp-sdk-next used for connection selection.
+ * Defined locally to avoid coupling to SDK internals and to type only what we need.
+ * If the SDK's Trip type changes, this interface should be updated accordingly.
+ */
+export interface OjpTrip {
   duration: string;
   startTime: string;
   endTime: string;
@@ -150,7 +154,7 @@ interface OjpTrip {
  * @param targetArrivalTime Optional target arrival time
  * @returns The best trip for the given criteria
  */
-function selectBestTrip(trips: OjpTrip[], targetArrivalTime?: Date): OjpTrip {
+export function selectBestTrip(trips: OjpTrip[], targetArrivalTime?: Date): OjpTrip {
   // If no target time, return first trip (earliest departure)
   if (!targetArrivalTime) {
     return trips[0]!;

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -104,8 +104,8 @@ export async function calculateTravelTime(
       throw new TransportApiError("No route found between locations", "NO_ROUTE");
     }
 
-    // Get the first (fastest) trip - safe access after length check
-    const trip = trips[0]!;
+    // Select the best trip based on target arrival time or take earliest departure
+    const trip = selectBestTrip(trips, options.targetArrivalTime);
 
     // Parse duration from ISO 8601 duration string (e.g., "PT1H30M")
     const durationMinutes = parseDurationToMinutes(trip.duration);
@@ -126,6 +126,63 @@ export async function calculateTravelTime(
     const message = error instanceof Error ? error.message : "Unknown transport API error";
     throw new TransportApiError(message, "API_ERROR");
   }
+}
+
+/** Trip type from OJP SDK */
+interface OjpTrip {
+  duration: string;
+  startTime: string;
+  endTime: string;
+  transfers: number;
+}
+
+/**
+ * Select the best trip based on target arrival time.
+ *
+ * Selection criteria (in priority order):
+ * 1. Must arrive on time (before or at target arrival time)
+ * 2. Prefer fewer transfers (less stressful journey)
+ * 3. Prefer arrival closest to target time (minimize waiting)
+ *
+ * If no targetArrivalTime is provided, returns the first trip (earliest departure).
+ *
+ * @param trips Array of trips from OJP API
+ * @param targetArrivalTime Optional target arrival time
+ * @returns The best trip for the given criteria
+ */
+function selectBestTrip(trips: OjpTrip[], targetArrivalTime?: Date): OjpTrip {
+  // If no target time, return first trip (earliest departure)
+  if (!targetArrivalTime) {
+    return trips[0]!;
+  }
+
+  const targetTime = targetArrivalTime.getTime();
+
+  // Find trips that arrive on time (before or at target)
+  const onTimeTrips = trips.filter((trip) => {
+    const arrivalTime = new Date(trip.endTime).getTime();
+    return arrivalTime <= targetTime;
+  });
+
+  // If no trips arrive on time, return the first trip (earliest arrival)
+  if (onTimeTrips.length === 0) {
+    return trips[0]!;
+  }
+
+  // Select best trip: fewer transfers first, then closest arrival to target
+  return onTimeTrips.reduce((best, trip) => {
+    // Prefer fewer transfers
+    if (trip.transfers < best.transfers) {
+      return trip;
+    }
+    if (trip.transfers > best.transfers) {
+      return best;
+    }
+    // Same transfers: prefer later arrival (closer to target time)
+    const bestArrival = new Date(best.endTime).getTime();
+    const tripArrival = new Date(trip.endTime).getTime();
+    return tripArrival > bestArrival ? trip : best;
+  });
 }
 
 /**

--- a/web-app/src/services/transport/types.ts
+++ b/web-app/src/services/transport/types.ts
@@ -25,6 +25,8 @@ export interface TravelTimeResult {
 export interface TravelTimeOptions {
   /** Desired departure time (defaults to now) */
   departureTime?: Date;
+  /** Target arrival time - selects connection arriving closest to this time without being late */
+  targetArrivalTime?: Date;
   /** Include raw trip data in result (for future itinerary display) */
   includeTrips?: boolean;
 }

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -38,6 +38,8 @@ export interface TravelTimeFilter {
   enabled: boolean;
   /** Maximum travel time in minutes */
   maxTravelTimeMinutes: number;
+  /** Minutes before game start to arrive (buffer time) */
+  arrivalBufferMinutes: number;
   /** Timestamp when cache was last invalidated (home location change) */
   cacheInvalidatedAt: number | null;
 }
@@ -64,6 +66,7 @@ interface SettingsState {
   travelTimeFilter: TravelTimeFilter;
   setTravelTimeFilterEnabled: (enabled: boolean) => void;
   setMaxTravelTimeMinutes: (minutes: number) => void;
+  setArrivalBufferMinutes: (minutes: number) => void;
   invalidateTravelTimeCache: () => void;
 
   // Reset all settings to defaults (keeps safe mode)
@@ -73,8 +76,11 @@ interface SettingsState {
 /** Default max distance in kilometers */
 const DEFAULT_MAX_DISTANCE_KM = 50;
 
-/** Default max travel time in minutes */
-const DEFAULT_MAX_TRAVEL_TIME_MINUTES = 60;
+/** Default max travel time in minutes (2 hours) */
+const DEFAULT_MAX_TRAVEL_TIME_MINUTES = 120;
+
+/** Default arrival buffer (minutes before game start) */
+const DEFAULT_ARRIVAL_BUFFER_MINUTES = 30;
 
 /**
  * Demo mode default location: Zurich main station area.
@@ -100,6 +106,7 @@ export const useSettingsStore = create<SettingsState>()(
       travelTimeFilter: {
         enabled: false,
         maxTravelTimeMinutes: DEFAULT_MAX_TRAVEL_TIME_MINUTES,
+        arrivalBufferMinutes: DEFAULT_ARRIVAL_BUFFER_MINUTES,
         cacheInvalidatedAt: null,
       },
 
@@ -146,6 +153,12 @@ export const useSettingsStore = create<SettingsState>()(
         }));
       },
 
+      setArrivalBufferMinutes: (minutes: number) => {
+        set((state) => ({
+          travelTimeFilter: { ...state.travelTimeFilter, arrivalBufferMinutes: minutes },
+        }));
+      },
+
       invalidateTravelTimeCache: () => {
         set((state) => ({
           travelTimeFilter: {
@@ -168,6 +181,7 @@ export const useSettingsStore = create<SettingsState>()(
           travelTimeFilter: {
             enabled: false,
             maxTravelTimeMinutes: DEFAULT_MAX_TRAVEL_TIME_MINUTES,
+            arrivalBufferMinutes: DEFAULT_ARRIVAL_BUFFER_MINUTES,
             cacheInvalidatedAt: null,
           },
         });


### PR DESCRIPTION
When multiple connections are returned by the OJP API, now selects the
best trip using these criteria (in priority order):
1. Must arrive on time (before or at target arrival time)
2. Prefer fewer transfers (less stressful journey)
3. Prefer arrival closest to target time (minimize waiting)

Previously just took the first connection (earliest departure).