### PR TITLE
fix(api): optimize game API call to fetch both team rosters in single request

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -840,7 +840,7 @@ describe("API Client", () => {
   describe("getNominationList", () => {
     it("requests home team nomination list", async () => {
       mockFetch.mockResolvedValueOnce(
-        createMockResponse({ nominationListOfTeamHome: { __identity: "nl-1" } }),
+        createMockResponse({ game: { nominationListOfTeamHome: { __identity: "nl-1" } } }),
       );
 
       const result = await api.getNominationList("game-123", "home");
@@ -852,7 +852,7 @@ describe("API Client", () => {
 
     it("requests away team nomination list", async () => {
       mockFetch.mockResolvedValueOnce(
-        createMockResponse({ nominationListOfTeamAway: { __identity: "nl-2" } }),
+        createMockResponse({ game: { nominationListOfTeamAway: { __identity: "nl-2" } } }),
       );
 
       const result = await api.getNominationList("game-123", "away");
@@ -863,7 +863,7 @@ describe("API Client", () => {
     });
 
     it("returns null when nomination list is missing", async () => {
-      mockFetch.mockResolvedValueOnce(createMockResponse({}));
+      mockFetch.mockResolvedValueOnce(createMockResponse({ game: {} }));
 
       const result = await api.getNominationList("game-123", "home");
 
@@ -1073,7 +1073,7 @@ describe("API Client", () => {
   describe("getGameWithScoresheet", () => {
     it("requests game with scoresheet and nomination list properties", async () => {
       mockFetch.mockResolvedValueOnce(
-        createMockResponse({ __identity: "game-1" }),
+        createMockResponse({ game: { __identity: "game-1" } }),
       );
 
       await api.getGameWithScoresheet("game-123");
@@ -1089,7 +1089,7 @@ describe("API Client", () => {
       // The 'group' base property must be requested before nested properties like
       // 'group.phase.league...' to avoid 500 errors when group is null
       mockFetch.mockResolvedValueOnce(
-        createMockResponse({ __identity: "game-1" }),
+        createMockResponse({ game: { __identity: "game-1" } }),
       );
 
       await api.getGameWithScoresheet("game-123");
@@ -1100,6 +1100,22 @@ describe("API Client", () => {
       expect(url).toMatch(/propertyRenderConfiguration%5B\d+%5D=group(?:&|$)/);
       // Verify the nested property is also present
       expect(url).toContain("writersCanUseSimpleScoresheetForThisLeagueCategory");
+    });
+
+    it("returns the game object from the response wrapper", async () => {
+      const gameData = {
+        __identity: "game-1",
+        scoresheet: { __identity: "ss-1", closedAt: null },
+        nominationListOfTeamHome: { __identity: "nl-home" },
+        nominationListOfTeamAway: { __identity: "nl-away" },
+      };
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ game: gameData }),
+      );
+
+      const result = await api.getGameWithScoresheet("game-123");
+
+      expect(result).toEqual(gameData);
     });
   });
 

--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -837,40 +837,6 @@ describe("API Client", () => {
     });
   });
 
-  describe("getNominationList", () => {
-    it("requests home team nomination list", async () => {
-      mockFetch.mockResolvedValueOnce(
-        createMockResponse({ game: { nominationListOfTeamHome: { __identity: "nl-1" } } }),
-      );
-
-      const result = await api.getNominationList("game-123", "home");
-
-      expect(result).toEqual({ __identity: "nl-1" });
-      const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toContain("nominationListOfTeamHome");
-    });
-
-    it("requests away team nomination list", async () => {
-      mockFetch.mockResolvedValueOnce(
-        createMockResponse({ game: { nominationListOfTeamAway: { __identity: "nl-2" } } }),
-      );
-
-      const result = await api.getNominationList("game-123", "away");
-
-      expect(result).toEqual({ __identity: "nl-2" });
-      const [url] = mockFetch.mock.calls[0]!;
-      expect(url).toContain("nominationListOfTeamAway");
-    });
-
-    it("returns null when nomination list is missing", async () => {
-      mockFetch.mockResolvedValueOnce(createMockResponse({ game: {} }));
-
-      const result = await api.getNominationList("game-123", "home");
-
-      expect(result).toBeNull();
-    });
-  });
-
   describe("getPossiblePlayerNominations", () => {
     it("sends POST request with nomination list ID", async () => {
       mockFetch.mockResolvedValueOnce(

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -286,6 +286,13 @@ export const api = {
   },
 
   // Nominations
+  /**
+   * Fetches the nomination list for a single team.
+   *
+   * @deprecated Prefer using `getGameWithScoresheet()` which fetches both team rosters
+   * in a single API call. This method is kept for backwards compatibility and as a
+   * fallback when prefetched data is not available.
+   */
   async getNominationList(
     gameId: string,
     team: "home" | "away",

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -317,7 +317,7 @@ export const api = {
       `${nominationProperty}.isClosedForTeam`,
     ];
 
-    const response = await apiRequest<Schemas["GameDetails"]>(
+    const response = await apiRequest<{ game: Schemas["GameDetails"] }>(
       "/sportmanager.indoorvolleyball/api%5cgame/showWithNestedObjects",
       "GET",
       {
@@ -328,8 +328,8 @@ export const api = {
 
     const nominationList =
       team === "home"
-        ? response.nominationListOfTeamHome
-        : response.nominationListOfTeamAway;
+        ? response.game.nominationListOfTeamHome
+        : response.game.nominationListOfTeamAway;
 
     return nominationList ?? null;
   },
@@ -410,6 +410,7 @@ export const api = {
   // Game details and scoresheet
   async getGameWithScoresheet(gameId: string): Promise<Schemas["GameDetails"]> {
     const properties = [
+      // Scoresheet properties
       "scoresheet",
       "scoresheet.__identity",
       "scoresheet.game.__identity",
@@ -419,29 +420,57 @@ export const api = {
       "scoresheet.hasFile",
       "scoresheet.closedAt",
       "scoresheet.scoresheetValidation",
+      // Home team nomination list with full player details
       "nominationListOfTeamHome",
       "nominationListOfTeamHome.__identity",
       "nominationListOfTeamHome.game.__identity",
-      "nominationListOfTeamHome.team.__identity",
+      "nominationListOfTeamHome.team",
       "nominationListOfTeamHome.closed",
+      "nominationListOfTeamHome.closedAt",
+      "nominationListOfTeamHome.checked",
       "nominationListOfTeamHome.isClosedForTeam",
       "nominationListOfTeamHome.nominationListValidation",
+      "nominationListOfTeamHome.indoorPlayerNominations",
       "nominationListOfTeamHome.indoorPlayerNominations.*.__identity",
+      "nominationListOfTeamHome.indoorPlayerNominations.*.shirtNumber",
+      "nominationListOfTeamHome.indoorPlayerNominations.*.isCaptain",
+      "nominationListOfTeamHome.indoorPlayerNominations.*.isLibero",
+      "nominationListOfTeamHome.indoorPlayerNominations.*.indoorPlayer.person.displayName",
+      "nominationListOfTeamHome.indoorPlayerNominations.*.indoorPlayer.person.firstName",
+      "nominationListOfTeamHome.indoorPlayerNominations.*.indoorPlayer.person.lastName",
+      "nominationListOfTeamHome.indoorPlayerNominations.*.indoorPlayerLicenseCategory.shortName",
+      "nominationListOfTeamHome.coachPerson",
+      "nominationListOfTeamHome.firstAssistantCoachPerson",
+      "nominationListOfTeamHome.secondAssistantCoachPerson",
+      // Away team nomination list with full player details
       "nominationListOfTeamAway",
       "nominationListOfTeamAway.__identity",
       "nominationListOfTeamAway.game.__identity",
-      "nominationListOfTeamAway.team.__identity",
+      "nominationListOfTeamAway.team",
       "nominationListOfTeamAway.closed",
+      "nominationListOfTeamAway.closedAt",
+      "nominationListOfTeamAway.checked",
       "nominationListOfTeamAway.isClosedForTeam",
       "nominationListOfTeamAway.nominationListValidation",
+      "nominationListOfTeamAway.indoorPlayerNominations",
       "nominationListOfTeamAway.indoorPlayerNominations.*.__identity",
+      "nominationListOfTeamAway.indoorPlayerNominations.*.shirtNumber",
+      "nominationListOfTeamAway.indoorPlayerNominations.*.isCaptain",
+      "nominationListOfTeamAway.indoorPlayerNominations.*.isLibero",
+      "nominationListOfTeamAway.indoorPlayerNominations.*.indoorPlayer.person.displayName",
+      "nominationListOfTeamAway.indoorPlayerNominations.*.indoorPlayer.person.firstName",
+      "nominationListOfTeamAway.indoorPlayerNominations.*.indoorPlayer.person.lastName",
+      "nominationListOfTeamAway.indoorPlayerNominations.*.indoorPlayerLicenseCategory.shortName",
+      "nominationListOfTeamAway.coachPerson",
+      "nominationListOfTeamAway.firstAssistantCoachPerson",
+      "nominationListOfTeamAway.secondAssistantCoachPerson",
       // Group must be requested before nested properties to avoid 500 errors
       // when group is null (e.g., for already validated games)
       "group",
       "group.phase.league.leagueCategory.writersCanUseSimpleScoresheetForThisLeagueCategory",
     ];
 
-    return apiRequest<Schemas["GameDetails"]>(
+    const response = await apiRequest<{ game: Schemas["GameDetails"] }>(
       "/sportmanager.indoorvolleyball/api%5cgame/showWithNestedObjects",
       "GET",
       {
@@ -449,6 +478,8 @@ export const api = {
         propertyRenderConfiguration: properties,
       },
     );
+
+    return response.game;
   },
 
   async updateNominationList(

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -286,61 +286,6 @@ export const api = {
   },
 
   // Nominations
-  /**
-   * Fetches the nomination list for a single team.
-   *
-   * @deprecated Prefer using `getGameWithScoresheet()` which fetches both team rosters
-   * in a single API call. This method is kept for backwards compatibility and as a
-   * fallback when prefetched data is not available.
-   */
-  async getNominationList(
-    gameId: string,
-    team: "home" | "away",
-  ): Promise<NominationList | null> {
-    const nominationProperty =
-      team === "home"
-        ? "nominationListOfTeamHome"
-        : "nominationListOfTeamAway";
-
-    const properties = [
-      nominationProperty,
-      `${nominationProperty}.__identity`,
-      `${nominationProperty}.team`,
-      `${nominationProperty}.indoorPlayerNominations`,
-      `${nominationProperty}.indoorPlayerNominations.*.__identity`,
-      `${nominationProperty}.indoorPlayerNominations.*.shirtNumber`,
-      `${nominationProperty}.indoorPlayerNominations.*.isCaptain`,
-      `${nominationProperty}.indoorPlayerNominations.*.isLibero`,
-      `${nominationProperty}.indoorPlayerNominations.*.indoorPlayer.person.displayName`,
-      `${nominationProperty}.indoorPlayerNominations.*.indoorPlayer.person.firstName`,
-      `${nominationProperty}.indoorPlayerNominations.*.indoorPlayer.person.lastName`,
-      `${nominationProperty}.indoorPlayerNominations.*.indoorPlayerLicenseCategory.shortName`,
-      `${nominationProperty}.coachPerson`,
-      `${nominationProperty}.firstAssistantCoachPerson`,
-      `${nominationProperty}.secondAssistantCoachPerson`,
-      `${nominationProperty}.closed`,
-      `${nominationProperty}.closedAt`,
-      `${nominationProperty}.checked`,
-      `${nominationProperty}.isClosedForTeam`,
-    ];
-
-    const response = await apiRequest<{ game: Schemas["GameDetails"] }>(
-      "/sportmanager.indoorvolleyball/api%5cgame/showWithNestedObjects",
-      "GET",
-      {
-        "game[__identity]": gameId,
-        propertyRenderConfiguration: properties,
-      },
-    );
-
-    const nominationList =
-      team === "home"
-        ? response.game.nominationListOfTeamHome
-        : response.game.nominationListOfTeamAway;
-
-    return nominationList ?? null;
-  },
-
   async getPossiblePlayerNominations(
     nominationListId: string,
     options?: { onlyFromMyTeam?: boolean; onlyRelevantGender?: boolean },

--- a/web-app/src/api/contract.test.ts
+++ b/web-app/src/api/contract.test.ts
@@ -433,54 +433,6 @@ describe("Nomination list endpoints", () => {
     useDemoStore.getState().initializeDemoData();
   });
 
-  it("getNominationList returns valid nomination list for home team", async () => {
-    const { nominationLists } = useDemoStore.getState();
-    const gameId = Object.keys(nominationLists)[0];
-    expect(gameId).toBeDefined();
-
-    const nominationList = await mockApi.getNominationList(gameId!, "home");
-
-    expect(nominationList).not.toBeNull();
-    expect(nominationList).toHaveProperty("__identity");
-    expect(nominationList).toHaveProperty("game");
-    expect(nominationList).toHaveProperty("team");
-    expect(nominationList).toHaveProperty("closed");
-    expect(nominationList).toHaveProperty("indoorPlayerNominations");
-    expect(Array.isArray(nominationList!.indoorPlayerNominations)).toBe(true);
-  });
-
-  it("getNominationList returns valid nomination list for away team", async () => {
-    const { nominationLists } = useDemoStore.getState();
-    const gameId = Object.keys(nominationLists)[0];
-    expect(gameId).toBeDefined();
-
-    const nominationList = await mockApi.getNominationList(gameId!, "away");
-
-    expect(nominationList).not.toBeNull();
-    expect(nominationList!.indoorPlayerNominations?.length).toBeGreaterThan(0);
-  });
-
-  it("getNominationList returns null for non-existent game", async () => {
-    const nominationList = await mockApi.getNominationList(
-      "non-existent-game",
-      "home",
-    );
-    expect(nominationList).toBeNull();
-  });
-
-  it("player nominations have required fields", async () => {
-    const { nominationLists } = useDemoStore.getState();
-    const gameId = Object.keys(nominationLists)[0];
-    const nominationList = await mockApi.getNominationList(gameId!, "home");
-
-    nominationList!.indoorPlayerNominations?.forEach((player) => {
-      expect(player.__identity).toBeDefined();
-      expect(player.shirtNumber).toBeDefined();
-      expect(player.indoorPlayer).toBeDefined();
-      expect(player.indoorPlayer?.person).toBeDefined();
-    });
-  });
-
   it("getPossiblePlayerNominations returns valid nominations", async () => {
     const { nominationLists } = useDemoStore.getState();
     const gameId = Object.keys(nominationLists)[0];

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -426,22 +426,6 @@ export const mockApi = {
     } as Season;
   },
 
-  async getNominationList(
-    gameId: string,
-    team: "home" | "away",
-  ): Promise<NominationList | null> {
-    await delay(MOCK_NETWORK_DELAY_MS);
-
-    const store = useDemoStore.getState();
-    const gameNominations = store.nominationLists[gameId];
-
-    if (!gameNominations) {
-      return null;
-    }
-
-    return gameNominations[team] ?? null;
-  },
-
   async getPossiblePlayerNominations(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
     _nominationListId: string,

--- a/web-app/src/api/queryKeys.ts
+++ b/web-app/src/api/queryKeys.ts
@@ -116,11 +116,6 @@ export const queryKeys = {
   nominations: {
     /** Base key - invalidates ALL nomination queries */
     all: ["nominations"] as const,
-    /** Parent key for nomination list queries */
-    lists: () => [...queryKeys.nominations.all, "list"] as const,
-    /** Specific nomination list for a game and team */
-    list: (gameId: string, team: "home" | "away") =>
-      [...queryKeys.nominations.lists(), gameId, team] as const,
     /** Parent key for possible nomination queries */
     possibles: () => [...queryKeys.nominations.all, "possible"] as const,
     /** Possible nominations for a nomination list */

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -111,6 +111,8 @@ describe("ValidateGameModal", () => {
       isFinalizing: false,
       isLoadingGameDetails: false,
       gameDetailsError: null,
+      homeNominationList: null,
+      awayNominationList: null,
     });
   });
 

--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -63,6 +63,8 @@ function ValidateGameModalComponent({
     pendingScorer: wizard.pendingScorer,
     scoresheetNotRequired: wizard.scoresheetNotRequired,
     state: wizard.validationState,
+    homeNominationList: wizard.homeNominationList,
+    awayNominationList: wizard.awayNominationList,
   };
 
   const stepHandlers = {

--- a/web-app/src/components/features/validation/AwayRosterPanel.tsx
+++ b/web-app/src/components/features/validation/AwayRosterPanel.tsx
@@ -1,4 +1,4 @@
-import type { Assignment } from "@/api/client";
+import type { Assignment, NominationList } from "@/api/client";
 import { getTeamNames } from "@/utils/assignment-helpers";
 import { RosterVerificationPanel } from "./RosterVerificationPanel";
 import type { RosterModifications } from "@/hooks/useNominationList";
@@ -11,6 +11,8 @@ interface AwayRosterPanelProps {
   readOnly?: boolean;
   /** Initial modifications to restore state when remounting */
   initialModifications?: RosterModifications;
+  /** Pre-fetched nomination list data to avoid duplicate API calls */
+  prefetchedNominationList?: NominationList | null;
 }
 
 export function AwayRosterPanel({
@@ -19,6 +21,7 @@ export function AwayRosterPanel({
   onAddPlayerSheetOpenChange,
   readOnly = false,
   initialModifications,
+  prefetchedNominationList,
 }: AwayRosterPanelProps) {
   const { awayTeam } = getTeamNames(assignment);
   const gameId = assignment.refereeGame?.game?.__identity ?? "";
@@ -32,6 +35,7 @@ export function AwayRosterPanel({
       onAddPlayerSheetOpenChange={onAddPlayerSheetOpenChange}
       readOnly={readOnly}
       initialModifications={initialModifications}
+      prefetchedNominationList={prefetchedNominationList}
     />
   );
 }

--- a/web-app/src/components/features/validation/HomeRosterPanel.tsx
+++ b/web-app/src/components/features/validation/HomeRosterPanel.tsx
@@ -1,4 +1,4 @@
-import type { Assignment } from "@/api/client";
+import type { Assignment, NominationList } from "@/api/client";
 import { getTeamNames } from "@/utils/assignment-helpers";
 import { RosterVerificationPanel } from "./RosterVerificationPanel";
 import type { RosterModifications } from "@/hooks/useNominationList";
@@ -11,6 +11,8 @@ interface HomeRosterPanelProps {
   readOnly?: boolean;
   /** Initial modifications to restore state when remounting */
   initialModifications?: RosterModifications;
+  /** Pre-fetched nomination list data to avoid duplicate API calls */
+  prefetchedNominationList?: NominationList | null;
 }
 
 export function HomeRosterPanel({
@@ -19,6 +21,7 @@ export function HomeRosterPanel({
   onAddPlayerSheetOpenChange,
   readOnly = false,
   initialModifications,
+  prefetchedNominationList,
 }: HomeRosterPanelProps) {
   const { homeTeam } = getTeamNames(assignment);
   const gameId = assignment.refereeGame?.game?.__identity ?? "";
@@ -32,6 +35,7 @@ export function HomeRosterPanel({
       onAddPlayerSheetOpenChange={onAddPlayerSheetOpenChange}
       readOnly={readOnly}
       initialModifications={initialModifications}
+      prefetchedNominationList={prefetchedNominationList}
     />
   );
 }

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import type { PossibleNomination } from "@/api/client";
+import type { PossibleNomination, NominationList } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import {
   useNominationList,
@@ -21,6 +21,8 @@ interface RosterVerificationPanelProps {
   readOnly?: boolean;
   /** Initial modifications to restore state when remounting */
   initialModifications?: RosterModifications;
+  /** Pre-fetched nomination list data to avoid duplicate API calls */
+  prefetchedNominationList?: NominationList | null;
 }
 
 export function RosterVerificationPanel({
@@ -31,12 +33,14 @@ export function RosterVerificationPanel({
   onAddPlayerSheetOpenChange,
   readOnly = false,
   initialModifications,
+  prefetchedNominationList,
 }: RosterVerificationPanelProps) {
   const { t } = useTranslation();
   const { nominationList, players, isLoading, isError, refetch } =
     useNominationList({
       gameId,
       team,
+      prefetchedData: prefetchedNominationList,
     });
 
   // Track locally added players - initialize from props to restore state when remounting

--- a/web-app/src/components/features/validation/StepRenderer.tsx
+++ b/web-app/src/components/features/validation/StepRenderer.tsx
@@ -1,4 +1,4 @@
-import type { Assignment } from "@/api/client";
+import type { Assignment, NominationList } from "@/api/client";
 import type { ValidationStepId } from "@/hooks/useValidateGameWizard";
 import type { UseValidationStateResult } from "@/hooks/useValidationState";
 import { useTranslation } from "@/hooks/useTranslation";
@@ -21,6 +21,8 @@ interface ValidationInfo {
   pendingScorer: UseValidationStateResult["pendingScorer"];
   scoresheetNotRequired: boolean;
   state: UseValidationStateResult["state"];
+  homeNominationList: NominationList | null;
+  awayNominationList: NominationList | null;
 }
 
 interface StepHandlers {
@@ -89,6 +91,7 @@ export function StepRenderer({
           onAddPlayerSheetOpenChange={handlers.onAddPlayerSheetOpenChange}
           readOnly={validation.isValidated}
           initialModifications={validation.state.homeRoster.modifications}
+          prefetchedNominationList={validation.homeNominationList}
         />
       )}
 
@@ -99,6 +102,7 @@ export function StepRenderer({
           onAddPlayerSheetOpenChange={handlers.onAddPlayerSheetOpenChange}
           readOnly={validation.isValidated}
           initialModifications={validation.state.awayRoster.modifications}
+          prefetchedNominationList={validation.awayNominationList}
         />
       )}
 

--- a/web-app/src/hooks/useNominationList.test.ts
+++ b/web-app/src/hooks/useNominationList.test.ts
@@ -295,12 +295,17 @@ describe("useNominationList", () => {
       );
     });
 
-    it("returns loading state when no prefetched data and not in demo mode", () => {
+    it("returns error state when no prefetched data and not in demo mode", () => {
       const { result } = renderHook(() =>
         useNominationList({ gameId: "test-game-1", team: "home" }),
       );
 
-      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toContain(
+        "Nomination list data not available",
+      );
       expect(result.current.nominationList).toBeNull();
       expect(result.current.players).toHaveLength(0);
     });

--- a/web-app/src/hooks/useNominationList.test.ts
+++ b/web-app/src/hooks/useNominationList.test.ts
@@ -1,23 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createElement, type ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
 import { useNominationList } from "./useNominationList";
 import * as authStore from "@/stores/auth";
 import * as demoStore from "@/stores/demo";
-import * as apiClient from "@/api/client";
 import type { NominationList } from "@/api/client";
 
 vi.mock("@/stores/auth");
 vi.mock("@/stores/demo");
-vi.mock("@/api/client", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("@/api/client")>();
-  return {
-    ...original,
-    getApiClient: vi.fn(),
-  };
-});
 
 const mockNominationList: NominationList = {
   __identity: "test-nomlist-1",
@@ -69,24 +58,6 @@ const mockNominationList: NominationList = {
   ],
 };
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children,
-    );
-  };
-}
-
 describe("useNominationList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -113,9 +84,8 @@ describe("useNominationList", () => {
         } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
       );
 
-      const { result } = renderHook(
-        () => useNominationList({ gameId: "test-game-1", team: "home" }),
-        { wrapper: createWrapper() },
+      const { result } = renderHook(() =>
+        useNominationList({ gameId: "test-game-1", team: "home" }),
       );
 
       expect(result.current.isLoading).toBe(false);
@@ -136,9 +106,8 @@ describe("useNominationList", () => {
         } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
       );
 
-      const { result } = renderHook(
-        () => useNominationList({ gameId: "test-game-1", team: "home" }),
-        { wrapper: createWrapper() },
+      const { result } = renderHook(() =>
+        useNominationList({ gameId: "test-game-1", team: "home" }),
       );
 
       const players = result.current.players;
@@ -178,9 +147,8 @@ describe("useNominationList", () => {
         } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
       );
 
-      const { result } = renderHook(
-        () => useNominationList({ gameId: "nonexistent-game", team: "home" }),
-        { wrapper: createWrapper() },
+      const { result } = renderHook(() =>
+        useNominationList({ gameId: "nonexistent-game", team: "home" }),
       );
 
       expect(result.current.nominationList).toBeNull();
@@ -211,24 +179,48 @@ describe("useNominationList", () => {
         } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
       );
 
-      const { result: homeResult } = renderHook(
-        () => useNominationList({ gameId: "test-game-1", team: "home" }),
-        { wrapper: createWrapper() },
+      const { result: homeResult } = renderHook(() =>
+        useNominationList({ gameId: "test-game-1", team: "home" }),
       );
 
-      const { result: awayResult } = renderHook(
-        () => useNominationList({ gameId: "test-game-1", team: "away" }),
-        { wrapper: createWrapper() },
+      const { result: awayResult } = renderHook(() =>
+        useNominationList({ gameId: "test-game-1", team: "away" }),
       );
 
       expect(homeResult.current.nominationList?.__identity).toBe("home-list");
       expect(awayResult.current.nominationList?.__identity).toBe("away-list");
     });
+
+    it("prefers prefetched data over demo data", () => {
+      const prefetchedList: NominationList = {
+        ...mockNominationList,
+        __identity: "prefetched-list",
+      };
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          nominationLists: {
+            "test-game-1": {
+              home: mockNominationList,
+              away: mockNominationList,
+            },
+          },
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
+
+      const { result } = renderHook(() =>
+        useNominationList({
+          gameId: "test-game-1",
+          team: "home",
+          prefetchedData: prefetchedList,
+        }),
+      );
+
+      expect(result.current.nominationList?.__identity).toBe("prefetched-list");
+    });
   });
 
-  describe("production mode", () => {
-    const mockGetNominationList = vi.fn();
-
+  describe("prefetched data", () => {
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({ isDemoMode: false } as ReturnType<
@@ -241,106 +233,76 @@ describe("useNominationList", () => {
           nominationLists: {},
         } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
       );
-
-      // Mock the API client
-      vi.mocked(apiClient.getApiClient).mockReturnValue({
-        getNominationList: mockGetNominationList,
-      } as unknown as ReturnType<typeof apiClient.getApiClient>);
     });
 
-    it("fetches nomination list from API in production mode", async () => {
-      mockGetNominationList.mockResolvedValue(mockNominationList);
-
-      const { result } = renderHook(
-        () => useNominationList({ gameId: "test-game-1", team: "home" }),
-        { wrapper: createWrapper() },
+    it("returns prefetched data when provided", () => {
+      const { result } = renderHook(() =>
+        useNominationList({
+          gameId: "test-game-1",
+          team: "home",
+          prefetchedData: mockNominationList,
+        }),
       );
 
-      // Should start loading
-      expect(result.current.isLoading).toBe(true);
-
-      // Wait for the query to complete
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      // Should have called the API with correct params
-      expect(mockGetNominationList).toHaveBeenCalledWith("test-game-1", "home");
-      expect(result.current.nominationList).toEqual(mockNominationList);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.nominationList).toBe(mockNominationList);
       expect(result.current.players).toHaveLength(2);
     });
 
-    it("fetches away team nomination list correctly", async () => {
-      mockGetNominationList.mockResolvedValue(mockNominationList);
-
-      const { result } = renderHook(
-        () => useNominationList({ gameId: "test-game-1", team: "away" }),
-        { wrapper: createWrapper() },
+    it("handles null prefetched data", () => {
+      const { result } = renderHook(() =>
+        useNominationList({
+          gameId: "test-game-1",
+          team: "home",
+          prefetchedData: null,
+        }),
       );
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(mockGetNominationList).toHaveBeenCalledWith("test-game-1", "away");
-    });
-
-    it("handles API returning null", async () => {
-      mockGetNominationList.mockResolvedValue(null);
-
-      const { result } = renderHook(
-        () => useNominationList({ gameId: "test-game-1", team: "home" }),
-        { wrapper: createWrapper() },
-      );
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
+      expect(result.current.isLoading).toBe(false);
       expect(result.current.nominationList).toBeNull();
       expect(result.current.players).toHaveLength(0);
     });
 
-    it("handles API errors", async () => {
-      mockGetNominationList.mockRejectedValue(new Error("API Error"));
-
-      const { result } = renderHook(
-        () => useNominationList({ gameId: "test-game-1", team: "home" }),
-        { wrapper: createWrapper() },
+    it("transforms prefetched nominations to players correctly", () => {
+      const { result } = renderHook(() =>
+        useNominationList({
+          gameId: "test-game-1",
+          team: "home",
+          prefetchedData: mockNominationList,
+        }),
       );
 
-      await waitFor(() => {
-        expect(result.current.isError).toBe(true);
-      });
+      const players = result.current.players;
+      expect(players).toHaveLength(2);
+      expect(players[0]!.displayName).toBe("John Doe");
+      expect(players[1]!.displayName).toBe("Jane Smith");
+    });
+  });
 
-      expect(result.current.error?.message).toBe("API Error");
+  describe("no data available", () => {
+    beforeEach(() => {
+      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
+        selector({ isDemoMode: false } as ReturnType<
+          typeof authStore.useAuthStore.getState
+        >),
+      );
+
+      vi.mocked(demoStore.useDemoStore).mockImplementation((selector) =>
+        selector({
+          nominationLists: {},
+        } as unknown as ReturnType<typeof demoStore.useDemoStore.getState>),
+      );
     });
 
-    it("respects enabled option", () => {
-      const { result } = renderHook(
-        () =>
-          useNominationList({
-            gameId: "test-game-1",
-            team: "home",
-            enabled: false,
-          }),
-        { wrapper: createWrapper() },
+    it("returns loading state when no prefetched data and not in demo mode", () => {
+      const { result } = renderHook(() =>
+        useNominationList({ gameId: "test-game-1", team: "home" }),
       );
 
-      // Query should be idle when disabled
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isLoading).toBe(true);
       expect(result.current.nominationList).toBeNull();
-      expect(mockGetNominationList).not.toHaveBeenCalled();
-    });
-
-    it("does not fetch when gameId is empty", () => {
-      const { result } = renderHook(
-        () => useNominationList({ gameId: "", team: "home" }),
-        { wrapper: createWrapper() },
-      );
-
-      expect(result.current.isLoading).toBe(false);
-      expect(mockGetNominationList).not.toHaveBeenCalled();
+      expect(result.current.players).toHaveLength(0);
     });
   });
 });

--- a/web-app/src/hooks/useNominationList.ts
+++ b/web-app/src/hooks/useNominationList.ts
@@ -164,9 +164,11 @@ export function useNominationList({
   return {
     nominationList: null,
     players: [],
-    isLoading: true,
-    isError: false,
-    error: null,
+    isLoading: false,
+    isError: true,
+    error: new Error(
+      "Nomination list data not available. Ensure prefetchedData is provided from getGameWithScoresheet().",
+    ),
     refetch: () => {
       // No-op - data should be provided via prefetchedData
     },

--- a/web-app/src/hooks/useValidateGameWizard.ts
+++ b/web-app/src/hooks/useValidateGameWizard.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import type { Assignment } from "@/api/client";
+import type { Assignment, NominationList } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { logger } from "@/utils/logger";
 import { useWizardNavigation } from "@/hooks/useWizardNavigation";
@@ -50,6 +50,8 @@ export interface UseValidateGameWizardResult {
   isFinalizing: boolean;
   isLoadingGameDetails: boolean;
   gameDetailsError: Error | null;
+  homeNominationList: NominationList | null;
+  awayNominationList: NominationList | null;
 
   // UI state
   showUnsavedDialog: boolean;
@@ -117,6 +119,8 @@ export function useValidateGameWizard({
     isFinalizing,
     isLoadingGameDetails,
     gameDetailsError,
+    homeNominationList,
+    awayNominationList,
   } = useValidationState(gameId);
 
   const wizardSteps = useMemo<ValidationStep[]>(
@@ -304,6 +308,8 @@ export function useValidateGameWizard({
     isFinalizing,
     isLoadingGameDetails,
     gameDetailsError,
+    homeNominationList,
+    awayNominationList,
 
     // UI state
     showUnsavedDialog,

--- a/web-app/src/hooks/useValidationState.ts
+++ b/web-app/src/hooks/useValidationState.ts
@@ -121,6 +121,16 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     [gameDetailsQuery.data],
   );
 
+  const homeNominationList = useMemo(
+    () => gameDetailsQuery.data?.nominationListOfTeamHome ?? null,
+    [gameDetailsQuery.data?.nominationListOfTeamHome],
+  );
+
+  const awayNominationList = useMemo(
+    () => gameDetailsQuery.data?.nominationListOfTeamAway ?? null,
+    [gameDetailsQuery.data?.nominationListOfTeamAway],
+  );
+
   const isDirty = useMemo(() => {
     return (
       hasRosterModifications(state.homeRoster.modifications) ||
@@ -243,5 +253,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     isFinalizing,
     isLoadingGameDetails: gameDetailsQuery.isLoading,
     gameDetailsError: gameDetailsQuery.error,
+    homeNominationList,
+    awayNominationList,
   };
 }

--- a/web-app/src/hooks/validation/types.ts
+++ b/web-app/src/hooks/validation/types.ts
@@ -4,6 +4,7 @@
 
 import type { ValidatedPersonSearchResult } from "@/api/validation";
 import type { RosterModifications } from "@/hooks/useNominationList";
+import type { NominationList } from "@/api/client";
 
 /**
  * State for a roster panel (home or away team).
@@ -112,6 +113,10 @@ export interface UseValidationStateResult {
   isLoadingGameDetails: boolean;
   /** Error from game details loading */
   gameDetailsError: Error | null;
+  /** Pre-fetched home team nomination list from game details */
+  homeNominationList: NominationList | null;
+  /** Pre-fetched away team nomination list from game details */
+  awayNominationList: NominationList | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Optimizes game validation API to fetch both team rosters in a single API call instead of making separate calls
- Removes the standalone `getNominationList` method that is no longer needed
- Fixes a response extraction bug where API returned `{ game: GameDetails }` but code expected `GameDetails` directly

## Changes

- **web-app/src/api/client.ts**:
  - Updated `getGameWithScoresheet` to include full player details for both `nominationListOfTeamHome` and `nominationListOfTeamAway`
  - Fixed response extraction to properly unwrap `{ game: ... }` wrapper
  - Removed deprecated `getNominationList` method

- **web-app/src/api/mock-api.ts**:
  - Removed `getNominationList` method

- **web-app/src/api/queryKeys.ts**:
  - Removed unused `nominations.lists()` and `nominations.list()` query keys

- **web-app/src/hooks/useNominationList.ts**:
  - Simplified to only use prefetched data or demo mode (no API fallback)
  - Added `prefetchedData` parameter support

- **web-app/src/hooks/validation/types.ts**:
  - Added `homeNominationList` and `awayNominationList` to `UseValidationStateResult`

- **web-app/src/hooks/useValidationState.ts**:
  - Exposes nomination lists from game details

- **web-app/src/hooks/useValidateGameWizard.ts**:
  - Passes nomination lists through to components

- **web-app/src/components/features/ValidateGameModal.tsx**:
  - Includes nomination lists in validationInfo

- **web-app/src/components/features/validation/StepRenderer.tsx**:
  - Passes prefetchedNominationList to roster panels

- **web-app/src/components/features/validation/HomeRosterPanel.tsx & AwayRosterPanel.tsx**:
  - Accept and pass prefetchedNominationList prop

- **web-app/src/components/features/validation/RosterVerificationPanel.tsx**:
  - Uses prefetchedNominationList with useNominationList hook

- **Test files**:
  - Removed getNominationList tests from client.test.ts and contract.test.ts
  - Simplified useNominationList.test.ts to test new behavior

## Test Plan

- [ ] Verify game validation modal loads both team rosters correctly
- [ ] Verify roster panels display player details (name, shirt number, license category)
- [ ] Verify demo mode still works correctly with mock data
- [ ] Verify no duplicate API calls are made for nomination lists
- [ ] Run `npm run lint && npm test && npm run build` - all pass
