### PR TITLE
fix(hooks): make PR description code block requirement explicit

### DIFF
--- a/.claude/hooks/post-git-push.sh
+++ b/.claude/hooks/post-git-push.sh
@@ -25,7 +25,7 @@ if [[ "$command" == *"git push"* ]]; then
   cat <<'EOF'
 {
   "decision": "block",
-  "reason": "Code pushed successfully. Generate a PR description for copy-paste into GitHub.\n\nIMPORTANT: Use 4-space indented code blocks (not triple backticks) to avoid markdown rendering issues in the Claude mobile app.\n\nFormat:\n\n## Summary\n\n- [bullet points]\n\n## Changes\n\n- [list of changes]\n\n## Test Plan\n\n- [ ] [checklist items]"
+  "reason": "Code pushed successfully.\n\nYou MUST now output the updated PR description inside a markdown code block so the user can copy it.\n\nOutput format (use EXACTLY this structure):\n\nHere is the updated PR description:\n\n```\n## Summary\n\n- [bullet points summarizing what was done]\n\n## Changes\n\n- [list of specific changes made]\n\n## Test Plan\n\n- [ ] [checklist items for testing]\n```\n\nThe triple backtick code block is REQUIRED so the user can easily copy the entire PR description."
 }
 EOF
   exit 0

--- a/.claude/hooks/post-git-push.sh
+++ b/.claude/hooks/post-git-push.sh
@@ -25,7 +25,7 @@ if [[ "$command" == *"git push"* ]]; then
   cat <<'EOF'
 {
   "decision": "block",
-  "reason": "Code pushed successfully.\n\nYou MUST now output the updated PR description inside a markdown code block so the user can copy it.\n\nOutput format (use EXACTLY this structure):\n\nHere is the updated PR description:\n\n```\n## Summary\n\n- [bullet points summarizing what was done]\n\n## Changes\n\n- [list of specific changes made]\n\n## Test Plan\n\n- [ ] [checklist items for testing]\n```\n\nThe triple backtick code block is REQUIRED so the user can easily copy the entire PR description."
+  "reason": "Code pushed successfully.\n\nYou MUST now output the updated PR description inside a markdown code block so the user can copy it.\n\nOutput format (use EXACTLY this structure):\n\nHere is the updated PR description:\n\n```\n## Summary\n\n- [bullet points summarizing what was done]\n\n## Changes\n\n- [list of specific changes made]\n\n## Test Plan\n\n- [ ] [checklist items for testing]\n```\n\nIMPORTANT:\n- The outer triple backtick code block is REQUIRED so the user can easily copy the entire PR description.\n- Any code snippets INSIDE the PR description must use 4-space indentation, NOT triple backticks (to avoid breaking the outer code block)."
 }
 EOF
   exit 0


### PR DESCRIPTION
## Summary

- Fix PR description formatting in post-git-push hook for Claude Code web sessions

## Changes

- Updated `.claude/hooks/post-git-push.sh` to explicitly require PR descriptions in a code block
- Added "Here is the updated PR description:" label before the code block
- Added instruction that nested code snippets must use 4-space indentation (not triple backticks) to avoid breaking the outer code block

## Test Plan

- [ ] Push code from Claude Code web and verify PR description is wrapped in a code block
- [ ] Verify the description includes the "updated PR description" label
- [ ] Test with a PR that includes code snippets to confirm indentation instruction is followed
