### PR TITLE
feat(validation): change validate button color for validated games

### DIFF
--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -266,8 +266,30 @@ export const mockApi = {
     const store = useDemoStore.getState();
     const { items, total } = processSearchRequest(store.assignments, config);
 
+    // Enrich assignments with scoresheet.closedAt from validated games
+    const enrichedItems = items.map((assignment) => {
+      const gameId = assignment.refereeGame?.game?.__identity;
+      const validatedData = gameId ? store.validatedGames[gameId] : null;
+
+      if (validatedData && assignment.refereeGame?.game) {
+        return {
+          ...assignment,
+          refereeGame: {
+            ...assignment.refereeGame,
+            game: {
+              ...assignment.refereeGame.game,
+              scoresheet: {
+                closedAt: validatedData.validatedAt,
+              },
+            },
+          },
+        };
+      }
+      return assignment;
+    });
+
     const response = {
-      items: items as Assignment[],
+      items: enrichedItems as Assignment[],
       totalItemsCount: total,
     };
 

--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -45,6 +45,8 @@ export const ASSIGNMENT_PROPERTIES = [
   // Compensation lock flags for editability check
   "convocationCompensation.paymentDone",
   "convocationCompensation.lockPayoutOnSiteCompensation",
+  // Validation status for swipe button color
+  "refereeGame.game.scoresheet.closedAt",
 ];
 
 /**

--- a/web-app/src/utils/assignment-actions.test.ts
+++ b/web-app/src/utils/assignment-actions.test.ts
@@ -81,4 +81,30 @@ describe("createAssignmentActions", () => {
     expect(actions.validateGame.color).toBe("bg-primary-500");
     expect(isValidElement(actions.validateGame.icon)).toBe(true);
   });
+
+  it("should use success color for validate button when game is validated", () => {
+    const validatedAssignment: Assignment = {
+      ...mockAssignment,
+      refereeGame: {
+        ...mockAssignment.refereeGame,
+        game: {
+          ...mockAssignment.refereeGame?.game,
+          scoresheet: {
+            closedAt: "2025-12-15T20:00:00Z",
+          },
+        },
+      },
+    } as Assignment;
+
+    const handlers = {
+      onEditCompensation: vi.fn(),
+      onValidateGame: vi.fn(),
+      onGenerateReport: vi.fn(),
+      onAddToExchange: vi.fn(),
+    };
+
+    const actions = createAssignmentActions(validatedAssignment, handlers);
+
+    expect(actions.validateGame.color).toBe("bg-slate-500");
+  });
 });

--- a/web-app/src/utils/assignment-actions.ts
+++ b/web-app/src/utils/assignment-actions.ts
@@ -40,7 +40,9 @@ export function createAssignmentActions(
       id: "validate-game",
       label: "Validate Game",
       shortLabel: "Validate",
-      color: "bg-primary-500",
+      color: assignment.refereeGame?.game?.scoresheet?.closedAt
+        ? "bg-slate-500"
+        : "bg-primary-500",
       icon: ICON_CHECK,
       onAction: () => handlers.onValidateGame(assignment),
     },


### PR DESCRIPTION
Show already done/view only (gray) on the validate swipe button when a game has
already been validated, following the existing design guidelines for
completed states.

- Add refereeGame.game.scoresheet.closedAt to ASSIGNMENT_PROPERTIES
- Update createAssignmentActions to use bg-success-500 for validated games
- Enrich mock API assignment responses with scoresheet.closedAt
- Add test for validated button color