### PR TITLE
feat(settings): add accessibility settings with zoom prevention toggle

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/utils/query-error-utils";
 import { usePreloadLocales } from "@/hooks/usePreloadLocales";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useViewportZoom } from "@/hooks/useViewportZoom";
 import { logger } from "@/utils/logger";
 
 // Lazy load TourProvider since it's only needed for first-time users
@@ -239,6 +240,7 @@ function QueryErrorHandler({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   usePreloadLocales();
+  useViewportZoom();
 
   return (
     <ErrorBoundary>

--- a/web-app/src/components/features/settings/AccessibilitySection.test.tsx
+++ b/web-app/src/components/features/settings/AccessibilitySection.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AccessibilitySection } from "./AccessibilitySection";
+
+// Mock useTranslation hook
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "settings.accessibility.title": "Accessibility",
+        "settings.accessibility.description":
+          "Adjust accessibility settings to customize your experience.",
+        "settings.accessibility.preventZoom": "Prevent browser zoom",
+        "settings.accessibility.preventZoomDescription":
+          "Disable pinch-to-zoom and double-tap zoom on touch devices.",
+        "settings.accessibility.preventZoomEnabled":
+          "Zoom prevention is enabled",
+        "settings.accessibility.preventZoomDisabled":
+          "Zoom prevention is disabled",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe("AccessibilitySection", () => {
+  const defaultProps = {
+    preventZoom: false,
+    onSetPreventZoom: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders section heading", () => {
+    render(<AccessibilitySection {...defaultProps} />);
+
+    expect(screen.getByText("Accessibility")).toBeInTheDocument();
+  });
+
+  it("renders description text", () => {
+    render(<AccessibilitySection {...defaultProps} />);
+
+    expect(
+      screen.getByText(/Adjust accessibility settings/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders prevent zoom setting label", () => {
+    render(<AccessibilitySection {...defaultProps} />);
+
+    expect(screen.getByText("Prevent browser zoom")).toBeInTheDocument();
+  });
+
+  it("renders prevent zoom description", () => {
+    render(<AccessibilitySection {...defaultProps} />);
+
+    expect(
+      screen.getByText(/Disable pinch-to-zoom and double-tap zoom/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows disabled status when prevent zoom is off", () => {
+    render(<AccessibilitySection {...defaultProps} preventZoom={false} />);
+
+    expect(screen.getByText("Zoom prevention is disabled")).toBeInTheDocument();
+  });
+
+  it("shows enabled status when prevent zoom is on", () => {
+    render(<AccessibilitySection {...defaultProps} preventZoom={true} />);
+
+    expect(screen.getByText("Zoom prevention is enabled")).toBeInTheDocument();
+  });
+
+  it("has toggle switch with correct aria attributes when disabled", () => {
+    render(<AccessibilitySection {...defaultProps} preventZoom={false} />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(toggle).toHaveAttribute("aria-label", "Prevent browser zoom");
+  });
+
+  it("has toggle switch with correct aria attributes when enabled", () => {
+    render(<AccessibilitySection {...defaultProps} preventZoom={true} />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("calls onSetPreventZoom with true when toggling from off to on", async () => {
+    const onSetPreventZoom = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <AccessibilitySection
+        preventZoom={false}
+        onSetPreventZoom={onSetPreventZoom}
+      />
+    );
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(onSetPreventZoom).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onSetPreventZoom with false when toggling from on to off", async () => {
+    const onSetPreventZoom = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <AccessibilitySection
+        preventZoom={true}
+        onSetPreventZoom={onSetPreventZoom}
+      />
+    );
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(onSetPreventZoom).toHaveBeenCalledWith(false);
+  });
+
+  it("applies correct styling to toggle when enabled", () => {
+    render(<AccessibilitySection {...defaultProps} preventZoom={true} />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveClass("bg-primary-600");
+  });
+
+  it("applies correct styling to toggle when disabled", () => {
+    render(<AccessibilitySection {...defaultProps} preventZoom={false} />);
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveClass("bg-surface-muted");
+  });
+});

--- a/web-app/src/components/features/settings/AccessibilitySection.tsx
+++ b/web-app/src/components/features/settings/AccessibilitySection.tsx
@@ -1,0 +1,75 @@
+import { useCallback, memo } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+
+interface AccessibilitySectionProps {
+  preventZoom: boolean;
+  onSetPreventZoom: (enabled: boolean) => void;
+}
+
+function AccessibilitySectionComponent({
+  preventZoom,
+  onSetPreventZoom,
+}: AccessibilitySectionProps) {
+  const { t } = useTranslation();
+
+  const handleTogglePreventZoom = useCallback(() => {
+    onSetPreventZoom(!preventZoom);
+  }, [preventZoom, onSetPreventZoom]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
+          {t("settings.accessibility.title")}
+        </h2>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t("settings.accessibility.description")}
+        </p>
+
+        {/* Prevent Zoom Toggle */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between py-2">
+            <div className="flex-1">
+              <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                {t("settings.accessibility.preventZoom")}
+              </div>
+              <div className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+                {t("settings.accessibility.preventZoomDescription")}
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleTogglePreventZoom}
+              className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+                preventZoom
+                  ? "bg-primary-600"
+                  : "bg-surface-muted dark:bg-surface-subtle-dark"
+              }`}
+              role="switch"
+              aria-checked={preventZoom}
+              aria-label={t("settings.accessibility.preventZoom")}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                  preventZoom ? "translate-x-6" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </div>
+
+          <div className="text-xs text-text-muted dark:text-text-muted-dark">
+            {preventZoom
+              ? t("settings.accessibility.preventZoomEnabled")
+              : t("settings.accessibility.preventZoomDisabled")}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export const AccessibilitySection = memo(AccessibilitySectionComponent);

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -34,6 +34,10 @@ function createMockSettingsStore(
     isSafeModeEnabled: false,
     setSafeMode: vi.fn(),
 
+    // Accessibility
+    preventZoom: false,
+    setPreventZoom: vi.fn(),
+
     // Home location
     homeLocation: {
       latitude: 46.9,

--- a/web-app/src/components/features/settings/index.ts
+++ b/web-app/src/components/features/settings/index.ts
@@ -5,6 +5,7 @@ export { TransportSection } from "./TransportSection";
 export { DataRetentionSection } from "./DataRetentionSection";
 export { TourSection } from "./TourSection";
 export { DemoSection } from "./DemoSection";
+export { AccessibilitySection } from "./AccessibilitySection";
 export { SafeModeSection } from "./SafeModeSection";
 export { UpdateSection } from "./UpdateSection";
 export { AboutSection } from "./AboutSection";

--- a/web-app/src/hooks/useViewportZoom.test.ts
+++ b/web-app/src/hooks/useViewportZoom.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useViewportZoom } from "./useViewportZoom";
+
+// Mock the settings store
+const mockPreventZoom = vi.fn(() => false);
+
+vi.mock("@/stores/settings", () => ({
+  useSettingsStore: (selector: (state: { preventZoom: boolean }) => boolean) =>
+    selector({ preventZoom: mockPreventZoom() }),
+}));
+
+describe("useViewportZoom", () => {
+  let viewportMeta: HTMLMetaElement;
+  const originalContent = "width=device-width, initial-scale=1.0, viewport-fit=cover";
+
+  beforeEach(() => {
+    // Create a mock viewport meta element
+    viewportMeta = document.createElement("meta");
+    viewportMeta.name = "viewport";
+    viewportMeta.content = originalContent;
+    document.head.appendChild(viewportMeta);
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Clean up the mock viewport meta element
+    if (viewportMeta.parentNode) {
+      viewportMeta.parentNode.removeChild(viewportMeta);
+    }
+  });
+
+  it("does not modify viewport when preventZoom is false", () => {
+    mockPreventZoom.mockReturnValue(false);
+
+    renderHook(() => useViewportZoom());
+
+    expect(viewportMeta.content).toBe(originalContent);
+  });
+
+  it("sets viewport to prevent zoom when preventZoom is true", () => {
+    mockPreventZoom.mockReturnValue(true);
+
+    renderHook(() => useViewportZoom());
+
+    expect(viewportMeta.content).toBe(
+      "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    );
+  });
+
+  it("restores original viewport on unmount", () => {
+    mockPreventZoom.mockReturnValue(true);
+
+    const { unmount } = renderHook(() => useViewportZoom());
+
+    // Verify it was set to prevent zoom
+    expect(viewportMeta.content).toContain("user-scalable=no");
+
+    // Unmount the hook
+    unmount();
+
+    // Verify it's restored to allow zoom
+    expect(viewportMeta.content).toBe(originalContent);
+  });
+
+  it("handles missing viewport meta gracefully", () => {
+    // Remove the viewport meta
+    viewportMeta.parentNode?.removeChild(viewportMeta);
+
+    mockPreventZoom.mockReturnValue(true);
+
+    // Should not throw
+    expect(() => {
+      renderHook(() => useViewportZoom());
+    }).not.toThrow();
+  });
+
+  it("updates viewport when preventZoom changes from false to true", () => {
+    mockPreventZoom.mockReturnValue(false);
+
+    const { rerender } = renderHook(() => useViewportZoom());
+
+    // Initially should allow zoom
+    expect(viewportMeta.content).toBe(originalContent);
+
+    // Change to prevent zoom
+    mockPreventZoom.mockReturnValue(true);
+    rerender();
+
+    // Should now prevent zoom
+    expect(viewportMeta.content).toContain("user-scalable=no");
+  });
+
+  it("updates viewport when preventZoom changes from true to false", () => {
+    mockPreventZoom.mockReturnValue(true);
+
+    const { rerender } = renderHook(() => useViewportZoom());
+
+    // Initially should prevent zoom
+    expect(viewportMeta.content).toContain("user-scalable=no");
+
+    // Change to allow zoom
+    mockPreventZoom.mockReturnValue(false);
+    rerender();
+
+    // Should now allow zoom
+    expect(viewportMeta.content).toBe(originalContent);
+  });
+});

--- a/web-app/src/hooks/useViewportZoom.ts
+++ b/web-app/src/hooks/useViewportZoom.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useSettingsStore } from "@/stores/settings";
+
+/**
+ * Viewport content value when zoom is allowed (default).
+ * This is the original viewport setting from index.html.
+ */
+const VIEWPORT_ZOOM_ALLOWED = "width=device-width, initial-scale=1.0, viewport-fit=cover";
+
+/**
+ * Viewport content value when zoom is prevented.
+ * Disables pinch-to-zoom and double-tap zoom on touch devices.
+ */
+const VIEWPORT_ZOOM_PREVENTED =
+  "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";
+
+/**
+ * Hook that manages the viewport meta tag based on the preventZoom setting.
+ * Updates the viewport dynamically when the setting changes.
+ *
+ * Should be called once at the app root level (e.g., in App.tsx).
+ */
+export function useViewportZoom(): void {
+  const preventZoom = useSettingsStore((state) => state.preventZoom);
+
+  useEffect(() => {
+    const viewport = document.querySelector('meta[name="viewport"]');
+    if (!viewport) {
+      return;
+    }
+
+    const content = preventZoom ? VIEWPORT_ZOOM_PREVENTED : VIEWPORT_ZOOM_ALLOWED;
+    viewport.setAttribute("content", content);
+
+    // Cleanup: restore default viewport on unmount
+    return () => {
+      viewport.setAttribute("content", VIEWPORT_ZOOM_ALLOWED);
+    };
+  }, [preventZoom]);
+}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -370,7 +370,7 @@ const de: Translations = {
         "Passen Sie die Barrierefreiheitseinstellungen an, um Ihr Erlebnis zu personalisieren.",
       preventZoom: "Browser-Zoom verhindern",
       preventZoomDescription:
-        "Deaktiviert Pinch-to-Zoom und Doppeltippen zum Zoomen auf Touch-Geräten. Dies kann versehentliches Zoomen verhindern.",
+        "Deaktiviert Pinch-to-Zoom und Doppeltippen zum Zoomen auf Touch-Geräten. Dies kann versehentliches Zoomen verhindern. Hinweis: Einige Benutzer sind auf Zoom für die Barrierefreiheit angewiesen, verwenden Sie diese Einstellung daher mit Bedacht.",
       preventZoomEnabled: "Zoom-Verhinderung ist aktiviert",
       preventZoomDisabled: "Zoom-Verhinderung ist deaktiviert",
     },

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -364,6 +364,16 @@ const de: Translations = {
       transportApiNote:
         "Bei aktivierter Reisezeitberechnung werden Ihre Heimatstandort-Koordinaten an die Schweizer ÖV-API (opentransportdata.swiss) gesendet.",
     },
+    accessibility: {
+      title: "Barrierefreiheit",
+      description:
+        "Passen Sie die Barrierefreiheitseinstellungen an, um Ihr Erlebnis zu personalisieren.",
+      preventZoom: "Browser-Zoom verhindern",
+      preventZoomDescription:
+        "Deaktiviert Pinch-to-Zoom und Doppeltippen zum Zoomen auf Touch-Geräten. Dies kann versehentliches Zoomen verhindern.",
+      preventZoomEnabled: "Zoom-Verhinderung ist aktiviert",
+      preventZoomDisabled: "Zoom-Verhinderung ist deaktiviert",
+    },
     safeMode: "Sicherheitsmodus",
     safeModeDescription:
       "Der Sicherheitsmodus beschränkt gefährliche Operationen wie das Hinzufügen/Übernehmen von Spielen zur/von Tauschbörse oder das Validieren von Spielen. Dies hilft, versehentliche Änderungen während des Testens der App zu vermeiden.",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -368,7 +368,7 @@ const en: Translations = {
         "Adjust accessibility settings to customize your experience.",
       preventZoom: "Prevent browser zoom",
       preventZoomDescription:
-        "Disable pinch-to-zoom and double-tap zoom on touch devices. This can help prevent accidental zooming.",
+        "Disable pinch-to-zoom and double-tap zoom on touch devices. This can help prevent accidental zooming. Note: Some users rely on zoom for accessibility, so use this setting thoughtfully.",
       preventZoomEnabled: "Zoom prevention is enabled",
       preventZoomDisabled: "Zoom prevention is disabled",
     },

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -362,6 +362,16 @@ const en: Translations = {
       transportApiNote:
         "When travel time calculations are enabled, your home location coordinates are sent to the Swiss public transport API (opentransportdata.swiss).",
     },
+    accessibility: {
+      title: "Accessibility",
+      description:
+        "Adjust accessibility settings to customize your experience.",
+      preventZoom: "Prevent browser zoom",
+      preventZoomDescription:
+        "Disable pinch-to-zoom and double-tap zoom on touch devices. This can help prevent accidental zooming.",
+      preventZoomEnabled: "Zoom prevention is enabled",
+      preventZoomDisabled: "Zoom prevention is disabled",
+    },
     safeMode: "Safe Mode",
     safeModeDescription:
       "Safe mode restricts dangerous operations like adding/taking games from exchange or validating games. This helps prevent accidental modifications while the app is being tested.",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -363,6 +363,16 @@ const fr: Translations = {
       transportApiNote:
         "Lorsque le calcul des temps de trajet est activé, les coordonnées de votre domicile sont envoyées à l'API des transports publics suisses (opentransportdata.swiss).",
     },
+    accessibility: {
+      title: "Accessibilité",
+      description:
+        "Ajustez les paramètres d'accessibilité pour personnaliser votre expérience.",
+      preventZoom: "Empêcher le zoom du navigateur",
+      preventZoomDescription:
+        "Désactive le pincement pour zoomer et le double appui pour zoomer sur les appareils tactiles. Cela peut aider à éviter les zooms accidentels.",
+      preventZoomEnabled: "La prévention du zoom est activée",
+      preventZoomDisabled: "La prévention du zoom est désactivée",
+    },
     safeMode: "Mode sécurisé",
     safeModeDescription:
       "Le mode sécurisé restreint les opérations dangereuses comme l'ajout/la prise de matchs depuis la bourse aux échanges ou la validation de matchs. Cela aide à éviter les modifications accidentelles pendant les tests de l'application.",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -369,7 +369,7 @@ const fr: Translations = {
         "Ajustez les paramètres d'accessibilité pour personnaliser votre expérience.",
       preventZoom: "Empêcher le zoom du navigateur",
       preventZoomDescription:
-        "Désactive le pincement pour zoomer et le double appui pour zoomer sur les appareils tactiles. Cela peut aider à éviter les zooms accidentels.",
+        "Désactive le pincement pour zoomer et le double appui pour zoomer sur les appareils tactiles. Cela peut aider à éviter les zooms accidentels. Remarque: Certains utilisateurs dépendent du zoom pour l'accessibilité, utilisez donc ce paramètre avec discernement.",
       preventZoomEnabled: "La prévention du zoom est activée",
       preventZoomDisabled: "La prévention du zoom est désactivée",
     },

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -367,7 +367,7 @@ const it: Translations = {
         "Regola le impostazioni di accessibilità per personalizzare la tua esperienza.",
       preventZoom: "Impedisci zoom del browser",
       preventZoomDescription:
-        "Disabilita il pizzico per zoomare e il doppio tocco per zoomare sui dispositivi touch. Questo può aiutare a prevenire zoom accidentali.",
+        "Disabilita il pizzico per zoomare e il doppio tocco per zoomare sui dispositivi touch. Questo può aiutare a prevenire zoom accidentali. Nota: Alcuni utenti dipendono dallo zoom per l'accessibilità, quindi usa questa impostazione con attenzione.",
       preventZoomEnabled: "La prevenzione dello zoom è attivata",
       preventZoomDisabled: "La prevenzione dello zoom è disattivata",
     },

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -361,6 +361,16 @@ const it: Translations = {
       transportApiNote:
         "Quando il calcolo dei tempi di viaggio è abilitato, le coordinate della tua posizione casa vengono inviate all'API dei trasporti pubblici svizzeri (opentransportdata.swiss).",
     },
+    accessibility: {
+      title: "Accessibilità",
+      description:
+        "Regola le impostazioni di accessibilità per personalizzare la tua esperienza.",
+      preventZoom: "Impedisci zoom del browser",
+      preventZoomDescription:
+        "Disabilita il pizzico per zoomare e il doppio tocco per zoomare sui dispositivi touch. Questo può aiutare a prevenire zoom accidentali.",
+      preventZoomEnabled: "La prevenzione dello zoom è attivata",
+      preventZoomDisabled: "La prevenzione dello zoom è disattivata",
+    },
     safeMode: "Modalità sicura",
     safeModeDescription:
       "La modalità sicura limita operazioni pericolose come l'aggiunta/assunzione di partite dalla borsa scambi o la convalida di partite. Questo aiuta a prevenire modifiche accidentali durante il test dell'app.",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -236,6 +236,14 @@ export interface Translations {
       externalServices: string;
       transportApiNote: string;
     };
+    accessibility: {
+      title: string;
+      description: string;
+      preventZoom: string;
+      preventZoomDescription: string;
+      preventZoomEnabled: string;
+      preventZoomDisabled: string;
+    };
     safeMode: string;
     safeModeDescription: string;
     safeModeEnabled: string;

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import {
   DataRetentionSection,
   TourSection,
   DemoSection,
+  AccessibilitySection,
   SafeModeSection,
   UpdateSection,
   AboutSection,
@@ -32,10 +33,12 @@ export function SettingsPage() {
       refreshData: state.refreshData,
     })),
   );
-  const { isSafeModeEnabled, setSafeMode } = useSettingsStore(
+  const { isSafeModeEnabled, setSafeMode, preventZoom, setPreventZoom } = useSettingsStore(
     useShallow((state) => ({
       isSafeModeEnabled: state.isSafeModeEnabled,
       setSafeMode: state.setSafeMode,
+      preventZoom: state.preventZoom,
+      setPreventZoom: state.setPreventZoom,
     })),
   );
   const { t } = useTranslation();
@@ -60,6 +63,11 @@ export function SettingsPage() {
       <DataRetentionSection />
 
       <TourSection isDemoMode={isDemoMode} />
+
+      <AccessibilitySection
+        preventZoom={preventZoom}
+        onSetPreventZoom={setPreventZoom}
+      />
 
       {isDemoMode && (
         <DemoSection

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -74,6 +74,10 @@ interface SettingsState {
   isSafeModeEnabled: boolean;
   setSafeMode: (enabled: boolean) => void;
 
+  // Accessibility settings
+  preventZoom: boolean;
+  setPreventZoom: (enabled: boolean) => void;
+
   // Home location for distance filtering
   homeLocation: UserLocation | null;
   setHomeLocation: (location: UserLocation | null) => void;
@@ -133,6 +137,7 @@ export const useSettingsStore = create<SettingsState>()(
   persist(
     (set, get) => ({
       isSafeModeEnabled: true,
+      preventZoom: false,
       homeLocation: null,
       distanceFilter: {
         enabled: false,
@@ -151,6 +156,10 @@ export const useSettingsStore = create<SettingsState>()(
 
       setSafeMode: (enabled: boolean) => {
         set({ isSafeModeEnabled: enabled });
+      },
+
+      setPreventZoom: (enabled: boolean) => {
+        set({ preventZoom: enabled });
       },
 
       setHomeLocation: (location: UserLocation | null) => {
@@ -281,6 +290,7 @@ export const useSettingsStore = create<SettingsState>()(
       version: 1,
       partialize: (state) => ({
         isSafeModeEnabled: state.isSafeModeEnabled,
+        preventZoom: state.preventZoom,
         homeLocation: state.homeLocation,
         distanceFilter: state.distanceFilter,
         transportEnabled: state.transportEnabled,
@@ -297,6 +307,8 @@ export const useSettingsStore = create<SettingsState>()(
           ...current,
           // Preserve safe mode setting
           isSafeModeEnabled: persistedState?.isSafeModeEnabled ?? current.isSafeModeEnabled,
+          // Preserve accessibility settings
+          preventZoom: persistedState?.preventZoom ?? current.preventZoom,
           // Preserve home location - critical user data
           homeLocation: persistedState?.homeLocation ?? current.homeLocation,
           // Merge distance filter with defaults for any missing fields


### PR DESCRIPTION
## Summary

- Added a new Accessibility section to the Settings page with a toggle to prevent browser zoom
- This feature helps users who may accidentally trigger pinch-to-zoom or double-tap zoom on touch devices

## Changes

- **Store**: Added `preventZoom` setting to Zustand settings store (`web-app/src/stores/settings.ts`) with localStorage persistence
- **Hook**: Created `useViewportZoom` hook (`web-app/src/hooks/useViewportZoom.ts`) to dynamically update the viewport meta tag based on the setting
- **Component**: Created `AccessibilitySection` component (`web-app/src/components/features/settings/AccessibilitySection.tsx`) with toggle switch
- **Integration**: Added the new section to SettingsPage and App.tsx
- **i18n**: Added translations for all 4 languages (de, en, fr, it)
- **Tests**: Added comprehensive unit tests for AccessibilitySection and useViewportZoom hook

## Test Plan

- [ ] Navigate to Settings page and verify the Accessibility section appears
- [ ] Toggle "Prevent browser zoom" and verify the setting persists after page reload
- [ ] On a touch device, enable the setting and verify pinch-to-zoom is disabled
- [ ] Disable the setting and verify zoom functionality is restored
- [ ] Verify translations display correctly in German, English, French, and Italian
- [ ] Run `npm run lint` - passes with 0 warnings
- [ ] Run `npm test` - all tests pass
- [ ] Run `npm run build` - builds successfully
