### PR TITLE
fix(auth): add fallback for association dropdown when groupedEligibleAttributeValues is empty

### DIFF
--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -79,15 +79,26 @@ const SESSION_CHECK_TIMEOUT_MS = 10_000;
 /**
  * Derives user occupations and active occupation ID from active party data.
  * Used during login and session restoration to populate the association dropdown.
+ *
+ * Uses groupedEligibleAttributeValues as the primary source for associations.
+ * Falls back to eligibleAttributeValues if groupedEligibleAttributeValues is empty,
+ * which can happen on some pages or with certain user configurations.
  */
 function deriveUserWithOccupations(
-  activeParty: { groupedEligibleAttributeValues?: AttributeValue[] | null } | null,
+  activeParty: {
+    groupedEligibleAttributeValues?: AttributeValue[] | null;
+    eligibleAttributeValues?: AttributeValue[] | null;
+  } | null,
   currentUser: UserProfile | null,
   currentActiveOccupationId: string | null,
 ): { user: UserProfile; activeOccupationId: string | null } {
-  const occupations = parseOccupationsFromActiveParty(
-    activeParty?.groupedEligibleAttributeValues,
-  );
+  // Use groupedEligibleAttributeValues first, fall back to eligibleAttributeValues
+  const attributeValues =
+    activeParty?.groupedEligibleAttributeValues?.length
+      ? activeParty.groupedEligibleAttributeValues
+      : activeParty?.eligibleAttributeValues ?? null;
+
+  const occupations = parseOccupationsFromActiveParty(attributeValues);
   const activeOccupationId = currentActiveOccupationId ?? occupations[0]?.id ?? null;
 
   const user = currentUser


### PR DESCRIPTION
## Summary

- Fix missing association dropdown on mobile (iOS Safari) for users with multiple associations
- The dropdown was not appearing because `groupedEligibleAttributeValues` was empty/missing in some cases
- Added fallback logic and deduplication to ensure associations are properly detected

## Changes

- **web-app/src/stores/auth.ts**: Updated `deriveUserWithOccupations` to fall back to `eligibleAttributeValues` when `groupedEligibleAttributeValues` is empty or missing
- **web-app/src/utils/parseOccupations.ts**: Added deduplication by association code in `parseOccupationsFromActiveParty` to handle potential duplicates from the fallback source

## Test Plan

- [ ] Login on iOS Safari with a user that has multiple associations
- [ ] Verify the association dropdown appears in the header
- [ ] Verify switching associations updates the displayed games
- [ ] Test login on desktop to ensure no regression
- [ ] Verify demo mode still shows multiple associations correctly
