### PR TITLE
fix(settings): add resilient merge for localStorage persistence

### DIFF
--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -278,6 +278,7 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: "volleykit-settings",
+      version: 1,
       partialize: (state) => ({
         isSafeModeEnabled: state.isSafeModeEnabled,
         homeLocation: state.homeLocation,
@@ -287,6 +288,35 @@ export const useSettingsStore = create<SettingsState>()(
         travelTimeFilter: state.travelTimeFilter,
         levelFilterEnabled: state.levelFilterEnabled,
       }),
+      merge: (persisted, current) => {
+        // Defensively merge persisted data with current defaults.
+        // This prevents data loss when the schema changes or data is corrupted.
+        const persistedState = persisted as Partial<SettingsState> | undefined;
+
+        return {
+          ...current,
+          // Preserve safe mode setting
+          isSafeModeEnabled: persistedState?.isSafeModeEnabled ?? current.isSafeModeEnabled,
+          // Preserve home location - critical user data
+          homeLocation: persistedState?.homeLocation ?? current.homeLocation,
+          // Merge distance filter with defaults for any missing fields
+          distanceFilter: {
+            ...current.distanceFilter,
+            ...(persistedState?.distanceFilter ?? {}),
+          },
+          // Preserve transport settings
+          transportEnabled: persistedState?.transportEnabled ?? current.transportEnabled,
+          transportEnabledByAssociation:
+            persistedState?.transportEnabledByAssociation ?? current.transportEnabledByAssociation,
+          // Merge travel time filter with defaults for any missing fields
+          travelTimeFilter: {
+            ...current.travelTimeFilter,
+            ...(persistedState?.travelTimeFilter ?? {}),
+          },
+          // Preserve level filter
+          levelFilterEnabled: persistedState?.levelFilterEnabled ?? current.levelFilterEnabled,
+        };
+      },
     },
   ),
 );


### PR DESCRIPTION
Add version number and defensive merge function to prevent home location
and other settings from being lost during app updates. The merge function
gracefully handles partial, corrupted, or schema-mismatched persisted data
by merging with current defaults.