### PR TITLE
refactor(api): replace z.any() with proper schema for referee convocations

### DIFF
--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -177,9 +177,24 @@ const refereeGameForExchangeSchema = z
   .object({
     __identity: uuidSchema.optional(),
     game: gameSchema.optional(),
+    // Head referees
     activeRefereeConvocationFirstHeadReferee:
       refereeConvocationRefSchema.optional(),
     activeRefereeConvocationSecondHeadReferee:
+      refereeConvocationRefSchema.optional(),
+    // Linesmen (1-4)
+    activeRefereeConvocationFirstLinesman:
+      refereeConvocationRefSchema.optional(),
+    activeRefereeConvocationSecondLinesman:
+      refereeConvocationRefSchema.optional(),
+    activeRefereeConvocationThirdLinesman:
+      refereeConvocationRefSchema.optional(),
+    activeRefereeConvocationFourthLinesman:
+      refereeConvocationRefSchema.optional(),
+    // Standby referees
+    activeRefereeConvocationStandbyHeadReferee:
+      refereeConvocationRefSchema.optional(),
+    activeRefereeConvocationStandbyLinesman:
       refereeConvocationRefSchema.optional(),
   })
   .passthrough();

--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -141,8 +141,28 @@ const personSummarySchema = z
     firstName: z.string().optional(),
     lastName: z.string().optional(),
     shortName: z.string().optional().nullable(),
+    displayName: z.string().optional(),
   })
   .passthrough();
+
+// Referee convocation reference schema (for head referee assignments)
+// Structure: { indoorAssociationReferee: { indoorReferee: { person: PersonSummary } } }
+const refereeConvocationRefSchema = z
+  .object({
+    indoorAssociationReferee: z
+      .object({
+        indoorReferee: z
+          .object({
+            person: personSummarySchema.optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()
+  .nullable();
 
 // Referee game schema
 const refereeGameSchema = z
@@ -157,8 +177,10 @@ const refereeGameForExchangeSchema = z
   .object({
     __identity: uuidSchema.optional(),
     game: gameSchema.optional(),
-    activeRefereeConvocationFirstHeadReferee: z.any().optional(),
-    activeRefereeConvocationSecondHeadReferee: z.any().optional(),
+    activeRefereeConvocationFirstHeadReferee:
+      refereeConvocationRefSchema.optional(),
+    activeRefereeConvocationSecondHeadReferee:
+      refereeConvocationRefSchema.optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
Replace generic z.any() with a typed refereeConvocationRefSchema for the
activeRefereeConvocationFirstHeadReferee and activeRefereeConvocationSecondHeadReferee
fields in the exchange validation schema. This improves type safety and aligns
with the documented OpenAPI spec.