### PR TITLE
refactor(exchange): reorder badges to show distance before travel time

### DIFF
--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -100,19 +100,19 @@ function ExchangeCardComponent({
           {/* Distance and travel time badges */}
           {(distanceKm != null || travelTimeMinutes !== undefined || travelTimeLoading) && (
             <div className="flex items-center gap-1 shrink-0">
-              {/* Travel time badge */}
-              {(travelTimeMinutes !== undefined || travelTimeLoading) && (
-                <TravelTimeBadge
-                  durationMinutes={travelTimeMinutes ?? undefined}
-                  isLoading={travelTimeLoading}
-                />
-              )}
               {/* Distance badge */}
               {distanceKm != null && (
                 <span className="text-xs font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 px-2 py-0.5 rounded-full flex items-center gap-1">
                   <Home className="w-3 h-3" aria-hidden="true" />
                   {distanceKm.toFixed(0)} {t("common.distanceUnit")}
                 </span>
+              )}
+              {/* Travel time badge */}
+              {(travelTimeMinutes !== undefined || travelTimeLoading) && (
+                <TravelTimeBadge
+                  durationMinutes={travelTimeMinutes ?? undefined}
+                  isLoading={travelTimeLoading}
+                />
               )}
             </div>
           )}

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -99,7 +99,7 @@ function ExchangeCardComponent({
 
           {/* Distance and travel time badges */}
           {(distanceKm != null || travelTimeMinutes !== undefined || travelTimeLoading) && (
-            <div className="flex items-center gap-1 shrink-0">
+            <div className="flex flex-col items-end gap-0.5 shrink-0">
               {/* Distance badge */}
               {distanceKm != null && (
                 <span className="text-xs font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 px-2 py-0.5 rounded-full flex items-center gap-1">


### PR DESCRIPTION
Move the distance badge (km from home) before the public transport
travel time badge for better visual hierarchy in exchange cards.