### PR TITLE
docs(ci): clarify that code review output should be raw markdown

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,7 +72,11 @@ jobs:
             - Security concerns
             - Test coverage for business logic
 
-            ## OUTPUT FORMAT (use this exact structure for consistency)
+            ## OUTPUT FORMAT
+
+            IMPORTANT: Output your review as a raw markdown code block (wrapped in triple backticks) that can be copy-pasted directly into GitHub. Do NOT output already-rendered/formatted text.
+
+            Use this exact structure:
 
             ```
             ## Claude Code Review


### PR DESCRIPTION
## Summary

- Clarify that Claude Code Review output should be a raw markdown code block for direct copy-paste into GitHub

## Changes

- Updated `.github/workflows/claude-code-review.yml` OUTPUT FORMAT section
- Added explicit instruction that output should be wrapped in triple backticks
- Added note to NOT output already-rendered/formatted text

## Test Plan

- [x] Trigger a code review on a test PR and verify output is a raw markdown code block
- [x] Confirm the output can be copy-pasted directly into GitHub comments
