### PR TITLE
feat(ui): add weekly separators to game item lists

### DIFF
--- a/web-app/src/components/ui/WeekSeparator.tsx
+++ b/web-app/src/components/ui/WeekSeparator.tsx
@@ -1,0 +1,39 @@
+import { format, isSameMonth, isSameYear } from "date-fns";
+import { useDateLocale } from "@/hooks/useDateFormat";
+import type { WeekInfo } from "@/utils/date-helpers";
+
+interface WeekSeparatorProps {
+  week: WeekInfo;
+}
+
+/**
+ * A subtle separator displaying a week date range (Mon-Sun).
+ * Formats the date range intelligently based on whether dates span months/years.
+ */
+export function WeekSeparator({ week }: WeekSeparatorProps) {
+  const locale = useDateLocale();
+  const { weekStart, weekEnd } = week;
+
+  // Format dates based on whether they span months or years
+  let dateRange: string;
+  if (isSameMonth(weekStart, weekEnd)) {
+    // Same month: "Dec 30 - 5"
+    dateRange = `${format(weekStart, "MMM d", { locale })} – ${format(weekEnd, "d", { locale })}`;
+  } else if (isSameYear(weekStart, weekEnd)) {
+    // Same year, different months: "Dec 30 - Jan 5"
+    dateRange = `${format(weekStart, "MMM d", { locale })} – ${format(weekEnd, "MMM d", { locale })}`;
+  } else {
+    // Different years: "Dec 30, 2024 - Jan 5, 2025"
+    dateRange = `${format(weekStart, "MMM d, yyyy", { locale })} – ${format(weekEnd, "MMM d, yyyy", { locale })}`;
+  }
+
+  return (
+    <div className="col-span-full flex items-center gap-3 py-1.5">
+      <div className="h-px flex-1 bg-border-default dark:bg-border-default-dark" />
+      <span className="text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap">
+        {dateRange}
+      </span>
+      <div className="h-px flex-1 bg-border-default dark:bg-border-default-dark" />
+    </div>
+  );
+}

--- a/web-app/src/components/ui/WeekSeparator.tsx
+++ b/web-app/src/components/ui/WeekSeparator.tsx
@@ -6,24 +6,16 @@ interface WeekSeparatorProps {
   week: WeekInfo;
 }
 
