### PR TITLE
refactor(modals): migrate SafeModeWarningModal from deprecated ModalButton to Button

### DIFF
--- a/web-app/src/components/features/SafeModeWarningModal.tsx
+++ b/web-app/src/components/features/SafeModeWarningModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { Modal } from "@/components/ui/Modal";
 import { ModalHeader } from "@/components/ui/ModalHeader";
 import { ModalFooter } from "@/components/ui/ModalFooter";
-import { ModalButton } from "@/components/ui/ModalButton";
+import { Button } from "@/components/ui/Button";
 
 const MODAL_TITLE_ID = "safe-mode-warning-title";
 
@@ -81,12 +81,12 @@ export function SafeModeWarningModal({
       </div>
 
       <ModalFooter divider>
-        <ModalButton variant="secondary" fullWidth onClick={onClose}>
+        <Button variant="secondary" className="flex-1 rounded-md" onClick={onClose}>
           {t("common.cancel")}
-        </ModalButton>
-        <ModalButton variant="danger" fullWidth onClick={handleConfirm}>
+        </Button>
+        <Button variant="danger" className="flex-1 rounded-md" onClick={handleConfirm}>
           {t("settings.safeModeConfirmButton")}
-        </ModalButton>
+        </Button>
       </ModalFooter>
     </Modal>
   );

--- a/web-app/src/components/ui/ModalFooter.tsx
+++ b/web-app/src/components/ui/ModalFooter.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 interface ModalFooterProps {
-  /** Footer content (typically ModalButton components) */
+  /** Footer content (typically Button components) */
   children: ReactNode;
   /** Whether to show a divider line above the footer */
   divider?: boolean;
@@ -13,12 +13,12 @@ interface ModalFooterProps {
  * @example
  * ```tsx
  * <ModalFooter divider>
- *   <ModalButton variant="secondary" fullWidth onClick={onClose}>
+ *   <Button variant="secondary" className="flex-1 rounded-md" onClick={onClose}>
  *     Cancel
- *   </ModalButton>
- *   <ModalButton variant="primary" fullWidth onClick={onConfirm}>
+ *   </Button>
+ *   <Button variant="primary" className="flex-1 rounded-md" onClick={onConfirm}>
  *     Confirm
- *   </ModalButton>
+ *   </Button>
  * </ModalFooter>
  * ```
  */


### PR DESCRIPTION
Replace ModalButton usage with Button component in SafeModeWarningModal
as part of the ongoing deprecation of ModalButton. Use flex-1 and
rounded-md classes to maintain the same visual appearance.

Also update ModalFooter documentation to reference Button instead of
ModalButton.