### PR TITLE
feat(assignments): display league name in compact card view

### DIFF
--- a/web-app/src/components/features/AssignmentCard.test.tsx
+++ b/web-app/src/components/features/AssignmentCard.test.tsx
@@ -81,6 +81,41 @@ describe("AssignmentCard", () => {
       expect(screen.getByText("NLA")).toBeInTheDocument();
     });
 
+    it("renders game number and league with gender in expanded view", () => {
+      const assignment = createMockAssignment({
+        refereeGame: {
+          game: {
+            id: "game-1",
+            number: 123456,
+            startingDateTime: "2025-12-15T14:00:00Z",
+            encounter: {
+              teamHome: { name: "VBC Zürich" },
+              teamAway: { name: "VBC Basel" },
+            },
+            hall: { name: "Sporthalle Zürich" },
+            group: {
+              phase: {
+                league: {
+                  leagueCategory: { name: "NLA" },
+                  gender: "m",
+                },
+              },
+            },
+          },
+        },
+      } as Partial<Assignment>);
+
+      render(<AssignmentCard assignment={assignment} />);
+
+      // Click to expand
+      fireEvent.click(screen.getByRole("button"));
+
+      // Game number is in expanded view
+      expect(screen.getByText("#123456")).toBeInTheDocument();
+      // League with gender is in expanded view
+      expect(screen.getByText(/NLA • Men/)).toBeInTheDocument();
+    });
+
     it("renders city in compact view when available", () => {
       const assignment = createMockAssignment({
         refereeGame: {

--- a/web-app/src/components/features/AssignmentCard.test.tsx
+++ b/web-app/src/components/features/AssignmentCard.test.tsx
@@ -74,13 +74,11 @@ describe("AssignmentCard", () => {
       expect(screen.getByText("Confirmed")).toBeInTheDocument();
     });
 
-    it("renders league category in expanded view", () => {
+    it("renders league category in compact view", () => {
       render(<AssignmentCard assignment={createMockAssignment()} />);
 
-      // Click to expand
-      fireEvent.click(screen.getByRole("button"));
-
-      expect(screen.getByText(/NLA/)).toBeInTheDocument();
+      // League category is visible in compact view (no expansion needed)
+      expect(screen.getByText("NLA")).toBeInTheDocument();
     });
 
     it("renders city in compact view when available", () => {

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -185,11 +185,6 @@ function AssignmentCardComponent({
               <span className="text-xs text-text-muted dark:text-text-muted-dark truncate w-full text-right">
                 {city || ""}
               </span>
-              {game?.number && (
-                <span className="text-xs text-text-subtle dark:text-text-subtle-dark">
-                  #{game.number}
-                </span>
-              )}
               {game?.group?.phase?.league?.leagueCategory?.name && (
                 <span className="text-xs text-text-subtle dark:text-text-subtle-dark truncate w-full text-right">
                   {game.group.phase.league.leagueCategory.name}
@@ -271,6 +266,22 @@ function AssignmentCardComponent({
               {statusConfig[status]?.label || t("assignments.active")}
             </Badge>
           </div>
+
+          {/* Game number */}
+          {game?.number && (
+            <div className="text-xs text-text-subtle dark:text-text-subtle-dark">
+              #{game.number}
+            </div>
+          )}
+
+          {/* Category/League */}
+          {game?.group?.phase?.league?.leagueCategory?.name && (
+            <div className="text-xs text-text-subtle dark:text-text-subtle-dark">
+              {game.group.phase.league.leagueCategory.name}
+              {game.group.phase.league.gender &&
+                ` • ${game.group.phase.league.gender === "m" ? t("common.men") : t("common.women")}`}
+            </div>
+          )}
 
           {/* Referee names */}
           {(headReferee1 || headReferee2 || linesmen.length > 0) && (

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -190,6 +190,11 @@ function AssignmentCardComponent({
                   #{game.number}
                 </span>
               )}
+              {game?.group?.phase?.league?.leagueCategory?.name && (
+                <span className="text-xs text-text-subtle dark:text-text-subtle-dark truncate w-full text-right">
+                  {game.group.phase.league.leagueCategory.name}
+                </span>
+              )}
             </div>
             {expandArrow}
           </div>
@@ -266,15 +271,6 @@ function AssignmentCardComponent({
               {statusConfig[status]?.label || t("assignments.active")}
             </Badge>
           </div>
-
-          {/* Category/League */}
-          {game?.group?.phase?.league?.leagueCategory?.name && (
-            <div className="text-xs text-text-subtle dark:text-text-subtle-dark">
-              {game.group.phase.league.leagueCategory.name}
-              {game.group.phase.league.gender &&
-                ` • ${game.group.phase.league.gender === "m" ? t("common.men") : t("common.women")}`}
-            </div>
-          )}
 
           {/* Referee names */}
           {(headReferee1 || headReferee2 || linesmen.length > 0) && (


### PR DESCRIPTION
## Summary

- Display league name in compact card view for quick reference
- Move game number and full league info (with gender) to expanded view

## Changes

- Added league name display under city in compact card view (`web-app/src/components/features/AssignmentCard.tsx:188-192`)
- Added game number display in expanded view (`web-app/src/components/features/AssignmentCard.tsx:270-275`)
- Added league category with gender display in expanded view (`web-app/src/components/features/AssignmentCard.tsx:277-284`)
- Added test for game number and league with gender in expanded view

## Test Plan

- [ ] View assignments page and verify league name appears under city in compact view
- [ ] Expand an assignment card and verify game number is displayed (e.g., "#123456")
- [ ] Verify league with gender is shown in expanded view (e.g., "NLA • Men")
- [ ] Test with assignments that have no league data (should not show anything)
- [ ] Verify layout looks correct on mobile and desktop viewports
