### PR TITLE
fix(exchange): use association-specific transport setting for travel time filter

### DIFF
--- a/web-app/src/components/features/ExchangeSettingsSheet.test.tsx
+++ b/web-app/src/components/features/ExchangeSettingsSheet.test.tsx
@@ -40,6 +40,11 @@ vi.mock("@/hooks/useTravelTime", () => ({
   useTravelTimeAvailable: () => mockUseTravelTimeAvailable(),
 }));
 
+// Mock useActiveAssociationCode hook
+vi.mock("@/hooks/useActiveAssociation", () => ({
+  useActiveAssociationCode: () => "TEST",
+}));
+
 // Mock ResponsiveSheet component
 vi.mock("@/components/ui/ResponsiveSheet", () => ({
   ResponsiveSheet: ({
@@ -58,7 +63,7 @@ describe("ExchangeSettingsSheet", () => {
     homeLocation: { lat: 47.3769, lng: 8.5417, name: "Zurich" },
     distanceFilter: { maxDistanceKm: 50, enabled: true },
     setMaxDistanceKm: vi.fn(),
-    transportEnabled: true,
+    isTransportEnabledForAssociation: () => true,
     travelTimeFilter: { maxTravelTimeMinutes: 60, enabled: true },
     setMaxTravelTimeMinutes: vi.fn(),
   };
@@ -139,7 +144,7 @@ describe("ExchangeSettingsSheet", () => {
   it("hides travel time slider when transport is disabled", async () => {
     mockSettingsState.mockReturnValue({
       ...defaultSettingsState,
-      transportEnabled: false,
+      isTransportEnabledForAssociation: () => false,
     });
     const user = userEvent.setup();
 

--- a/web-app/src/components/features/ExchangeSettingsSheet.tsx
+++ b/web-app/src/components/features/ExchangeSettingsSheet.tsx
@@ -28,7 +28,6 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
     homeLocation,
     distanceFilter,
     setMaxDistanceKm,
-    isTransportEnabledForAssociation,
     travelTimeFilter,
     setMaxTravelTimeMinutes,
   } = useSettingsStore(
@@ -36,10 +35,14 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
       homeLocation: state.homeLocation,
       distanceFilter: state.distanceFilter,
       setMaxDistanceKm: state.setMaxDistanceKm,
-      isTransportEnabledForAssociation: state.isTransportEnabledForAssociation,
       travelTimeFilter: state.travelTimeFilter,
       setMaxTravelTimeMinutes: state.setMaxTravelTimeMinutes,
     })),
+  );
+
+  // Get function separately - functions don't need shallow comparison
+  const isTransportEnabledForAssociation = useSettingsStore(
+    (state) => state.isTransportEnabledForAssociation,
   );
 
   const handleDistanceChange = useCallback(

--- a/web-app/src/components/features/ExchangeSettingsSheet.tsx
+++ b/web-app/src/components/features/ExchangeSettingsSheet.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, memo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useSettingsStore } from "@/stores/settings";
+import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTravelTimeAvailable } from "@/hooks/useTravelTime";
 import { ResponsiveSheet } from "@/components/ui/ResponsiveSheet";
@@ -21,12 +22,13 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const isTravelTimeAvailable = useTravelTimeAvailable();
+  const associationCode = useActiveAssociationCode();
 
   const {
     homeLocation,
     distanceFilter,
     setMaxDistanceKm,
-    transportEnabled,
+    isTransportEnabledForAssociation,
     travelTimeFilter,
     setMaxTravelTimeMinutes,
   } = useSettingsStore(
@@ -34,7 +36,7 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
       homeLocation: state.homeLocation,
       distanceFilter: state.distanceFilter,
       setMaxDistanceKm: state.setMaxDistanceKm,
-      transportEnabled: state.transportEnabled,
+      isTransportEnabledForAssociation: state.isTransportEnabledForAssociation,
       travelTimeFilter: state.travelTimeFilter,
       setMaxTravelTimeMinutes: state.setMaxTravelTimeMinutes,
     })),
@@ -57,7 +59,9 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
   // Determine which settings are available
   const hasHomeLocation = Boolean(homeLocation);
   const canShowDistanceSlider = hasHomeLocation;
-  const canShowTravelTimeSlider = hasHomeLocation && transportEnabled && isTravelTimeAvailable;
+  // Use association-specific transport check for consistency with ExchangePage
+  const isTransportEnabled = isTransportEnabledForAssociation(associationCode);
+  const canShowTravelTimeSlider = hasHomeLocation && isTransportEnabled && isTravelTimeAvailable;
 
   // Don't show the gear icon if no settings are available
   if (!canShowDistanceSlider && !canShowTravelTimeSlider) {

--- a/web-app/src/pages/ExchangePage.test.tsx
+++ b/web-app/src/pages/ExchangePage.test.tsx
@@ -12,6 +12,12 @@ vi.mock("@/hooks/useConvocations");
 vi.mock("@/stores/auth");
 vi.mock("@/stores/demo");
 vi.mock("@/stores/settings");
+vi.mock("@/hooks/useActiveAssociation", () => ({
+  useActiveAssociationCode: () => "TEST",
+}));
+vi.mock("@/hooks/useTravelTime", () => ({
+  useTravelTimeAvailable: () => false,
+}));
 vi.mock("@/hooks/useTravelTimeFilter", () => ({
   useTravelTimeFilter: () => ({
     exchangesWithTravelTime: null,
@@ -97,12 +103,14 @@ describe("ExchangePage", () => {
       userRefereeLevelGradationValue: null,
     });
 
-    // Default settings store mock
-    vi.mocked(settingsStore.useSettingsStore).mockReturnValue({
+    // Default settings store mock - use mockImplementation to handle selectors
+    const defaultState = {
       homeLocation: null,
       distanceFilter: { enabled: false, maxDistanceKm: 50 },
       setDistanceFilterEnabled: vi.fn(),
       transportEnabled: false,
+      isTransportEnabledForAssociation: () => false,
+      getArrivalBufferForAssociation: () => 30,
       travelTimeFilter: {
         enabled: false,
         maxTravelTimeMinutes: 120,
@@ -110,9 +118,15 @@ describe("ExchangePage", () => {
         cacheInvalidatedAt: null,
       },
       setTravelTimeFilterEnabled: vi.fn(),
+      setMaxDistanceKm: vi.fn(),
+      setMaxTravelTimeMinutes: vi.fn(),
       levelFilterEnabled: false,
       setLevelFilterEnabled: mockSetLevelFilterEnabled,
-    });
+    };
+    vi.mocked(settingsStore.useSettingsStore).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (selector?: (state: any) => any) => selector ? selector(defaultState) : defaultState,
+    );
 
     vi.mocked(useConvocations.useGameExchanges).mockReturnValue(
       createMockQueryResult([]),
@@ -237,11 +251,13 @@ describe("ExchangePage", () => {
 
     it("should show user level indicator when filter is enabled", () => {
       // Mock filter as already enabled
-      vi.mocked(settingsStore.useSettingsStore).mockReturnValue({
+      const stateWithFilter = {
         homeLocation: null,
         distanceFilter: { enabled: false, maxDistanceKm: 50 },
         setDistanceFilterEnabled: vi.fn(),
         transportEnabled: false,
+        isTransportEnabledForAssociation: () => false,
+        getArrivalBufferForAssociation: () => 30,
         travelTimeFilter: {
           enabled: false,
           maxTravelTimeMinutes: 120,
@@ -249,9 +265,15 @@ describe("ExchangePage", () => {
           cacheInvalidatedAt: null,
         },
         setTravelTimeFilterEnabled: vi.fn(),
+        setMaxDistanceKm: vi.fn(),
+        setMaxTravelTimeMinutes: vi.fn(),
         levelFilterEnabled: true,
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
-      });
+      };
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (selector?: (state: any) => any) => selector ? selector(stateWithFilter) : stateWithFilter,
+      );
 
       render(<ExchangePage />);
 
@@ -266,11 +288,13 @@ describe("ExchangePage", () => {
       );
 
       // Mock filter as enabled
-      vi.mocked(settingsStore.useSettingsStore).mockReturnValue({
+      const stateWithFilter = {
         homeLocation: null,
         distanceFilter: { enabled: false, maxDistanceKm: 50 },
         setDistanceFilterEnabled: vi.fn(),
         transportEnabled: false,
+        isTransportEnabledForAssociation: () => false,
+        getArrivalBufferForAssociation: () => 30,
         travelTimeFilter: {
           enabled: false,
           maxTravelTimeMinutes: 120,
@@ -278,9 +302,15 @@ describe("ExchangePage", () => {
           cacheInvalidatedAt: null,
         },
         setTravelTimeFilterEnabled: vi.fn(),
+        setMaxDistanceKm: vi.fn(),
+        setMaxTravelTimeMinutes: vi.fn(),
         levelFilterEnabled: true,
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
-      });
+      };
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (selector?: (state: any) => any) => selector ? selector(stateWithFilter) : stateWithFilter,
+      );
 
       render(<ExchangePage />);
 

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -57,7 +57,6 @@ export function ExchangePage() {
     homeLocation,
     distanceFilter,
     setDistanceFilterEnabled,
-    transportEnabled,
     travelTimeFilter,
     setTravelTimeFilterEnabled,
     levelFilterEnabled,
@@ -67,7 +66,6 @@ export function ExchangePage() {
       homeLocation: state.homeLocation,
       distanceFilter: state.distanceFilter,
       setDistanceFilterEnabled: state.setDistanceFilterEnabled,
-      transportEnabled: state.transportEnabled,
       travelTimeFilter: state.travelTimeFilter,
       setTravelTimeFilterEnabled: state.setTravelTimeFilterEnabled,
       levelFilterEnabled: state.levelFilterEnabled,
@@ -159,11 +157,11 @@ export function ExchangePage() {
       });
     }
 
-    // Apply travel time filter (only on "open" tab when transport is enabled)
+    // Apply travel time filter (only on "open" tab when transport is available)
     if (
       travelTimeFilter.enabled &&
       statusFilter === "open" &&
-      transportEnabled &&
+      isTravelTimeAvailable &&
       travelTimeMap.size > 0
     ) {
       result = result.filter(({ exchange }) => {
@@ -186,7 +184,7 @@ export function ExchangePage() {
     homeLocation,
     travelTimeFilter.enabled,
     travelTimeFilter.maxTravelTimeMinutes,
-    transportEnabled,
+    isTravelTimeAvailable,
     travelTimeMap,
   ]);
 
@@ -246,8 +244,8 @@ export function ExchangePage() {
   // Determine if filters are available
   const isLevelFilterAvailable = isDemoMode && userRefereeLevel !== null;
   const isDistanceFilterAvailable = homeLocation !== null;
-  const isTravelTimeFilterAvailable =
-    transportEnabled && isTravelTimeAvailable && homeLocation !== null;
+  // isTravelTimeAvailable from hook already includes association-specific transport check and homeLocation
+  const isTravelTimeFilterAvailable = isTravelTimeAvailable;
 
   const hasAnyFilter =
     isLevelFilterAvailable || isDistanceFilterAvailable || isTravelTimeFilterAvailable;


### PR DESCRIPTION
## Summary

- Fixed the public transport duration filter not working on the exchange tab
- The ExchangePage was using the global `transportEnabled` setting instead of the association-specific `isTravelTimeAvailable` from the useTravelTimeFilter hook

## Changes

- Removed unused `transportEnabled` from the settings store destructuring in ExchangePage
- Changed the travel time filter condition to use `isTravelTimeAvailable` instead of `transportEnabled`
- Simplified `isTravelTimeFilterAvailable` to directly use `isTravelTimeAvailable` (which already includes association-specific transport check and homeLocation validation)

## Test Plan

- [ ] Enable transport for a specific association in settings
- [ ] Navigate to Exchange tab and verify the travel time filter toggle appears
- [ ] Enable the travel time filter and verify exchanges are filtered by travel duration
- [ ] Switch associations and verify the filter respects per-association transport settings
- [ ] Verify all existing tests pass (23 tests in ExchangePage.test.tsx and useTravelTimeFilter.test.tsx)
