### PR TITLE
fix(api): add group base property to prevent 500 errors on validated games

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -1084,6 +1084,23 @@ describe("API Client", () => {
       expect(url).toContain("nominationListOfTeamHome");
       expect(url).toContain("nominationListOfTeamAway");
     });
+
+    it("requests group base property before nested group properties", async () => {
+      // The 'group' base property must be requested before nested properties like
+      // 'group.phase.league...' to avoid 500 errors when group is null
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ __identity: "game-1" }),
+      );
+
+      await api.getGameWithScoresheet("game-123");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      // Verify 'group' appears as a standalone property (not just nested)
+      // propertyRenderConfiguration[N]=group (URL encoded as group)
+      expect(url).toMatch(/propertyRenderConfiguration%5B\d+%5D=group(?:&|$)/);
+      // Verify the nested property is also present
+      expect(url).toContain("writersCanUseSimpleScoresheetForThisLeagueCategory");
+    });
   });
 
   describe("getAssociationSettings", () => {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -435,6 +435,9 @@ export const api = {
       "nominationListOfTeamAway.isClosedForTeam",
       "nominationListOfTeamAway.nominationListValidation",
       "nominationListOfTeamAway.indoorPlayerNominations.*.__identity",
+      // Group must be requested before nested properties to avoid 500 errors
+      // when group is null (e.g., for already validated games)
+      "group",
       "group.phase.league.leagueCategory.writersCanUseSimpleScoresheetForThisLeagueCategory",
     ];
 


### PR DESCRIPTION
## Summary

- Fixed 500 Internal Server Error when viewing already-validated games using the real API
- The error occurred because nested `group` properties were requested without first requesting the base `group` property, causing the TYPO3 Neos/Flow backend to fail when `group` is null

## Changes

- Added `"group"` base property to `getGameWithScoresheet` property list before the nested `group.phase.league.leagueCategory.writersCanUseSimpleScoresheetForThisLeagueCategory` property (`web-app/src/api/client.ts:440`)
- Added regression test to verify the `group` base property is included in API requests (`web-app/src/api/client.test.ts:1088-1103`)

## Test Plan

- [ ] Open the ValidateGameModal for an already-validated game and verify no 500 error occurs
- [ ] Verify the game details load correctly for validated games
- [ ] Verify the game details still load correctly for non-validated games
- [ ] Run `npm test` - all 2389 tests should pass
- [ ] Run `npm run lint` - should pass with 0 warnings
