### PR TITLE
feat(settings): add per-association arrival time before game setting

### DIFF
--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -30,14 +30,55 @@ function createMockSettingsStore(
   overrides: Partial<ReturnType<typeof useSettingsStore>> = {},
 ) {
   return {
-    homeLocation: { lat: 46.9, lng: 7.4 },
+    // Safe mode
+    isSafeModeEnabled: false,
+    setSafeMode: vi.fn(),
+
+    // Home location
+    homeLocation: {
+      latitude: 46.9,
+      longitude: 7.4,
+      label: "Test Location",
+      source: "manual" as const,
+    },
+    setHomeLocation: vi.fn(),
+
+    // Distance filter
+    distanceFilter: { enabled: false, maxDistanceKm: 50 },
+    setDistanceFilterEnabled: vi.fn(),
+    setMaxDistanceKm: vi.fn(),
+
+    // Transport toggle (legacy global)
     transportEnabled: true,
+    setTransportEnabled: vi.fn(),
+
+    // Per-association transport
     transportEnabledByAssociation: {},
     setTransportEnabledForAssociation: vi.fn(),
+    isTransportEnabledForAssociation: vi.fn().mockReturnValue(true),
+
+    // Travel time filter
     travelTimeFilter: {
+      enabled: false,
+      maxTravelTimeMinutes: 120,
+      arrivalBufferMinutes: 30,
       arrivalBufferByAssociation: {},
+      cacheInvalidatedAt: null,
     },
+    setTravelTimeFilterEnabled: vi.fn(),
+    setMaxTravelTimeMinutes: vi.fn(),
+    setArrivalBufferMinutes: vi.fn(),
     setArrivalBufferForAssociation: vi.fn(),
+    getArrivalBufferForAssociation: vi.fn().mockReturnValue(60),
+    invalidateTravelTimeCache: vi.fn(),
+
+    // Level filter
+    levelFilterEnabled: false,
+    setLevelFilterEnabled: vi.fn(),
+
+    // Reset
+    resetLocationSettings: vi.fn(),
+
     ...overrides,
   };
 }

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { TransportSection } from "./TransportSection";
+import { useSettingsStore } from "@/stores/settings";
+import { useAuthStore } from "@/stores/auth";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Mock the stores
+vi.mock("@/stores/settings", () => ({
+  useSettingsStore: vi.fn(),
+  getDefaultArrivalBuffer: (code: string | undefined) => (code === "SV" ? 60 : 45),
+  MIN_ARRIVAL_BUFFER_MINUTES: 0,
+  MAX_ARRIVAL_BUFFER_MINUTES: 180,
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn(),
+}));
+
+vi.mock("@/hooks/useTravelTime", () => ({
+  useTravelTimeAvailable: () => true,
+}));
+
+vi.mock("@/services/transport", () => ({
+  clearTravelTimeCache: vi.fn(),
+  getTravelTimeCacheStats: () => ({ entryCount: 0 }),
+}));
+
+function createMockSettingsStore(
+  overrides: Partial<ReturnType<typeof useSettingsStore>> = {},
+) {
+  return {
+    homeLocation: { lat: 46.9, lng: 7.4 },
+    transportEnabled: true,
+    transportEnabledByAssociation: {},
+    setTransportEnabledForAssociation: vi.fn(),
+    travelTimeFilter: {
+      arrivalBufferByAssociation: {},
+    },
+    setArrivalBufferForAssociation: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createMockAuthStore(
+  overrides: Partial<ReturnType<typeof useAuthStore>> = {},
+) {
+  return {
+    user: {
+      id: "user-1",
+      firstName: "John",
+      lastName: "Doe",
+      occupations: [{ id: "ref-1", type: "referee", associationCode: "SV" }],
+    },
+    activeOccupationId: "ref-1",
+    status: "authenticated" as const,
+    error: null,
+    csrfToken: null,
+    isDemoMode: false,
+    _checkSessionPromise: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    checkSession: vi.fn(),
+    setUser: vi.fn(),
+    setDemoAuthenticated: vi.fn(),
+    setActiveOccupation: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = createQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe("TransportSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("render stability", () => {
+    it("should not cause infinite render loops when mounting", () => {
+      // Track render count using a counter object
+      const counter = { renders: 0 };
+      function RenderCounter({ children }: { children: React.ReactNode }) {
+        // eslint-disable-next-line react-hooks/immutability -- test counter
+        counter.renders += 1;
+        return <>{children}</>;
+      }
+
+      vi.mocked(useSettingsStore).mockImplementation((selector) => {
+        const state = createMockSettingsStore();
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      vi.mocked(useAuthStore).mockImplementation((selector) => {
+        const state = createMockAuthStore();
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      renderWithProviders(
+        <RenderCounter>
+          <TransportSection />
+        </RenderCounter>,
+      );
+
+      // Component should render a reasonable number of times (initial + effects)
+      // If there's an infinite loop, this would be much higher
+      expect(counter.renders).toBeLessThan(10);
+    });
+
+    it("should not cause infinite loops when store value changes", () => {
+      const counter = { renders: 0 };
+      function RenderCounter({ children }: { children: React.ReactNode }) {
+        // eslint-disable-next-line react-hooks/immutability -- test counter
+        counter.renders += 1;
+        return <>{children}</>;
+      }
+
+      const mockStore = createMockSettingsStore();
+
+      vi.mocked(useSettingsStore).mockImplementation((selector) => {
+        return typeof selector === "function" ? selector(mockStore) : mockStore;
+      });
+
+      vi.mocked(useAuthStore).mockImplementation((selector) => {
+        const state = createMockAuthStore();
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      const { rerender } = renderWithProviders(
+        <RenderCounter>
+          <TransportSection />
+        </RenderCounter>,
+      );
+
+      const initialRenderCount = counter.renders;
+
+      // Simulate store update by re-rendering with new value
+      mockStore.travelTimeFilter.arrivalBufferByAssociation = { SV: 90 };
+
+      act(() => {
+        rerender(
+          <QueryClientProvider client={createQueryClient()}>
+            <RenderCounter>
+              <TransportSection />
+            </RenderCounter>
+          </QueryClientProvider>,
+        );
+      });
+
+      // Should only add a few more renders, not explode
+      expect(counter.renders - initialRenderCount).toBeLessThan(5);
+    });
+
+    it("should handle hydration-like scenario without infinite loops", () => {
+      // Simulate the hydration scenario where arrivalBufferByAssociation
+      // starts undefined and then gets populated
+      const counter = { renders: 0 };
+      function RenderCounter({ children }: { children: React.ReactNode }) {
+        // eslint-disable-next-line react-hooks/immutability -- test counter
+        counter.renders += 1;
+        return <>{children}</>;
+      }
+
+      // First render: no per-association settings (simulates pre-hydration)
+      const mockStore = createMockSettingsStore({
+        travelTimeFilter: {
+          arrivalBufferByAssociation: {},
+        },
+      });
+
+      vi.mocked(useSettingsStore).mockImplementation((selector) => {
+        return typeof selector === "function" ? selector(mockStore) : mockStore;
+      });
+
+      vi.mocked(useAuthStore).mockImplementation((selector) => {
+        const state = createMockAuthStore();
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      const { rerender } = renderWithProviders(
+        <RenderCounter>
+          <TransportSection />
+        </RenderCounter>,
+      );
+
+      const preHydrationCount = counter.renders;
+
+      // Simulate hydration: arrivalBufferByAssociation now has a value
+      mockStore.travelTimeFilter.arrivalBufferByAssociation = { SV: 60 };
+
+      act(() => {
+        rerender(
+          <QueryClientProvider client={createQueryClient()}>
+            <RenderCounter>
+              <TransportSection />
+            </RenderCounter>
+          </QueryClientProvider>,
+        );
+      });
+
+      // Total renders should be bounded
+      expect(counter.renders).toBeLessThan(15);
+      // The hydration step shouldn't cause excessive re-renders
+      expect(counter.renders - preHydrationCount).toBeLessThan(5);
+    });
+  });
+
+  describe("arrival buffer input", () => {
+    it("should render arrival time input when transport is enabled", () => {
+      vi.mocked(useSettingsStore).mockImplementation((selector) => {
+        const state = createMockSettingsStore({
+          transportEnabledByAssociation: { SV: true },
+        });
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      vi.mocked(useAuthStore).mockImplementation((selector) => {
+        const state = createMockAuthStore();
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      renderWithProviders(<TransportSection />);
+
+      expect(
+        screen.getByLabelText("Arrive before game"),
+      ).toBeInTheDocument();
+    });
+
+    it("should not render arrival time input when transport is disabled", () => {
+      vi.mocked(useSettingsStore).mockImplementation((selector) => {
+        const state = createMockSettingsStore({
+          transportEnabled: false,
+          transportEnabledByAssociation: { SV: false },
+        });
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      vi.mocked(useAuthStore).mockImplementation((selector) => {
+        const state = createMockAuthStore();
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      renderWithProviders(<TransportSection />);
+
+      expect(
+        screen.queryByLabelText("Arrive before game"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should debounce store updates when typing", async () => {
+      vi.useFakeTimers();
+      const setArrivalBufferForAssociation = vi.fn();
+
+      vi.mocked(useSettingsStore).mockImplementation((selector) => {
+        const state = createMockSettingsStore({
+          transportEnabledByAssociation: { SV: true },
+          setArrivalBufferForAssociation,
+        });
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      vi.mocked(useAuthStore).mockImplementation((selector) => {
+        const state = createMockAuthStore();
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      renderWithProviders(<TransportSection />);
+
+      const input = screen.getByLabelText("Arrive before game");
+
+      // Type multiple characters quickly
+      fireEvent.change(input, { target: { value: "9" } });
+      fireEvent.change(input, { target: { value: "90" } });
+
+      // Store should not be called yet (debounced)
+      expect(setArrivalBufferForAssociation).not.toHaveBeenCalled();
+
+      // Advance past debounce delay
+      act(() => {
+        vi.advanceTimersByTime(350);
+      });
+
+      // Now store should be called with final value
+      expect(setArrivalBufferForAssociation).toHaveBeenCalledTimes(1);
+      expect(setArrivalBufferForAssociation).toHaveBeenCalledWith("SV", 90);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("association badge", () => {
+    it("should display association code badge", () => {
+      vi.mocked(useSettingsStore).mockImplementation((selector) => {
+        const state = createMockSettingsStore({
+          transportEnabledByAssociation: { SV: true },
+        });
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      vi.mocked(useAuthStore).mockImplementation((selector) => {
+        const state = createMockAuthStore();
+        return typeof selector === "function" ? selector(state) : state;
+      });
+
+      renderWithProviders(<TransportSection />);
+
+      // Should show SV badge (association code from mock user)
+      expect(screen.getAllByText("SV").length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -91,7 +91,9 @@ function createMockAuthStore(
       id: "user-1",
       firstName: "John",
       lastName: "Doe",
-      occupations: [{ id: "ref-1", type: "referee", associationCode: "SV" }],
+      occupations: [
+        { id: "ref-1", type: "referee" as const, associationCode: "SV" },
+      ],
     },
     activeOccupationId: "ref-1",
     status: "authenticated" as const,

--- a/web-app/src/components/features/settings/TransportSection.tsx
+++ b/web-app/src/components/features/settings/TransportSection.tsx
@@ -26,6 +26,9 @@ function AssociationBadge({ code }: { code: string }) {
   );
 }
 
+/** Debounce delay for arrival buffer input to reduce localStorage writes */
+const ARRIVAL_BUFFER_DEBOUNCE_MS = 300;
+
 function TransportSectionComponent() {
   const { t, tInterpolate } = useTranslation();
   const isAvailable = useTravelTimeAvailable();
@@ -126,7 +129,7 @@ function TransportSectionComponent() {
         }
         debounceRef.current = setTimeout(() => {
           setArrivalBufferForAssociation(associationCode, value);
-        }, 300);
+        }, ARRIVAL_BUFFER_DEBOUNCE_MS);
       }
     },
     [associationCode, setArrivalBufferForAssociation],

--- a/web-app/src/components/tour/definitions/settings.ts
+++ b/web-app/src/components/tour/definitions/settings.ts
@@ -20,6 +20,14 @@ export const settingsTour: TourDefinition = {
       completionEvent: { type: "click" },
     },
     {
+      id: "arrivalTime",
+      targetSelector: "[data-tour='arrival-time']",
+      titleKey: "tour.settings.arrivalTime.title",
+      descriptionKey: "tour.settings.arrivalTime.description",
+      placement: "bottom",
+      completionEvent: { type: "click" },
+    },
+    {
       id: "complete",
       targetSelector: "[data-tour='tour-reset']",
       titleKey: "tour.settings.complete.title",

--- a/web-app/src/hooks/useActiveAssociation.ts
+++ b/web-app/src/hooks/useActiveAssociation.ts
@@ -1,0 +1,24 @@
+/**
+ * Hook to get the active association code from the current user session.
+ */
+
+import { useAuthStore } from "@/stores/auth";
+
+/**
+ * Returns the association code of the currently active occupation.
+ * Falls back to the first occupation if no active occupation is set.
+ *
+ * @returns The association code (e.g., "SV", "SVRBA") or undefined if not available
+ */
+export function useActiveAssociationCode(): string | undefined {
+  const { user, activeOccupationId } = useAuthStore((state) => ({
+    user: state.user,
+    activeOccupationId: state.activeOccupationId,
+  }));
+
+  const activeOccupation =
+    user?.occupations?.find((o) => o.id === activeOccupationId) ??
+    user?.occupations?.[0];
+
+  return activeOccupation?.associationCode;
+}

--- a/web-app/src/hooks/useActiveAssociation.ts
+++ b/web-app/src/hooks/useActiveAssociation.ts
@@ -2,6 +2,7 @@
  * Hook to get the active association code from the current user session.
  */
 
+import { useShallow } from "zustand/react/shallow";
 import { useAuthStore } from "@/stores/auth";
 
 /**
@@ -11,10 +12,13 @@ import { useAuthStore } from "@/stores/auth";
  * @returns The association code (e.g., "SV", "SVRBA") or undefined if not available
  */
 export function useActiveAssociationCode(): string | undefined {
-  const { user, activeOccupationId } = useAuthStore((state) => ({
-    user: state.user,
-    activeOccupationId: state.activeOccupationId,
-  }));
+  // Use useShallow to prevent infinite re-renders from object selector
+  const { user, activeOccupationId } = useAuthStore(
+    useShallow((state) => ({
+      user: state.user,
+      activeOccupationId: state.activeOccupationId,
+    })),
+  );
 
   const activeOccupation =
     user?.occupations?.find((o) => o.id === activeOccupationId) ??

--- a/web-app/src/hooks/useTravelTime.test.tsx
+++ b/web-app/src/hooks/useTravelTime.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@/services/transport", () => ({
 // Mock the stores - using AnyFunction to avoid strict type checking in tests
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector: AnyFunction) =>
-    selector({ isDemoMode: false }),
+    selector({ isDemoMode: false, user: null, activeOccupationId: null }),
   ),
 }));
 
@@ -34,6 +34,7 @@ vi.mock("@/stores/settings", () => ({
     selector({
       homeLocation: null,
       transportEnabled: false,
+      isTransportEnabledForAssociation: () => false,
     }),
   ),
 }));
@@ -87,6 +88,7 @@ describe("useTravelTime", () => {
         selector({
           homeLocation: mockHomeLocation,
           transportEnabled: false,
+          isTransportEnabledForAssociation: () => false,
         }),
       );
 
@@ -108,6 +110,7 @@ describe("useTravelTime", () => {
         selector({
           homeLocation: null,
           transportEnabled: true,
+          isTransportEnabledForAssociation: () => true,
         }),
       );
 
@@ -129,6 +132,7 @@ describe("useTravelTime", () => {
         selector({
           homeLocation: mockHomeLocation,
           transportEnabled: true,
+          isTransportEnabledForAssociation: () => true,
         }),
       );
 
@@ -150,6 +154,7 @@ describe("useTravelTime", () => {
         selector({
           homeLocation: mockHomeLocation,
           transportEnabled: true,
+          isTransportEnabledForAssociation: () => true,
         }),
       );
 
@@ -171,13 +176,14 @@ describe("useTravelTime", () => {
       const { useSettingsStore } = await import("@/stores/settings");
 
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: true }),
+        selector({ isDemoMode: true, user: null, activeOccupationId: null }),
       );
 
       vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
         selector({
           homeLocation: mockHomeLocation,
           transportEnabled: true,
+          isTransportEnabledForAssociation: () => true,
         }),
       );
 
@@ -214,6 +220,7 @@ describe("useTravelTime", () => {
         selector({
           homeLocation: mockHomeLocation,
           transportEnabled: true,
+          isTransportEnabledForAssociation: () => true,
         }),
       );
 
@@ -250,6 +257,7 @@ describe("useTravelTime", () => {
         selector({
           homeLocation: mockHomeLocation,
           transportEnabled: true,
+          isTransportEnabledForAssociation: () => true,
         }),
       );
 
@@ -273,13 +281,14 @@ describe("useTravelTime", () => {
       const { useSettingsStore } = await import("@/stores/settings");
 
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: true }),
+        selector({ isDemoMode: true, user: null, activeOccupationId: null }),
       );
 
       vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
         selector({
           homeLocation: mockHomeLocation,
           transportEnabled: true,
+          isTransportEnabledForAssociation: () => true,
         }),
       );
 
@@ -332,7 +341,7 @@ describe("useTravelTimeAvailable", () => {
     const { isOjpConfigured } = await import("@/services/transport");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
     );
     vi.mocked(isOjpConfigured).mockReturnValue(false);
 
@@ -398,13 +407,14 @@ describe("day type caching", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
       selector({
         homeLocation: mockHomeLocation,
         transportEnabled: true,
+        isTransportEnabledForAssociation: () => true,
       }),
     );
 
@@ -432,13 +442,14 @@ describe("day type caching", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
       selector({
         homeLocation: mockHomeLocation,
         transportEnabled: true,
+        isTransportEnabledForAssociation: () => true,
       }),
     );
 
@@ -488,13 +499,14 @@ describe("localStorage persistence", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
       selector({
         homeLocation: mockHomeLocation,
         transportEnabled: true,
+        isTransportEnabledForAssociation: () => true,
       }),
     );
 
@@ -527,13 +539,14 @@ describe("localStorage persistence", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
       selector({
         homeLocation: mockHomeLocation,
         transportEnabled: true,
+        isTransportEnabledForAssociation: () => true,
       }),
     );
 
@@ -571,13 +584,14 @@ describe("localStorage persistence", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
       selector({
         homeLocation: mockHomeLocation,
         transportEnabled: true,
+        isTransportEnabledForAssociation: () => true,
       }),
     );
 

--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -48,10 +48,23 @@ export function useTravelTime(
   options: UseTravelTimeOptions = {},
 ) {
   const { date, targetArrivalTime } = options;
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const homeLocation = useSettingsStore((state) => state.homeLocation);
-  const transportEnabled = useSettingsStore((state) => state.transportEnabled);
+  const { isDemoMode, user, activeOccupationId } = useAuthStore((state) => ({
+    isDemoMode: state.isDemoMode,
+    user: state.user,
+    activeOccupationId: state.activeOccupationId,
+  }));
+  const { homeLocation, isTransportEnabledForAssociation } = useSettingsStore((state) => ({
+    homeLocation: state.homeLocation,
+    isTransportEnabledForAssociation: state.isTransportEnabledForAssociation,
+  }));
   const queryClient = useQueryClient();
+
+  // Get active association code
+  const activeOccupation = user?.occupations?.find((o) => o.id === activeOccupationId) ?? user?.occupations?.[0];
+  const associationCode = activeOccupation?.associationCode;
+
+  // Check if transport is enabled for current association
+  const transportEnabled = isTransportEnabledForAssociation(associationCode);
 
   // Create a hash of home location for cache key stability
   const homeLocationHash = homeLocation ? hashLocation(homeLocation) : null;

--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -9,6 +9,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useAuthStore } from "@/stores/auth";
 import { useSettingsStore } from "@/stores/settings";
+import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { queryKeys } from "@/api/queryKeys";
 import {
   calculateTravelTime,
@@ -48,20 +49,13 @@ export function useTravelTime(
   options: UseTravelTimeOptions = {},
 ) {
   const { date, targetArrivalTime } = options;
-  const { isDemoMode, user, activeOccupationId } = useAuthStore((state) => ({
-    isDemoMode: state.isDemoMode,
-    user: state.user,
-    activeOccupationId: state.activeOccupationId,
-  }));
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
   const { homeLocation, isTransportEnabledForAssociation } = useSettingsStore((state) => ({
     homeLocation: state.homeLocation,
     isTransportEnabledForAssociation: state.isTransportEnabledForAssociation,
   }));
   const queryClient = useQueryClient();
-
-  // Get active association code
-  const activeOccupation = user?.occupations?.find((o) => o.id === activeOccupationId) ?? user?.occupations?.[0];
-  const associationCode = activeOccupation?.associationCode;
+  const associationCode = useActiveAssociationCode();
 
   // Check if transport is enabled for current association
   const transportEnabled = isTransportEnabledForAssociation(associationCode);

--- a/web-app/src/hooks/useTravelTimeFilter.ts
+++ b/web-app/src/hooks/useTravelTimeFilter.ts
@@ -5,7 +5,7 @@
 import { useMemo, useCallback } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { useAuthStore } from "@/stores/auth";
-import { useSettingsStore } from "@/stores/settings";
+import { useSettingsStore, getDefaultArrivalBuffer } from "@/stores/settings";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { queryKeys } from "@/api/queryKeys";
 import {
@@ -68,19 +68,41 @@ function getHallInfo(exchange: GameExchange): HallInfo | null {
  */
 export function useTravelTimeFilter<T extends GameExchange>(exchanges: T[] | null) {
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const { homeLocation, isTransportEnabledForAssociation, travelTimeFilter, getArrivalBufferForAssociation } = useSettingsStore((state) => ({
-    homeLocation: state.homeLocation,
-    isTransportEnabledForAssociation: state.isTransportEnabledForAssociation,
-    travelTimeFilter: state.travelTimeFilter,
-    getArrivalBufferForAssociation: state.getArrivalBufferForAssociation,
-  }));
+  const homeLocation = useSettingsStore((state) => state.homeLocation);
+  const transportEnabled = useSettingsStore((state) => state.transportEnabled);
+  const transportEnabledByAssociation = useSettingsStore(
+    (state) => state.transportEnabledByAssociation,
+  );
+  // Select individual properties to prevent infinite re-renders from object reference changes
+  const travelTimeFilterEnabled = useSettingsStore(
+    (state) => state.travelTimeFilter.enabled,
+  );
+  const maxTravelTimeMinutes = useSettingsStore(
+    (state) => state.travelTimeFilter.maxTravelTimeMinutes,
+  );
+  const arrivalBufferByAssociation = useSettingsStore(
+    (state) => state.travelTimeFilter.arrivalBufferByAssociation,
+  );
   const associationCode = useActiveAssociationCode();
 
   // Check if transport is enabled for current association
-  const transportEnabled = isTransportEnabledForAssociation(associationCode);
+  // Use per-association setting if available, otherwise fall back to global
+  const isTransportEnabled = useMemo(() => {
+    const enabledMap = transportEnabledByAssociation ?? {};
+    if (associationCode && enabledMap[associationCode] !== undefined) {
+      return enabledMap[associationCode];
+    }
+    return transportEnabled;
+  }, [associationCode, transportEnabledByAssociation, transportEnabled]);
 
   // Get arrival buffer for current association
-  const arrivalBufferMinutes = getArrivalBufferForAssociation(associationCode);
+  const arrivalBufferMinutes = useMemo(() => {
+    const bufferMap = arrivalBufferByAssociation ?? {};
+    if (associationCode && bufferMap[associationCode] !== undefined) {
+      return bufferMap[associationCode];
+    }
+    return getDefaultArrivalBuffer(associationCode);
+  }, [associationCode, arrivalBufferByAssociation]);
 
   // Get unique halls to query
   const hallInfos = useMemo(() => {
@@ -108,7 +130,7 @@ export function useTravelTimeFilter<T extends GameExchange>(exchanges: T[] | nul
 
   // Check if we should fetch travel times
   const canFetch = Boolean(
-    transportEnabled &&
+    isTransportEnabled &&
       homeLocation &&
       (isDemoMode || isOjpConfigured()),
   );
@@ -218,15 +240,15 @@ export function useTravelTimeFilter<T extends GameExchange>(exchanges: T[] | nul
   const filterByTravelTime = useCallback(
     (exchangeWithTravelTime: ExchangeWithTravelTime<T>): boolean => {
       // If filtering is disabled, include all
-      if (!travelTimeFilter.enabled) return true;
+      if (!travelTimeFilterEnabled) return true;
 
       // If no travel time available, include (conservative approach)
       if (exchangeWithTravelTime.travelTimeMinutes === null) return true;
 
       // Apply the filter
-      return exchangeWithTravelTime.travelTimeMinutes <= travelTimeFilter.maxTravelTimeMinutes;
+      return exchangeWithTravelTime.travelTimeMinutes <= maxTravelTimeMinutes;
     },
-    [travelTimeFilter.enabled, travelTimeFilter.maxTravelTimeMinutes],
+    [travelTimeFilterEnabled, maxTravelTimeMinutes],
   );
 
   // Get filtered list

--- a/web-app/src/hooks/useTravelTimeFilter.ts
+++ b/web-app/src/hooks/useTravelTimeFilter.ts
@@ -6,6 +6,7 @@ import { useMemo, useCallback } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { useAuthStore } from "@/stores/auth";
 import { useSettingsStore } from "@/stores/settings";
+import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { queryKeys } from "@/api/queryKeys";
 import {
   calculateTravelTime,
@@ -66,21 +67,14 @@ function getHallInfo(exchange: GameExchange): HallInfo | null {
  * @returns Object with travel time data for each exchange and filter helper
  */
 export function useTravelTimeFilter<T extends GameExchange>(exchanges: T[] | null) {
-  const { isDemoMode, user, activeOccupationId } = useAuthStore((state) => ({
-    isDemoMode: state.isDemoMode,
-    user: state.user,
-    activeOccupationId: state.activeOccupationId,
-  }));
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
   const { homeLocation, isTransportEnabledForAssociation, travelTimeFilter, getArrivalBufferForAssociation } = useSettingsStore((state) => ({
     homeLocation: state.homeLocation,
     isTransportEnabledForAssociation: state.isTransportEnabledForAssociation,
     travelTimeFilter: state.travelTimeFilter,
     getArrivalBufferForAssociation: state.getArrivalBufferForAssociation,
   }));
-
-  // Get active association code
-  const activeOccupation = user?.occupations?.find((o) => o.id === activeOccupationId) ?? user?.occupations?.[0];
-  const associationCode = activeOccupation?.associationCode;
+  const associationCode = useActiveAssociationCode();
 
   // Check if transport is enabled for current association
   const transportEnabled = isTransportEnabledForAssociation(associationCode);

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -84,6 +84,11 @@ const de: Translations = {
         description:
           "Legen Sie Ihren Heimatstandort fest, um Tauschangebote nach Entfernung zu filtern. So finden Sie leichter Spiele in Ihrer Nähe.",
       },
+      arrivalTime: {
+        title: "Ankunftszeit-Einstellung",
+        description:
+          "Legen Sie fest, wie viele Minuten vor dem Spiel Sie ankommen möchten. Diese Einstellung wird für jeden Verband separat gespeichert.",
+      },
       complete: {
         title: "Tour abgeschlossen!",
         description:
@@ -331,6 +336,8 @@ const de: Translations = {
       requiresHomeLocation: "Legen Sie zuerst Ihren Heimatstandort fest",
       apiNotConfigured: "Transport-API ist nicht konfiguriert",
       maxTravelTime: "Maximale Reisezeit",
+      arrivalTime: "Ankunft vor Spielbeginn",
+      arrivalTimeDescription: "Minuten vor Spielbeginn ankommen (pro Verband)",
       cacheInfo:
         "Reisezeiten werden nach Tagestyp (Werktag/Samstag/Sonntag) für 30 Tage zwischengespeichert.",
       cacheEntries: "{count} gespeicherte Routen",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -84,6 +84,11 @@ const en: Translations = {
         description:
           "Set your home location to filter exchange offers by distance. This helps you find games near you more easily.",
       },
+      arrivalTime: {
+        title: "Arrival Time Setting",
+        description:
+          "Configure how many minutes before the game you want to arrive. This setting is saved separately for each association.",
+      },
       complete: {
         title: "Tour Complete!",
         description:
@@ -329,6 +334,8 @@ const en: Translations = {
       requiresHomeLocation: "Set your home location first",
       apiNotConfigured: "Transport API is not configured",
       maxTravelTime: "Maximum travel time",
+      arrivalTime: "Arrive before game",
+      arrivalTimeDescription: "Minutes to arrive before game start (per association)",
       cacheInfo:
         "Travel times are cached by day type (weekday/Saturday/Sunday) for 30 days.",
       cacheEntries: "{count} cached routes",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -84,6 +84,11 @@ const fr: Translations = {
         description:
           "Définissez votre emplacement pour filtrer les échanges par distance. Cela vous aide à trouver plus facilement des matchs près de chez vous.",
       },
+      arrivalTime: {
+        title: "Paramètre d'heure d'arrivée",
+        description:
+          "Configurez combien de minutes avant le match vous souhaitez arriver. Ce paramètre est enregistré séparément pour chaque association.",
+      },
       complete: {
         title: "Visite terminée !",
         description:
@@ -330,6 +335,8 @@ const fr: Translations = {
       requiresHomeLocation: "Définissez d'abord votre emplacement domicile",
       apiNotConfigured: "L'API de transport n'est pas configurée",
       maxTravelTime: "Temps de trajet maximum",
+      arrivalTime: "Arrivée avant le match",
+      arrivalTimeDescription: "Minutes d'arrivée avant le début du match (par association)",
       cacheInfo:
         "Les temps de trajet sont mis en cache par type de jour (semaine/samedi/dimanche) pendant 30 jours.",
       cacheEntries: "{count} trajets en cache",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -84,6 +84,11 @@ const it: Translations = {
         description:
           "Imposta la tua posizione per filtrare gli scambi per distanza. Questo ti aiuta a trovare più facilmente le partite vicino a te.",
       },
+      arrivalTime: {
+        title: "Impostazione orario di arrivo",
+        description:
+          "Configura quanti minuti prima della partita vuoi arrivare. Questa impostazione viene salvata separatamente per ogni associazione.",
+      },
       complete: {
         title: "Tour completato!",
         description:
@@ -328,6 +333,8 @@ const it: Translations = {
       requiresHomeLocation: "Imposta prima la tua posizione casa",
       apiNotConfigured: "API trasporti non configurata",
       maxTravelTime: "Tempo di viaggio massimo",
+      arrivalTime: "Arrivo prima della partita",
+      arrivalTimeDescription: "Minuti di anticipo all'arrivo (per associazione)",
       cacheInfo:
         "I tempi di viaggio sono memorizzati in cache per tipo di giorno (feriale/sabato/domenica) per 30 giorni.",
       cacheEntries: "{count} percorsi in cache",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -213,6 +213,8 @@ export interface Translations {
       requiresHomeLocation: string;
       apiNotConfigured: string;
       maxTravelTime: string;
+      arrivalTime: string;
+      arrivalTimeDescription: string;
       cacheInfo: string;
       cacheEntries: string;
       refreshCache: string;
@@ -456,6 +458,10 @@ export interface Translations {
         description: string;
       };
       homeLocation: {
+        title: string;
+        description: string;
+      };
+      arrivalTime: {
         title: string;
         description: string;
       };

--- a/web-app/src/stores/settings.test.ts
+++ b/web-app/src/stores/settings.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useSettingsStore, type UserLocation } from "./settings";
+import {
+  useSettingsStore,
+  type UserLocation,
+  DEFAULT_ARRIVAL_BUFFER_SV_MINUTES,
+  DEFAULT_ARRIVAL_BUFFER_REGIONAL_MINUTES,
+  getDefaultArrivalBuffer,
+} from "./settings";
 
 describe("useSettingsStore", () => {
   beforeEach(() => {
@@ -151,6 +157,173 @@ describe("useSettingsStore", () => {
         expect(parsed.state.distanceFilter.enabled).toBe(true);
         expect(parsed.state.distanceFilter.maxDistanceKm).toBe(75);
       }
+    });
+  });
+
+  describe("per-association transport settings", () => {
+    beforeEach(() => {
+      useSettingsStore.setState({
+        transportEnabled: false,
+        transportEnabledByAssociation: {},
+        travelTimeFilter: {
+          enabled: false,
+          maxTravelTimeMinutes: 120,
+          arrivalBufferMinutes: 30,
+          arrivalBufferByAssociation: {},
+          cacheInvalidatedAt: null,
+        },
+      });
+    });
+
+    describe("isTransportEnabledForAssociation", () => {
+      it("should fall back to global transportEnabled when no per-association setting exists", () => {
+        const { isTransportEnabledForAssociation, setTransportEnabled } = useSettingsStore.getState();
+
+        // With global transport disabled
+        expect(isTransportEnabledForAssociation("SV")).toBe(false);
+
+        // Enable global transport
+        setTransportEnabled(true);
+        expect(isTransportEnabledForAssociation("SV")).toBe(true);
+      });
+
+      it("should use per-association setting when available", () => {
+        const { isTransportEnabledForAssociation, setTransportEnabledForAssociation, setTransportEnabled } =
+          useSettingsStore.getState();
+
+        // Set global to true but SV to false
+        setTransportEnabled(true);
+        setTransportEnabledForAssociation("SV", false);
+
+        expect(isTransportEnabledForAssociation("SV")).toBe(false);
+        // Other associations should still use global
+        expect(isTransportEnabledForAssociation("SVRBA")).toBe(true);
+      });
+
+      it("should handle undefined association code gracefully", () => {
+        const { isTransportEnabledForAssociation, setTransportEnabled } = useSettingsStore.getState();
+
+        setTransportEnabled(true);
+        expect(isTransportEnabledForAssociation(undefined)).toBe(true);
+      });
+    });
+
+    describe("setTransportEnabledForAssociation", () => {
+      it("should set per-association transport setting", () => {
+        const { setTransportEnabledForAssociation } = useSettingsStore.getState();
+
+        setTransportEnabledForAssociation("SV", true);
+
+        const state = useSettingsStore.getState();
+        expect(state.transportEnabledByAssociation["SV"]).toBe(true);
+      });
+
+      it("should preserve settings for other associations", () => {
+        const { setTransportEnabledForAssociation } = useSettingsStore.getState();
+
+        setTransportEnabledForAssociation("SV", true);
+        setTransportEnabledForAssociation("SVRBA", false);
+
+        const state = useSettingsStore.getState();
+        expect(state.transportEnabledByAssociation["SV"]).toBe(true);
+        expect(state.transportEnabledByAssociation["SVRBA"]).toBe(false);
+      });
+    });
+  });
+
+  describe("per-association arrival buffer settings", () => {
+    beforeEach(() => {
+      useSettingsStore.setState({
+        travelTimeFilter: {
+          enabled: false,
+          maxTravelTimeMinutes: 120,
+          arrivalBufferMinutes: 30,
+          arrivalBufferByAssociation: {},
+          cacheInvalidatedAt: null,
+        },
+      });
+    });
+
+    describe("getDefaultArrivalBuffer", () => {
+      it("should return 60 minutes for SV (Swiss Volley national)", () => {
+        expect(getDefaultArrivalBuffer("SV")).toBe(DEFAULT_ARRIVAL_BUFFER_SV_MINUTES);
+        expect(getDefaultArrivalBuffer("SV")).toBe(60);
+      });
+
+      it("should return 45 minutes for regional associations", () => {
+        expect(getDefaultArrivalBuffer("SVRBA")).toBe(DEFAULT_ARRIVAL_BUFFER_REGIONAL_MINUTES);
+        expect(getDefaultArrivalBuffer("SVRZ")).toBe(45);
+        expect(getDefaultArrivalBuffer("OTHER")).toBe(45);
+      });
+
+      it("should return 45 minutes for undefined association", () => {
+        expect(getDefaultArrivalBuffer(undefined)).toBe(DEFAULT_ARRIVAL_BUFFER_REGIONAL_MINUTES);
+      });
+    });
+
+    describe("getArrivalBufferForAssociation", () => {
+      it("should return default value when no custom setting exists", () => {
+        const { getArrivalBufferForAssociation } = useSettingsStore.getState();
+
+        expect(getArrivalBufferForAssociation("SV")).toBe(60);
+        expect(getArrivalBufferForAssociation("SVRBA")).toBe(45);
+      });
+
+      it("should return custom value when set", () => {
+        const { getArrivalBufferForAssociation, setArrivalBufferForAssociation } =
+          useSettingsStore.getState();
+
+        setArrivalBufferForAssociation("SV", 90);
+
+        expect(getArrivalBufferForAssociation("SV")).toBe(90);
+        // Other associations should still use default
+        expect(getArrivalBufferForAssociation("SVRBA")).toBe(45);
+      });
+
+      it("should handle undefined association code", () => {
+        const { getArrivalBufferForAssociation } = useSettingsStore.getState();
+
+        expect(getArrivalBufferForAssociation(undefined)).toBe(45);
+      });
+    });
+
+    describe("setArrivalBufferForAssociation", () => {
+      it("should set per-association arrival buffer", () => {
+        const { setArrivalBufferForAssociation, getArrivalBufferForAssociation } =
+          useSettingsStore.getState();
+
+        setArrivalBufferForAssociation("SV", 75);
+
+        expect(getArrivalBufferForAssociation("SV")).toBe(75);
+      });
+
+      it("should preserve settings for other associations", () => {
+        const { setArrivalBufferForAssociation, getArrivalBufferForAssociation } =
+          useSettingsStore.getState();
+
+        setArrivalBufferForAssociation("SV", 90);
+        setArrivalBufferForAssociation("SVRBA", 30);
+
+        expect(getArrivalBufferForAssociation("SV")).toBe(90);
+        expect(getArrivalBufferForAssociation("SVRBA")).toBe(30);
+        // SVRZ should still use default
+        expect(getArrivalBufferForAssociation("SVRZ")).toBe(45);
+      });
+
+      it("should persist per-association settings", () => {
+        const { setArrivalBufferForAssociation } = useSettingsStore.getState();
+
+        setArrivalBufferForAssociation("SV", 120);
+
+        const storageKey = "volleykit-settings";
+        const persistedData = localStorage.getItem(storageKey);
+        expect(persistedData).toBeTruthy();
+
+        if (persistedData) {
+          const parsed = JSON.parse(persistedData);
+          expect(parsed.state.travelTimeFilter.arrivalBufferByAssociation["SV"]).toBe(120);
+        }
+      });
     });
   });
 });

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -52,6 +52,12 @@ export const DEFAULT_ARRIVAL_BUFFER_SV_MINUTES = 60;
 /** Default arrival buffer for regional associations - 45 minutes */
 export const DEFAULT_ARRIVAL_BUFFER_REGIONAL_MINUTES = 45;
 
+/** Minimum allowed arrival buffer in minutes */
+export const MIN_ARRIVAL_BUFFER_MINUTES = 0;
+
+/** Maximum allowed arrival buffer in minutes (3 hours) */
+export const MAX_ARRIVAL_BUFFER_MINUTES = 180;
+
 /**
  * Get the default arrival buffer for an association.
  * SV (Swiss Volley national) defaults to 60 minutes, others to 45 minutes.


### PR DESCRIPTION
Add configurable arrival buffer (minutes before game start) per association
in the public transport settings section.

- Default 60 minutes for SV (Swiss Volley national)
- Default 45 minutes for regional associations (SVRBA, SVRZ, etc.)
- Shows association badge next to setting for clarity
- Only visible when public transport calculations are enabled
- Persisted per-association in localStorage
- Added guided tour step explaining the feature
- Translations for all 4 languages (de, en, fr, it)