### PR TITLE
fix(transport): normalize Swiss station IDs for SBB deep links

### DIFF
--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -136,6 +136,35 @@ describe("sbb-url", () => {
         expect(url).toContain("%22value%22%3A%228503000%22");
         expect(url).not.toContain("Bahnhofstrasse");
       });
+
+      it("normalizes station IDs without 85 prefix", () => {
+        const params = {
+          ...baseParams,
+          originStation: { id: "4000", name: "Pully-Nord" },
+          destinationStation: { id: "73232", name: "Kloten, Freienberg" },
+        };
+        const url = generateSbbUrl(params, "website");
+
+        // IDs should be normalized to include the 85 prefix
+        expect(url).toContain("%22value%22%3A%228504000%22");
+        expect(url).toContain("%22value%22%3A%228573232%22");
+      });
+
+      it("does not double-prefix station IDs that already have 85", () => {
+        const params = {
+          ...baseParams,
+          originStation: { id: "8504000", name: "Pully-Nord" },
+          destinationStation: { id: "8573232", name: "Kloten, Freienberg" },
+        };
+        const url = generateSbbUrl(params, "website");
+
+        // IDs should remain unchanged
+        expect(url).toContain("%22value%22%3A%228504000%22");
+        expect(url).toContain("%22value%22%3A%228573232%22");
+        // Should NOT have double prefix
+        expect(url).not.toContain("858504000");
+        expect(url).not.toContain("858573232");
+      });
     });
 
     describe("app target", () => {


### PR DESCRIPTION
SBB requires the full 7-digit UIC format with "85" prefix for Swiss
stations. The OJP SDK sometimes returns shorter IDs without the prefix
(e.g., "4000" instead of "8504000"). This adds normalization to ensure
station IDs are always in the correct format for SBB URLs.