### PR TITLE
feat(transport): add SBB app integration for public transport links

### DIFF
--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -39,6 +39,8 @@ export const ASSIGNMENT_PROPERTIES = [
   "refereeGame.game.hall.primaryPostalAddress.postalCode",
   "refereeGame.game.hall.primaryPostalAddress.city",
   "refereeGame.game.hall.primaryPostalAddress.geographicalLocation.plusCode",
+  "refereeGame.game.hall.primaryPostalAddress.geographicalLocation.latitude",
+  "refereeGame.game.hall.primaryPostalAddress.geographicalLocation.longitude",
   "refereeGame.game.lastPostponement.activeRefereeConvocationsAtTimeOfAcceptedPostponement.*.indoorAssociationReferee.indoorReferee.person",
   "refereeGame.game.lastPostponement.createdAt",
   "refereeGame.isGameInFuture",

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -226,12 +226,12 @@ function AssignmentCardComponent({
                 href={sbbUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex-shrink-0 p-1 -m-1 text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded"
+                className="flex-shrink-0 ml-2 p-1.5 text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 hover:bg-primary-50 dark:hover:bg-primary-900/20 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-md transition-colors"
                 onClick={(e) => e.stopPropagation()}
                 title={t("assignments.openSbbConnection")}
                 aria-label={t("assignments.openSbbConnection")}
               >
-                <TrainFront className="w-4 h-4" aria-hidden="true" />
+                <TrainFront className="w-5 h-5" aria-hidden="true" />
               </a>
             )}
           </div>

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -125,7 +125,7 @@ function AssignmentCardComponent({
         destination: city,
         date: gameDate,
         arrivalTime,
-        language: locale as "de" | "en" | "fr" | "it",
+        language: locale,
       },
       sbbLinkTarget,
     );
@@ -228,8 +228,8 @@ function AssignmentCardComponent({
                 rel="noopener noreferrer"
                 className="flex-shrink-0 p-1 -m-1 text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded"
                 onClick={(e) => e.stopPropagation()}
-                title={t("exchange.travelTime")}
-                aria-label={t("exchange.travelTime")}
+                title={t("assignments.openSbbConnection")}
+                aria-label={t("assignments.openSbbConnection")}
               >
                 <TrainFront className="w-4 h-4" aria-hidden="true" />
               </a>

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -76,6 +76,11 @@ function createMockSettingsStore(
     levelFilterEnabled: false,
     setLevelFilterEnabled: vi.fn(),
 
+    // SBB link target
+    sbbLinkTargetByAssociation: {},
+    setSbbLinkTargetForAssociation: vi.fn(),
+    getSbbLinkTargetForAssociation: vi.fn().mockReturnValue("website"),
+
     // Reset
     resetLocationSettings: vi.fn(),
 

--- a/web-app/src/components/features/settings/TransportSection.tsx
+++ b/web-app/src/components/features/settings/TransportSection.tsx
@@ -6,6 +6,7 @@ import {
   getDefaultArrivalBuffer,
   MIN_ARRIVAL_BUFFER_MINUTES,
   MAX_ARRIVAL_BUFFER_MINUTES,
+  type SbbLinkTarget,
 } from "@/stores/settings";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
@@ -43,6 +44,8 @@ function TransportSectionComponent() {
     setTransportEnabledForAssociation,
     arrivalBufferByAssociation,
     setArrivalBufferForAssociation,
+    sbbLinkTargetByAssociation,
+    setSbbLinkTargetForAssociation,
   } = useSettingsStore(
     useShallow((state) => ({
       homeLocation: state.homeLocation,
@@ -51,6 +54,8 @@ function TransportSectionComponent() {
       setTransportEnabledForAssociation: state.setTransportEnabledForAssociation,
       arrivalBufferByAssociation: state.travelTimeFilter.arrivalBufferByAssociation,
       setArrivalBufferForAssociation: state.setArrivalBufferForAssociation,
+      sbbLinkTargetByAssociation: state.sbbLinkTargetByAssociation,
+      setSbbLinkTargetForAssociation: state.setSbbLinkTargetForAssociation,
     })),
   );
 
@@ -76,6 +81,15 @@ function TransportSectionComponent() {
     }
     return getDefaultArrivalBuffer(associationCode);
   }, [associationCode, arrivalBufferByAssociation]);
+
+  // Get current SBB link target for this association
+  const currentSbbLinkTarget = useMemo((): SbbLinkTarget => {
+    const targetMap = sbbLinkTargetByAssociation ?? {};
+    if (associationCode && targetMap[associationCode] !== undefined) {
+      return targetMap[associationCode];
+    }
+    return "website";
+  }, [associationCode, sbbLinkTargetByAssociation]);
 
   // Local state for immediate input feedback, synced with store via debounce
   const [localArrivalBuffer, setLocalArrivalBuffer] = useState(storeArrivalBuffer);
@@ -137,6 +151,14 @@ function TransportSectionComponent() {
       }
     },
     [associationCode, setArrivalBufferForAssociation],
+  );
+
+  const handleSbbLinkTargetChange = useCallback(
+    (target: SbbLinkTarget) => {
+      if (!associationCode) return;
+      setSbbLinkTargetForAssociation(associationCode, target);
+    },
+    [associationCode, setSbbLinkTargetForAssociation],
   );
 
   const hasHomeLocation = Boolean(homeLocation);
@@ -278,6 +300,51 @@ function TransportSectionComponent() {
                 <span className="text-sm text-text-muted dark:text-text-muted-dark">
                   {t("common.minutesUnit")}
                 </span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* SBB link target setting - only show when transport is enabled */}
+        {isTransportEnabled && (
+          <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+            <div className="flex items-center justify-between py-2">
+              <div className="flex-1 pr-3">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                    {t("settings.transport.sbbLinkTarget")}
+                  </span>
+                  {associationCode && <AssociationBadge code={associationCode} />}
+                </div>
+                <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5">
+                  {t("settings.transport.sbbLinkTargetDescription")}
+                </div>
+              </div>
+              <div className="flex items-center gap-1 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg p-0.5">
+                <button
+                  type="button"
+                  onClick={() => handleSbbLinkTargetChange("website")}
+                  className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+                    currentSbbLinkTarget === "website"
+                      ? "bg-white dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark shadow-sm"
+                      : "text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
+                  }`}
+                  aria-pressed={currentSbbLinkTarget === "website"}
+                >
+                  {t("settings.transport.sbbLinkTargetWebsite")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleSbbLinkTargetChange("app")}
+                  className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
+                    currentSbbLinkTarget === "app"
+                      ? "bg-white dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark shadow-sm"
+                      : "text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
+                  }`}
+                  aria-pressed={currentSbbLinkTarget === "app"}
+                >
+                  {t("settings.transport.sbbLinkTargetApp")}
+                </button>
               </div>
             </div>
           </div>

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -23,6 +23,7 @@ export { FileText } from "lucide-react";
 export { AlertCircle } from "lucide-react";
 export { UserPlus } from "lucide-react";
 export { RefreshCw } from "lucide-react";
+export { Loader2 } from "lucide-react";
 export { Trash2 } from "lucide-react";
 export { Undo2 } from "lucide-react";
 export { ChevronDown } from "lucide-react";

--- a/web-app/src/hooks/useSbbUrl.ts
+++ b/web-app/src/hooks/useSbbUrl.ts
@@ -1,0 +1,192 @@
+/**
+ * Hook for generating SBB URLs with station IDs from OJP trip data.
+ * Fetches trip data on demand and caches results.
+ */
+
+import { useState, useCallback } from "react";
+import { useAuthStore } from "@/stores/auth";
+import { useSettingsStore } from "@/stores/settings";
+import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
+import {
+  calculateTravelTime,
+  calculateMockTravelTime,
+  isOjpConfigured,
+  hashLocation,
+  getDayType,
+  getCachedTravelTime,
+  setCachedTravelTime,
+  type Coordinates,
+  type StationInfo,
+} from "@/services/transport";
+import { generateSbbUrl, calculateArrivalTime } from "@/utils/sbb-url";
+import type { Locale } from "@/i18n";
+
+interface UseSbbUrlOptions {
+  /** Hall coordinates for routing */
+  hallCoords: Coordinates | null;
+  /** Hall ID for caching */
+  hallId: string | undefined;
+  /** City name as fallback destination */
+  city: string | undefined;
+  /** Game start time */
+  gameStartTime: string | undefined;
+  /** Language for the URL */
+  language: Locale;
+}
+
+interface UseSbbUrlResult {
+  /** Whether trip data is being fetched */
+  isLoading: boolean;
+  /** Error from fetching trip data */
+  error: Error | null;
+  /** Cached destination station info (if available) */
+  destinationStation: StationInfo | undefined;
+  /** Open the SBB connection in a new tab, fetching trip data if needed */
+  openSbbConnection: () => Promise<void>;
+}
+
+/**
+ * Hook to generate and open SBB URLs with proper station IDs.
+ * Fetches trip data on demand and caches results.
+ */
+export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
+  const { hallCoords, hallId, city, gameStartTime, language } = options;
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [destinationStation, setDestinationStation] = useState<StationInfo | undefined>();
+
+  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const homeLocation = useSettingsStore((state) => state.homeLocation);
+  const associationCode = useActiveAssociationCode();
+  const sbbLinkTarget = useSettingsStore((state) =>
+    state.getSbbLinkTargetForAssociation(associationCode),
+  );
+  const arrivalBuffer = useSettingsStore((state) =>
+    state.getArrivalBufferForAssociation(associationCode),
+  );
+
+  const openSbbConnection = useCallback(async () => {
+    if (!city || !gameStartTime) {
+      return;
+    }
+
+    const gameDate = new Date(gameStartTime);
+    const arrivalTime = calculateArrivalTime(gameDate, arrivalBuffer);
+
+    // If we already have cached station info, use it directly
+    if (destinationStation) {
+      const url = generateSbbUrl(
+        {
+          destination: city,
+          date: gameDate,
+          arrivalTime,
+          language,
+          destinationStation,
+        },
+        sbbLinkTarget,
+      );
+      window.open(url, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    // If we can fetch trip data, try to get the station ID
+    const canFetchTrip = homeLocation && hallCoords && hallId && (isDemoMode || isOjpConfigured());
+
+    if (canFetchTrip) {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const homeLocationHash = hashLocation(homeLocation);
+        const dayType = getDayType(gameDate);
+
+        // Check cache first
+        let tripResult = getCachedTravelTime(hallId, homeLocationHash, dayType);
+
+        if (!tripResult) {
+          // Fetch trip data
+          const fromCoords: Coordinates = {
+            latitude: homeLocation.latitude,
+            longitude: homeLocation.longitude,
+          };
+
+          if (isDemoMode) {
+            tripResult = await calculateMockTravelTime(fromCoords, hallCoords);
+          } else {
+            tripResult = await calculateTravelTime(fromCoords, hallCoords, {
+              targetArrivalTime: arrivalTime,
+            });
+          }
+
+          // Cache the result
+          setCachedTravelTime(hallId, homeLocationHash, dayType, tripResult);
+        }
+
+        // Update state with station info for future clicks
+        if (tripResult.destinationStation) {
+          setDestinationStation(tripResult.destinationStation);
+        }
+
+        // Generate URL with station ID
+        const url = generateSbbUrl(
+          {
+            destination: city,
+            date: gameDate,
+            arrivalTime,
+            language,
+            destinationStation: tripResult.destinationStation,
+          },
+          sbbLinkTarget,
+        );
+        window.open(url, "_blank", "noopener,noreferrer");
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error("Failed to fetch trip data"));
+
+        // Fall back to URL without station ID
+        const url = generateSbbUrl(
+          {
+            destination: city,
+            date: gameDate,
+            arrivalTime,
+            language,
+          },
+          sbbLinkTarget,
+        );
+        window.open(url, "_blank", "noopener,noreferrer");
+      } finally {
+        setIsLoading(false);
+      }
+    } else {
+      // No trip data available, use city name only
+      const url = generateSbbUrl(
+        {
+          destination: city,
+          date: gameDate,
+          arrivalTime,
+          language,
+        },
+        sbbLinkTarget,
+      );
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  }, [
+    city,
+    gameStartTime,
+    arrivalBuffer,
+    destinationStation,
+    language,
+    sbbLinkTarget,
+    homeLocation,
+    hallCoords,
+    hallId,
+    isDemoMode,
+  ]);
+
+  return {
+    isLoading,
+    error,
+    destinationStation,
+    openSbbConnection,
+  };
+}

--- a/web-app/src/hooks/useSbbUrl.ts
+++ b/web-app/src/hooks/useSbbUrl.ts
@@ -116,7 +116,10 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
           };
 
           if (isDemoMode) {
-            tripResult = await calculateMockTravelTime(fromCoords, hallCoords);
+            tripResult = await calculateMockTravelTime(fromCoords, hallCoords, {
+              originLabel: homeLocation.label,
+              destinationLabel: city,
+            });
           } else {
             tripResult = await calculateTravelTime(fromCoords, hallCoords, {
               targetArrivalTime: arrivalTime,

--- a/web-app/src/hooks/useSbbUrl.ts
+++ b/web-app/src/hooks/useSbbUrl.ts
@@ -93,17 +93,6 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
     // If we can fetch trip data, try to get the station ID
     const canFetchTrip = homeLocation && hallCoords && hallId && (isDemoMode || isOjpConfigured());
 
-    // Log why we can or cannot fetch trip
-    console.log("[useSbbUrl] Can fetch trip:", {
-      canFetchTrip,
-      hasHomeLocation: !!homeLocation,
-      hasHallCoords: !!hallCoords,
-      hallCoords,
-      hasHallId: !!hallId,
-      isDemoMode,
-      isOjpConfigured: isOjpConfigured(),
-    });
-
     if (canFetchTrip) {
       setIsLoading(true);
       setError(null);
@@ -133,13 +122,6 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
           // Cache the result
           setCachedTravelTime(hallId, homeLocationHash, dayType, tripResult);
         }
-
-        // Update state with station info for future clicks
-        // Log trip result for debugging
-        console.log("[useSbbUrl] Trip result:", {
-          hasDestinationStation: !!tripResult.destinationStation,
-          destinationStation: tripResult.destinationStation,
-        });
 
         // Update state with station info for future clicks
         if (tripResult.destinationStation) {

--- a/web-app/src/hooks/useSbbUrl.ts
+++ b/web-app/src/hooks/useSbbUrl.ts
@@ -39,6 +39,8 @@ interface UseSbbUrlResult {
   isLoading: boolean;
   /** Error from fetching trip data */
   error: Error | null;
+  /** Cached origin station info (if available) */
+  originStation: StationInfo | undefined;
   /** Cached destination station info (if available) */
   destinationStation: StationInfo | undefined;
   /** Open the SBB connection in a new tab, fetching trip data if needed */
@@ -54,6 +56,7 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [originStation, setOriginStation] = useState<StationInfo | undefined>();
   const [destinationStation, setDestinationStation] = useState<StationInfo | undefined>();
 
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
@@ -75,13 +78,14 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
     const arrivalTime = calculateArrivalTime(gameDate, arrivalBuffer);
 
     // If we already have cached station info, use it directly
-    if (destinationStation) {
+    if (originStation && destinationStation) {
       const url = generateSbbUrl(
         {
           destination: city,
           date: gameDate,
           arrivalTime,
           language,
+          originStation,
           destinationStation,
         },
         sbbLinkTarget,
@@ -124,17 +128,21 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
         }
 
         // Update state with station info for future clicks
+        if (tripResult.originStation) {
+          setOriginStation(tripResult.originStation);
+        }
         if (tripResult.destinationStation) {
           setDestinationStation(tripResult.destinationStation);
         }
 
-        // Generate URL with station ID
+        // Generate URL with station IDs
         const url = generateSbbUrl(
           {
             destination: city,
             date: gameDate,
             arrivalTime,
             language,
+            originStation: tripResult.originStation,
             destinationStation: tripResult.destinationStation,
           },
           sbbLinkTarget,
@@ -174,6 +182,7 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
     city,
     gameStartTime,
     arrivalBuffer,
+    originStation,
     destinationStation,
     language,
     sbbLinkTarget,
@@ -186,6 +195,7 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
   return {
     isLoading,
     error,
+    originStation,
     destinationStation,
     openSbbConnection,
   };

--- a/web-app/src/hooks/useSbbUrl.ts
+++ b/web-app/src/hooks/useSbbUrl.ts
@@ -93,6 +93,17 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
     // If we can fetch trip data, try to get the station ID
     const canFetchTrip = homeLocation && hallCoords && hallId && (isDemoMode || isOjpConfigured());
 
+    // Log why we can or cannot fetch trip
+    console.log("[useSbbUrl] Can fetch trip:", {
+      canFetchTrip,
+      hasHomeLocation: !!homeLocation,
+      hasHallCoords: !!hallCoords,
+      hallCoords,
+      hasHallId: !!hallId,
+      isDemoMode,
+      isOjpConfigured: isOjpConfigured(),
+    });
+
     if (canFetchTrip) {
       setIsLoading(true);
       setError(null);
@@ -122,6 +133,13 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
           // Cache the result
           setCachedTravelTime(hallId, homeLocationHash, dayType, tripResult);
         }
+
+        // Update state with station info for future clicks
+        // Log trip result for debugging
+        console.log("[useSbbUrl] Trip result:", {
+          hasDestinationStation: !!tripResult.destinationStation,
+          destinationStation: tripResult.destinationStation,
+        });
 
         // Update state with station info for future clicks
         if (tripResult.destinationStation) {

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -345,6 +345,10 @@ const de: Translations = {
       refreshCacheConfirm:
         "Alle gespeicherten Reisezeiten löschen? Neue Berechnungen werden von der API abgerufen.",
       cacheCleared: "Reisezeit-Cache geleert",
+      sbbLinkTarget: "Verbindungen öffnen in",
+      sbbLinkTargetDescription: "Wählen Sie, wo SBB-Fahrplanlinks geöffnet werden",
+      sbbLinkTargetWebsite: "SBB Webseite",
+      sbbLinkTargetApp: "SBB App",
     },
     dataRetention: {
       title: "Daten & Datenschutz",

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -205,6 +205,7 @@ const de: Translations = {
     gameReportNotAvailable:
       "Spielberichte sind nur für NLA- und NLB-Spiele verfügbar.",
     reportGenerated: "Bericht erfolgreich erstellt",
+    openSbbConnection: "ÖV-Verbindung öffnen",
     invalidKilometers: "Bitte geben Sie eine gültige positive Zahl ein",
     failedToLoadData: "Daten konnten nicht geladen werden",
   },

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -205,6 +205,7 @@ const en: Translations = {
     gameReportNotAvailable:
       "Game reports are only available for NLA and NLB games.",
     reportGenerated: "Report generated successfully",
+    openSbbConnection: "Open public transport connection",
     invalidKilometers: "Please enter a valid positive number",
     failedToLoadData: "Failed to load data",
   },

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -343,6 +343,10 @@ const en: Translations = {
       refreshCacheConfirm:
         "Clear all cached travel times? New calculations will be fetched from the API.",
       cacheCleared: "Travel time cache cleared",
+      sbbLinkTarget: "Open connections in",
+      sbbLinkTargetDescription: "Choose where to open SBB timetable links",
+      sbbLinkTargetWebsite: "SBB website",
+      sbbLinkTargetApp: "SBB app",
     },
     dataRetention: {
       title: "Data & Privacy",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -204,6 +204,7 @@ const fr: Translations = {
     gameReportNotAvailable:
       "Les rapports de match sont uniquement disponibles pour les matchs NLA et NLB.",
     reportGenerated: "Rapport généré avec succès",
+    openSbbConnection: "Ouvrir la connexion transports publics",
     invalidKilometers: "Veuillez entrer un nombre positif valide",
     failedToLoadData: "Échec du chargement des données",
   },

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -344,6 +344,10 @@ const fr: Translations = {
       refreshCacheConfirm:
         "Effacer tous les temps de trajet en cache ? Les nouveaux calculs seront récupérés depuis l'API.",
       cacheCleared: "Cache des temps de trajet vidé",
+      sbbLinkTarget: "Ouvrir les connexions dans",
+      sbbLinkTargetDescription: "Choisissez où ouvrir les liens horaires CFF",
+      sbbLinkTargetWebsite: "Site web CFF",
+      sbbLinkTargetApp: "App CFF",
     },
     dataRetention: {
       title: "Données et confidentialité",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -204,6 +204,7 @@ const it: Translations = {
     gameReportNotAvailable:
       "I rapporti delle partite sono disponibili solo per le partite NLA e NLB.",
     reportGenerated: "Rapporto generato con successo",
+    openSbbConnection: "Apri collegamento trasporti pubblici",
     invalidKilometers: "Inserisci un numero positivo valido",
     failedToLoadData: "Impossibile caricare i dati",
   },

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -342,6 +342,10 @@ const it: Translations = {
       refreshCacheConfirm:
         "Cancellare tutti i tempi di viaggio in cache? I nuovi calcoli verranno recuperati dall'API.",
       cacheCleared: "Cache tempi di viaggio svuotata",
+      sbbLinkTarget: "Apri connessioni in",
+      sbbLinkTargetDescription: "Scegli dove aprire i link orari FFS",
+      sbbLinkTargetWebsite: "Sito web FFS",
+      sbbLinkTargetApp: "App FFS",
     },
     dataRetention: {
       title: "Dati e privacy",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -220,6 +220,10 @@ export interface Translations {
       refreshCache: string;
       refreshCacheConfirm: string;
       cacheCleared: string;
+      sbbLinkTarget: string;
+      sbbLinkTargetDescription: string;
+      sbbLinkTargetWebsite: string;
+      sbbLinkTargetApp: string;
     };
     dataRetention: {
       title: string;

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -94,6 +94,7 @@ export interface Translations {
     numberOfSets: string;
     gameReportNotAvailable: string;
     reportGenerated: string;
+    openSbbConnection: string;
     invalidKilometers: string;
     failedToLoadData: string;
   };

--- a/web-app/src/services/transport/index.ts
+++ b/web-app/src/services/transport/index.ts
@@ -8,11 +8,12 @@ export type {
   TravelTimeOptions,
   Coordinates,
   TransportConfig,
+  StationInfo,
 } from "./types";
 
 export { TransportApiError } from "./types";
 
-export { calculateTravelTime, isOjpConfigured, selectBestTrip } from "./ojp-client";
+export { calculateTravelTime, isOjpConfigured, selectBestTrip, extractDestinationStation } from "./ojp-client";
 
 export type { OjpTrip } from "./ojp-client";
 

--- a/web-app/src/services/transport/index.ts
+++ b/web-app/src/services/transport/index.ts
@@ -13,7 +13,13 @@ export type {
 
 export { TransportApiError } from "./types";
 
-export { calculateTravelTime, isOjpConfigured, selectBestTrip, extractDestinationStation } from "./ojp-client";
+export {
+  calculateTravelTime,
+  isOjpConfigured,
+  selectBestTrip,
+  extractOriginStation,
+  extractDestinationStation,
+} from "./ojp-client";
 
 export type { OjpTrip } from "./ojp-client";
 

--- a/web-app/src/services/transport/mock-transport.ts
+++ b/web-app/src/services/transport/mock-transport.ts
@@ -120,7 +120,12 @@ export async function calculateMockTravelTime(
   const departureTime = options.departureTime ?? new Date();
   const arrivalTime = new Date(departureTime.getTime() + durationMinutes * 60 * 1000);
 
-  // Generate mock destination station for SBB deep linking
+  // Generate mock origin and destination stations for SBB deep linking
+  const originStation: StationInfo = {
+    id: generateMockStationId(from),
+    name: generateMockStationName(from),
+  };
+
   const destinationStation: StationInfo = {
     id: generateMockStationId(to),
     name: generateMockStationName(to),
@@ -131,6 +136,7 @@ export async function calculateMockTravelTime(
     departureTime: departureTime.toISOString(),
     arrivalTime: arrivalTime.toISOString(),
     transfers,
+    originStation,
     destinationStation,
     tripData: undefined,
   };

--- a/web-app/src/services/transport/mock-transport.ts
+++ b/web-app/src/services/transport/mock-transport.ts
@@ -121,14 +121,15 @@ export async function calculateMockTravelTime(
   const arrivalTime = new Date(departureTime.getTime() + durationMinutes * 60 * 1000);
 
   // Generate mock origin and destination stations for SBB deep linking
+  // Use provided labels if available, otherwise fall back to coordinate-based names
   const originStation: StationInfo = {
     id: generateMockStationId(from),
-    name: generateMockStationName(from),
+    name: options.originLabel ?? generateMockStationName(from),
   };
 
   const destinationStation: StationInfo = {
     id: generateMockStationId(to),
-    name: generateMockStationName(to),
+    name: options.destinationLabel ?? generateMockStationName(to),
   };
 
   return {

--- a/web-app/src/services/transport/mock-transport.ts
+++ b/web-app/src/services/transport/mock-transport.ts
@@ -3,7 +3,7 @@
  * Provides realistic travel times based on straight-line distance.
  */
 
-import type { Coordinates, TravelTimeResult, TravelTimeOptions } from "./types";
+import type { Coordinates, TravelTimeResult, TravelTimeOptions, StationInfo } from "./types";
 
 /** Network delay for realistic demo behavior */
 const MOCK_DELAY_MS = 100;
@@ -72,6 +72,29 @@ function delay(ms: number): Promise<void> {
 }
 
 /**
+ * Generate a mock Didok station ID from coordinates.
+ * Uses a hash of the coordinates to create a realistic-looking ID.
+ */
+function generateMockStationId(coords: Coordinates): string {
+  // Create a deterministic ID from coordinates (Swiss Didok IDs are 7 digits starting with 85)
+  const latHash = Math.abs(Math.round(coords.latitude * 10000));
+  const lonHash = Math.abs(Math.round(coords.longitude * 1000));
+  const combined = (latHash + lonHash) % 100000;
+  return `85${String(combined).padStart(5, "0")}`;
+}
+
+/**
+ * Generate a mock station name from coordinates.
+ * In demo mode, we just use a generic name.
+ */
+function generateMockStationName(coords: Coordinates): string {
+  // Generate a simple name based on rounded coordinates
+  const latDeg = Math.round(coords.latitude * 10) / 10;
+  const lonDeg = Math.round(coords.longitude * 10) / 10;
+  return `Station ${latDeg}N ${lonDeg}E`;
+}
+
+/**
  * Calculate mock travel time between two coordinates.
  * Used in demo mode when the real OJP API is not available.
  *
@@ -97,11 +120,18 @@ export async function calculateMockTravelTime(
   const departureTime = options.departureTime ?? new Date();
   const arrivalTime = new Date(departureTime.getTime() + durationMinutes * 60 * 1000);
 
+  // Generate mock destination station for SBB deep linking
+  const destinationStation: StationInfo = {
+    id: generateMockStationId(to),
+    name: generateMockStationName(to),
+  };
+
   return {
     durationMinutes,
     departureTime: departureTime.toISOString(),
     arrivalTime: arrivalTime.toISOString(),
     transfers,
+    destinationStation,
     tripData: undefined,
   };
 }

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -107,15 +107,11 @@ export async function calculateTravelTime(
     // Select the best trip based on target arrival time or take earliest departure
     const trip = selectBestTrip(trips, options.targetArrivalTime);
 
-    // Log trip for debugging station extraction
-    console.log("[OJP] Selected trip toLocation:", JSON.stringify(trip.toLocation, null, 2));
-
     // Parse duration from ISO 8601 duration string (e.g., "PT1H30M")
     const durationMinutes = parseDurationToMinutes(trip.duration);
 
     // Extract destination station for SBB deep linking
     const destinationStation = extractDestinationStation(trip);
-    console.log("[OJP] Extracted destination station:", destinationStation);
 
     return {
       durationMinutes,

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -5,7 +5,7 @@
  * The SDK is loaded lazily to reduce initial bundle size.
  */
 
-import type { Coordinates, TravelTimeResult, TravelTimeOptions } from "./types";
+import type { Coordinates, TravelTimeResult, TravelTimeOptions, StationInfo } from "./types";
 import { TransportApiError } from "./types";
 
 /** Lazily loaded OJP SDK module */
@@ -110,11 +110,15 @@ export async function calculateTravelTime(
     // Parse duration from ISO 8601 duration string (e.g., "PT1H30M")
     const durationMinutes = parseDurationToMinutes(trip.duration);
 
+    // Extract destination station for SBB deep linking
+    const destinationStation = extractDestinationStation(trip);
+
     return {
       durationMinutes,
       departureTime: trip.startTime,
       arrivalTime: trip.endTime,
       transfers: trip.transfers,
+      destinationStation,
       tripData: options.includeTrips ? trip : undefined,
     };
   } catch (error) {
@@ -129,6 +133,18 @@ export async function calculateTravelTime(
 }
 
 /**
+ * Location type from ojp-sdk-next for extracting station info.
+ */
+interface OjpLocation {
+  stopPointRef?: string;
+  locationName?: string;
+  stopPlace?: {
+    stopPlaceRef?: string;
+    stopPlaceName?: string;
+  };
+}
+
+/**
  * Subset of trip properties from ojp-sdk-next used for connection selection.
  * Defined locally to avoid coupling to SDK internals and to type only what we need.
  * If the SDK's Trip type changes, this interface should be updated accordingly.
@@ -138,6 +154,56 @@ export interface OjpTrip {
   startTime: string;
   endTime: string;
   transfers: number;
+  toLocation?: OjpLocation;
+}
+
+/**
+ * Extract Didok station ID from OJP stopPointRef or stopPlaceRef.
+ * Format: "ch:1:sloid:8507000" -> "8507000"
+ */
+function extractDidokId(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+
+  // Handle sloid format: "ch:1:sloid:8507000" or "ch:1:sloid:8507000:1"
+  const sloidMatch = ref.match(/sloid:(\d+)/);
+  if (sloidMatch) {
+    return sloidMatch[1];
+  }
+
+  // Handle direct numeric ID
+  if (/^\d+$/.test(ref)) {
+    return ref;
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract destination station info from an OJP trip.
+ */
+export function extractDestinationStation(trip: OjpTrip): StationInfo | undefined {
+  const toLocation = trip.toLocation;
+  if (!toLocation) return undefined;
+
+  // Try stopPlaceRef first (more reliable for SBB linking)
+  const stopPlaceId = extractDidokId(toLocation.stopPlace?.stopPlaceRef);
+  if (stopPlaceId && toLocation.stopPlace?.stopPlaceName) {
+    return {
+      id: stopPlaceId,
+      name: toLocation.stopPlace.stopPlaceName,
+    };
+  }
+
+  // Fall back to stopPointRef
+  const stopPointId = extractDidokId(toLocation.stopPointRef);
+  if (stopPointId) {
+    return {
+      id: stopPointId,
+      name: toLocation.locationName ?? toLocation.stopPlace?.stopPlaceName ?? "",
+    };
+  }
+
+  return undefined;
 }
 
 /**

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -107,11 +107,15 @@ export async function calculateTravelTime(
     // Select the best trip based on target arrival time or take earliest departure
     const trip = selectBestTrip(trips, options.targetArrivalTime);
 
+    // Log trip for debugging station extraction
+    console.log("[OJP] Selected trip toLocation:", JSON.stringify(trip.toLocation, null, 2));
+
     // Parse duration from ISO 8601 duration string (e.g., "PT1H30M")
     const durationMinutes = parseDurationToMinutes(trip.duration);
 
     // Extract destination station for SBB deep linking
     const destinationStation = extractDestinationStation(trip);
+    console.log("[OJP] Extracted destination station:", destinationStation);
 
     return {
       durationMinutes,

--- a/web-app/src/services/transport/types.ts
+++ b/web-app/src/services/transport/types.ts
@@ -43,6 +43,10 @@ export interface TravelTimeOptions {
   targetArrivalTime?: Date;
   /** Include raw trip data in result (for future itinerary display) */
   includeTrips?: boolean;
+  /** Origin location label (for mock transport station names) */
+  originLabel?: string;
+  /** Destination location label (for mock transport station names) */
+  destinationLabel?: string;
 }
 
 /**

--- a/web-app/src/services/transport/types.ts
+++ b/web-app/src/services/transport/types.ts
@@ -4,6 +4,16 @@
  */
 
 /**
+ * Station information extracted from trip data.
+ */
+export interface StationInfo {
+  /** Didok station ID (e.g., "8507000" for Bern) */
+  id: string;
+  /** Station name */
+  name: string;
+}
+
+/**
  * Result of a travel time calculation.
  */
 export interface TravelTimeResult {
@@ -15,6 +25,8 @@ export interface TravelTimeResult {
   arrivalTime: string;
   /** Number of transfers required */
   transfers: number;
+  /** Destination station info for SBB deep linking */
+  destinationStation?: StationInfo;
   /** Raw trip data for future itinerary display */
   tripData?: unknown;
 }

--- a/web-app/src/services/transport/types.ts
+++ b/web-app/src/services/transport/types.ts
@@ -25,6 +25,8 @@ export interface TravelTimeResult {
   arrivalTime: string;
   /** Number of transfers required */
   transfers: number;
+  /** Origin station info for SBB deep linking */
+  originStation?: StationInfo;
   /** Destination station info for SBB deep linking */
   destinationStation?: StationInfo;
   /** Raw trip data for future itinerary display */

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -46,6 +46,13 @@ export interface TravelTimeFilter {
   cacheInvalidatedAt: number | null;
 }
 
+/**
+ * Target for SBB timetable links.
+ * - 'website': Opens SBB website (works everywhere)
+ * - 'app': Opens SBB mobile app (requires app installed)
+ */
+export type SbbLinkTarget = "website" | "app";
+
 /** Default arrival buffer for SV (Swiss Volley national) - 60 minutes */
 export const DEFAULT_ARRIVAL_BUFFER_SV_MINUTES = 60;
 
@@ -101,6 +108,11 @@ interface SettingsState {
   getArrivalBufferForAssociation: (associationCode: string | undefined) => number;
   invalidateTravelTimeCache: () => void;
 
+  // SBB link target settings (per-association)
+  sbbLinkTargetByAssociation: Record<string, SbbLinkTarget>;
+  setSbbLinkTargetForAssociation: (associationCode: string, target: SbbLinkTarget) => void;
+  getSbbLinkTargetForAssociation: (associationCode: string | undefined) => SbbLinkTarget;
+
   // Level filter (demo mode only)
   levelFilterEnabled: boolean;
   setLevelFilterEnabled: (enabled: boolean) => void;
@@ -148,6 +160,7 @@ export const useSettingsStore = create<SettingsState>()(
         cacheInvalidatedAt: null,
       },
       levelFilterEnabled: false,
+      sbbLinkTargetByAssociation: {},
 
       setSafeMode: (enabled: boolean) => {
         set({ isSafeModeEnabled: enabled });
@@ -250,6 +263,25 @@ export const useSettingsStore = create<SettingsState>()(
         }));
       },
 
+      setSbbLinkTargetForAssociation: (associationCode: string, target: SbbLinkTarget) => {
+        set((state) => ({
+          sbbLinkTargetByAssociation: {
+            ...state.sbbLinkTargetByAssociation,
+            [associationCode]: target,
+          },
+        }));
+      },
+
+      getSbbLinkTargetForAssociation: (associationCode: string | undefined) => {
+        const state = get();
+        const targetMap = state.sbbLinkTargetByAssociation ?? {};
+        if (associationCode && targetMap[associationCode] !== undefined) {
+          return targetMap[associationCode];
+        }
+        // Default to website (works everywhere)
+        return "website";
+      },
+
       setLevelFilterEnabled: (enabled: boolean) => {
         set({ levelFilterEnabled: enabled });
       },
@@ -273,6 +305,7 @@ export const useSettingsStore = create<SettingsState>()(
             cacheInvalidatedAt: null,
           },
           levelFilterEnabled: false,
+          sbbLinkTargetByAssociation: {},
         });
       },
     }),
@@ -286,6 +319,7 @@ export const useSettingsStore = create<SettingsState>()(
         transportEnabledByAssociation: state.transportEnabledByAssociation,
         travelTimeFilter: state.travelTimeFilter,
         levelFilterEnabled: state.levelFilterEnabled,
+        sbbLinkTargetByAssociation: state.sbbLinkTargetByAssociation,
       }),
     },
   ),

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -131,13 +131,13 @@ const DEFAULT_MAX_TRAVEL_TIME_MINUTES = 120;
 const DEFAULT_ARRIVAL_BUFFER_MINUTES = 30;
 
 /**
- * Demo mode default location: Zurich main station area.
+ * Demo mode default location: Bern (central Switzerland).
  * Provides a central location in Switzerland to showcase distance filtering.
  */
 export const DEMO_HOME_LOCATION: UserLocation = {
-  latitude: 47.3769,
-  longitude: 8.5417,
-  label: "Zürich HB",
+  latitude: 46.949,
+  longitude: 7.4474,
+  label: "Bern",
   source: "geocoded",
 };
 

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -15,10 +15,11 @@ describe("sbb-url", () => {
         const url = generateSbbUrl(baseParams, "website");
 
         expect(url).toContain("https://www.sbb.ch/de?stops=");
-        expect(url).toContain("date=2024-12-28");
-        expect(url).toContain("time=14:30");
-        // Check that destination is in the stops parameter (not URL-encoded per SBB spec)
-        expect(url).toContain('"label":"Bern"');
+        // Date and time should be quoted and encoded
+        expect(url).toContain("date=%222024-12-28%22");
+        expect(url).toContain("time=%2214:30%22");
+        // Quotes in stops JSON should be encoded as %22
+        expect(url).toContain("%22label%22:%22Bern%22");
       });
 
       it("generates correct URL for French", () => {
@@ -46,20 +47,20 @@ describe("sbb-url", () => {
         expect(url).toContain("https://www.sbb.ch/de?stops=");
       });
 
-      it("includes destination in stops JSON", () => {
+      it("includes destination in stops JSON with encoded quotes", () => {
         const params = {
           ...baseParams,
           destination: "Zürich HB",
         };
         const url = generateSbbUrl(params, "website");
-        // The destination should be inside the JSON stops parameter (not URL-encoded)
-        expect(url).toContain('"label":"Zürich HB"');
+        // The destination should be inside the JSON with quotes encoded
+        expect(url).toContain("%22label%22:%22Zürich HB%22");
       });
 
-      it("includes empty origin in stops array", () => {
+      it("includes empty origin in stops array with encoded quotes", () => {
         const url = generateSbbUrl(baseParams, "website");
-        // First stop should be empty (origin)
-        expect(url).toContain('{"value":"","type":"","label":""}');
+        // First stop should be empty (origin) with encoded quotes
+        expect(url).toContain("{%22value%22:%22%22,%22type%22:%22%22,%22label%22:%22%22}");
       });
     });
 
@@ -69,20 +70,20 @@ describe("sbb-url", () => {
 
         // App also uses the SBB website URL (responsive, works on mobile)
         expect(url).toContain("https://www.sbb.ch/de?stops=");
-        expect(url).toContain("date=2024-12-28");
-        expect(url).toContain("time=14:30");
+        expect(url).toContain("date=%222024-12-28%22");
+        expect(url).toContain("time=%2214:30%22");
       });
     });
 
     describe("date formatting", () => {
-      it("formats date as YYYY-MM-DD with leading zeros", () => {
+      it("formats date as YYYY-MM-DD with leading zeros and quotes", () => {
         const params = {
           ...baseParams,
           date: new Date("2024-01-05T10:00:00"),
           arrivalTime: new Date("2024-01-05T10:00:00"),
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("date=2024-01-05");
+        expect(url).toContain("date=%222024-01-05%22");
       });
 
       it("formats single-digit month with leading zero", () => {
@@ -92,27 +93,27 @@ describe("sbb-url", () => {
           arrivalTime: new Date("2024-03-15T10:00:00"),
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("date=2024-03-15");
+        expect(url).toContain("date=%222024-03-15%22");
       });
     });
 
     describe("time formatting", () => {
-      it("formats single-digit hours with leading zero", () => {
+      it("formats single-digit hours with leading zero and quotes", () => {
         const params = {
           ...baseParams,
           arrivalTime: new Date("2024-12-28T09:05:00"),
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("time=09:05");
+        expect(url).toContain("time=%2209:05%22");
       });
 
-      it("formats midnight correctly", () => {
+      it("formats midnight correctly with quotes", () => {
         const params = {
           ...baseParams,
           arrivalTime: new Date("2024-12-28T00:00:00"),
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("time=00:00");
+        expect(url).toContain("time=%2200:00%22");
       });
     });
   });

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -62,6 +62,24 @@ describe("sbb-url", () => {
         // First stop should be empty (origin) with encoded quotes
         expect(url).toContain("{%22value%22:%22%22,%22type%22:%22%22,%22label%22:%22%22}");
       });
+
+      it("uses station ID when destinationStation is provided", () => {
+        const params = {
+          ...baseParams,
+          destinationStation: { id: "8507000", name: "Bern" },
+        };
+        const url = generateSbbUrl(params, "website");
+        // Should contain the Didok ID and type "ID"
+        expect(url).toContain("%22value%22:%228507000%22");
+        expect(url).toContain("%22type%22:%22ID%22");
+        expect(url).toContain("%22label%22:%22Bern%22");
+      });
+
+      it("uses destination label as fallback when no station ID", () => {
+        const url = generateSbbUrl(baseParams, "website");
+        // Should have empty value and type, but destination in label
+        expect(url).toContain("%22value%22:%22%22,%22type%22:%22%22,%22label%22:%22Bern%22");
+      });
     });
 
     describe("app target", () => {

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -21,7 +21,7 @@ describe("sbb-url", () => {
         // Quotes in stops JSON should be encoded as %22
         expect(url).toContain("%22label%22:%22Bern%22");
         // Should use arrival time mode
-        expect(url).toContain("deparr=arr");
+        expect(url).toContain("moment=ARRIVAL");
       });
 
       it("generates correct URL for French", () => {

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -11,40 +11,27 @@ describe("sbb-url", () => {
     };
 
     describe("website target", () => {
-      it("generates correct URL for German", () => {
+      it("generates correct search.ch URL", () => {
         const url = generateSbbUrl(baseParams, "website");
 
-        expect(url).toContain("https://www.sbb.ch/de/kaufen/pages/fahrplan/fahrplan.xhtml");
-        expect(url).toContain("nach=Bern");
-        expect(url).toContain("datum=28.12.2024");
-        expect(url).toContain("zeit=14%3A30");
-        expect(url).toContain("an=true");
-        expect(url).toContain("suche=true");
+        expect(url).toContain("https://search.ch/fahrplan/");
+        expect(url).toContain("to=Bern");
+        expect(url).toContain("date=28.12.2024");
+        expect(url).toContain("time=14%3A30");
+        expect(url).toContain("time_type=arrival");
       });
 
-      it("generates correct URL for French", () => {
-        const url = generateSbbUrl({ ...baseParams, language: "fr" }, "website");
-        expect(url).toContain("https://www.sbb.ch/fr/acheter/pages/fahrplan/fahrplan.xhtml");
-      });
+      it("uses search.ch regardless of language", () => {
+        const urlDe = generateSbbUrl({ ...baseParams, language: "de" }, "website");
+        const urlFr = generateSbbUrl({ ...baseParams, language: "fr" }, "website");
+        const urlIt = generateSbbUrl({ ...baseParams, language: "it" }, "website");
+        const urlEn = generateSbbUrl({ ...baseParams, language: "en" }, "website");
 
-      it("generates correct URL for Italian", () => {
-        const url = generateSbbUrl({ ...baseParams, language: "it" }, "website");
-        expect(url).toContain("https://www.sbb.ch/it/acquistare/pages/fahrplan/fahrplan.xhtml");
-      });
-
-      it("generates correct URL for English", () => {
-        const url = generateSbbUrl({ ...baseParams, language: "en" }, "website");
-        expect(url).toContain("https://www.sbb.ch/en/buying/pages/fahrplan/fahrplan.xhtml");
-      });
-
-      it("defaults to English when no language specified", () => {
-        const params = {
-          destination: "Zürich",
-          date: new Date("2024-12-28T10:00:00"),
-          arrivalTime: new Date("2024-12-28T10:00:00"),
-        };
-        const url = generateSbbUrl(params, "website");
-        expect(url).toContain("https://www.sbb.ch/en/buying/pages/fahrplan/fahrplan.xhtml");
+        // All should use search.ch
+        expect(urlDe).toContain("https://search.ch/fahrplan/");
+        expect(urlFr).toContain("https://search.ch/fahrplan/");
+        expect(urlIt).toContain("https://search.ch/fahrplan/");
+        expect(urlEn).toContain("https://search.ch/fahrplan/");
       });
 
       it("URL-encodes special characters in destination", () => {
@@ -53,22 +40,22 @@ describe("sbb-url", () => {
           destination: "Zürich HB",
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("nach=Z%C3%BCrich+HB");
+        expect(url).toContain("to=Z%C3%BCrich+HB");
       });
     });
 
     describe("app target", () => {
-      it("generates correct app URL", () => {
+      it("generates correct SBB app URL", () => {
         const url = generateSbbUrl(baseParams, "app");
 
         expect(url).toContain("https://app.sbbmobile.ch/timetable");
-        expect(url).toContain("nach=Bern");
-        expect(url).toContain("datum=28.12.2024");
-        expect(url).toContain("zeit=14%3A30");
-        expect(url).toContain("an=true");
+        expect(url).toContain("to=Bern");
+        expect(url).toContain("date=28.12.2024");
+        expect(url).toContain("time=14%3A30");
+        expect(url).toContain("timeType=arrival");
       });
 
-      it("does not include language in app URL", () => {
+      it("does not include language path in app URL", () => {
         const url = generateSbbUrl(baseParams, "app");
         expect(url).not.toContain("/de/");
         expect(url).not.toContain("/fr/");
@@ -83,7 +70,7 @@ describe("sbb-url", () => {
           arrivalTime: new Date("2024-01-05T10:00:00"),
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("datum=05.01.2024");
+        expect(url).toContain("date=05.01.2024");
       });
 
       it("formats single-digit month with leading zero", () => {
@@ -93,7 +80,7 @@ describe("sbb-url", () => {
           arrivalTime: new Date("2024-03-15T10:00:00"),
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("datum=15.03.2024");
+        expect(url).toContain("date=15.03.2024");
       });
     });
 
@@ -104,7 +91,7 @@ describe("sbb-url", () => {
           arrivalTime: new Date("2024-12-28T09:05:00"),
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("zeit=09%3A05");
+        expect(url).toContain("time=09%3A05");
       });
 
       it("formats midnight correctly", () => {
@@ -113,7 +100,7 @@ describe("sbb-url", () => {
           arrivalTime: new Date("2024-12-28T00:00:00"),
         };
         const url = generateSbbUrl(params, "website");
-        expect(url).toContain("zeit=00%3A00");
+        expect(url).toContain("time=00%3A00");
       });
     });
   });

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { generateSbbUrl, calculateArrivalTime } from "./sbb-url";
+
+describe("sbb-url", () => {
+  describe("generateSbbUrl", () => {
+    const baseParams = {
+      destination: "Bern",
+      date: new Date("2024-12-28T14:30:00"),
+      arrivalTime: new Date("2024-12-28T14:30:00"),
+      language: "de" as const,
+    };
+
+    describe("website target", () => {
+      it("generates correct URL for German", () => {
+        const url = generateSbbUrl(baseParams, "website");
+
+        expect(url).toContain("https://www.sbb.ch/de/kaufen/pages/fahrplan/fahrplan.xhtml");
+        expect(url).toContain("nach=Bern");
+        expect(url).toContain("datum=28.12.2024");
+        expect(url).toContain("zeit=14%3A30");
+        expect(url).toContain("an=true");
+        expect(url).toContain("suche=true");
+      });
+
+      it("generates correct URL for French", () => {
+        const url = generateSbbUrl({ ...baseParams, language: "fr" }, "website");
+        expect(url).toContain("https://www.sbb.ch/fr/acheter/pages/fahrplan/fahrplan.xhtml");
+      });
+
+      it("generates correct URL for Italian", () => {
+        const url = generateSbbUrl({ ...baseParams, language: "it" }, "website");
+        expect(url).toContain("https://www.sbb.ch/it/acquistare/pages/fahrplan/fahrplan.xhtml");
+      });
+
+      it("generates correct URL for English", () => {
+        const url = generateSbbUrl({ ...baseParams, language: "en" }, "website");
+        expect(url).toContain("https://www.sbb.ch/en/buying/pages/fahrplan/fahrplan.xhtml");
+      });
+
+      it("defaults to English when no language specified", () => {
+        const params = {
+          destination: "Zürich",
+          date: new Date("2024-12-28T10:00:00"),
+          arrivalTime: new Date("2024-12-28T10:00:00"),
+        };
+        const url = generateSbbUrl(params, "website");
+        expect(url).toContain("https://www.sbb.ch/en/buying/pages/fahrplan/fahrplan.xhtml");
+      });
+
+      it("URL-encodes special characters in destination", () => {
+        const params = {
+          ...baseParams,
+          destination: "Zürich HB",
+        };
+        const url = generateSbbUrl(params, "website");
+        expect(url).toContain("nach=Z%C3%BCrich+HB");
+      });
+    });
+
+    describe("app target", () => {
+      it("generates correct app URL", () => {
+        const url = generateSbbUrl(baseParams, "app");
+
+        expect(url).toContain("https://app.sbbmobile.ch/timetable");
+        expect(url).toContain("nach=Bern");
+        expect(url).toContain("datum=28.12.2024");
+        expect(url).toContain("zeit=14%3A30");
+        expect(url).toContain("an=true");
+      });
+
+      it("does not include language in app URL", () => {
+        const url = generateSbbUrl(baseParams, "app");
+        expect(url).not.toContain("/de/");
+        expect(url).not.toContain("/fr/");
+      });
+    });
+
+    describe("date formatting", () => {
+      it("formats single-digit day with leading zero", () => {
+        const params = {
+          ...baseParams,
+          date: new Date("2024-01-05T10:00:00"),
+          arrivalTime: new Date("2024-01-05T10:00:00"),
+        };
+        const url = generateSbbUrl(params, "website");
+        expect(url).toContain("datum=05.01.2024");
+      });
+
+      it("formats single-digit month with leading zero", () => {
+        const params = {
+          ...baseParams,
+          date: new Date("2024-03-15T10:00:00"),
+          arrivalTime: new Date("2024-03-15T10:00:00"),
+        };
+        const url = generateSbbUrl(params, "website");
+        expect(url).toContain("datum=15.03.2024");
+      });
+    });
+
+    describe("time formatting", () => {
+      it("formats single-digit hours with leading zero", () => {
+        const params = {
+          ...baseParams,
+          arrivalTime: new Date("2024-12-28T09:05:00"),
+        };
+        const url = generateSbbUrl(params, "website");
+        expect(url).toContain("zeit=09%3A05");
+      });
+
+      it("formats midnight correctly", () => {
+        const params = {
+          ...baseParams,
+          arrivalTime: new Date("2024-12-28T00:00:00"),
+        };
+        const url = generateSbbUrl(params, "website");
+        expect(url).toContain("zeit=00%3A00");
+      });
+    });
+  });
+
+  describe("calculateArrivalTime", () => {
+    it("subtracts buffer minutes from game start time", () => {
+      const gameStart = new Date("2024-12-28T15:00:00");
+      const arrivalTime = calculateArrivalTime(gameStart, 60);
+
+      expect(arrivalTime.getHours()).toBe(14);
+      expect(arrivalTime.getMinutes()).toBe(0);
+    });
+
+    it("handles ISO string input", () => {
+      const arrivalTime = calculateArrivalTime("2024-12-28T15:00:00", 30);
+
+      expect(arrivalTime.getHours()).toBe(14);
+      expect(arrivalTime.getMinutes()).toBe(30);
+    });
+
+    it("handles zero buffer", () => {
+      const gameStart = new Date("2024-12-28T15:00:00");
+      const arrivalTime = calculateArrivalTime(gameStart, 0);
+
+      expect(arrivalTime.getTime()).toBe(gameStart.getTime());
+    });
+
+    it("handles large buffer crossing midnight", () => {
+      const gameStart = new Date("2024-12-28T01:00:00");
+      const arrivalTime = calculateArrivalTime(gameStart, 120);
+
+      expect(arrivalTime.getDate()).toBe(27);
+      expect(arrivalTime.getHours()).toBe(23);
+    });
+  });
+});

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -20,6 +20,8 @@ describe("sbb-url", () => {
         expect(url).toContain("time=%2214:30%22");
         // Quotes in stops JSON should be encoded as %22
         expect(url).toContain("%22label%22:%22Bern%22");
+        // Should use arrival time mode
+        expect(url).toContain("deparr=arr");
       });
 
       it("generates correct URL for French", () => {

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -18,8 +18,9 @@ describe("sbb-url", () => {
         // Date and time should be quoted and encoded
         expect(url).toContain("date=%222024-12-28%22");
         expect(url).toContain("time=%2214:30%22");
-        // Quotes in stops JSON should be encoded as %22
-        expect(url).toContain("%22label%22:%22Bern%22");
+        // Stops JSON should be fully URL-encoded (brackets, braces, quotes, colons, commas)
+        expect(url).toContain("%5B%7B%22value%22"); // [{"value"
+        expect(url).toContain("%22label%22%3A%22Bern%22%7D%5D"); // "label":"Bern"}]
         // Should use arrival time mode
         expect(url).toContain("moment=ARRIVAL");
       });
@@ -49,20 +50,20 @@ describe("sbb-url", () => {
         expect(url).toContain("https://www.sbb.ch/de?stops=");
       });
 
-      it("includes destination in stops JSON with encoded quotes", () => {
+      it("includes destination in stops JSON with full URL encoding", () => {
         const params = {
           ...baseParams,
           destination: "Zürich HB",
         };
         const url = generateSbbUrl(params, "website");
-        // The destination should be inside the JSON with quotes encoded
-        expect(url).toContain("%22label%22:%22Zürich HB%22");
+        // The destination should be fully URL-encoded
+        expect(url).toContain("%22label%22%3A%22Z%C3%BCrich%20HB%22");
       });
 
-      it("includes empty origin in stops array with encoded quotes", () => {
+      it("includes empty origin in stops array when not provided", () => {
         const url = generateSbbUrl(baseParams, "website");
-        // First stop should be empty (origin) with encoded quotes
-        expect(url).toContain("{%22value%22:%22%22,%22type%22:%22%22,%22label%22:%22%22}");
+        // First stop should be empty (origin) - fully URL-encoded
+        expect(url).toContain("%7B%22value%22%3A%22%22%2C%22type%22%3A%22%22%2C%22label%22%3A%22%22%7D");
       });
 
       it("uses station ID when destinationStation is provided", () => {
@@ -71,16 +72,28 @@ describe("sbb-url", () => {
           destinationStation: { id: "8507000", name: "Bern" },
         };
         const url = generateSbbUrl(params, "website");
-        // Should contain the Didok ID and type "ID"
-        expect(url).toContain("%22value%22:%228507000%22");
-        expect(url).toContain("%22type%22:%22ID%22");
-        expect(url).toContain("%22label%22:%22Bern%22");
+        // Should contain the Didok ID and type "ID" - fully URL-encoded
+        expect(url).toContain("%22value%22%3A%228507000%22");
+        expect(url).toContain("%22type%22%3A%22ID%22");
+        expect(url).toContain("%22label%22%3A%22Bern%22");
       });
 
       it("uses destination label as fallback when no station ID", () => {
         const url = generateSbbUrl(baseParams, "website");
-        // Should have empty value and type, but destination in label
-        expect(url).toContain("%22value%22:%22%22,%22type%22:%22%22,%22label%22:%22Bern%22");
+        // Should have empty value and type, but destination in label - fully URL-encoded
+        expect(url).toContain("%22value%22%3A%22%22%2C%22type%22%3A%22%22%2C%22label%22%3A%22Bern%22");
+      });
+
+      it("includes origin station when provided", () => {
+        const params = {
+          ...baseParams,
+          originStation: { id: "8503000", name: "Zürich HB" },
+          destinationStation: { id: "8507000", name: "Bern" },
+        };
+        const url = generateSbbUrl(params, "website");
+        // Origin should have station ID
+        expect(url).toContain("%22value%22%3A%228503000%22");
+        expect(url).toContain("%22label%22%3A%22Z%C3%BCrich%20HB%22");
       });
     });
 

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -21,8 +21,8 @@ describe("sbb-url", () => {
         // Stops JSON should be fully URL-encoded (brackets, braces, quotes, colons, commas)
         expect(url).toContain("%5B%7B%22value%22"); // [{"value"
         expect(url).toContain("%22label%22%3A%22Bern%22%7D%5D"); // "label":"Bern"}]
-        // Should use arrival time mode
-        expect(url).toContain("moment=ARRIVAL");
+        // Should use arrival time mode (quoted like other params)
+        expect(url).toContain("moment=%22ARRIVAL%22");
       });
 
       it("generates correct URL for French", () => {

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -17,8 +17,8 @@ describe("sbb-url", () => {
         expect(url).toContain("https://www.sbb.ch/de?stops=");
         expect(url).toContain("date=2024-12-28");
         expect(url).toContain("time=14:30");
-        // Check that destination is in the encoded stops parameter
-        expect(url).toContain(encodeURIComponent('"label":"Bern"'));
+        // Check that destination is in the stops parameter (not URL-encoded per SBB spec)
+        expect(url).toContain('"label":"Bern"');
       });
 
       it("generates correct URL for French", () => {
@@ -46,20 +46,20 @@ describe("sbb-url", () => {
         expect(url).toContain("https://www.sbb.ch/de?stops=");
       });
 
-      it("URL-encodes special characters in destination", () => {
+      it("includes destination in stops JSON", () => {
         const params = {
           ...baseParams,
           destination: "Zürich HB",
         };
         const url = generateSbbUrl(params, "website");
-        // The destination should be inside the JSON stops parameter
-        expect(url).toContain(encodeURIComponent('"label":"Zürich HB"'));
+        // The destination should be inside the JSON stops parameter (not URL-encoded)
+        expect(url).toContain('"label":"Zürich HB"');
       });
 
       it("includes empty origin in stops array", () => {
         const url = generateSbbUrl(baseParams, "website");
         // First stop should be empty (origin)
-        expect(url).toContain(encodeURIComponent('{"value":"","type":"","label":""}'));
+        expect(url).toContain('{"value":"","type":"","label":""}');
       });
     });
 

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -76,9 +76,8 @@ export function generateSbbUrl(
   const stopsJson = JSON.stringify(stops);
 
   // Use the official SBB deep linking format
-  // The SBB website is responsive and works well on mobile
-  // Using this format ensures the destination is pre-filled
-  return `https://www.sbb.ch/${language}?stops=${encodeURIComponent(stopsJson)}&date=${formattedDate}&time=${formattedTime}`;
+  // Note: The JSON is NOT URL-encoded per SBB documentation examples
+  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${formattedDate}&time=${formattedTime}`;
 }
 
 /**

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -1,0 +1,121 @@
+import type { SbbLinkTarget } from "@/stores/settings";
+
+/**
+ * Parameters for generating an SBB timetable URL.
+ */
+export interface SbbUrlParams {
+  /** Destination location (city, station, or address) */
+  destination: string;
+  /** Date of travel (used to format the date parameter) */
+  date: Date;
+  /** Target arrival time at destination */
+  arrivalTime: Date;
+  /** Language code for the URL (de, en, fr, it) */
+  language?: "de" | "en" | "fr" | "it";
+}
+
+/**
+ * Format a date as DD.MM.YYYY for SBB URL parameters.
+ */
+function formatSbbDate(date: Date): string {
+  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = date.getFullYear();
+  return `${day}.${month}.${year}`;
+}
+
+/**
+ * Format a time as HH:MM for SBB URL parameters.
+ */
+function formatSbbTime(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+/**
+ * Get the SBB website path segment for a given language.
+ */
+function getSbbLanguagePath(language: string): string {
+  switch (language) {
+    case "de":
+      return "de/kaufen";
+    case "fr":
+      return "fr/acheter";
+    case "it":
+      return "it/acquistare";
+    case "en":
+    default:
+      return "en/buying";
+  }
+}
+
+/**
+ * Generate an SBB timetable URL for a given destination and arrival time.
+ *
+ * @param params - The parameters for generating the URL
+ * @param target - Whether to generate a website or app URL
+ * @returns The SBB timetable URL
+ *
+ * @example
+ * ```ts
+ * const url = generateSbbUrl({
+ *   destination: "Bern",
+ *   date: new Date("2024-12-28"),
+ *   arrivalTime: new Date("2024-12-28T14:30:00"),
+ *   language: "de",
+ * }, "website");
+ * // Returns: https://www.sbb.ch/de/kaufen/pages/fahrplan/fahrplan.xhtml?nach=Bern&datum=28.12.2024&zeit=14:30&an=true&suche=true
+ * ```
+ */
+export function generateSbbUrl(
+  params: SbbUrlParams,
+  target: SbbLinkTarget,
+): string {
+  const { destination, date, arrivalTime, language = "en" } = params;
+
+  const formattedDate = formatSbbDate(date);
+  const formattedTime = formatSbbTime(arrivalTime);
+
+  if (target === "app") {
+    // Use the SBB mobile app universal link
+    // This will open the app if installed, or fall back to the app store
+    const appParams = new URLSearchParams({
+      nach: destination,
+      datum: formattedDate,
+      zeit: formattedTime,
+      an: "true",
+    });
+    return `https://app.sbbmobile.ch/timetable?${appParams.toString()}`;
+  }
+
+  // Website URL
+  const langPath = getSbbLanguagePath(language);
+  const websiteParams = new URLSearchParams({
+    nach: destination,
+    datum: formattedDate,
+    zeit: formattedTime,
+    an: "true",
+    suche: "true",
+  });
+
+  return `https://www.sbb.ch/${langPath}/pages/fahrplan/fahrplan.xhtml?${websiteParams.toString()}`;
+}
+
+/**
+ * Calculate the target arrival time for a game, accounting for the arrival buffer.
+ *
+ * @param gameStartTime - The game start time as an ISO string or Date
+ * @param arrivalBufferMinutes - Minutes before game start to arrive
+ * @returns The target arrival time
+ */
+export function calculateArrivalTime(
+  gameStartTime: string | Date,
+  arrivalBufferMinutes: number,
+): Date {
+  const startTime =
+    typeof gameStartTime === "string"
+      ? new Date(gameStartTime)
+      : gameStartTime;
+  return new Date(startTime.getTime() - arrivalBufferMinutes * 60 * 1000);
+}

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -88,13 +88,13 @@ export function generateSbbUrl(
   ];
 
   // SBB expects full URL encoding for the stops JSON
-  // Date and time values must be quoted: date="2024-12-28"
+  // Date, time, and moment values must be quoted: date="2024-12-28"
   const stopsJson = encodeURIComponent(JSON.stringify(stops));
   const quotedDate = `%22${formattedDate}%22`;
   const quotedTime = `%22${formattedTime}%22`;
 
   // moment=ARRIVAL indicates arrival time (default is DEPARTURE)
-  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${quotedDate}&time=${quotedTime}&moment=ARRIVAL`;
+  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${quotedDate}&time=${quotedTime}&moment=%22ARRIVAL%22`;
 }
 
 /**

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -73,11 +73,14 @@ export function generateSbbUrl(
     { value: "", type: "", label: "" },
     { value: "", type: "", label: destination },
   ];
-  const stopsJson = JSON.stringify(stops);
 
-  // Use the official SBB deep linking format
-  // Note: The JSON is NOT URL-encoded per SBB documentation examples
-  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${formattedDate}&time=${formattedTime}`;
+  // SBB expects: only quotes encoded (%22), brackets/colons literal
+  // Date and time values must be quoted: date="2024-12-28"
+  const stopsJson = JSON.stringify(stops).replace(/"/g, "%22");
+  const quotedDate = `%22${formattedDate}%22`;
+  const quotedTime = `%22${formattedTime}%22`;
+
+  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${quotedDate}&time=${quotedTime}`;
 }
 
 /**

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -87,8 +87,8 @@ export function generateSbbUrl(
   const quotedDate = `%22${formattedDate}%22`;
   const quotedTime = `%22${formattedTime}%22`;
 
-  // deparr=arr indicates arrival time (default is departure)
-  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${quotedDate}&time=${quotedTime}&deparr=arr`;
+  // moment=ARRIVAL indicates arrival time (default is DEPARTURE)
+  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${quotedDate}&time=${quotedTime}&moment=ARRIVAL`;
 }
 
 /**

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -1,5 +1,6 @@
 import type { Locale } from "@/i18n";
 import type { SbbLinkTarget } from "@/stores/settings";
+import type { StationInfo } from "@/services/transport/types";
 
 /**
  * Parameters for generating a public transport timetable URL.
@@ -13,6 +14,8 @@ export interface SbbUrlParams {
   arrivalTime: Date;
   /** Language code for the URL */
   language?: Locale;
+  /** Destination station info with Didok ID for precise routing */
+  destinationStation?: StationInfo;
 }
 
 /**
@@ -61,17 +64,21 @@ export function generateSbbUrl(
   // Target parameter kept for future use (e.g., if SBB provides app-specific deep links)
   void target;
 
-  const { destination, date, arrivalTime, language = "de" } = params;
+  const { destination, date, arrivalTime, language = "de", destinationStation } = params;
 
   const formattedDate = formatDateSbb(date);
   const formattedTime = formatTime(arrivalTime);
 
   // Build the stops JSON array per SBB deep linking spec
   // First element is origin (empty = user sets their starting point)
-  // Second element is destination with label
+  // Second element is destination with Didok ID if available, or just label
+  const destinationStop = destinationStation
+    ? { value: destinationStation.id, type: "ID", label: destinationStation.name }
+    : { value: "", type: "", label: destination };
+
   const stops = [
     { value: "", type: "", label: "" },
-    { value: "", type: "", label: destination },
+    destinationStop,
   ];
 
   // SBB expects: only quotes encoded (%22), brackets/colons literal

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -1,3 +1,4 @@
+import type { Locale } from "@/i18n";
 import type { SbbLinkTarget } from "@/stores/settings";
 
 /**
@@ -10,8 +11,8 @@ export interface SbbUrlParams {
   date: Date;
   /** Target arrival time at destination */
   arrivalTime: Date;
-  /** Language code for the URL (de, en, fr, it) */
-  language?: "de" | "en" | "fr" | "it";
+  /** Language code for the URL */
+  language?: Locale;
 }
 
 /**

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -87,7 +87,8 @@ export function generateSbbUrl(
   const quotedDate = `%22${formattedDate}%22`;
   const quotedTime = `%22${formattedTime}%22`;
 
-  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${quotedDate}&time=${quotedTime}`;
+  // deparr=arr indicates arrival time (default is departure)
+  return `https://www.sbb.ch/${language}?stops=${stopsJson}&date=${quotedDate}&time=${quotedTime}&deparr=arr`;
 }
 
 /**


### PR DESCRIPTION
Add setting to choose between SBB website or SBB app when opening
timetable connections. The setting is per-association and appears
in the Transport section when transport calculations are enabled.

- Add SbbLinkTarget type ('website' | 'app') to settings store
- Add per-association sbbLinkTargetByAssociation setting
- Add UI toggle in TransportSection with segmented button control
- Create sbb-url.ts utility for generating SBB timetable URLs
- Add train icon link in AssignmentCard that opens SBB connection
- Add translations for all 4 languages (de, en, fr, it)

The SBB link uses the arrival buffer setting to calculate the
target arrival time at the venue, so referees arrive on time.