### PR TITLE
feat(tour): standardize guided tour with dummy assignment

### DIFF
--- a/web-app/src/components/tour/definitions/assignments.ts
+++ b/web-app/src/components/tour/definitions/assignments.ts
@@ -46,6 +46,13 @@ function getUpcomingDate(): string {
   return date.toISOString();
 }
 
+/**
+ * Tour dummy assignment configured to showcase ALL available action buttons:
+ * - Validate: requires refereePosition === "head-one" ✓
+ * - Edit Compensation: requires !paymentDone && !lockPayoutOnSiteCompensation ✓
+ * - Hall Report: requires NLA/NLB league + head-one position ✓
+ * - Exchange: requires isGameInFuture === "1" ✓
+ */
 export const TOUR_DUMMY_ASSIGNMENT: TourDummyAssignment = {
   __identity: "tour-dummy-assignment",
   refereePosition: "head-one",
@@ -68,6 +75,20 @@ export const TOUR_DUMMY_ASSIGNMENT: TourDummyAssignment = {
         name: "Musterhalle",
         city: "Zürich",
       },
+      // NLA league category to enable hall report generation
+      group: {
+        __identity: "tour-dummy-group",
+        phase: {
+          __identity: "tour-dummy-phase",
+          league: {
+            __identity: "tour-dummy-league",
+            leagueCategory: {
+              __identity: "tour-dummy-league-category",
+              name: "NLA",
+            },
+          },
+        },
+      },
     },
     isGameInFuture: "1",
   },
@@ -75,5 +96,8 @@ export const TOUR_DUMMY_ASSIGNMENT: TourDummyAssignment = {
     __identity: "tour-dummy-compensation",
     distanceInMetres: 25000,
     distanceFormatted: "25 km",
+    // Compensation is editable (not paid, not locked)
+    paymentDone: false,
+    lockPayoutOnSiteCompensation: false,
   },
 };

--- a/web-app/src/components/tour/definitions/types.ts
+++ b/web-app/src/components/tour/definitions/types.ts
@@ -58,6 +58,20 @@ export interface TourDummyAssignment {
         name: string;
         city: string;
       };
+      // League category structure for game report eligibility
+      group?: {
+        __identity: string;
+        phase?: {
+          __identity: string;
+          league?: {
+            __identity: string;
+            leagueCategory?: {
+              __identity: string;
+              name: string;
+            };
+          };
+        };
+      };
     };
     isGameInFuture: string;
   };
