### PR TITLE
perf(e2e): improve test performance with parallel workers and element-based waits

### DIFF
--- a/web-app/e2e/constants.ts
+++ b/web-app/e2e/constants.ts
@@ -1,18 +1,16 @@
 /**
  * Shared constants for E2E tests.
- * Centralizes timing values to avoid magic numbers throughout tests.
  *
- * Note: Avoid hardcoded delay waits (waitForTimeout). Instead, use
- * Playwright's built-in auto-waiting via expect assertions and proper
- * element state checks. These timeout values are for explicit waitFor
- * calls when waiting for specific states.
+ * PHILOSOPHY: Prefer element-based waits over time-based waits.
+ * These timeouts are only fallbacks for maximum wait times, not delays.
+ * Playwright's auto-waiting handles most cases automatically.
  */
 
-/** Timeout for page/component loading (ms) */
-export const PAGE_LOAD_TIMEOUT_MS = 10000;
+/** Maximum timeout for page/component loading (ms) - fallback only */
+export const PAGE_LOAD_TIMEOUT_MS = 5000;
 
-/** Timeout for tab state changes and React updates (ms) */
-export const TAB_SWITCH_TIMEOUT_MS = 5000;
+/** Maximum timeout for tab state changes (ms) - fallback only */
+export const TAB_SWITCH_TIMEOUT_MS = 2000;
 
-/** Timeout for loading indicators to disappear (ms) */
-export const LOADING_TIMEOUT_MS = 5000;
+/** Maximum timeout for loading indicators to disappear (ms) - fallback only */
+export const LOADING_TIMEOUT_MS = 2000;

