### PR TITLE
fix(auth): detect all user associations from groupedEligibleAttributeValues

### DIFF
--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -2875,9 +2875,10 @@ export interface components {
             username?: string | null;
         };
         /**
-         * @description Detailed person information for profile page.
-         *     This is the "active party" data embedded in page loads, containing the user's
-         *     association memberships and current context.
+         * @description Detailed person information returned by the profile API.
+         *     Note: The following fields are only available in embedded HTML data,
+         *     not in the API response: eligibleAttributeValues, eligibleRoles,
+         *     groupedEligibleAttributeValues, activeAttributeValue.
          */
         PersonDetails: {
             /**
@@ -2983,22 +2984,11 @@ export interface components {
             primaryPhoneNumber?: components["schemas"]["PhoneNumber"];
             postalAddresses?: components["schemas"]["PostalAddress"][];
             primaryPostalAddress?: components["schemas"]["PostalAddress"];
-            activeAttributeValue?: components["schemas"]["AttributeValue"];
             /**
              * @description Current role identifier
              * @example Indoorvolleyball.RefAdmin:Referee
              */
             activeRoleIdentifier?: string;
-            /** @description All association memberships/roles the user is eligible for */
-            eligibleAttributeValues?: components["schemas"]["AttributeValue"][];
-            /** @description Eligible attribute values grouped by role */
-            groupedEligibleAttributeValues?: components["schemas"]["AttributeValue"][];
-            /** @description Visible eligible attribute values */
-            groupedEligibleAttributeValuesWithoutHiddenRoles?: components["schemas"]["AttributeValue"][];
-            /** @description Map of role identifiers to role definitions */
-            eligibleRoles?: {
-                [key: string]: components["schemas"]["RoleDefinition"];
-            };
             accounts?: {
                 /** Format: uuid */
                 __identity?: string;
@@ -3340,6 +3330,16 @@ export interface components {
             teamBan?: Record<string, never>[];
             clubBan?: Record<string, never>[];
             notes?: string | null;
+            /**
+             * Format: date-time
+             * @description When the referee record was created
+             */
+            createdAt?: string;
+            /**
+             * Format: date-time
+             * @description When the referee record was last updated
+             */
+            updatedAt?: string;
             createdBy?: string;
             createdByIpAddress?: string;
             createdByPersistenceIdentifier?: string;
@@ -4795,7 +4795,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PersonDetails"];
+                    "application/json": {
+                        person: components["schemas"]["PersonDetails"];
+                    };
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -106,6 +106,7 @@ function createMockAuthStore(
     isDemoMode: false,
     _checkSessionPromise: null,
     eligibleAttributeValues: null,
+    groupedEligibleAttributeValues: null,
     eligibleRoles: null,
     login: vi.fn(),
     logout: vi.fn(),

--- a/web-app/src/utils/active-party-parser.test.ts
+++ b/web-app/src/utils/active-party-parser.test.ts
@@ -503,31 +503,4 @@ describe("hasMultipleAssociations", () => {
     expect(hasMultipleAssociations(attributeValues)).toBe(false);
   });
 
-  // Backward compatibility test for old data without type field
-  it("returns false for old data format without type field", () => {
-    const attributeValues: AttributeValue[] = [
-      {
-        __identity: "attr-1",
-        attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
-        roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
-        // No type field - old format
-        inflatedValue: {
-          __identity: "assoc-1",
-          name: "Swiss Volley",
-        },
-      },
-      {
-        __identity: "attr-2",
-        attributeIdentifier: "Indoorvolleyball.RefAdmin:AbstractAssociation",
-        roleIdentifier: "Indoorvolleyball.RefAdmin:Referee",
-        // No type field - old format
-        inflatedValue: {
-          __identity: "assoc-2",
-          name: "SVRZ",
-        },
-      },
-    ];
-    // Without type field, filterRefereeAssociations will filter them out
-    expect(hasMultipleAssociations(attributeValues)).toBe(false);
-  });
 });


### PR DESCRIPTION
## Summary

- Fixed multiple association detection for users who belong to multiple regional associations (e.g., SVRZ, SVRBA, SV)
- The app was only reading `eligibleAttributeValues` but the complete list is in `groupedEligibleAttributeValues`
- Added proper filtering to distinguish referee associations from boolean player roles
- Added storage versioning for clean break - old cached data is invalidated, users will re-login to get fresh data

## Changes

- **web-app/src/utils/active-party-parser.ts**:
  - Added `InflatedAssociationValue` interface with `identifier` and `originId` fields
  - Extended `AttributeValue` interface with `type` and `value` fields
  - Added `filterRefereeAssociations()` function to filter by referee role and association type
  - Updated `hasMultipleAssociations()` to use the new filtering logic

- **web-app/src/stores/auth.ts**:
  - Added `AUTH_STORE_VERSION = 2` constant with version history documentation
  - Added `groupedEligibleAttributeValues` to store state
  - Store now captures and persists `groupedEligibleAttributeValues` from login/session checks
  - Added `migrate` function to invalidate old cached state (clean break approach)
  - Simplified `hasMultipleAssociations()` to use only `groupedEligibleAttributeValues`

- **web-app/src/utils/active-party-parser.test.ts**:
  - Added tests for `filterRefereeAssociations()` function
  - Updated `hasMultipleAssociations()` tests with proper `type` field
  - Added real-world test case with 3 associations (SVRZ, SVRBA, SV)

- **web-app/src/components/features/settings/TransportSection.test.tsx**:
  - Added `groupedEligibleAttributeValues` to mock auth state

## Test Plan

- [ ] Login with a user who belongs to multiple associations (e.g., SVRZ, SVRBA, SV)
- [ ] Verify that `hasMultipleAssociations()` returns `true` for multi-association users
- [ ] Check browser devtools/React devtools for the store state showing all 3 associations
- [ ] Verify that users with only one referee association still show `hasMultipleAssociations()` as `false`
- [ ] Verify that boolean player roles are correctly filtered out
- [ ] Verify old cached data is invalidated (user should be logged out on first load after update)
- [ ] Run `npm test` - all 2378 tests pass
- [ ] Run `npm run lint` - no warnings
- [ ] Run `npm run build` - builds successfully
