### PR TITLE
refactor(transport): remove SBB mobile app code

### DIFF
--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -76,11 +76,6 @@ function createMockSettingsStore(
     levelFilterEnabled: false,
     setLevelFilterEnabled: vi.fn(),
 
-    // SBB link target
-    sbbLinkTargetByAssociation: {},
-    setSbbLinkTargetForAssociation: vi.fn(),
-    getSbbLinkTargetForAssociation: vi.fn().mockReturnValue("website"),
-
     // Reset
     resetLocationSettings: vi.fn(),
 

--- a/web-app/src/components/features/settings/TransportSection.tsx
+++ b/web-app/src/components/features/settings/TransportSection.tsx
@@ -6,7 +6,6 @@ import {
   getDefaultArrivalBuffer,
   MIN_ARRIVAL_BUFFER_MINUTES,
   MAX_ARRIVAL_BUFFER_MINUTES,
-  type SbbLinkTarget,
 } from "@/stores/settings";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
@@ -44,8 +43,6 @@ function TransportSectionComponent() {
     setTransportEnabledForAssociation,
     arrivalBufferByAssociation,
     setArrivalBufferForAssociation,
-    sbbLinkTargetByAssociation,
-    setSbbLinkTargetForAssociation,
   } = useSettingsStore(
     useShallow((state) => ({
       homeLocation: state.homeLocation,
@@ -54,8 +51,6 @@ function TransportSectionComponent() {
       setTransportEnabledForAssociation: state.setTransportEnabledForAssociation,
       arrivalBufferByAssociation: state.travelTimeFilter.arrivalBufferByAssociation,
       setArrivalBufferForAssociation: state.setArrivalBufferForAssociation,
-      sbbLinkTargetByAssociation: state.sbbLinkTargetByAssociation,
-      setSbbLinkTargetForAssociation: state.setSbbLinkTargetForAssociation,
     })),
   );
 
@@ -81,15 +76,6 @@ function TransportSectionComponent() {
     }
     return getDefaultArrivalBuffer(associationCode);
   }, [associationCode, arrivalBufferByAssociation]);
-
-  // Get current SBB link target for this association
-  const currentSbbLinkTarget = useMemo((): SbbLinkTarget => {
-    const targetMap = sbbLinkTargetByAssociation ?? {};
-    if (associationCode && targetMap[associationCode] !== undefined) {
-      return targetMap[associationCode];
-    }
-    return "website";
-  }, [associationCode, sbbLinkTargetByAssociation]);
 
   // Local state for immediate input feedback, synced with store via debounce
   const [localArrivalBuffer, setLocalArrivalBuffer] = useState(storeArrivalBuffer);
@@ -151,14 +137,6 @@ function TransportSectionComponent() {
       }
     },
     [associationCode, setArrivalBufferForAssociation],
-  );
-
-  const handleSbbLinkTargetChange = useCallback(
-    (target: SbbLinkTarget) => {
-      if (!associationCode) return;
-      setSbbLinkTargetForAssociation(associationCode, target);
-    },
-    [associationCode, setSbbLinkTargetForAssociation],
   );
 
   const hasHomeLocation = Boolean(homeLocation);
@@ -300,51 +278,6 @@ function TransportSectionComponent() {
                 <span className="text-sm text-text-muted dark:text-text-muted-dark">
                   {t("common.minutesUnit")}
                 </span>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* SBB link target setting - only show when transport is enabled */}
-        {isTransportEnabled && (
-          <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
-            <div className="flex items-center justify-between py-2">
-              <div className="flex-1 pr-3">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                    {t("settings.transport.sbbLinkTarget")}
-                  </span>
-                  {associationCode && <AssociationBadge code={associationCode} />}
-                </div>
-                <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5">
-                  {t("settings.transport.sbbLinkTargetDescription")}
-                </div>
-              </div>
-              <div className="flex items-center gap-1 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg p-0.5">
-                <button
-                  type="button"
-                  onClick={() => handleSbbLinkTargetChange("website")}
-                  className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
-                    currentSbbLinkTarget === "website"
-                      ? "bg-white dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark shadow-sm"
-                      : "text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
-                  }`}
-                  aria-pressed={currentSbbLinkTarget === "website"}
-                >
-                  {t("settings.transport.sbbLinkTargetWebsite")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleSbbLinkTargetChange("app")}
-                  className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
-                    currentSbbLinkTarget === "app"
-                      ? "bg-white dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark shadow-sm"
-                      : "text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
-                  }`}
-                  aria-pressed={currentSbbLinkTarget === "app"}
-                >
-                  {t("settings.transport.sbbLinkTargetApp")}
-                </button>
               </div>
             </div>
           </div>