@@ -65,6 +79,9 @@ export interface TourDummyAssignment {
     __identity: string;
     distanceInMetres: number;
     distanceFormatted: string;
+    // Compensation editability flags
+    paymentDone?: boolean;
+    lockPayoutOnSiteCompensation?: boolean;
   };
 }
 

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -21,17 +21,17 @@ const de: Translations = {
       welcome: {
         title: "Ihre Einsätze",
         description:
-          "Hier sehen Sie Ihre bevorstehenden Schiedsrichtereinsätze. Jede Karte zeigt die Spieldetails.",
+          "Hier sehen Sie Ihre bevorstehenden Schiedsrichtereinsätze. Jede Karte zeigt die Spieldetails. Dieses Beispiel zeigt alle verfügbaren Aktionen.",
       },
       swipeValidate: {
         title: "Nach links wischen",
         description:
-          "Wischen Sie nach links, um die Aktionsschaltflächen anzuzeigen: Validieren (Spiel bestätigen), Bearbeiten (Entschädigung anpassen) und Bericht (Hallenrapport für NLA/NLB).",
+          "Wischen Sie nach links, um die Aktionsschaltflächen anzuzeigen. Validieren erscheint für 1. Schiedsrichter, Bearbeiten für bearbeitbare Entschädigungen und Bericht für NLA/NLB-Spiele. Bei Ihren Spielen werden je nach Rolle und Berechtigung möglicherweise weniger Schaltflächen angezeigt.",
       },
       swipeExchange: {
         title: "Nach rechts wischen",
         description:
-          "Wischen Sie nach rechts, um den Einsatz zur Börse anzubieten. Andere Schiedsrichter können das Spiel dann übernehmen.",
+          "Wischen Sie nach rechts, um den Einsatz zur Börse anzubieten. Andere Schiedsrichter können das Spiel dann übernehmen. Dies ist für alle bevorstehenden Spiele verfügbar.",
       },
       tapDetails: {
         title: "Details anzeigen",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -21,17 +21,17 @@ const en: Translations = {
       welcome: {
         title: "Your Assignments",
         description:
-          "This is where you'll see your upcoming referee assignments. Each card shows the game details.",
+          "This is where you'll see your upcoming referee assignments. Each card shows the game details. This example shows all available actions.",
       },
       swipeValidate: {
         title: "Try Swiping Left",
         description:
-          "Swipe left on a card to reveal action buttons: Validate (confirm the game), Edit (adjust your compensation), and Report (generate sports hall report for NLA/NLB).",
+          "Swipe left on a card to reveal action buttons. Validate appears for 1st referees, Edit for editable compensations, and Report for NLA/NLB games. Your actual games may show fewer buttons based on your role and permissions.",
       },
       swipeExchange: {
         title: "Try Swiping Right",
         description:
-          "Swipe right on a card to put the assignment up for exchange. Other referees can then take over the game.",
+          "Swipe right on a card to put the assignment up for exchange. Other referees can then take over the game. This is available for all upcoming games.",
       },
       tapDetails: {
         title: "View Details",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -21,17 +21,17 @@ const fr: Translations = {
       welcome: {
         title: "Vos désignations",
         description:
-          "Ici vous verrez vos prochaines désignations d'arbitre. Chaque carte affiche les détails du match.",
+          "Ici vous verrez vos prochaines désignations d'arbitre. Chaque carte affiche les détails du match. Cet exemple montre toutes les actions disponibles.",
       },
       swipeValidate: {
         title: "Glissez vers la gauche",
         description:
-          "Glissez vers la gauche pour révéler les boutons d'action: Valider (confirmer le match), Modifier (ajuster l'indemnité) et Rapport (générer le rapport de salle pour NLA/NLB).",
+          "Glissez vers la gauche pour révéler les boutons d'action. Valider apparaît pour le 1er arbitre, Modifier pour les indemnités modifiables, et Rapport pour les matchs NLA/NLB. Vos matchs réels peuvent afficher moins de boutons selon votre rôle et vos permissions.",
       },
       swipeExchange: {
         title: "Glissez vers la droite",
         description:
-          "Glissez vers la droite pour proposer la désignation à la bourse. D'autres arbitres pourront alors reprendre le match.",
+          "Glissez vers la droite pour proposer la désignation à la bourse. D'autres arbitres pourront alors reprendre le match. Disponible pour tous les matchs à venir.",
       },
       tapDetails: {
         title: "Voir les détails",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -21,17 +21,17 @@ const it: Translations = {
       welcome: {
         title: "Le tue designazioni",
         description:
-          "Qui vedrai le tue prossime designazioni arbitrali. Ogni scheda mostra i dettagli della partita.",
+          "Qui vedrai le tue prossime designazioni arbitrali. Ogni scheda mostra i dettagli della partita. Questo esempio mostra tutte le azioni disponibili.",
       },
       swipeValidate: {
         title: "Scorri verso sinistra",
         description:
-          "Scorri verso sinistra per rivelare i pulsanti d'azione: Valida (conferma la partita), Modifica (regola il compenso) e Rapporto (genera il rapporto palestra per NLA/NLB).",
+          "Scorri verso sinistra per rivelare i pulsanti d'azione. Valida appare per il 1° arbitro, Modifica per i compensi modificabili, e Rapporto per le partite NLA/NLB. Le tue partite reali potrebbero mostrare meno pulsanti in base al tuo ruolo e permessi.",
       },
       swipeExchange: {
         title: "Scorri verso destra",
         description:
-          "Scorri verso destra per offrire la designazione alla borsa. Altri arbitri potranno quindi prendere in carico la partita.",
+          "Scorri verso destra per offrire la designazione alla borsa. Altri arbitri potranno quindi prendere in carico la partita. Disponibile per tutte le partite in programma.",
       },
       tapDetails: {
         title: "Visualizza dettagli",


### PR DESCRIPTION
When the guided tour is active on the assignments page, prepend a
standardized dummy assignment that showcases all available action
buttons regardless of the user's actual assignments:

- Validate button (1st referee position)
- Edit compensation button (editable compensation)
- Hall report button (NLA league + head-one position)
- Exchange button (future game)

Updates tour step descriptions in all 4 languages (de, en, fr, it) to
explain that some buttons only appear based on role and permissions.