### PR TITLE
fix(transport): invalidate cached travel times with dirty station names

### DIFF
--- a/web-app/src/services/transport/persistence.test.ts
+++ b/web-app/src/services/transport/persistence.test.ts
@@ -165,5 +165,29 @@ describe("persistence", () => {
       const cached = getCachedTravelTime("hall-123", "47.377,8.542", "weekday");
       expect(cached).toBeNull();
     });
+
+    it("invalidates old cache versions", () => {
+      // Simulate old v1 cache with dirty station names
+      const oldCache = {
+        version: 1,
+        entries: {
+          "hall-123:47.377,8.542:weekday": {
+            result: {
+              ...mockResult,
+              destinationStation: {
+                id: "8502113",
+                name: "Aarau PLATFORM_NOT_WHEELCHAIR_ACCESSIBLE",
+              },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      };
+      localStorage.setItem(TRAVEL_TIME_STORAGE_KEY, JSON.stringify(oldCache));
+
+      // Old cache should be invalidated due to version mismatch
+      const cached = getCachedTravelTime("hall-123", "47.377,8.542", "weekday");
+      expect(cached).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Increment cache version to v2 to invalidate old cached entries that
may contain OJP accessibility keywords (like PLATFORM_NOT_WHEELCHAIR_ACCESSIBLE)
in station names. This completes the fix from b791ee1 which only cleaned
names at the OJP extraction point but didn't address already-cached data
with 30-day TTL.