### PR TITLE
ci: add comprehensive caching to improve CI performance

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -102,21 +102,22 @@ jobs:
           cache-dependency-path: web-app/package-lock.json
       - name: Install dependencies
         run: npm ci
-      - name: Cache generated API types
-        id: api-cache
-        uses: actions/cache@v4
-        with:
-          path: web-app/src/api/schema.ts
-          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
-      - name: Generate API types
-        if: steps.api-cache.outputs.cache-hit != 'true'
-        run: npm run generate:api
       - name: Cache build output
         id: build-cache
         uses: actions/cache@v4
         with:
           path: web-app/dist
           key: build-${{ hashFiles('web-app/src/**', 'web-app/public/**', 'web-app/package-lock.json', 'web-app/vite.config.ts', 'web-app/index.html', 'web-app/tsconfig.json', 'docs/api/volleymanager-openapi.yaml') }}
+      - name: Cache generated API types
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
+      - name: Generate API types
+        if: steps.build-cache.outputs.cache-hit != 'true' && steps.api-cache.outputs.cache-hit != 'true'
+        run: npm run generate:api
       - name: Build
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -46,7 +46,14 @@ jobs:
           cache-dependency-path: web-app/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Cache generated API types
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
       - name: Generate API types
+        if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
       - name: Lint
         run: npm run lint
@@ -67,7 +74,14 @@ jobs:
           cache-dependency-path: web-app/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Cache generated API types
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
       - name: Generate API types
+        if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
       - name: Run tests
         run: npm test
@@ -88,9 +102,23 @@ jobs:
           cache-dependency-path: web-app/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Cache generated API types
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
       - name: Generate API types
+        if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
+      - name: Cache build output
+        id: build-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/dist
+          key: build-${{ hashFiles('web-app/src/**', 'web-app/public/**', 'web-app/package-lock.json', 'web-app/vite.config.ts', 'web-app/index.html', 'web-app/tsconfig.json', 'docs/api/volleymanager-openapi.yaml') }}
       - name: Build
+        if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build
       - name: Check bundle size
         run: npm run size

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -28,7 +28,14 @@ jobs:
           cache-dependency-path: web-app/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Cache generated API types
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
       - name: Generate API types
+        if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
       - name: Lint
         run: npm run lint

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: worker/package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Deploy to Cloudflare Workers
@@ -54,7 +56,14 @@ jobs:
           cache-dependency-path: web-app/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Cache generated API types
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
       - name: Generate API types
+        if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
       - name: Lint
         run: npm run lint

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache generated API types
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
+
       - name: Generate API types
+        if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
 
       - name: Build application
@@ -78,8 +86,24 @@ jobs:
           name: web-app-build
           path: web-app/dist
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ matrix.browser }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Install Playwright browser dependencies (for cached browsers)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps ${{ matrix.browser }}
 
       - name: Run E2E tests
         run: npx playwright test --project=${{ matrix.browser }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,14 +27,21 @@ jobs:
           cache-dependency-path: web-app/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Cache generated API types
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
       - name: Generate API types
+        if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
       - name: Cache build output
         id: build-cache
         uses: actions/cache@v4
         with:
           path: web-app/dist
-          key: build-${{ hashFiles('web-app/src/**', 'web-app/package-lock.json', 'web-app/vite.config.ts', 'web-app/index.html') }}
+          key: build-${{ hashFiles('web-app/src/**', 'web-app/public/**', 'web-app/package-lock.json', 'web-app/vite.config.ts', 'web-app/index.html', 'web-app/tsconfig.json', 'docs/api/volleymanager-openapi.yaml') }}
       - name: Build application
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,21 +27,22 @@ jobs:
           cache-dependency-path: web-app/package-lock.json
       - name: Install dependencies
         run: npm ci
-      - name: Cache generated API types
-        id: api-cache
-        uses: actions/cache@v4
-        with:
-          path: web-app/src/api/schema.ts
-          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
-      - name: Generate API types
-        if: steps.api-cache.outputs.cache-hit != 'true'
-        run: npm run generate:api
       - name: Cache build output
         id: build-cache
         uses: actions/cache@v4
         with:
           path: web-app/dist
           key: build-${{ hashFiles('web-app/src/**', 'web-app/public/**', 'web-app/package-lock.json', 'web-app/vite.config.ts', 'web-app/index.html', 'web-app/tsconfig.json', 'docs/api/volleymanager-openapi.yaml') }}
+      - name: Cache generated API types
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        id: api-cache
+        uses: actions/cache@v4
+        with:
+          path: web-app/src/api/schema.ts
+          key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
+      - name: Generate API types
+        if: steps.build-cache.outputs.cache-hit != 'true' && steps.api-cache.outputs.cache-hit != 'true'
+        run: npm run generate:api
       - name: Build application
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: npm run build


### PR DESCRIPTION
## Summary

- Add comprehensive caching across CI workflows to improve build times and reduce redundant work
- Cache Playwright browsers, generated API types, and build outputs with proper invalidation keys

## Changes

### Playwright Browser Caching (e2e.yml)
- Cache browsers at `~/.cache/ms-playwright` keyed by browser type and Playwright version
- On cache hit, only install system dependencies (much faster than full browser download)
- Extracts Playwright version dynamically from package-lock.json

### Generated API Types Caching (all workflows)
- Cache `web-app/src/api/schema.ts` generated from OpenAPI spec
- Key includes both `volleymanager-openapi.yaml` and `package-lock.json` (for openapi-typescript version)
- Added to: ci-web.yml, e2e.yml, lighthouse.yml, deploy-web.yml, deploy-pr-preview.yml

### Build Output Caching (ci-web.yml, lighthouse.yml)
- Cache `web-app/dist` to skip rebuild when source hasn't changed
- Comprehensive cache key includes: `src/**`, `public/**`, `package-lock.json`, `vite.config.ts`, `index.html`, `tsconfig.json`, and OpenAPI spec

### npm Cache for Worker (deploy-web.yml)
- Added missing npm cache configuration to worker deployment job

## Test plan

- [ ] Verify ci-web workflow runs successfully with cache misses on first run
- [ ] Verify subsequent runs hit caches when source files haven't changed
- [ ] Verify caches invalidate correctly when OpenAPI spec is modified
- [ ] Verify e2e workflow caches Playwright browsers correctly
