### PR TITLE
fix(transport): prefer real OJP API when configured over mock transport

### DIFF
--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -111,14 +111,15 @@ export function useTravelTime(
         longitude: homeLocation.longitude,
       };
 
-      // Use mock transport in demo mode, real API otherwise
+      // Prefer real OJP API when configured, fall back to mock transport
+      // This matches the logic in useSbbUrl for consistency
       let result: TravelTimeResult;
-      if (isDemoMode) {
-        result = await calculateMockTravelTime(fromCoords, hallCoords);
-      } else {
+      if (isOjpConfigured()) {
         result = await calculateTravelTime(fromCoords, hallCoords, {
           targetArrivalTime,
         });
+      } else {
+        result = await calculateMockTravelTime(fromCoords, hallCoords);
       }
 
       // Persist successful result to localStorage


### PR DESCRIPTION
## Summary

- Fixed inconsistent behavior between `useTravelTime` and `useSbbUrl` hooks for transport API selection

## Changes

- `web-app/src/hooks/useTravelTime.ts`: Check `isOjpConfigured()` instead of `isDemoMode` when selecting transport API
  - Previously: demo mode always used mock transport, even when real OJP API was available
  - Now: prefers real OJP API when configured, matching `useSbbUrl` behavior

## Test Plan

- [ ] Enable demo mode on production and verify travel times use real OJP API (not mock estimates)
- [ ] Verify SBB URL button and travel time display show consistent data
- [ ] Test with OJP API key not configured - should fall back to mock transport
- [ ] All existing tests pass
