### PR TITLE
fix(transport): include nameSuffix in OJP station name parsing

### DIFF
--- a/web-app/src/services/transport/ojp-client.test.ts
+++ b/web-app/src/services/transport/ojp-client.test.ts
@@ -294,6 +294,53 @@ describe("extractDestinationStation", () => {
     const result = extractDestinationStation(trip);
     expect(result).toEqual({ id: "8507000", name: "Bern" });
   });
+
+  it("combines stopPointName with nameSuffix when present", () => {
+    const trip: OjpTrip = {
+      ...baseTrip,
+      leg: [
+        {
+          timedLeg: {
+            legBoard: {
+              stopPointRef: "ch:1:sloid:8503000",
+              stopPointName: { text: "Zürich HB" },
+            },
+            legAlight: {
+              stopPointRef: "ch:1:sloid:8502206",
+              stopPointName: { text: "Schönenwerd" },
+              nameSuffix: { text: "SO, Bahnhof" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = extractDestinationStation(trip);
+    expect(result).toEqual({ id: "8502206", name: "Schönenwerd SO, Bahnhof" });
+  });
+
+  it("uses only stopPointName when nameSuffix is not present", () => {
+    const trip: OjpTrip = {
+      ...baseTrip,
+      leg: [
+        {
+          timedLeg: {
+            legBoard: {
+              stopPointRef: "ch:1:sloid:8503000",
+              stopPointName: { text: "Zürich HB" },
+            },
+            legAlight: {
+              stopPointRef: "ch:1:sloid:8507000",
+              stopPointName: { text: "Bern" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = extractDestinationStation(trip);
+    expect(result).toEqual({ id: "8507000", name: "Bern" });
+  });
 });
 
 describe("extractOriginStation", () => {
@@ -367,5 +414,29 @@ describe("extractOriginStation", () => {
 
     const result = extractOriginStation(trip);
     expect(result).toEqual({ id: "8503000", name: "Zürich HB" });
+  });
+
+  it("combines stopPointName with nameSuffix when present", () => {
+    const trip: OjpTrip = {
+      ...baseTrip,
+      leg: [
+        {
+          timedLeg: {
+            legBoard: {
+              stopPointRef: "ch:1:sloid:8502206",
+              stopPointName: { text: "Schönenwerd" },
+              nameSuffix: { text: "SO, Bahnhof" },
+            },
+            legAlight: {
+              stopPointRef: "ch:1:sloid:8507000",
+              stopPointName: { text: "Bern" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = extractOriginStation(trip);
+    expect(result).toEqual({ id: "8502206", name: "Schönenwerd SO, Bahnhof" });
   });
 });

--- a/web-app/src/services/transport/ojp-client.ts
+++ b/web-app/src/services/transport/ojp-client.ts
@@ -142,6 +142,9 @@ interface OjpStopPoint {
   stopPointName: {
     text: string;
   };
+  nameSuffix?: {
+    text: string;
+  };
 }
 
 /**
@@ -196,6 +199,20 @@ function extractDidokId(ref: string | undefined): string | undefined {
 }
 
 /**
+ * Build full station name by combining stopPointName and optional nameSuffix.
+ * Example: "Schönenwerd" + "SO, Bahnhof" -> "Schönenwerd SO, Bahnhof"
+ */
+function buildStationName(stopPoint: OjpStopPoint): string {
+  const baseName = stopPoint.stopPointName.text;
+  const suffix = stopPoint.nameSuffix?.text;
+
+  if (suffix) {
+    return `${baseName} ${suffix}`;
+  }
+  return baseName;
+}
+
+/**
  * Extract station info from a stop point.
  */
 function extractStationFromStopPoint(stopPoint: OjpStopPoint | undefined): StationInfo | undefined {
@@ -206,7 +223,7 @@ function extractStationFromStopPoint(stopPoint: OjpStopPoint | undefined): Stati
 
   return {
     id,
-    name: stopPoint.stopPointName.text,
+    name: buildStationName(stopPoint),
   };
 }
 


### PR DESCRIPTION
The OJP API returns station names with an optional nameSuffix field that contains location context like canton codes (e.g., "SO, Bahnhof"). Previously only stopPointName.text was used, resulting in incomplete station names like "Schönenwerd" instead of "Schönenwerd SO, Bahnhof".

This fix:
- Adds nameSuffix field to OjpStopPoint interface
- Creates buildStationName helper to combine name and suffix
- Updates extractStationFromStopPoint to use full station name
- Adds tests for nameSuffix handling scenarios