--- a/web-app/src/hooks/useSbbUrl.test.ts
+++ b/web-app/src/hooks/useSbbUrl.test.ts
@@ -16,7 +16,6 @@ vi.mock("@/stores/settings", () => ({
         label: "Zurich, Switzerland",
         source: "geocoded",
       },
-      getSbbLinkTargetForAssociation: () => "sbb",
       getArrivalBufferForAssociation: () => 30,
     })
   ),
@@ -228,8 +227,7 @@ describe("useSbbUrl", () => {
         language: "de",
         originStation: tripResult.originStation,
         destinationStation: tripResult.destinationStation,
-      }),
-      "sbb"
+      })
     );
   });
 });

--- a/web-app/src/hooks/useSbbUrl.ts
+++ b/web-app/src/hooks/useSbbUrl.ts
@@ -62,9 +62,6 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
   const homeLocation = useSettingsStore((state) => state.homeLocation);
   const associationCode = useActiveAssociationCode();
-  const sbbLinkTarget = useSettingsStore((state) =>
-    state.getSbbLinkTargetForAssociation(associationCode),
-  );
   const arrivalBuffer = useSettingsStore((state) =>
     state.getArrivalBufferForAssociation(associationCode),
   );
@@ -82,18 +79,15 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
 
     // If we already have cached station info, use it directly
     if (originStation && destinationStation) {
-      const url = generateSbbUrl(
-        {
-          destination: city,
-          date: gameDate,
-          arrivalTime,
-          language,
-          originStation,
-          destinationStation,
-          originAddress,
-        },
-        sbbLinkTarget,
-      );
+      const url = generateSbbUrl({
+        destination: city,
+        date: gameDate,
+        arrivalTime,
+        language,
+        originStation,
+        destinationStation,
+        originAddress,
+      });
       openSbbUrl(url);
       return;
     }
@@ -145,49 +139,40 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
         }
 
         // Generate URL with station IDs
