### PR TITLE
docs(api): update profile endpoints with response examples from HAR capture

### DIFF
--- a/docs/api/captures/profile_endpoints.md
+++ b/docs/api/captures/profile_endpoints.md
@@ -44,6 +44,55 @@ GET ...person/showWithNestedObjects
   &person[__identity]=<person-uuid>
 ```
 
+**Response Structure:**
+
+```json
+{
+  "person": {
+    "__identity": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "persistenceObjectIdentifier": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "svNumber": 12345,
+    "associationId": 12345,
+    "externalId": "12345",
+    "firstName": "Jean",
+    "lastName": "Dupont",
+    "displayName": "Jean Dupont",
+    "fullName": "Jean Dupont",
+    "gender": "m",
+    "genderNoun": "Homme",
+    "genderAdjective": "masculin",
+    "birthday": "1989-08-07T22:00:00.000000+00:00",
+    "formattedAndTimezoneIndependentBirthday": "1989-08-08",
+    "yearOfBirth": 1989,
+    "age": 36,
+    "correspondenceLanguage": "fr",
+    "accountActive": true,
+    "hasAccount": true,
+    "hasProfilePicture": true,
+    "activeRoleIdentifier": "Indoorvolleyball.RefAdmin:Referee",
+    "nationality": {
+      "__identity": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      "isoCode2": "CH",
+      "isoCode3": "CHE",
+      "translations": {
+        "de": { "name": "Schweiz" },
+        "fr": { "name": "Suisse" }
+      }
+    },
+    "_permissions": {
+      "properties": {
+        "firstName": { "create": true, "read": true, "update": true },
+        "lastName": { "create": true, "read": true, "update": true },
+        "correspondenceLanguage": { "create": true, "read": true, "update": true }
+      },
+      "object": { "create": true, "update": true, "delete": false }
+    },
+    "createdAt": "2020-01-15T10:30:00.000000+00:00",
+    "updatedAt": "2024-06-20T14:45:00.000000+00:00"
+  }
+}
+```
+
 ______________________________________________________________________
 
 ### 2. Get Indoor Referee by Active Person
@@ -63,6 +112,54 @@ GET /api/indoorvolleyball.refadmin/api\indoorreferee/getIndoorRefereeByActivePer
 
 ```
 GET ...getIndoorRefereeByActivePerson?person=<person-uuid>
