### PR TITLE
fix(test): resolve flaky Escape key test in EditCompensationModal

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.test.tsx
+++ b/web-app/src/components/features/EditCompensationModal.test.tsx
@@ -454,11 +454,13 @@ describe("EditCompensationModal", () => {
 
       await waitForFormToLoad();
 
-      // Wrap in act to ensure React has finished processing state updates
-      // and effect cleanup/re-registration before firing the event
+      // Flush pending effects to ensure the escape key handler is registered
+      // with the updated isLoading=false state before firing the event
       await act(async () => {
-        fireEvent.keyDown(document, { key: "Escape" });
+        await new Promise((resolve) => setTimeout(resolve, 0));
       });
+
+      fireEvent.keyDown(document, { key: "Escape" });
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
The test was failing intermittently in CI due to a race condition.
When isLoading changes from true to false, React needs to re-register
the keydown event listener in useModalDismissal, but the effect may
not have run by the time the keydown event was fired.

Fix by flushing pending effects with a microtask delay before firing
the Escape key event, ensuring the handler is properly registered.