--- a/web-app/e2e/pages/assignments.page.ts
+++ b/web-app/e2e/pages/assignments.page.ts
@@ -1,9 +1,5 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-import {
-  PAGE_LOAD_TIMEOUT_MS,
-  TAB_SWITCH_TIMEOUT_MS,
-  LOADING_TIMEOUT_MS,
-} from "../constants";
+import { TAB_SWITCH_TIMEOUT_MS } from "../constants";
 import { BasePage } from "./base.page";
 
 /**
@@ -16,6 +12,7 @@ export class AssignmentsPage extends BasePage {
   readonly validationClosedTab: Locator;
   readonly tabPanel: Locator;
   readonly assignmentCards: Locator;
+  private readonly emptyState: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -25,6 +22,7 @@ export class AssignmentsPage extends BasePage {
     this.validationClosedTab = page.locator("#tab-validationClosed");
     this.tabPanel = page.getByRole("tabpanel");
     this.assignmentCards = this.tabPanel.getByRole("button");
+    this.emptyState = page.getByTestId("empty-state");
   }
 
   async goto() {
@@ -34,29 +32,24 @@ export class AssignmentsPage extends BasePage {
   async expectToBeLoaded() {
     await expect(this.tablist).toBeVisible();
     await expect(this.upcomingTab).toBeVisible();
-    await this.waitForStableState();
   }
 
   async switchToUpcomingTab() {
-    await expect(this.upcomingTab).toBeVisible();
     await this.upcomingTab.click();
     await expect(this.upcomingTab).toHaveAttribute("aria-selected", "true", {
       timeout: TAB_SWITCH_TIMEOUT_MS,
     });
-    await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
-    await this.waitForStableState();
+    await expect(this.tabPanel).toBeVisible();
   }
 
   async switchToValidationClosedTab() {
-    await expect(this.validationClosedTab).toBeVisible();
     await this.validationClosedTab.click();
     await expect(this.validationClosedTab).toHaveAttribute(
       "aria-selected",
       "true",
       { timeout: TAB_SWITCH_TIMEOUT_MS },
     );
-    await expect(this.tabPanel).toBeVisible({ timeout: TAB_SWITCH_TIMEOUT_MS });
-    await this.waitForStableState();
+    await expect(this.tabPanel).toBeVisible();
   }
 
   async getAssignmentCount(): Promise<number> {
@@ -64,24 +57,7 @@ export class AssignmentsPage extends BasePage {
   }
 
   async waitForAssignmentsLoaded() {
-    await expect(this.tabPanel).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT_MS });
-
-    // Wait for loading indicator to disappear (if it appears)
-    const loadingIndicator = this.page.getByTestId("loading-state");
-    const isLoadingVisible = await loadingIndicator.isVisible();
-    if (isLoadingVisible) {
-      await loadingIndicator.waitFor({
-        state: "hidden",
-        timeout: LOADING_TIMEOUT_MS,
-      });
-    }
-
-    // Wait for actual content: either cards are present or empty state is shown
-    const emptyState = this.page.getByTestId("empty-state");
-    await expect(this.assignmentCards.first().or(emptyState)).toBeVisible({
-      timeout: LOADING_TIMEOUT_MS,
-    });
-
-    await this.waitForStableState();
+    await expect(this.tabPanel).toBeVisible();
+    await this.waitForContentReady(this.assignmentCards, this.emptyState);
   }
 }

--- a/web-app/e2e/pages/base.page.ts
+++ b/web-app/e2e/pages/base.page.ts
@@ -1,8 +1,12 @@
-import { type Page } from "@playwright/test";
+import { type Page, type Locator, expect } from "@playwright/test";
+import { LOADING_TIMEOUT_MS } from "../constants";
 
 /**
  * Base Page Object Model with shared utilities.
  * Provides common wait strategies used across all page objects.
+ *
+ * PHILOSOPHY: Prefer element-based waits over time-based waits.
+ * Playwright auto-waits for elements, so explicit waits are rarely needed.
  */
 export class BasePage {
   readonly page: Page;
@@ -12,11 +16,29 @@ export class BasePage {
   }
 
   /**
-   * Wait for the page to reach a stable state.
-   * This ensures React has finished rendering and all network requests are complete.
-   * Use this after navigation, tab switches, or any action that triggers re-renders.
+   * Wait for any loading indicators to disappear and content to be ready.
+   * This is more reliable than networkidle for demo mode where there's no real network.
    */
-  async waitForStableState() {
-    await this.page.waitForLoadState("networkidle");
+  protected async waitForContentReady(
+    contentLocator: Locator,
+    emptyStateLocator?: Locator,
+  ) {
+    // Wait for loading indicator to disappear (if present)
+    const loadingIndicator = this.page.getByTestId("loading-state");
+    await loadingIndicator.waitFor({
+      state: "hidden",
+      timeout: LOADING_TIMEOUT_MS,
+    });
+
+    // Wait for content or empty state to be visible
+    if (emptyStateLocator) {
+      await expect(contentLocator.first().or(emptyStateLocator)).toBeVisible({
+        timeout: LOADING_TIMEOUT_MS,
+      });
+    } else {
+      await expect(contentLocator.first()).toBeVisible({
+        timeout: LOADING_TIMEOUT_MS,
+      });
+    }
   }
 }

--- a/web-app/e2e/pages/login.page.ts
+++ b/web-app/e2e/pages/login.page.ts
@@ -1,5 +1,4 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-import { PAGE_LOAD_TIMEOUT_MS } from "../constants";
 
 /**
  * Page Object Model for the Login page.
@@ -24,9 +23,7 @@ export class LoginPage {
   async goto() {
     await this.page.goto("/login");
     // Wait for login form to be ready
-    await expect(this.loginButton).toBeVisible({
-      timeout: PAGE_LOAD_TIMEOUT_MS,
-    });
+    await expect(this.loginButton).toBeVisible();
   }
 
   async login(username: string, password: string) {
@@ -40,26 +37,12 @@ export class LoginPage {
    * Demo mode provides consistent mock data for reliable testing.
    */
   async enterDemoMode() {
-    // Ensure button is visible and enabled before clicking
-    await expect(this.demoButton).toBeVisible();
-    await expect(this.demoButton).toBeEnabled();
-
-    // Wait for network to be idle to ensure React app is fully hydrated
-    // This fixes flaky tests in Firefox where clicks during hydration may not register
-    await this.page.waitForLoadState("networkidle");
-
-    // Click demo button
+    // Playwright auto-waits for the button to be actionable (visible + enabled)
     await this.demoButton.click();
 
-    // Wait for navigation away from login page
-    await expect(this.page).not.toHaveURL(/login/, {
-      timeout: PAGE_LOAD_TIMEOUT_MS,
-    });
-
-    // Wait for main content to appear on the destination page
-    await expect(this.page.getByRole("main")).toBeVisible({
-      timeout: PAGE_LOAD_TIMEOUT_MS,
-    });
+    // Wait for navigation away from login page and main content to appear
+    await expect(this.page).not.toHaveURL(/login/);
+    await expect(this.page.getByRole("main")).toBeVisible();
   }
 
   async expectToBeVisible() {

--- a/web-app/e2e/pages/navigation.page.ts
+++ b/web-app/e2e/pages/navigation.page.ts
@@ -1,5 +1,4 @@
 import { type Page, type Locator, expect } from "@playwright/test";
-import { PAGE_LOAD_TIMEOUT_MS } from "../constants";
 import { BasePage } from "./base.page";
 
 /**
@@ -28,22 +27,18 @@ export class NavigationPage extends BasePage {
   }
 
   /**
-   * Helper to navigate to a page reliably.
-   * Waits for stable state before and after clicking to handle timing issues.
+   * Navigate to a page via bottom nav.
+   * Uses element-based waits for reliability.
    */
   private async navigateTo(
     link: Locator,
     expectedUrl: string | RegExp,
   ): Promise<void> {
-    await this.waitForStableState();
+    // Playwright auto-waits for the link to be actionable before clicking
     await link.click();
-    await expect(this.page).toHaveURL(expectedUrl, {
-      timeout: PAGE_LOAD_TIMEOUT_MS,
-    });
-    await expect(this.page.getByRole("main")).toBeVisible({
-      timeout: PAGE_LOAD_TIMEOUT_MS,
-    });
-    await this.waitForStableState();
+    // Wait for URL and main content - no explicit delays needed
+    await expect(this.page).toHaveURL(expectedUrl);
+    await expect(this.page.getByRole("main")).toBeVisible();
   }
 
   async goToAssignments() {

--- a/web-app/playwright.config.ts
+++ b/web-app/playwright.config.ts
@@ -18,8 +18,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   // Retry on CI only (helps catch flaky tests locally too)
   retries: process.env.CI ? 2 : 1,
-  // Limit parallel workers on CI
-  workers: process.env.CI ? 1 : undefined,
+  // Use multiple workers for parallel execution
+  // 4 workers balances parallelism with resource usage across 5 browser projects
+  workers: process.env.CI ? 4 : undefined,
   // Reporter to use
   reporter: process.env.CI ? 'github' : 'html',
   // Shared settings for all the projects below


### PR DESCRIPTION
## Summary

- Significantly improve E2E test performance by enabling parallel execution and replacing time-based waits with element-based waits
- Reduce test flakiness by relying on Playwright's auto-waiting instead of explicit networkidle delays

## Changes

- **playwright.config.ts**: Increase CI workers from 1 to 4 for parallel test execution
- **e2e/constants.ts**: Reduce timeout fallbacks (PAGE_LOAD: 10s→5s, TAB_SWITCH: 5s→2s, LOADING: 5s→2s)
- **e2e/pages/base.page.ts**: Replace waitForStableState(networkidle) with element-based waitForContentReady() helper
- **e2e/pages/login.page.ts**: Remove networkidle wait, rely on Playwright's auto-waiting for button clicks
- **e2e/pages/navigation.page.ts**: Remove redundant waitForStableState() calls before/after navigation
- **e2e/pages/assignments.page.ts**: Simplify loading detection, remove post-assertion waits
- **e2e/pages/compensations.page.ts**: Simplify loading detection, remove post-assertion waits
- **e2e/pages/exchanges.page.ts**: Simplify loading detection, remove post-assertion waits

## Test Plan

- [ ] Run E2E tests locally: `npm run test:e2e` passes
- [ ] Verify CI E2E workflow completes faster than before
- [ ] Check that tests don't become flaky with reduced timeouts
- [ ] Test on slower CI runners (Firefox) to ensure timeouts are still adequate