-        const url = generateSbbUrl(
-          {
-            destination: city,
-            date: gameDate,
-            arrivalTime,
-            language,
-            originStation: tripResult.originStation,
-            destinationStation: tripResult.destinationStation,
-            originAddress,
-          },
-          sbbLinkTarget,
-        );
+        const url = generateSbbUrl({
+          destination: city,
+          date: gameDate,
+          arrivalTime,
+          language,
+          originStation: tripResult.originStation,
+          destinationStation: tripResult.destinationStation,
+          originAddress,
+        });
         openSbbUrl(url);
       } catch (err) {
         setError(err instanceof Error ? err : new Error("Failed to fetch trip data"));
 
         // Fall back to URL without station ID but with address
-        const url = generateSbbUrl(
-          {
-            destination: city,
-            date: gameDate,
-            arrivalTime,
-            language,
-            originAddress,
-          },
-          sbbLinkTarget,
-        );
+        const url = generateSbbUrl({
+          destination: city,
+          date: gameDate,
+          arrivalTime,
+          language,
+          originAddress,
+        });
         openSbbUrl(url);
       } finally {
         setIsLoading(false);
       }
     } else {
       // No trip data available, use city name and address fallbacks
-      const url = generateSbbUrl(
-        {
-          destination: city,
-          date: gameDate,
-          arrivalTime,
-          language,
-          originAddress,
-        },
-        sbbLinkTarget,
-      );
+      const url = generateSbbUrl({
+        destination: city,
+        date: gameDate,
+        arrivalTime,
+        language,
+        originAddress,
+      });
       openSbbUrl(url);
     }
   }, [
@@ -197,7 +182,6 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
     originStation,
     destinationStation,
     language,
-    sbbLinkTarget,
     homeLocation,
     hallCoords,
     hallId,

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -348,10 +348,6 @@ const de: Translations = {
       refreshCacheConfirm:
         "Alle gespeicherten Reisezeiten löschen? Neue Berechnungen werden von der API abgerufen.",
       cacheCleared: "Reisezeit-Cache geleert",
-      sbbLinkTarget: "Verbindungen öffnen in",
-      sbbLinkTargetDescription: "Wählen Sie, wo SBB-Fahrplanlinks geöffnet werden",
-      sbbLinkTargetWebsite: "SBB Webseite",
-      sbbLinkTargetApp: "SBB App",
     },
     dataRetention: {
       title: "Daten & Datenschutz",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -346,10 +346,6 @@ const en: Translations = {
       refreshCacheConfirm:
         "Clear all cached travel times? New calculations will be fetched from the API.",
       cacheCleared: "Travel time cache cleared",
-      sbbLinkTarget: "Open connections in",
-      sbbLinkTargetDescription: "Choose where to open SBB timetable links",
-      sbbLinkTargetWebsite: "SBB website",
-      sbbLinkTargetApp: "SBB app",
     },
     dataRetention: {
       title: "Data & Privacy",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -347,10 +347,6 @@ const fr: Translations = {
       refreshCacheConfirm:
         "Effacer tous les temps de trajet en cache ? Les nouveaux calculs seront récupérés depuis l'API.",
       cacheCleared: "Cache des temps de trajet vidé",
-      sbbLinkTarget: "Ouvrir les connexions dans",
-      sbbLinkTargetDescription: "Choisissez où ouvrir les liens horaires CFF",
-      sbbLinkTargetWebsite: "Site web CFF",
-      sbbLinkTargetApp: "App CFF",
     },
     dataRetention: {
       title: "Données et confidentialité",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -345,10 +345,6 @@ const it: Translations = {
       refreshCacheConfirm:
         "Cancellare tutti i tempi di viaggio in cache? I nuovi calcoli verranno recuperati dall'API.",
       cacheCleared: "Cache tempi di viaggio svuotata",
-      sbbLinkTarget: "Apri connessioni in",
-      sbbLinkTargetDescription: "Scegli dove aprire i link orari FFS",
-      sbbLinkTargetWebsite: "Sito web FFS",
-      sbbLinkTargetApp: "App FFS",
     },
     dataRetention: {
       title: "Dati e privacy",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -223,10 +223,6 @@ export interface Translations {
       refreshCache: string;
       refreshCacheConfirm: string;
       cacheCleared: string;
-      sbbLinkTarget: string;
-      sbbLinkTargetDescription: string;
-      sbbLinkTargetWebsite: string;
-      sbbLinkTargetApp: string;
     };
     dataRetention: {
       title: string;

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -46,13 +46,6 @@ export interface TravelTimeFilter {
   cacheInvalidatedAt: number | null;
 }
 
-/**
- * Target for SBB timetable links.
- * - 'website': Opens SBB website (works everywhere)
- * - 'app': Opens SBB mobile app (requires app installed)
- */
-export type SbbLinkTarget = "website" | "app";
-
 /** Default arrival buffer for SV (Swiss Volley national) - 60 minutes */
 export const DEFAULT_ARRIVAL_BUFFER_SV_MINUTES = 60;
 
@@ -108,11 +101,6 @@ interface SettingsState {
   getArrivalBufferForAssociation: (associationCode: string | undefined) => number;
   invalidateTravelTimeCache: () => void;
 
-  // SBB link target settings (per-association)
-  sbbLinkTargetByAssociation: Record<string, SbbLinkTarget>;
-  setSbbLinkTargetForAssociation: (associationCode: string, target: SbbLinkTarget) => void;
-  getSbbLinkTargetForAssociation: (associationCode: string | undefined) => SbbLinkTarget;
-
   // Level filter (demo mode only)
   levelFilterEnabled: boolean;
   setLevelFilterEnabled: (enabled: boolean) => void;
@@ -160,7 +148,6 @@ export const useSettingsStore = create<SettingsState>()(
         cacheInvalidatedAt: null,
       },
       levelFilterEnabled: false,
-      sbbLinkTargetByAssociation: {},
 
       setSafeMode: (enabled: boolean) => {
         set({ isSafeModeEnabled: enabled });
@@ -263,25 +250,6 @@ export const useSettingsStore = create<SettingsState>()(
         }));
       },
 
-      setSbbLinkTargetForAssociation: (associationCode: string, target: SbbLinkTarget) => {
-        set((state) => ({
-          sbbLinkTargetByAssociation: {
-            ...state.sbbLinkTargetByAssociation,
-            [associationCode]: target,
-          },
-        }));
-      },
-
-      getSbbLinkTargetForAssociation: (associationCode: string | undefined) => {
-        const state = get();
-        const targetMap = state.sbbLinkTargetByAssociation ?? {};
-        if (associationCode && targetMap[associationCode] !== undefined) {
-          return targetMap[associationCode];
-        }
-        // Default to website (works everywhere)
-        return "website";
-      },
-
       setLevelFilterEnabled: (enabled: boolean) => {
         set({ levelFilterEnabled: enabled });
       },
@@ -305,7 +273,6 @@ export const useSettingsStore = create<SettingsState>()(
             cacheInvalidatedAt: null,
           },
           levelFilterEnabled: false,
-          sbbLinkTargetByAssociation: {},
         });
       },
     }),
