### PR TITLE
feat(exchange): add Google Maps and SBB navigation buttons

### DIFF
--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -6,6 +6,7 @@ import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { getPositionLabel } from "@/utils/position-labels";
+import { buildMapsUrls } from "@/utils/maps-url";
 import { useSettingsStore } from "@/stores/settings";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { useSbbUrl } from "@/hooks/useSbbUrl";
@@ -58,33 +59,11 @@ function AssignmentCardComponent({
   const awayTeam = game?.encounter?.teamAway?.name || t("common.tbd");
   const hallName = game?.hall?.name || t("common.locationTbd");
   const postalAddress = game?.hall?.primaryPostalAddress;
-  const plusCode = postalAddress?.geographicalLocation?.plusCode;
-  const googleMapsUrl = plusCode
-    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(plusCode)}`
-    : null;
   const city = postalAddress?.city;
 
-  // Full address for display (street + postal code + city)
-  const fullAddress = postalAddress?.combinedAddress
-    || (postalAddress?.streetAndHouseNumber && postalAddress?.postalCodeAndCity
-      ? `${postalAddress.streetAndHouseNumber}, ${postalAddress.postalCodeAndCity}`
-      : null);
+  // Build maps URLs using shared utility
+  const { googleMapsUrl, nativeMapsUrl: addressMapsUrl, fullAddress } = buildMapsUrls(postalAddress, hallName);
 
-  // Platform-specific maps URL: iOS uses maps: scheme, Android uses geo: URI
-  // Prefer address over coordinates for better accuracy
-  const geoLat = postalAddress?.geographicalLocation?.latitude;
-  const geoLon = postalAddress?.geographicalLocation?.longitude;
-  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
-  const hasCoords = geoLat !== undefined && geoLon !== undefined;
-  const addressMapsUrl = fullAddress
-    ? isIOS
-      ? `maps:?q=${encodeURIComponent(fullAddress)}`
-      : `geo:0,0?q=${encodeURIComponent(fullAddress)}`
-    : hasCoords
-      ? isIOS
-        ? `maps:?q=${geoLat},${geoLon}&ll=${geoLat},${geoLon}`
-        : `geo:${geoLat},${geoLon}?q=${geoLat},${geoLon}(${encodeURIComponent(hallName)})`
-      : null;
   const status = assignment.refereeConvocationStatus;
 
   const position = getPositionLabel(

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -2,10 +2,13 @@ import { memo, useMemo } from "react";
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { TravelTimeBadge } from "@/components/features/TravelTimeBadge";
-import { MapPin, MaleIcon, FemaleIcon, Home } from "@/components/ui/icons";
+import { MapPin, MaleIcon, FemaleIcon, Home, Navigation, TrainFront, Loader2 } from "@/components/ui/icons";
 import type { GameExchange } from "@/api/client";
 import { useDateLocale } from "@/hooks/useDateFormat";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useSettingsStore } from "@/stores/settings";
+import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
+import { useSbbUrl } from "@/hooks/useSbbUrl";
 
 type RoleLabelKey = "positions.head-one" | "positions.head-two" | "positions.linesman-one" | "positions.linesman-two";
 
@@ -46,8 +49,9 @@ function ExchangeCardComponent({
   travelTimeMinutes,
   travelTimeLoading,
 }: ExchangeCardProps) {
-  const { t, tInterpolate } = useTranslation();
+  const { t, tInterpolate, locale } = useTranslation();
   const dateLocale = useDateLocale();
+  const associationCode = useActiveAssociationCode();
 
   const game = exchange.refereeGame?.game;
   const startDate = game?.startingDateTime
@@ -72,15 +76,63 @@ function ExchangeCardComponent({
   const homeTeam = game?.encounter?.teamHome?.name || t("common.tbd");
   const awayTeam = game?.encounter?.teamAway?.name || t("common.tbd");
   const hallName = game?.hall?.name || t("common.locationTbd");
-  const plusCode =
-    game?.hall?.primaryPostalAddress?.geographicalLocation?.plusCode;
+  const postalAddress = game?.hall?.primaryPostalAddress;
+  const plusCode = postalAddress?.geographicalLocation?.plusCode;
   const googleMapsUrl = plusCode
     ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(plusCode)}`
     : null;
+  const city = postalAddress?.city;
+
+  // Full address for display (street + postal code + city)
+  const fullAddress = postalAddress?.combinedAddress
+    || (postalAddress?.streetAndHouseNumber && postalAddress?.postalCodeAndCity
+      ? `${postalAddress.streetAndHouseNumber}, ${postalAddress.postalCodeAndCity}`
+      : null);
+
+  // Platform-specific maps URL: iOS uses maps: scheme, Android uses geo: URI
+  const geoLat = postalAddress?.geographicalLocation?.latitude;
+  const geoLon = postalAddress?.geographicalLocation?.longitude;
+  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const hasCoords = geoLat !== undefined && geoLon !== undefined;
+  const addressMapsUrl = fullAddress
+    ? isIOS
+      ? `maps:?q=${encodeURIComponent(fullAddress)}`
+      : `geo:0,0?q=${encodeURIComponent(fullAddress)}`
+    : hasCoords
+      ? isIOS
+        ? `maps:?q=${geoLat},${geoLon}&ll=${geoLat},${geoLon}`
+        : `geo:${geoLat},${geoLon}?q=${geoLat},${geoLon}(${encodeURIComponent(hallName)})`
+      : null;
+
   const requiredLevel = exchange.requiredRefereeLevel;
 
   const leagueCategory = game?.group?.phase?.league?.leagueCategory?.name;
   const gender = game?.group?.phase?.league?.gender;
+
+  // Get transport settings for the association
+  const isTransportEnabled = useSettingsStore((state) =>
+    state.isTransportEnabledForAssociation(associationCode),
+  );
+
+  // Extract hall coordinates and ID for travel time queries
+  const geoLocation = game?.hall?.primaryPostalAddress?.geographicalLocation;
+  const hallCoords = geoLocation?.latitude !== undefined && geoLocation?.longitude !== undefined
+    ? { latitude: geoLocation.latitude, longitude: geoLocation.longitude }
+    : null;
+  const hallId = game?.hall?.__identity;
+  const gameStartingDateTime = game?.startingDateTime;
+
+  // Hook to fetch trip data on demand and generate SBB URL with station ID
+  const { isLoading: isSbbLoading, openSbbConnection } = useSbbUrl({
+    hallCoords,
+    hallId,
+    city,
+    gameStartTime: gameStartingDateTime,
+    language: locale,
+  });
+
+  // Show SBB button if transport is enabled and we have the required data
+  const showSbbButton = isTransportEnabled && city && gameStartingDateTime;
 
   return (
     <ExpandableCard
@@ -155,22 +207,64 @@ function ExchangeCardComponent({
       )}
       renderDetails={() => (
         <div className="px-2 pb-2 pt-0 border-t border-border-subtle dark:border-border-subtle-dark space-y-1">
-          {/* Location */}
-          <div className="flex items-center gap-2 text-sm text-text-muted dark:text-text-muted-dark pt-2">
-            <MapPin className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-            {googleMapsUrl ? (
-              <a
-                href={googleMapsUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="truncate text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded"
-                onClick={(e) => e.stopPropagation()}
-              >
+          {/* Location - Hall name */}
+          <div className="flex items-start gap-2 text-sm text-text-muted dark:text-text-muted-dark pt-2">
+            <MapPin className="w-4 h-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <div className="font-medium text-text-primary dark:text-text-primary-dark">
                 {hallName}
-              </a>
-            ) : (
-              <span className="truncate">{hallName}</span>
-            )}
+              </div>
+              {/* Full address - clickable to open in native maps app */}
+              {fullAddress && (
+                addressMapsUrl ? (
+                  <a
+                    href={addressMapsUrl}
+                    className="text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded block"
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label={tInterpolate("assignments.openAddressInMaps", { address: fullAddress })}
+                  >
+                    {fullAddress}
+                  </a>
+                ) : (
+                  <span>{fullAddress}</span>
+                )
+              )}
+            </div>
+            {/* Navigation buttons */}
+            <div className="flex items-center gap-1.5 flex-shrink-0">
+              {googleMapsUrl && (
+                <a
+                  href={googleMapsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 hover:bg-primary-200 dark:hover:bg-primary-800/40 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-lg transition-colors"
+                  onClick={(e) => e.stopPropagation()}
+                  title={t("assignments.openInGoogleMaps")}
+                  aria-label={t("assignments.openInGoogleMaps")}
+                >
+                  <Navigation className="w-5 h-5" aria-hidden="true" />
+                </a>
+              )}
+              {showSbbButton && (
+                <button
+                  type="button"
+                  className="p-2 bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 hover:bg-primary-200 dark:hover:bg-primary-800/40 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-lg transition-colors disabled:opacity-50"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void openSbbConnection();
+                  }}
+                  disabled={isSbbLoading}
+                  title={t("assignments.openSbbConnection")}
+                  aria-label={t("assignments.openSbbConnection")}
+                >
+                  {isSbbLoading ? (
+                    <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <TrainFront className="w-5 h-5" aria-hidden="true" />
+                  )}
+                </button>
+              )}
+            </div>
           </div>
 
           {/* Required level */}

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -6,6 +6,7 @@ import { MapPin, MaleIcon, FemaleIcon, Home, Navigation, TrainFront, Loader2 } f
 import type { GameExchange } from "@/api/client";
 import { useDateLocale } from "@/hooks/useDateFormat";
 import { useTranslation } from "@/hooks/useTranslation";
+import { buildMapsUrls } from "@/utils/maps-url";
 import { useSettingsStore } from "@/stores/settings";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { useSbbUrl } from "@/hooks/useSbbUrl";
@@ -77,32 +78,10 @@ function ExchangeCardComponent({
   const awayTeam = game?.encounter?.teamAway?.name || t("common.tbd");
   const hallName = game?.hall?.name || t("common.locationTbd");
   const postalAddress = game?.hall?.primaryPostalAddress;
-  const plusCode = postalAddress?.geographicalLocation?.plusCode;
-  const googleMapsUrl = plusCode
-    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(plusCode)}`
-    : null;
   const city = postalAddress?.city;
 
-  // Full address for display (street + postal code + city)
-  const fullAddress = postalAddress?.combinedAddress
-    || (postalAddress?.streetAndHouseNumber && postalAddress?.postalCodeAndCity
-      ? `${postalAddress.streetAndHouseNumber}, ${postalAddress.postalCodeAndCity}`
-      : null);
-
-  // Platform-specific maps URL: iOS uses maps: scheme, Android uses geo: URI
-  const geoLat = postalAddress?.geographicalLocation?.latitude;
-  const geoLon = postalAddress?.geographicalLocation?.longitude;
-  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
-  const hasCoords = geoLat !== undefined && geoLon !== undefined;
-  const addressMapsUrl = fullAddress
-    ? isIOS
-      ? `maps:?q=${encodeURIComponent(fullAddress)}`
-      : `geo:0,0?q=${encodeURIComponent(fullAddress)}`
-    : hasCoords
-      ? isIOS
-        ? `maps:?q=${geoLat},${geoLon}&ll=${geoLat},${geoLon}`
-        : `geo:${geoLat},${geoLon}?q=${geoLat},${geoLon}(${encodeURIComponent(hallName)})`
-      : null;
+  // Build maps URLs using shared utility
+  const { googleMapsUrl, nativeMapsUrl: addressMapsUrl, fullAddress } = buildMapsUrls(postalAddress, hallName);
 
   const requiredLevel = exchange.requiredRefereeLevel;
 

--- a/web-app/src/utils/maps-url.ts
+++ b/web-app/src/utils/maps-url.ts
@@ -1,0 +1,98 @@
+/**
+ * Utility functions for building maps URLs (Google Maps, iOS Maps, Android Geo).
+ */
+
+export interface PostalAddress {
+  combinedAddress?: string;
+  streetAndHouseNumber?: string;
+  postalCodeAndCity?: string;
+  city?: string;
+  geographicalLocation?: {
+    plusCode?: string;
+    latitude?: number;
+    longitude?: number;
+  };
+}
+
+export interface MapsUrls {
+  /** Google Maps URL using Plus Code (opens in browser) */
+  googleMapsUrl: string | null;
+  /** Platform-specific URL for native maps app (iOS maps: / Android geo:) */
+  nativeMapsUrl: string | null;
+  /** Full formatted address string */
+  fullAddress: string | null;
+}
+
+/**
+ * Build the full address string from postal address components.
+ */
+export function buildFullAddress(postalAddress: PostalAddress | null | undefined): string | null {
+  if (!postalAddress) return null;
+
+  return postalAddress.combinedAddress
+    || (postalAddress.streetAndHouseNumber && postalAddress.postalCodeAndCity
+      ? `${postalAddress.streetAndHouseNumber}, ${postalAddress.postalCodeAndCity}`
+      : null);
+}
+
+/**
+ * Build Google Maps URL from Plus Code.
+ */
+export function buildGoogleMapsUrl(plusCode: string | null | undefined): string | null {
+  if (!plusCode) return null;
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(plusCode)}`;
+}
+
+/**
+ * Build platform-specific native maps URL.
+ * iOS uses maps: scheme, Android uses geo: URI.
+ */
+export function buildNativeMapsUrl(
+  fullAddress: string | null,
+  coords: { latitude: number; longitude: number } | null,
+  hallName: string,
+): string | null {
+  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+  if (fullAddress) {
+    return isIOS
+      ? `maps:?q=${encodeURIComponent(fullAddress)}`
+      : `geo:0,0?q=${encodeURIComponent(fullAddress)}`;
+  }
+
+  if (coords) {
+    const { latitude, longitude } = coords;
+    return isIOS
+      ? `maps:?q=${latitude},${longitude}&ll=${latitude},${longitude}`
+      : `geo:${latitude},${longitude}?q=${latitude},${longitude}(${encodeURIComponent(hallName)})`;
+  }
+
+  return null;
+}
+
+/**
+ * Build all maps URLs from postal address data.
+ */
+export function buildMapsUrls(
+  postalAddress: PostalAddress | null | undefined,
+  hallName: string,
+): MapsUrls {
+  const plusCode = postalAddress?.geographicalLocation?.plusCode;
+  const googleMapsUrl = buildGoogleMapsUrl(plusCode);
+
+  const fullAddress = buildFullAddress(postalAddress);
+
+  const geoLat = postalAddress?.geographicalLocation?.latitude;
+  const geoLon = postalAddress?.geographicalLocation?.longitude;
+  const coords = geoLat !== undefined && geoLon !== undefined
+    ? { latitude: geoLat, longitude: geoLon }
+    : null;
+
+  const nativeMapsUrl = buildNativeMapsUrl(fullAddress, coords, hallName);
+
+  return {
+    googleMapsUrl,
+    nativeMapsUrl,
+    fullAddress,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds Google Maps and SBB public transport navigation buttons to exchange items, matching the existing functionality in assignment cards

## Changes

- Added Navigation, TrainFront, and Loader2 icons to ExchangeCard
- Integrated useSbbUrl hook for fetching SBB trip data on demand
- Added transport settings check via useSettingsStore
- Display full address with platform-native maps link (iOS maps: / Android geo:)
- Added Google Maps button with Navigation icon (opens Plus Code location)
- Added SBB button with loading spinner while fetching trip data
- Improved location section layout to match AssignmentCard structure

## Test Plan

- [ ] Expand an exchange card and verify Google Maps button appears when location has Plus Code
- [ ] Click Google Maps button and verify it opens correct location in new tab
- [ ] Enable transport in Settings for the association
- [ ] Verify SBB button appears on exchange cards with city and start time
- [ ] Click SBB button and verify loading spinner shows, then SBB opens with correct connection
- [ ] Verify full address appears and is clickable on mobile (opens native maps app)
- [ ] Test on both iOS and Android for platform-specific maps URLs
- [ ] Verify buttons don't appear when data is missing (no Plus Code, transport disabled, etc.)
