### PR TITLE
fix(transport): clean SBB URLs by filtering OJP accessibility keywords

### DIFF
--- a/web-app/src/hooks/useSbbUrl.ts
+++ b/web-app/src/hooks/useSbbUrl.ts
@@ -77,6 +77,9 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
     const gameDate = new Date(gameStartTime);
     const arrivalTime = calculateArrivalTime(gameDate, arrivalBuffer);
 
+    // Get fallback address for origin (used when station lookup fails)
+    const originAddress = homeLocation?.source === "geocoded" ? homeLocation.label : undefined;
+
     // If we already have cached station info, use it directly
     if (originStation && destinationStation) {
       const url = generateSbbUrl(
@@ -87,6 +90,7 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
           language,
           originStation,
           destinationStation,
+          originAddress,
         },
         sbbLinkTarget,
       );
@@ -149,6 +153,7 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
             language,
             originStation: tripResult.originStation,
             destinationStation: tripResult.destinationStation,
+            originAddress,
           },
           sbbLinkTarget,
         );
@@ -156,13 +161,14 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
       } catch (err) {
         setError(err instanceof Error ? err : new Error("Failed to fetch trip data"));
 
-        // Fall back to URL without station ID
+        // Fall back to URL without station ID but with address
         const url = generateSbbUrl(
           {
             destination: city,
             date: gameDate,
             arrivalTime,
             language,
+            originAddress,
           },
           sbbLinkTarget,
         );
@@ -171,13 +177,14 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
         setIsLoading(false);
       }
     } else {
-      // No trip data available, use city name only
+      // No trip data available, use city name and address fallbacks
       const url = generateSbbUrl(
         {
           destination: city,
           date: gameDate,
           arrivalTime,
           language,
+          originAddress,
         },
         sbbLinkTarget,
       );

--- a/web-app/src/services/transport/ojp-client.test.ts
+++ b/web-app/src/services/transport/ojp-client.test.ts
@@ -319,6 +319,102 @@ describe("extractDestinationStation", () => {
     expect(result).toEqual({ id: "8502206", name: "Schönenwerd SO, Bahnhof" });
   });
 
+  it("filters out ALTERNATIVE_TRANSPORT from nameSuffix", () => {
+    const trip: OjpTrip = {
+      ...baseTrip,
+      leg: [
+        {
+          timedLeg: {
+            legBoard: {
+              stopPointRef: "ch:1:sloid:8503000",
+              stopPointName: { text: "Zürich HB" },
+            },
+            legAlight: {
+              stopPointRef: "ch:1:sloid:90727",
+              stopPointName: { text: "Oberengstringen, Paradies" },
+              nameSuffix: { text: "ALTERNATIVE_TRANSPORT" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = extractDestinationStation(trip);
+    expect(result).toEqual({ id: "90727", name: "Oberengstringen, Paradies" });
+  });
+
+  it("filters out PLATFORM_ACCESS_WITH_ASSISTANCE from nameSuffix", () => {
+    const trip: OjpTrip = {
+      ...baseTrip,
+      leg: [
+        {
+          timedLeg: {
+            legBoard: {
+              stopPointRef: "ch:1:sloid:8503000",
+              stopPointName: { text: "Zürich HB" },
+            },
+            legAlight: {
+              stopPointRef: "ch:1:sloid:73232",
+              stopPointName: { text: "Kloten, Freienberg" },
+              nameSuffix: { text: "PLATFORM_ACCESS_WITH_ASSISTANCE" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = extractDestinationStation(trip);
+    expect(result).toEqual({ id: "73232", name: "Kloten, Freienberg" });
+  });
+
+  it("removes accessibility keyword from end of nameSuffix", () => {
+    const trip: OjpTrip = {
+      ...baseTrip,
+      leg: [
+        {
+          timedLeg: {
+            legBoard: {
+              stopPointRef: "ch:1:sloid:8503000",
+              stopPointName: { text: "Zürich HB" },
+            },
+            legAlight: {
+              stopPointRef: "ch:1:sloid:8502206",
+              stopPointName: { text: "Schönenwerd" },
+              nameSuffix: { text: "SO, Bahnhof ALTERNATIVE_TRANSPORT" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = extractDestinationStation(trip);
+    expect(result).toEqual({ id: "8502206", name: "Schönenwerd SO, Bahnhof" });
+  });
+
+  it("removes multiple accessibility keywords from end of nameSuffix", () => {
+    const trip: OjpTrip = {
+      ...baseTrip,
+      leg: [
+        {
+          timedLeg: {
+            legBoard: {
+              stopPointRef: "ch:1:sloid:8503000",
+              stopPointName: { text: "Zürich HB" },
+            },
+            legAlight: {
+              stopPointRef: "ch:1:sloid:8502206",
+              stopPointName: { text: "Schönenwerd" },
+              nameSuffix: { text: "SO, Bahnhof WHEELCHAIR_ACCESS ALTERNATIVE_TRANSPORT" },
+            },
+          },
+        },
+      ],
+    };
+
+    const result = extractDestinationStation(trip);
+    expect(result).toEqual({ id: "8502206", name: "Schönenwerd SO, Bahnhof" });
+  });
+
   it("uses only stopPointName when nameSuffix is not present", () => {
     const trip: OjpTrip = {
       ...baseTrip,


### PR DESCRIPTION
## Fix SBB URL encoding issues

This PR fixes two issues with SBB (Swiss Federal Railways) URL generation:

### Problem 1: Accessibility keywords in station names
Station names were including OJP accessibility attributes like `ALTERNATIVE_TRANSPORT` and `PLATFORM_ACCESS_WITH_ASSISTANCE`, resulting in URLs like:

    ...label=Oberengstringen,+Paradies+ALTERNATIVE_TRANSPORT...

### Problem 2: Empty origin values when OJP fails
When station lookup failed, the URL had empty JSON values:

    stops=[{"value":"","type":"","label":""},{"value":"","type":"","label":"Schönenwerd"}]

### Solution

1. **Filter accessibility keywords** from OJP `nameSuffix` field (`ojp-client.ts:205-252`)
   - Removes `ALTERNATIVE_TRANSPORT`, `PLATFORM_ACCESS_WITH_ASSISTANCE`, `WHEELCHAIR_ACCESS`, etc.
   - Handles both standalone keywords and keywords appended to location suffixes

2. **Use `von`/`nach` parameters** for address-based URLs (`sbb-url.ts:91-103`)
   - When station IDs aren't available, uses cleaner format: `von=Address&nach=Destination`
   - Only uses `stops` JSON format when both origin and destination have station IDs

3. **Pass home address as fallback** (`useSbbUrl.ts:80-81`)
   - When OJP lookup fails, uses the user's geocoded home address for the origin

### Examples

**Before (with accessibility keyword):**

    https://www.sbb.ch/fr?stops=[{"value":"90727","type":"ID","label":"Oberengstringen, Paradies ALTERNATIVE_TRANSPORT"}...]

**After:**

    https://www.sbb.ch/fr?stops=[{"value":"90727","type":"ID","label":"Oberengstringen, Paradies"}...]

**Before (when OJP fails):**

    https://www.sbb.ch/fr?stops=[{"value":"","type":"","label":""},{"value":"","type":"","label":"Schönenwerd"}]

**After:**

    https://www.sbb.ch/fr?von=Zürich,+Bahnhofstrasse+1&nach=Schönenwerd&date=...