-/**
- * A subtle separator displaying a week date range (Mon-Sun).
- * Formats the date range intelligently based on whether dates span months/years.
- */
 export function WeekSeparator({ week }: WeekSeparatorProps) {
   const locale = useDateLocale();
   const { weekStart, weekEnd } = week;
 
-  // Format dates based on whether they span months or years
   let dateRange: string;
   if (isSameMonth(weekStart, weekEnd)) {
-    // Same month: "Dec 30 - 5"
     dateRange = `${format(weekStart, "MMM d", { locale })} – ${format(weekEnd, "d", { locale })}`;
   } else if (isSameYear(weekStart, weekEnd)) {
-    // Same year, different months: "Dec 30 - Jan 5"
     dateRange = `${format(weekStart, "MMM d", { locale })} – ${format(weekEnd, "MMM d", { locale })}`;
   } else {
-    // Different years: "Dec 30, 2024 - Jan 5, 2025"
     dateRange = `${format(weekStart, "MMM d, yyyy", { locale })} – ${format(weekEnd, "MMM d, yyyy", { locale })}`;
   }
 

--- a/web-app/src/utils/date-helpers.test.ts
+++ b/web-app/src/utils/date-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDateTime, formatDOB } from "./date-helpers";
+import { formatDateTime, formatDOB, groupByWeek } from "./date-helpers";
 
 describe("formatDateTime", () => {
   it("returns TBD for undefined", () => {
@@ -71,5 +71,129 @@ describe("formatDOB", () => {
 
   it("handles dates from 2000s correctly", () => {
     expect(formatDOB("2005-07-20")).toBe("20.07.05");
+  });
+});
+
+describe("groupByWeek", () => {
+  interface TestItem {
+    id: string;
+    date: string | null | undefined;
+  }
+
+  const getDate = (item: TestItem) => item.date;
+
+  it("returns empty array for empty input", () => {
+    expect(groupByWeek([], getDate)).toEqual([]);
+  });
+
+  it("groups items in a single week into one group", () => {
+    const items: TestItem[] = [
+      { id: "1", date: "2025-01-06T10:00:00Z" }, // Monday
+      { id: "2", date: "2025-01-08T14:00:00Z" }, // Wednesday
+      { id: "3", date: "2025-01-12T09:00:00Z" }, // Sunday
+    ];
+
+    const result = groupByWeek(items, getDate);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].week.key).toBe("2025-W02");
+    expect(result[0].items).toHaveLength(3);
+    expect(result[0].items.map((i) => i.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("groups items spanning multiple weeks into separate groups", () => {
+    const items: TestItem[] = [
+      { id: "1", date: "2025-01-06T10:00:00Z" }, // Week 2
+      { id: "2", date: "2025-01-13T14:00:00Z" }, // Week 3
+      { id: "3", date: "2025-01-20T09:00:00Z" }, // Week 4
+    ];
+
+    const result = groupByWeek(items, getDate);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].week.key).toBe("2025-W02");
+    expect(result[1].week.key).toBe("2025-W03");
+    expect(result[2].week.key).toBe("2025-W04");
+    expect(result[0].items[0].id).toBe("1");
+    expect(result[1].items[0].id).toBe("2");
+    expect(result[2].items[0].id).toBe("3");
+  });
+
+  it("skips items with null dates", () => {
+    const items: TestItem[] = [
+      { id: "1", date: "2025-01-06T10:00:00Z" },
+      { id: "2", date: null },
+      { id: "3", date: "2025-01-08T14:00:00Z" },
+    ];
+
+    const result = groupByWeek(items, getDate);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].items).toHaveLength(2);
+    expect(result[0].items.map((i) => i.id)).toEqual(["1", "3"]);
+  });
+
+  it("skips items with undefined dates", () => {
+    const items: TestItem[] = [
+      { id: "1", date: "2025-01-06T10:00:00Z" },
+      { id: "2", date: undefined },
+      { id: "3", date: "2025-01-08T14:00:00Z" },
+    ];
+
+    const result = groupByWeek(items, getDate);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].items).toHaveLength(2);
+  });
+
+  it("skips items with invalid date strings", () => {
+    const items: TestItem[] = [
+      { id: "1", date: "2025-01-06T10:00:00Z" },
+      { id: "2", date: "not-a-date" },
+      { id: "3", date: "2025-01-08T14:00:00Z" },
+    ];
+
+    const result = groupByWeek(items, getDate);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].items).toHaveLength(2);
+  });
+
+  it("handles cross-year week boundaries correctly", () => {
+    const items: TestItem[] = [
+      { id: "1", date: "2024-12-30T10:00:00Z" }, // Monday of week 1, 2025 (ISO week)
+      { id: "2", date: "2025-01-05T14:00:00Z" }, // Sunday of week 1, 2025
+    ];
+
+    const result = groupByWeek(items, getDate);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].week.weekNumber).toBe(1);
+    expect(result[0].items).toHaveLength(2);
+  });
+
+  it("sets correct week start and end dates", () => {
+    const items: TestItem[] = [
+      { id: "1", date: "2025-01-08T10:00:00Z" }, // Wednesday
+    ];
+
+    const result = groupByWeek(items, getDate);
+
+    expect(result).toHaveLength(1);
+    // Week starts on Monday (Jan 6) and ends on Sunday (Jan 12)
+    expect(result[0].week.weekStart.getDate()).toBe(6);
+    expect(result[0].week.weekEnd.getDate()).toBe(12);
+  });
+
+  it("returns empty array when all items have invalid dates", () => {
+    const items: TestItem[] = [
+      { id: "1", date: null },
+      { id: "2", date: "invalid" },
+      { id: "3", date: undefined },
+    ];
+
+    const result = groupByWeek(items, getDate);
+
+    expect(result).toEqual([]);
   });
 });

