### PR TITLE
fix(worker): handle iOS Safari auth routing issue

### DIFF
--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -61,6 +61,11 @@ export function LoginPage() {
     // bypassing React's event handling in some cases
     e.preventDefault();
     e.stopPropagation();
+    await performLogin();
+  }
+
+  async function performLogin() {
+    if (isLoading) return; // Prevent double submission
 
     const password = passwordRef.current?.value || "";
     const success = await login(username, password);
@@ -70,6 +75,15 @@ export function LoginPage() {
         passwordRef.current.value = "";
       }
       navigate("/");
+    }
+  }
+
+  // Handle Enter key on password field to trigger login
+  // This provides keyboard submit without relying on form submission
+  function handlePasswordKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" && !isLoading) {
+      e.preventDefault();
+      performLogin();
     }
   }
 
@@ -112,7 +126,8 @@ export function LoginPage() {
 
         {/* Login form */}
         <div className="card p-6">
-          <form onSubmit={handleSubmit} className="space-y-6">
+          {/* method="post" is defensive fallback if native submission somehow occurs */}
+          <form onSubmit={handleSubmit} method="post" className="space-y-6">
             <div>
               <label
                 htmlFor="username"
@@ -148,6 +163,7 @@ export function LoginPage() {
                 autoComplete="current-password"
                 required
                 disabled={isLoading}
+                onKeyDown={handlePasswordKeyDown}
                 className="input"
               />
             </div>
@@ -161,10 +177,11 @@ export function LoginPage() {
             )}
 
             <Button
-              type="submit"
+              type="button"
               variant="primary"
               fullWidth
               loading={isLoading}
+              onClick={performLogin}
               data-testid="login-button"
             >
               {isLoading ? t("auth.loggingIn") : t("auth.loginButton")}

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -56,7 +56,11 @@ export function LoginPage() {
   }, [initializeDemoData, setDemoAuthenticated, navigate]);
 
   async function handleSubmit(e: FormEvent) {
+    // Prevent native form submission - critical for iOS autofill compatibility
+    // iOS Safari's password autofill can trigger native form submission,
+    // bypassing React's event handling in some cases
     e.preventDefault();
+    e.stopPropagation();
 
     const password = passwordRef.current?.value || "";
     const success = await login(username, password);

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -34,6 +34,8 @@ export function LoginPage() {
   const [username, setUsername] = useState("");
   // Use ref for password to minimize memory exposure (avoids re-renders with password in state)
   const passwordRef = useRef<HTMLInputElement>(null);
+  // Form ref for manual validation trigger (needed since button is type="button")
+  const formRef = useRef<HTMLFormElement>(null);
   // Ref to prevent race condition with double submission
   // State updates are async, so we need a synchronous guard
   const isSubmittingRef = useRef(false);
@@ -70,6 +72,13 @@ export function LoginPage() {
   async function performLogin() {
     // Use ref for synchronous double-submit prevention (state updates are async)
     if (isSubmittingRef.current || isLoading) return;
+
+    // Trigger HTML5 form validation (needed since button is type="button")
+    // reportValidity() shows validation messages and returns false if invalid
+    if (formRef.current && !formRef.current.reportValidity()) {
+      return;
+    }
+
     isSubmittingRef.current = true;
 
     try {
@@ -136,7 +145,7 @@ export function LoginPage() {
         {/* Login form */}
         <div className="card p-6">
           {/* method="post" is defensive fallback if native submission somehow occurs */}
-          <form onSubmit={handleSubmit} method="post" className="space-y-6">
+          <form ref={formRef} onSubmit={handleSubmit} method="post" className="space-y-6">
             <div>
               <label
                 htmlFor="username"

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -191,6 +191,10 @@ export default defineConfig(({ mode }) => {
             /\/neos/,
             /\/indoorvolleyball\.refadmin/,
             /\/sportmanager\.indoorvolleyball/,
+            // Don't intercept security/auth routes - critical for login flow
+            /\/sportmanager\.security/,
+            /\/login$/,
+            /\/logout$/,
             // Don't intercept PR preview routes - let them load their own assets
             /\/pr-\d+/,
           ],

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -137,8 +137,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251229.0.tgz",
       "integrity": "sha512-LgzxDZaT9bQhycQInf7S/fcZCQRTvWWQPE9xnEyedI+CXxWsXAD7hg84kvVyr+KUz+W9Oblzo75g6XZ3HdI5Yg==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1596,7 +1595,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -1925,7 +1923,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2340,7 +2337,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3065,7 +3061,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3412,7 +3407,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3461,7 +3455,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -3482,7 +3475,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3680,7 +3672,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -437,7 +437,7 @@ export default {
         requestBody = await clonedRequest.text();
 
         if (hasAuthCredentials(requestBody)) {
-          console.log("iOS auth workaround: Rewriting POST /login to auth endpoint");
+          // Rewrite to correct auth endpoint (iOS Safari workaround)
           rawPathAndSearch = AUTH_ENDPOINT;
           requestBody = transformAuthFormData(requestBody);
         }
@@ -446,7 +446,7 @@ export default {
         // or with postData attached to GET (invalid HTTP, but Safari does it)
         const queryBody = url.search.slice(1); // Remove leading '?'
         if (hasAuthCredentials(queryBody)) {
-          console.log("iOS auth workaround: Converting GET /login to POST auth endpoint");
+          // Convert GET to POST and rewrite to correct auth endpoint (iOS Safari workaround)
           rawPathAndSearch = AUTH_ENDPOINT;
           requestBody = transformAuthFormData(queryBody);
           methodOverride = "POST";


### PR DESCRIPTION
## Summary

- Fix iOS Safari authentication issue where form submission used GET instead of POST
- Prevent native form submission in PWA by using button click instead of form submit
- Add worker-side fallback to handle and convert misdirected GET auth requests to POST
- Add Origin/Referer header rewriting for CSRF validation compatibility
- Add Partitioned cookie attribute for iOS Safari ITP compatibility

## Changes

### PWA (`web-app/src/pages/LoginPage.tsx`)
- Change login button from `type="submit"` to `type="button"` with `onClick={performLogin}`
- Extract `performLogin()` function that handles login without form submission
- Add `onKeyDown` handler on password field for Enter key submission
- Add `method="post"` to form element as defensive fallback
- Add `e.stopPropagation()` in form submit handler for extra protection

### Worker (`worker/src/index.ts`)
- Handle GET to `/login` with auth credentials in query string (iOS Safari bug)
- Convert GET requests to POST when auth credentials are detected
- Rewrite request path to correct auth endpoint `/sportmanager.security/authentication/authenticate`
- Transform simple form fields (`username`/`password`) to Neos Flow format
- Set `Content-Type: application/x-www-form-urlencoded` when overriding to POST
- Rewrite `Origin` header to match target host for CSRF validation
- Rewrite `Referer` header to match target host while preserving path
- Add `Partitioned` attribute to cookies for iOS Safari ITP (CHIPS)

### Service Worker Config (`web-app/vite.config.ts`)
- Add `/sportmanager\.security/`, `/login$/`, `/logout$/` to `navigateFallbackDenylist`

## Test Plan

- [ ] Test login on iPhone Safari (standalone PWA mode) - should now use POST
- [ ] Test login on iPhone Safari (browser mode)
- [ ] Test login on desktop browser (regression check)
- [ ] Test Enter key submission on password field
- [ ] Test button click submission
- [ ] Verify worker logs show workaround messages when triggered
- [ ] Capture new HAR on iPhone to confirm POST method is used
- [ ] Verify cookies are set with Partitioned attribute
- [ ] Run `npm test` in web-app (2370 tests passing)
- [ ] Run `npm test` in worker (78 tests passing)
