### PR TITLE
fix(exchange): display referee position in expanded card view

### DIFF
--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -2,11 +2,12 @@ import { memo, useMemo } from "react";
 import { format, parseISO } from "date-fns";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { TravelTimeBadge } from "@/components/features/TravelTimeBadge";
-import { MapPin, MaleIcon, FemaleIcon, Home, Navigation, TrainFront, Loader2 } from "@/components/ui/icons";
+import { MapPin, MaleIcon, FemaleIcon, Home, Navigation, TrainFront, Loader2, User } from "@/components/ui/icons";
 import type { GameExchange } from "@/api/client";
 import { useDateLocale } from "@/hooks/useDateFormat";
 import { useTranslation } from "@/hooks/useTranslation";
 import { buildMapsUrls } from "@/utils/maps-url";
+import { getPositionLabel } from "@/utils/position-labels";
 import { useSettingsStore } from "@/stores/settings";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { useSbbUrl } from "@/hooks/useSbbUrl";
@@ -84,6 +85,9 @@ function ExchangeCardComponent({
   const { googleMapsUrl, nativeMapsUrl: addressMapsUrl, fullAddress } = buildMapsUrls(postalAddress, hallName);
 
   const requiredLevel = exchange.requiredRefereeLevel;
+
+  // Get the translated position label for the exchange
+  const positionLabel = getPositionLabel(exchange.refereePosition, t);
 
   const leagueCategory = game?.group?.phase?.league?.leagueCategory?.name;
   const gender = game?.group?.phase?.league?.gender;
@@ -245,6 +249,17 @@ function ExchangeCardComponent({
               )}
             </div>
           </div>
+
+          {/* Position being exchanged */}
+          {positionLabel && (
+            <div className="flex items-center gap-2 text-sm text-text-muted dark:text-text-muted-dark">
+              <User className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+              <div>
+                <span className="text-text-subtle dark:text-text-subtle-dark">{t("common.position")}: </span>
+                <span className="font-medium text-text-primary dark:text-text-primary-dark">{positionLabel}</span>
+              </div>
+            </div>
+          )}
 
           {/* Required level */}
           {requiredLevel && (

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -21,6 +21,7 @@ export { Camera } from "lucide-react";
 export { Check } from "lucide-react";
 export { FileText } from "lucide-react";
 export { AlertCircle } from "lucide-react";
+export { User } from "lucide-react";
 export { UserPlus } from "lucide-react";
 export { RefreshCw } from "lucide-react";
 export { Loader2 } from "lucide-react";


### PR DESCRIPTION
## Summary

- Clarify which referee position (1st or 2nd referee) the user would be taking over when viewing exchange offers in the expanded card view

## Changes

- Added import for `User` icon and `getPositionLabel` utility in `ExchangeCard.tsx`
- Computed translated position label from `exchange.refereePosition` field
- Display position prominently in expanded card view with user icon, positioned between location and required level sections

## Test Plan

- [ ] Open the Exchange tab in demo mode
- [ ] Expand an exchange card by tapping on it
- [ ] Verify the position (e.g., "1st Referee" or "2nd Referee") is clearly visible in the expanded details
- [ ] Verify the position label is translated correctly in all 4 languages (de, en, fr, it)
- [ ] Verify lint passes with no warnings
- [ ] Verify all unit tests pass
