### PR TITLE
fix(auth): preserve occupations when activeParty data is missing

### DIFF
--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -83,6 +83,10 @@ const SESSION_CHECK_TIMEOUT_MS = 10_000;
  * Uses groupedEligibleAttributeValues as the primary source for associations.
  * Falls back to eligibleAttributeValues if groupedEligibleAttributeValues is empty,
  * which can happen on some pages or with certain user configurations.
+ *
+ * IMPORTANT: Preserves existing occupations if new parsing returns empty.
+ * This prevents the association dropdown from disappearing when loading a page
+ * that doesn't have complete activeParty data embedded in the HTML.
  */
 function deriveUserWithOccupations(
   activeParty: {
@@ -98,7 +102,16 @@ function deriveUserWithOccupations(
       ? activeParty.groupedEligibleAttributeValues
       : activeParty?.eligibleAttributeValues ?? null;
 
-  const occupations = parseOccupationsFromActiveParty(attributeValues);
+  const parsedOccupations = parseOccupationsFromActiveParty(attributeValues);
+
+  // Preserve existing occupations if parsing returns empty
+  // This prevents the dropdown from disappearing when navigating to pages
+  // that don't have complete activeParty data
+  const occupations =
+    parsedOccupations.length > 0
+      ? parsedOccupations
+      : (currentUser?.occupations ?? []);
+
   const activeOccupationId = currentActiveOccupationId ?? occupations[0]?.id ?? null;
 
   const user = currentUser


### PR DESCRIPTION
## Summary

- Fixed association switching not working for users with multiple associations
- The association dropdown was disappearing after page loads because occupations were being overwritten with an empty array when the dashboard HTML didn't contain complete activeParty data

## Changes

- Modified `deriveUserWithOccupations()` in `web-app/src/stores/auth.ts` to preserve existing occupations when the new parsing returns empty
- Added test case in `web-app/src/stores/auth.test.ts` to verify occupations are preserved when dashboard has no activeParty data

## Test Plan

- [ ] Log in with a user who has multiple associations (e.g., SV, SVRZ, SVRBA)
- [ ] Verify the association dropdown appears in the header
- [ ] Switch between associations using the dropdown
- [ ] Refresh the page and verify the dropdown still shows all associations
- [ ] Navigate between different pages and verify the dropdown remains visible
- [ ] Verify the selected association persists after switching