--- a/web-app/src/utils/date-helpers.test.ts
+++ b/web-app/src/utils/date-helpers.test.ts
@@ -96,9 +96,9 @@ describe("groupByWeek", () => {
     const result = groupByWeek(items, getDate);
 
     expect(result).toHaveLength(1);
-    expect(result[0].week.key).toBe("2025-W02");
-    expect(result[0].items).toHaveLength(3);
-    expect(result[0].items.map((i) => i.id)).toEqual(["1", "2", "3"]);
+    expect(result[0]!.week.key).toBe("2025-W02");
+    expect(result[0]!.items).toHaveLength(3);
+    expect(result[0]!.items.map((i) => i.id)).toEqual(["1", "2", "3"]);
   });
 
   it("groups items spanning multiple weeks into separate groups", () => {
@@ -111,12 +111,12 @@ describe("groupByWeek", () => {
     const result = groupByWeek(items, getDate);
 
     expect(result).toHaveLength(3);
-    expect(result[0].week.key).toBe("2025-W02");
-    expect(result[1].week.key).toBe("2025-W03");
-    expect(result[2].week.key).toBe("2025-W04");
-    expect(result[0].items[0].id).toBe("1");
-    expect(result[1].items[0].id).toBe("2");
-    expect(result[2].items[0].id).toBe("3");
+    expect(result[0]!.week.key).toBe("2025-W02");
+    expect(result[1]!.week.key).toBe("2025-W03");
+    expect(result[2]!.week.key).toBe("2025-W04");
+    expect(result[0]!.items[0]!.id).toBe("1");
+    expect(result[1]!.items[0]!.id).toBe("2");
+    expect(result[2]!.items[0]!.id).toBe("3");
   });
 
   it("skips items with null dates", () => {
@@ -129,8 +129,8 @@ describe("groupByWeek", () => {
     const result = groupByWeek(items, getDate);
 
     expect(result).toHaveLength(1);
-    expect(result[0].items).toHaveLength(2);
-    expect(result[0].items.map((i) => i.id)).toEqual(["1", "3"]);
+    expect(result[0]!.items).toHaveLength(2);
+    expect(result[0]!.items.map((i) => i.id)).toEqual(["1", "3"]);
   });
 
   it("skips items with undefined dates", () => {
@@ -143,7 +143,7 @@ describe("groupByWeek", () => {
     const result = groupByWeek(items, getDate);
 
     expect(result).toHaveLength(1);
-    expect(result[0].items).toHaveLength(2);
+    expect(result[0]!.items).toHaveLength(2);
   });
 
   it("skips items with invalid date strings", () => {
@@ -156,7 +156,7 @@ describe("groupByWeek", () => {
     const result = groupByWeek(items, getDate);
 
     expect(result).toHaveLength(1);
-    expect(result[0].items).toHaveLength(2);
+    expect(result[0]!.items).toHaveLength(2);
   });
 
   it("handles cross-year week boundaries correctly", () => {
@@ -168,8 +168,8 @@ describe("groupByWeek", () => {
     const result = groupByWeek(items, getDate);
 
     expect(result).toHaveLength(1);
-    expect(result[0].week.weekNumber).toBe(1);
-    expect(result[0].items).toHaveLength(2);
+    expect(result[0]!.week.weekNumber).toBe(1);
+    expect(result[0]!.items).toHaveLength(2);
   });
 
   it("sets correct week start and end dates", () => {
@@ -181,8 +181,8 @@ describe("groupByWeek", () => {
 
     expect(result).toHaveLength(1);
     // Week starts on Monday (Jan 6) and ends on Sunday (Jan 12)
-    expect(result[0].week.weekStart.getDate()).toBe(6);
-    expect(result[0].week.weekEnd.getDate()).toBe(12);
+    expect(result[0]!.week.weekStart.getDate()).toBe(6);
+    expect(result[0]!.week.weekEnd.getDate()).toBe(12);
   });
 
   it("returns empty array when all items have invalid dates", () => {

--- a/web-app/src/utils/date-helpers.ts
+++ b/web-app/src/utils/date-helpers.ts
@@ -94,14 +94,12 @@ export function groupByWeek<T>(
     const date = parseISO(dateString);
     if (!isValid(date)) continue;
 
-    // Get week boundaries (Monday as start of week)
     const weekStart = startOfWeek(date, { weekStartsOn: 1 });
     const weekEnd = endOfWeek(date, { weekStartsOn: 1 });
     const weekNumber = getISOWeek(date);
     const year = getYear(weekStart);
     const weekKey = `${year}-W${String(weekNumber).padStart(2, "0")}`;
 
-    // Check if we need a new group
     if (!currentGroup || currentGroup.week.key !== weekKey) {
       currentGroup = {
         week: {

--- a/web-app/src/utils/date-helpers.ts
+++ b/web-app/src/utils/date-helpers.ts
@@ -2,6 +2,8 @@
  * Date formatting utilities for VolleyKit.
  */
 
+import { parseISO, startOfWeek, endOfWeek, isValid, getISOWeek, getYear } from "date-fns";
+
 const DATE_TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   weekday: "short",
   year: "numeric",
@@ -44,4 +46,78 @@ export function formatDOB(birthday: string | null | undefined): string {
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const year = String(date.getFullYear()).slice(-2);
   return `${day}.${month}.${year}`;
+}
+
+/**
+ * Represents a week with its start and end dates.
+ */
+export interface WeekInfo {
+  /** Unique key for the week (e.g., "2025-W05") */
+  key: string;
+  /** Start of week (Monday) */
+  weekStart: Date;
+  /** End of week (Sunday) */
+  weekEnd: Date;
+  /** ISO week number */
+  weekNumber: number;
+  /** Year the week belongs to */
+  year: number;
+}
+
+/**
+ * Represents items grouped by week.
+ */
+export interface WeekGroup<T> {
+  week: WeekInfo;
+  items: T[];
+}
+
+/**
+ * Groups items by ISO week (Monday-Sunday).
+ * Items are expected to already be sorted by date.
+ *
+ * @param items - Array of items to group
+ * @param getDateString - Function to extract the ISO date string from an item
+ * @returns Array of week groups with their items
+ */
+export function groupByWeek<T>(
+  items: T[],
+  getDateString: (item: T) => string | undefined | null,
+): WeekGroup<T>[] {
+  const groups: WeekGroup<T>[] = [];
+  let currentGroup: WeekGroup<T> | null = null;
+
+  for (const item of items) {
+    const dateString = getDateString(item);
+    if (!dateString) continue;
+
+    const date = parseISO(dateString);
+    if (!isValid(date)) continue;
+
+    // Get week boundaries (Monday as start of week)
+    const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+    const weekEnd = endOfWeek(date, { weekStartsOn: 1 });
+    const weekNumber = getISOWeek(date);
+    const year = getYear(weekStart);
+    const weekKey = `${year}-W${String(weekNumber).padStart(2, "0")}`;
+
+    // Check if we need a new group
+    if (!currentGroup || currentGroup.week.key !== weekKey) {
+      currentGroup = {
+        week: {
+          key: weekKey,
+          weekStart,
+          weekEnd,
+          weekNumber,
+          year,
+        },
+        items: [],
+      };
+      groups.push(currentGroup);
+    }
+
+    currentGroup.items.push(item);
+  }
+
+  return groups;
 }


### PR DESCRIPTION
## Summary

- Add subtle weekly separators to all game item tabs to improve visual organization
- Separators display the week date range (Mon-Sun) and only appear when items span multiple weeks
- Date formatting is locale-aware using date-fns locales

## Changes

- Add `groupByWeek` utility function in `web-app/src/utils/date-helpers.ts` for grouping items by ISO week
- Create `WeekSeparator` component in `web-app/src/components/ui/WeekSeparator.tsx` with intelligent date range formatting
- Update `AssignmentsPage.tsx` to display weekly separators between assignment groups
- Update `ExchangePage.tsx` to display weekly separators between exchange groups
- Update `CompensationsPage.tsx` to display weekly separators between compensation groups

## Test Plan

- [ ] Verify weekly separators appear on Assignments page when items span multiple weeks
- [ ] Verify weekly separators appear on Exchange page when items span multiple weeks
- [ ] Verify weekly separators appear on Compensations page when items span multiple weeks
- [ ] Verify separators do NOT appear when all items are within a single week
- [ ] Verify date range formatting handles same-month dates (e.g., "Dec 30 – 5")
- [ ] Verify date range formatting handles cross-month dates (e.g., "Dec 30 – Jan 5")
- [ ] Verify date range formatting handles cross-year dates (e.g., "Dec 30, 2024 – Jan 5, 2025")
- [ ] Verify date formatting respects user's language setting (de, en, fr, it)
- [ ] Verify separator styling is subtle and works in both light and dark mode
- [ ] Verify tour functionality still works correctly on all pages