@@ -320,7 +287,6 @@ export const useSettingsStore = create<SettingsState>()(
         transportEnabledByAssociation: state.transportEnabledByAssociation,
         travelTimeFilter: state.travelTimeFilter,
         levelFilterEnabled: state.levelFilterEnabled,
-        sbbLinkTargetByAssociation: state.sbbLinkTargetByAssociation,
       }),
       merge: (persisted, current) => {
         // Defensively merge persisted data with current defaults.

--- a/web-app/src/utils/sbb-url.test.ts
+++ b/web-app/src/utils/sbb-url.test.ts
@@ -12,7 +12,7 @@ describe("sbb-url", () => {
 
     describe("von/nach format (no station IDs)", () => {
       it("uses von/nach parameters when no station IDs provided", () => {
-        const url = generateSbbUrl(baseParams, "website");
+        const url = generateSbbUrl(baseParams);
 
         expect(url).toContain("https://www.sbb.ch/de?");
         expect(url).toContain("nach=Bern");
@@ -30,32 +30,32 @@ describe("sbb-url", () => {
           ...baseParams,
           originAddress: "Zürich, Bahnhofstrasse 1",
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
 
         expect(url).toContain("von=Z%C3%BCrich%2C+Bahnhofstrasse+1");
         expect(url).toContain("nach=Bern");
       });
 
       it("omits von when no origin provided", () => {
-        const url = generateSbbUrl(baseParams, "website");
+        const url = generateSbbUrl(baseParams);
 
         expect(url).not.toContain("von=");
         expect(url).toContain("nach=Bern");
       });
 
       it("generates correct URL for French", () => {
-        const url = generateSbbUrl({ ...baseParams, language: "fr" }, "website");
+        const url = generateSbbUrl({ ...baseParams, language: "fr" });
         expect(url).toContain("https://www.sbb.ch/fr?");
         expect(url).toContain("nach=Bern");
       });
 
       it("generates correct URL for Italian", () => {
-        const url = generateSbbUrl({ ...baseParams, language: "it" }, "website");
+        const url = generateSbbUrl({ ...baseParams, language: "it" });
         expect(url).toContain("https://www.sbb.ch/it?");
       });
 
       it("generates correct URL for English", () => {
-        const url = generateSbbUrl({ ...baseParams, language: "en" }, "website");
+        const url = generateSbbUrl({ ...baseParams, language: "en" });
         expect(url).toContain("https://www.sbb.ch/en?");
       });
 
@@ -65,7 +65,7 @@ describe("sbb-url", () => {
           date: new Date("2024-12-28T10:00:00"),
           arrivalTime: new Date("2024-12-28T10:00:00"),
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         expect(url).toContain("https://www.sbb.ch/de?");
         expect(url).toContain("nach=Z%C3%BCrich");
       });
@@ -75,7 +75,7 @@ describe("sbb-url", () => {
           ...baseParams,
           destination: "Zürich HB",
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         expect(url).toContain("nach=Z%C3%BCrich+HB");
       });
 
@@ -84,7 +84,7 @@ describe("sbb-url", () => {
           ...baseParams,
           destinationStation: { id: "8507000", name: "Bern" },
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         // Should use von/nach because origin doesn't have station ID
         expect(url).toContain("nach=Bern");
         expect(url).not.toContain("stops=");
@@ -95,7 +95,7 @@ describe("sbb-url", () => {
           ...baseParams,
           originStation: { id: "8503000", name: "Zürich HB" },
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         // Should use von/nach because destination doesn't have station ID
         expect(url).toContain("von=Z%C3%BCrich+HB");
         expect(url).toContain("nach=Bern");
@@ -110,7 +110,7 @@ describe("sbb-url", () => {
           originStation: { id: "8503000", name: "Zürich HB" },
           destinationStation: { id: "8507000", name: "Bern" },
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
 
         expect(url).toContain("stops=");
         expect(url).not.toContain("von=");
@@ -130,7 +130,7 @@ describe("sbb-url", () => {
           originAddress: "Zürich, Bahnhofstrasse 1",
           destinationStation: { id: "8507000", name: "Bern" },
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         // Should use stops format with station ID, not von/nach with address
         expect(url).toContain("stops=");
         expect(url).toContain("%22value%22%3A%228503000%22");
@@ -143,7 +143,7 @@ describe("sbb-url", () => {
           originStation: { id: "4000", name: "Pully-Nord" },
           destinationStation: { id: "73232", name: "Kloten, Freienberg" },
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
 
         // IDs should be normalized to include the 85 prefix
         expect(url).toContain("%22value%22%3A%228504000%22");
@@ -156,7 +156,7 @@ describe("sbb-url", () => {
           originStation: { id: "8504000", name: "Pully-Nord" },
           destinationStation: { id: "8573232", name: "Kloten, Freienberg" },
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
 
         // IDs should remain unchanged
         expect(url).toContain("%22value%22%3A%228504000%22");
@@ -167,19 +167,6 @@ describe("sbb-url", () => {
       });
     });
 
-    describe("app target", () => {
-      it("generates same URL as website (sbbmobile:// not yet implemented)", () => {
-        const url = generateSbbUrl(baseParams, "app");
-
-        // Currently uses website URL for app target too
-        // TODO: Update when sbbmobile:// deep links are implemented
-        expect(url).toContain("https://www.sbb.ch/de?");
-        expect(url).toContain("nach=Bern");
-        expect(url).toContain("date=%222024-12-28%22");
-        expect(url).toContain("time=%2214:30%22");
-      });
-    });
-
     describe("date formatting", () => {
       it("formats date as YYYY-MM-DD with leading zeros and quotes", () => {
         const params = {
@@ -187,7 +174,7 @@ describe("sbb-url", () => {
           date: new Date("2024-01-05T10:00:00"),
           arrivalTime: new Date("2024-01-05T10:00:00"),
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         expect(url).toContain("date=%222024-01-05%22");
       });
 
@@ -197,7 +184,7 @@ describe("sbb-url", () => {
           date: new Date("2024-03-15T10:00:00"),
           arrivalTime: new Date("2024-03-15T10:00:00"),
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         expect(url).toContain("date=%222024-03-15%22");
       });
     });
@@ -208,7 +195,7 @@ describe("sbb-url", () => {
           ...baseParams,
           arrivalTime: new Date("2024-12-28T09:05:00"),
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         expect(url).toContain("time=%2209:05%22");
       });
 
@@ -217,7 +204,7 @@ describe("sbb-url", () => {
           ...baseParams,
           arrivalTime: new Date("2024-12-28T00:00:00"),
         };
-        const url = generateSbbUrl(params, "website");
+        const url = generateSbbUrl(params);
         expect(url).toContain("time=%2200:00%22");
       });
     });

--- a/web-app/src/utils/sbb-url.ts
+++ b/web-app/src/utils/sbb-url.ts
@@ -1,5 +1,4 @@
 import type { Locale } from "@/i18n";
-import type { SbbLinkTarget } from "@/stores/settings";
 import type { StationInfo } from "@/services/transport/types";
 
 /**
@@ -77,7 +76,6 @@ function formatTime(date: Date): string {
  * 2. For addresses without IDs: https://www.sbb.ch/{lang}?von=address&nach=address&date=...
  *
  * @param params - The parameters for generating the URL
- * @param target - Whether to generate a website or app URL
  * @returns The timetable URL
  *
  * @example
@@ -87,17 +85,10 @@ function formatTime(date: Date): string {
  *   date: new Date("2024-12-28"),
  *   arrivalTime: new Date("2024-12-28T14:30:00"),
  *   language: "de",
- * }, "website");
+ * });
  * ```
  */
-export function generateSbbUrl(
-  params: SbbUrlParams,
-  target: SbbLinkTarget,
-): string {
-  // TODO: Implement sbbmobile:// deep links when we figure out the correct URL format
-  // For now, always use the website URL (works on mobile too)
-  void target;
-
+export function generateSbbUrl(params: SbbUrlParams): string {
   const { destination, date, arrivalTime, language = "de", originStation, destinationStation, originAddress } = params;
 
   const formattedDate = formatDateSbb(date);
@@ -106,19 +97,6 @@ export function generateSbbUrl(
   // Determine origin and destination names
   const origin = originStation?.name ?? originAddress;
   const dest = destinationStation?.name ?? destination;
-
-  // Generate SBB mobile app deep link (commented out - needs correct URL format)
-  // if (target === "app") {
-  //   const appParams = new URLSearchParams();
-  //   if (origin) {
-  //     appParams.set("von", origin);
-  //   }
-  //   appParams.set("nach", dest);
-  //   appParams.set("date", formattedDate);
-  //   appParams.set("time", formattedTime);
-  //   appParams.set("arriving", "true");
-  //   return `sbbmobile://timetable?${appParams.toString()}`;
-  // }
 
   // Generate SBB website URL
   // Common time/date parameters (quoted per SBB spec)
@@ -171,10 +149,5 @@ export function calculateArrivalTime(
  * @param url - The SBB URL to open
  */
 export function openSbbUrl(url: string): void {
-  // TODO: Handle sbbmobile:// deep links when implemented
-  // if (url.startsWith("sbbmobile://")) {
-  //   window.location.href = url;
-  // } else {
   window.open(url, "_blank", "noopener,noreferrer");
-  // }
 }


### PR DESCRIPTION
## Summary

- Remove the SBB mobile app deep link feature (`sbbmobile://`) due to lack of reliable documentation
- The SBB website remains the only transport link target, simplifying the codebase

## Changes

- Remove `SbbLinkTarget` type and related store state/methods from `settings.ts`
- Remove `target` parameter from `generateSbbUrl()` function in `sbb-url.ts`
- Remove commented-out `sbbmobile://` URL generation code
- Remove SBB link target toggle UI from TransportSection settings
- Remove related i18n keys (`sbbLinkTarget`, `sbbLinkTargetDescription`, `sbbLinkTargetWebsite`, `sbbLinkTargetApp`) from all 4 locales
- Update `useSbbUrl` hook to no longer read link target preference
- Update all related tests to reflect simplified API

## Test Plan

- [ ] Verify lint passes (`npm run lint`)
- [ ] Verify all tests pass (`npm test`)
- [ ] Verify build succeeds (`npm run build`)
- [ ] Verify SBB button on Exchange page still opens SBB website correctly
- [ ] Verify Transport section in Settings no longer shows link target toggle
- [ ] Verify no TypeScript errors in the codebase
