### PR TITLE
fix(icons): use Lucide's native Volleyball icon

### DIFF
--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -45,8 +45,8 @@ export { Lock } from "lucide-react";
 export { Inbox } from "lucide-react";
 export { Info } from "lucide-react";
 
-// App branding - custom volleyball icon since Lucide doesn't have one
-export { CircleDot as Volleyball } from "lucide-react";
+// App branding
+export { Volleyball } from "lucide-react";
 
 // Gender icons - custom SVGs since Lucide doesn't have Mars/Venus symbols
 import type { SVGProps } from "react";


### PR DESCRIPTION
## Summary

- Replace CircleDot placeholder icon with Lucide's native Volleyball icon for VolleyKit branding

## Changes

- Updated `web-app/src/components/ui/icons.tsx` to export the actual `Volleyball` icon from lucide-react instead of aliasing `CircleDot`
- Removed outdated comment about Lucide not having a volleyball icon

## Test Plan

- [ ] Verify the volleyball icon renders correctly in the header (AppShell)
- [ ] Verify the volleyball icon renders correctly on the login page
- [ ] Verify the icon looks appropriate at different sizes (w-6 h-6 in header, w-16 h-16 on login)
- [ ] Check icon appearance in both light and dark modes
