### PR TITLE
refactor(api): consolidate duplicate file upload constants

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -30,8 +30,12 @@ if (!import.meta.env.DEV && !API_BASE) {
 }
 
 const DEFAULT_SEARCH_RESULTS_LIMIT = 50;
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-const ALLOWED_FILE_TYPES = ["application/pdf", "image/jpeg", "image/png"];
+
+/** Maximum file size for uploads (10 MB) */
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Allowed MIME types for file uploads */
+export const ALLOWED_FILE_TYPES = ["application/pdf", "image/jpeg", "image/png"];
 
 // Re-export schema types
 export type Schemas = components["schemas"];

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useAuthStore } from "@/stores/auth";
+import { MAX_FILE_SIZE_BYTES, ALLOWED_FILE_TYPES } from "@/api/client";
 import {
   Upload,
   Camera,
@@ -21,8 +22,6 @@ interface ScoresheetPanelProps {
   scoresheetNotRequired?: boolean;
 }
 
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-const ACCEPTED_FILE_TYPES = ["image/jpeg", "image/png", "application/pdf"];
 const ACCEPTED_EXTENSIONS = ".jpg,.jpeg,.png,.pdf";
 const SIMULATED_UPLOAD_DURATION_MS = 1500;
 const PROGRESS_INCREMENT_PERCENT = 10;
@@ -91,7 +90,7 @@ export function ScoresheetPanel({
 
   const validateFile = useCallback(
     (file: File): string | null => {
-      if (!ACCEPTED_FILE_TYPES.includes(file.type)) {
+      if (!ALLOWED_FILE_TYPES.includes(file.type)) {
         return t("validation.scoresheetUpload.invalidFileType");
       }
       if (file.size > MAX_FILE_SIZE_BYTES) {


### PR DESCRIPTION
## Summary

- Consolidate duplicate file upload constants into a single source of truth
- The `MAX_FILE_SIZE_BYTES` and `ALLOWED_FILE_TYPES` constants were defined in both `api/client.ts` and `ScoresheetPanel.tsx`

## Changes

- Export `MAX_FILE_SIZE_BYTES` and `ALLOWED_FILE_TYPES` from `web-app/src/api/client.ts` with JSDoc comments
- Update `web-app/src/components/features/validation/ScoresheetPanel.tsx` to import these constants instead of defining duplicates
- Rename local `ACCEPTED_FILE_TYPES` usage to `ALLOWED_FILE_TYPES` for consistency

## Test Plan

- [x] All 2304 unit tests pass
- [x] ESLint passes with no warnings
- [ ] Verify file upload validation still works in the scoresheet panel (accepts JPG, PNG, PDF under 10MB)
- [ ] Verify file upload validation in the API client still rejects invalid files