+```
+
+**Response Structure:**
+
+```json
+{
+  "__identity": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+  "persistenceObjectIdentifier": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+  "person": {
+    "__identity": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "firstName": "Jean",
+    "lastName": "Dupont",
+    "displayName": "Jean Dupont"
+  },
+  "refereeLevel": {
+    "__identity": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+    "name": "National A",
+    "shortName": "NA"
+  },
+  "refereeNumber": 12345,
+  "jerseyNumber": null,
+  "refereeInformation": "Jean Dupont (12345, 1989-08-08, )",
+  "refereeSinceDate": "2015-09-01",
+  "validated": true,
+  "isInternationalReferee": false,
+  "hasLinesmanCertification": true,
+  "hasNotes": false,
+  "transportationMode": "car",
+  "mobilePhoneNumbers": "+41 79 123 45 67",
+  "fixnetPhoneNumbers": "",
+  "privatePostalAddresses": "Rue Example 1, 1000 Lausanne",
+  "managingAssociation": {
+    "__identity": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+    "name": "Association Vaudoise de Volleyball",
+    "shortName": "AVV"
+  },
+  "_permissions": {
+    "properties": {
+      "transportationMode": { "create": true, "read": true, "update": true },
+      "notes": { "create": true, "read": true, "update": true }
+    },
+    "object": { "create": true, "update": true, "delete": false }
+  },
+  "createdAt": "2015-09-01T08:00:00.000000+00:00",
+  "updatedAt": "2024-08-15T16:30:00.000000+00:00",
+  "createdBy": "system",
+  "updatedBy": "Jean Dupont"
+}
 ```
 
 ______________________________________________________________________

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -789,7 +789,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PersonDetails'
+                type: object
+                properties:
+                  person:
+                    $ref: '#/components/schemas/PersonDetails'
+                required:
+                  - person
         '401':
           $ref: '#/components/responses/Unauthorized'
   /indoorvolleyball.refadmin/api\indoorreferee/getIndoorRefereeByActivePerson:
@@ -4147,9 +4152,10 @@ components:
     PersonDetails:
       type: object
       description: |
-        Detailed person information for profile page.
-        This is the "active party" data embedded in page loads, containing the user's
-        association memberships and current context.
+        Detailed person information returned by the profile API.
+        Note: The following fields are only available in embedded HTML data,
+        not in the API response: eligibleAttributeValues, eligibleRoles,
+        groupedEligibleAttributeValues, activeAttributeValue.
       properties:
         __identity:
           type: string
@@ -4269,33 +4275,11 @@ components:
             $ref: '#/components/schemas/PostalAddress'
         primaryPostalAddress:
           $ref: '#/components/schemas/PostalAddress'
-        # Association context (critical for multi-association users)
-        activeAttributeValue:
-          $ref: '#/components/schemas/AttributeValue'
+        # Association context
         activeRoleIdentifier:
           type: string
           description: Current role identifier
           example: "Indoorvolleyball.RefAdmin:Referee"
-        eligibleAttributeValues:
-          type: array
-          description: All association memberships/roles the user is eligible for
-          items:
-            $ref: '#/components/schemas/AttributeValue'
-        groupedEligibleAttributeValues:
-          type: array
-          description: Eligible attribute values grouped by role
-          items:
-            $ref: '#/components/schemas/AttributeValue'
-        groupedEligibleAttributeValuesWithoutHiddenRoles:
-          type: array
-          description: Visible eligible attribute values
-          items:
-            $ref: '#/components/schemas/AttributeValue'
-        eligibleRoles:
-          type: object
-          description: Map of role identifiers to role definitions
-          additionalProperties:
-            $ref: '#/components/schemas/RoleDefinition'
         # Accounts
         accounts:
           type: array
@@ -4875,6 +4859,14 @@ components:
           type: string
           nullable: true
         # Audit fields
+        createdAt:
+          type: string
+          format: date-time
+          description: When the referee record was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the referee record was last updated
         createdBy:
           type: string
         createdByIpAddress:

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -105,12 +105,15 @@ function createMockAuthStore(
     csrfToken: null,
     isDemoMode: false,
     _checkSessionPromise: null,
+    eligibleAttributeValues: null,
+    eligibleRoles: null,
     login: vi.fn(),
     logout: vi.fn(),
     checkSession: vi.fn(),
     setUser: vi.fn(),
     setDemoAuthenticated: vi.fn(),
     setActiveOccupation: vi.fn(),
+    hasMultipleAssociations: vi.fn().mockReturnValue(false),
     ...overrides,
   };
 }

--- a/web-app/src/utils/active-party-parser.test.ts
+++ b/web-app/src/utils/active-party-parser.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractActivePartyFromHtml,
+  hasMultipleAssociations,
+  type ActiveParty,
+} from "./active-party-parser";
+
+// Helper to create HTML with embedded activeParty JSON
+function createHtmlWithActiveParty(activePartyJson: string): string {
+  // The JSON is HTML-entity encoded in the actual pages
+  // Order matters: encode & first, then quotes
+  const encodedJson = activePartyJson
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;");
+
+  return `
+    <html data-csrf-token="test-token">
+      <head>
+        <script>
+          window.activeParty = JSON.parse('${encodedJson}');
+        </script>
+      </head>
+      <body>Dashboard</body>
+    </html>
+  `;
+}
+
+describe("extractActivePartyFromHtml", () => {
+  describe("successful extraction", () => {
+    it("extracts activeParty with eligibleAttributeValues", () => {
+      const activePartyData = {
+        __identity: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        eligibleAttributeValues: [
+          {
+            __identity: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
+            roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+            inflatedValue: {
+              __identity: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+              name: "Swiss Volley",
+              shortName: "SV",
+            },
+          },
+        ],
+        activeRoleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+      };
+
+      const html = createHtmlWithActiveParty(JSON.stringify(activePartyData));
+      const result = extractActivePartyFromHtml(html);
+
+      expect(result).toEqual(activePartyData);
+    });
+
+    it("extracts activeParty with multiple associations", () => {
+      const activePartyData = {
+        eligibleAttributeValues: [
+          {
+            __identity: "attr-1",
+            attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
+            roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+            inflatedValue: {
+              __identity: "assoc-1",
+              name: "Swiss Volley",
+              shortName: "SV",
+            },
+          },
+          {
+            __identity: "attr-2",
+            attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
+            roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+            inflatedValue: {
+              __identity: "assoc-2",
+              name: "Volleyball Romandie",
+              shortName: "VR",
+            },
+          },
+        ],
+      };
+
+      const html = createHtmlWithActiveParty(JSON.stringify(activePartyData));
+      const result = extractActivePartyFromHtml(html);
+
+      expect(result?.eligibleAttributeValues).toHaveLength(2);
+    });
+
+    it("extracts activeParty with eligibleRoles", () => {
+      const activePartyData = {
+        eligibleRoles: {
+          "Indoorvolleyball.RefAdmin:Referee": {
+            identifier: "Indoorvolleyball.RefAdmin:Referee",
+            name: "Referee",
+            packageKey: "Indoorvolleyball.RefAdmin",
+          },
+          "SportManager.Core:ClubAdmin": {
+            identifier: "SportManager.Core:ClubAdmin",
+            name: "Club Administrator",
+            packageKey: "SportManager.Core",
+          },
+        },
+      };
+
+      const html = createHtmlWithActiveParty(JSON.stringify(activePartyData));
+      const result = extractActivePartyFromHtml(html);
+
+      expect(result?.eligibleRoles).toBeDefined();
+      expect(Object.keys(result?.eligibleRoles ?? {})).toHaveLength(2);
+    });
+
+    it("handles HTML entity decoding correctly", () => {
+      // Create HTML with actual HTML entities that need decoding
+      const html = `
+        <html>
+          <script>
+            window.activeParty = JSON.parse('{&quot;__identity&quot;:&quot;test-id&quot;,&quot;activeRoleIdentifier&quot;:&quot;Referee&quot;}');
+          </script>
+        </html>
+      `;
+
+      const result = extractActivePartyFromHtml(html);
+
+      expect(result?.__identity).toBe("test-id");
+      expect(result?.activeRoleIdentifier).toBe("Referee");
+    });
+
+    it("handles various HTML entity types", () => {
+      // Test with different HTML entities
+      const html = `
+        <html>
+          <script>
+            window.activeParty = JSON.parse('{&quot;name&quot;:&quot;Test &amp; Demo&quot;,&quot;symbol&quot;:&quot;&lt;test&gt;&quot;}');
+          </script>
+        </html>
+      `;
+
+      const result = extractActivePartyFromHtml(html);
+
+      expect(result).toEqual({
+        name: "Test & Demo",
+        symbol: "<test>",
+      });
+    });
+  });
+
+  describe("graceful failure", () => {
+    it("returns null for empty string", () => {
+      const result = extractActivePartyFromHtml("");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when activeParty is not present", () => {
+      const html = `
+        <html data-csrf-token="test-token">
+          <body>Login Page</body>
+        </html>
+      `;
+      const result = extractActivePartyFromHtml(html);
+      expect(result).toBeNull();
+    });
+
+    it("returns null for malformed JSON", () => {
+      const html = `
+        <html>
+          <script>
+            window.activeParty = JSON.parse('{invalid json}');
+          </script>
+        </html>
+      `;
+      const result = extractActivePartyFromHtml(html);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when JSON.parse result is not an object", () => {
+      const html = `
+        <html>
+          <script>
+            window.activeParty = JSON.parse('&quot;just a string&quot;');
+          </script>
+        </html>
+      `;
+      const result = extractActivePartyFromHtml(html);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when JSON.parse result is null", () => {
+      const html = `
+        <html>
+          <script>
+            window.activeParty = JSON.parse('null');
+          </script>
+        </html>
+      `;
+      const result = extractActivePartyFromHtml(html);
+      expect(result).toBeNull();
+    });
+
+    it("returns null for incomplete activeParty pattern", () => {
+      const html = `
+        <html>
+          <script>
+            window.activeParty = something.else;
+          </script>
+        </html>
+      `;
+      const result = extractActivePartyFromHtml(html);
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("hasMultipleAssociations", () => {
+  it("returns false for null", () => {
+    expect(hasMultipleAssociations(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(hasMultipleAssociations(undefined)).toBe(false);
+  });
+
+  it("returns false for empty array", () => {
+    expect(hasMultipleAssociations([])).toBe(false);
+  });
+
+  it("returns false for single association", () => {
+    const eligibleAttributeValues: ActiveParty["eligibleAttributeValues"] = [
+      {
+        __identity: "attr-1",
+        attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+        inflatedValue: {
+          __identity: "assoc-1",
+          name: "Swiss Volley",
+        },
+      },
+    ];
+    expect(hasMultipleAssociations(eligibleAttributeValues)).toBe(false);
+  });
+
+  it("returns true for multiple different associations", () => {
+    const eligibleAttributeValues: ActiveParty["eligibleAttributeValues"] = [
+      {
+        __identity: "attr-1",
+        attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+        inflatedValue: {
+          __identity: "assoc-1",
+          name: "Swiss Volley",
+        },
+      },
+      {
+        __identity: "attr-2",
+        attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+        inflatedValue: {
+          __identity: "assoc-2",
+          name: "Volleyball Romandie",
+        },
+      },
+    ];
+    expect(hasMultipleAssociations(eligibleAttributeValues)).toBe(true);
+  });
+
+  it("returns false for same association with multiple roles", () => {
+    const eligibleAttributeValues: ActiveParty["eligibleAttributeValues"] = [
+      {
+        __identity: "attr-1",
+        attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
+        roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
+        inflatedValue: {
+          __identity: "assoc-1",
+          name: "Swiss Volley",
+        },
+      },
+      {
+        __identity: "attr-2",
+        attributeIdentifier: "SportManager.Core:AbstractClub",
+        roleIdentifier: "SportManager.Core:ClubAdmin",
+        inflatedValue: {
+          __identity: "assoc-1", // Same association
+          name: "Swiss Volley",
+        },
+      },
+    ];
+    expect(hasMultipleAssociations(eligibleAttributeValues)).toBe(false);
+  });
+
+  it("handles attribute values without inflatedValue", () => {
+    const eligibleAttributeValues: ActiveParty["eligibleAttributeValues"] = [
+      {
+        __identity: "attr-1",
+        attributeIdentifier: "test",
+        roleIdentifier: "test",
+        // no inflatedValue
+      },
+      {
+        __identity: "attr-2",
+        attributeIdentifier: "test",
+        roleIdentifier: "test",
+        inflatedValue: {
+          __identity: "assoc-1",
+        },
+      },
+    ];
+    // Only one has a valid inflatedValue.__identity
+    expect(hasMultipleAssociations(eligibleAttributeValues)).toBe(false);
+  });
+});

--- a/web-app/src/utils/active-party-parser.ts
+++ b/web-app/src/utils/active-party-parser.ts
@@ -1,0 +1,139 @@
+/**
+ * Parser for activeParty data embedded in VolleyManager HTML pages.
+ *
+ * The activeParty object contains user context data that is only available
+ * in embedded HTML, not via API. This includes eligibleAttributeValues and
+ * eligibleRoles which are needed to determine if a user has multiple associations.
+ */
+
+import { logger } from "@/utils/logger";
+
+/**
+ * Represents an association that a user is a member of.
+ */
+export interface AttributeValue {
+  __identity: string;
+  attributeIdentifier: string;
+  roleIdentifier: string;
+  inflatedValue?: {
+    __identity: string;
+    name?: string;
+    shortName?: string;
+  };
+}
+
+/**
+ * Definition of a role in the VolleyManager system.
+ */
+export interface RoleDefinition {
+  identifier: string;
+  name?: string;
+  packageKey?: string;
+}
+
+/**
+ * The activeParty data embedded in VolleyManager HTML pages.
+ * Contains user context including association memberships and roles.
+ */
+export interface ActiveParty {
+  __identity?: string;
+  eligibleAttributeValues?: AttributeValue[];
+  eligibleRoles?: Record<string, RoleDefinition>;
+  activeAttributeValue?: AttributeValue;
+  activeRoleIdentifier?: string;
+  groupedEligibleAttributeValues?: AttributeValue[];
+}
+
+/**
+ * Regex pattern to match window.activeParty = JSON.parse('...') in HTML.
+ * Captures the JSON string inside the parse() call.
+ * Uses (?:[^'\\]|\\.)+ to handle escaped characters including \' within the string.
+ */
+const ACTIVE_PARTY_PATTERN = /window\.activeParty\s*=\s*JSON\.parse\s*\(\s*'((?:[^'\\]|\\.)*)'\s*\)/;
+
+/**
+ * Decode HTML entities in a string.
+ * The embedded JSON uses HTML entities like &quot; for quotes.
+ */
+function decodeHtmlEntities(str: string): string {
+  const entities: Record<string, string> = {
+    "&quot;": '"',
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&apos;": "'",
+    "&#39;": "'",
+    "&#x27;": "'",
+    "&#34;": '"',
+    "&#x22;": '"',
+  };
+
+  let decoded = str;
+  for (const [entity, char] of Object.entries(entities)) {
+    decoded = decoded.replaceAll(entity, char);
+  }
+
+  return decoded;
+}
+
+/**
+ * Extract the activeParty JSON data from HTML page content.
+ *
+ * The VolleyManager app embeds user context in script tags like:
+ * window.activeParty = JSON.parse('{"eligibleAttributeValues":[...],...}')
+ *
+ * @param html - The HTML page content
+ * @returns The parsed ActiveParty object, or null if parsing fails
+ */
+export function extractActivePartyFromHtml(html: string): ActiveParty | null {
+  if (!html) {
+    return null;
+  }
+
+  try {
+    const match = ACTIVE_PARTY_PATTERN.exec(html);
+    if (!match?.[1]) {
+      // activeParty not found in HTML - this is normal for login pages
+      return null;
+    }
+
+    const encodedJson = match[1];
+    const decodedJson = decodeHtmlEntities(encodedJson);
+
+    const parsed = JSON.parse(decodedJson) as unknown;
+
+    // Basic validation that we got an object
+    if (typeof parsed !== "object" || parsed === null) {
+      logger.warn("activeParty parsed but is not an object");
+      return null;
+    }
+
+    return parsed as ActiveParty;
+  } catch (error) {
+    logger.warn("Failed to parse activeParty from HTML:", error);
+    return null;
+  }
+}
+
+/**
+ * Check if a user has access to multiple associations based on their eligible attribute values.
+ *
+ * @param eligibleAttributeValues - The user's eligible attribute values (from activeParty or store)
+ * @returns true if the user has multiple eligible associations
+ */
+export function hasMultipleAssociations(
+  eligibleAttributeValues: AttributeValue[] | null | undefined,
+): boolean {
+  if (!eligibleAttributeValues) {
+    return false;
+  }
+
+  // Count unique associations by their identity
+  const uniqueAssociations = new Set(
+    eligibleAttributeValues
+      .map((av) => av.inflatedValue?.__identity)
+      .filter(Boolean),
+  );
+
+  return uniqueAssociations.size > 1;
+}

--- a/web-app/src/utils/auth-parsers.test.ts
+++ b/web-app/src/utils/auth-parsers.test.ts
@@ -253,7 +253,7 @@ describe("submitLoginCredentials", () => {
   };
 
   describe("successful login", () => {
-    it("returns success with CSRF token when redirected to dashboard", async () => {
+    it("returns success with CSRF token and dashboard HTML when redirected to dashboard", async () => {
       const dashboardHtml = createDashboardHtml("success-csrf-token");
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -263,7 +263,11 @@ describe("submitLoginCredentials", () => {
 
       const result = await submitLoginCredentials(authUrl, username, password, formFields);
 
-      expect(result).toEqual({ success: true, csrfToken: "success-csrf-token" });
+      expect(result).toEqual({
+        success: true,
+        csrfToken: "success-csrf-token",
+        dashboardHtml,
+      });
     });
 
     it("sends correct form data", async () => {
@@ -314,7 +318,11 @@ describe("submitLoginCredentials", () => {
 
       const result = await submitLoginCredentials(authUrl, username, password, formFields);
 
-      expect(result).toEqual({ success: true, csrfToken: "fallback-token" });
+      expect(result).toEqual({
+        success: true,
+        csrfToken: "fallback-token",
+        dashboardHtml: htmlWithCsrf,
+      });
     });
   });
 

--- a/web-app/src/utils/auth-parsers.ts
+++ b/web-app/src/utils/auth-parsers.ts
@@ -127,9 +127,10 @@ export function extractCsrfTokenFromPage(html: string): string | null {
 
 /**
  * Result of submitting login credentials.
+ * On success, includes the dashboard HTML for extracting additional data like activeParty.
  */
 export type LoginResult =
-  | { success: true; csrfToken: string }
+  | { success: true; csrfToken: string; dashboardHtml: string }
   | { success: false; error: string };
 
 /**
@@ -200,7 +201,7 @@ export async function submitLoginCredentials(
     // Successfully redirected to dashboard - extract CSRF token
     const csrfToken = extractCsrfTokenFromPage(html);
     if (csrfToken) {
-      return { success: true, csrfToken };
+      return { success: true, csrfToken, dashboardHtml: html };
     }
     // Redirected to dashboard but couldn't find CSRF token
     // This is a parsing issue, not invalid credentials
@@ -238,7 +239,7 @@ export async function submitLoginCredentials(
   // Fallback: Check if CSRF token exists (might be on dashboard without redirect flag)
   const csrfToken = extractCsrfTokenFromPage(html);
   if (csrfToken) {
-    return { success: true, csrfToken };
+    return { success: true, csrfToken, dashboardHtml: html };
   }
 
   // Unknown state - couldn't determine success or failure


### PR DESCRIPTION
## Summary

- Updated OpenAPI spec for profile endpoints based on captured HAR data
- Added activeParty extraction from login HTML to access eligibleAttributeValues and eligibleRoles (only available in embedded HTML, not API)

## Changes

### OpenAPI Spec Updates (docs/api/)
- Fixed `/sportmanager.volleyball/api\person/showWithNestedObjects` response to wrap PersonDetails in a `{ "person": ... }` object
- Added missing `createdAt` and `updatedAt` timestamp fields to IndoorReferee schema
- Updated PersonDetails schema description to clarify embedded-only fields
- Removed embedded-only fields from PersonDetails: `activeAttributeValue`, `eligibleAttributeValues`, `groupedEligibleAttributeValues`, `groupedEligibleAttributeValuesWithoutHiddenRoles`, `eligibleRoles`
- Added response structure examples to profile_endpoints.md with sanitized sample data and accurate `_permissions` structure

### ActiveParty Extraction (web-app/src/)
- Created `utils/active-party-parser.ts` with:
  - `extractActivePartyFromHtml()` - extracts window.activeParty JSON from HTML
  - Regex handles escaped characters (e.g., `\'`) within JSON strings
  - `hasMultipleAssociations()` - checks if user has multiple association memberships
  - HTML entity decoding support (&quot;, &amp;, etc.)
  - Type definitions for ActiveParty, AttributeValue, RoleDefinition
- Updated `stores/auth.ts`:
  - Added `eligibleAttributeValues` and `eligibleRoles` to AuthState
  - Parse activeParty during login and session check
  - Persist `eligibleAttributeValues` for immediate access after page refresh
  - Added `hasMultipleAssociations()` selector
  - Clear activeParty data on logout
- Updated `utils/auth-parsers.ts`:
  - Modified LoginResult to include `dashboardHtml` for activeParty extraction
- Added comprehensive unit tests for active-party-parser (18 tests)

## Test Plan

- [ ] Verify OpenAPI spec is valid YAML (`npm run generate:api` in web-app)
- [ ] Run `npm test` - all tests pass
- [ ] Run `npm run lint` - no warnings
- [ ] Test login flow extracts activeParty correctly
- [ ] Verify `hasMultipleAssociations()` returns true for users with multiple associations
- [ ] Confirm `hasMultipleAssociations()` works immediately after page refresh (persisted data)
- [ ] Confirm graceful degradation when activeParty is not present in HTML
