### PR TITLE
fix(transport): reduce cache TTL to avoid 32-bit integer overflow

### DIFF
--- a/docs/DATA_RETENTION.md
+++ b/docs/DATA_RETENTION.md
@@ -20,7 +20,7 @@ This data never leaves your device and is not transmitted to our servers.
 
 | Data | Purpose | Retention |
 |------|---------|-----------|
-| Travel times to sports halls | Avoid repeated API calls | 7 days, auto-expires |
+| Travel times to sports halls | Avoid repeated API calls | 14 days, auto-expires |
 
 ### Authentication (`volleykit-auth` in localStorage)
 

--- a/web-app/src/hooks/useTravelTime.test.tsx
+++ b/web-app/src/hooks/useTravelTime.test.tsx
@@ -18,8 +18,8 @@ vi.mock("@/services/transport", () => ({
   getCachedTravelTime: vi.fn(() => null),
   setCachedTravelTime: vi.fn(),
   removeCachedTravelTime: vi.fn(),
-  TRAVEL_TIME_STALE_TIME: 30 * 24 * 60 * 60 * 1000,
-  TRAVEL_TIME_GC_TIME: 30 * 24 * 60 * 60 * 1000,
+  TRAVEL_TIME_STALE_TIME: 14 * 24 * 60 * 60 * 1000,
+  TRAVEL_TIME_GC_TIME: 14 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock the stores - using AnyFunction to avoid strict type checking in tests

--- a/web-app/src/hooks/useTravelTimeFilter.test.tsx
+++ b/web-app/src/hooks/useTravelTimeFilter.test.tsx
@@ -20,8 +20,8 @@ vi.mock("@/services/transport", () => ({
   getDayType: vi.fn(() => "weekday"),
   getCachedTravelTime: vi.fn(() => null),
   setCachedTravelTime: vi.fn(),
-  TRAVEL_TIME_STALE_TIME: 30 * 24 * 60 * 60 * 1000,
-  TRAVEL_TIME_GC_TIME: 30 * 24 * 60 * 60 * 1000,
+  TRAVEL_TIME_STALE_TIME: 14 * 24 * 60 * 60 * 1000,
+  TRAVEL_TIME_GC_TIME: 14 * 24 * 60 * 60 * 1000,
 }));
 
 vi.mock("@/stores/auth", () => ({

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -342,7 +342,7 @@ const de: Translations = {
       arrivalTime: "Ankunft vor Spielbeginn",
       arrivalTimeDescription: "Minuten vor Spielbeginn ankommen (pro Verband)",
       cacheInfo:
-        "Reisezeiten werden nach Tagestyp (Werktag/Samstag/Sonntag) für 30 Tage zwischengespeichert.",
+        "Reisezeiten werden nach Tagestyp (Werktag/Samstag/Sonntag) für 14 Tage zwischengespeichert.",
       cacheEntries: "{count} gespeicherte Routen",
       refreshCache: "Cache leeren",
       refreshCacheConfirm:
@@ -355,7 +355,7 @@ const de: Translations = {
         "Diese App speichert bestimmte Daten lokal in Ihrem Browser. Diese Daten verlassen Ihr Gerät nie und werden nicht an unsere Server übertragen.",
       homeLocation: "Ihr Heimatstandort (für Distanzfilterung)",
       filterPreferences: "Filtereinstellungen",
-      travelTimeCache: "Zwischengespeicherte Reisezeiten (läuft nach 30 Tagen ab)",
+      travelTimeCache: "Zwischengespeicherte Reisezeiten (läuft nach 14 Tagen ab)",
       languagePreference: "Spracheinstellung",
       clearData: "Lokale Daten löschen",
       clearDataConfirm:

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -340,7 +340,7 @@ const en: Translations = {
       arrivalTime: "Arrive before game",
       arrivalTimeDescription: "Minutes to arrive before game start (per association)",
       cacheInfo:
-        "Travel times are cached by day type (weekday/Saturday/Sunday) for 30 days.",
+        "Travel times are cached by day type (weekday/Saturday/Sunday) for 14 days.",
       cacheEntries: "{count} cached routes",
       refreshCache: "Clear Cache",
       refreshCacheConfirm:
@@ -353,7 +353,7 @@ const en: Translations = {
         "This app stores certain data locally in your browser. This data never leaves your device and is not transmitted to our servers.",
       homeLocation: "Your home location (for distance filtering)",
       filterPreferences: "Filter preferences",
-      travelTimeCache: "Cached travel times (expires after 30 days)",
+      travelTimeCache: "Cached travel times (expires after 14 days)",
       languagePreference: "Language preference",
       clearData: "Clear Local Data",
       clearDataConfirm:

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -341,7 +341,7 @@ const fr: Translations = {
       arrivalTime: "Arrivée avant le match",
       arrivalTimeDescription: "Minutes d'arrivée avant le début du match (par association)",
       cacheInfo:
-        "Les temps de trajet sont mis en cache par type de jour (semaine/samedi/dimanche) pendant 30 jours.",
+        "Les temps de trajet sont mis en cache par type de jour (semaine/samedi/dimanche) pendant 14 jours.",
       cacheEntries: "{count} trajets en cache",
       refreshCache: "Vider le cache",
       refreshCacheConfirm:
@@ -354,7 +354,7 @@ const fr: Translations = {
         "Cette application stocke certaines données localement dans votre navigateur. Ces données ne quittent jamais votre appareil et ne sont pas transmises à nos serveurs.",
       homeLocation: "Votre emplacement domicile (pour le filtrage par distance)",
       filterPreferences: "Préférences de filtre",
-      travelTimeCache: "Temps de trajet en cache (expire après 30 jours)",
+      travelTimeCache: "Temps de trajet en cache (expire après 14 jours)",
       languagePreference: "Préférence de langue",
       clearData: "Effacer les données locales",
       clearDataConfirm:

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -339,7 +339,7 @@ const it: Translations = {
       arrivalTime: "Arrivo prima della partita",
       arrivalTimeDescription: "Minuti di anticipo all'arrivo (per associazione)",
       cacheInfo:
-        "I tempi di viaggio sono memorizzati in cache per tipo di giorno (feriale/sabato/domenica) per 30 giorni.",
+        "I tempi di viaggio sono memorizzati in cache per tipo di giorno (feriale/sabato/domenica) per 14 giorni.",
       cacheEntries: "{count} percorsi in cache",
       refreshCache: "Svuota cache",
       refreshCacheConfirm:
@@ -352,7 +352,7 @@ const it: Translations = {
         "Questa app memorizza alcuni dati localmente nel tuo browser. Questi dati non lasciano mai il tuo dispositivo e non vengono trasmessi ai nostri server.",
       homeLocation: "La tua posizione casa (per il filtraggio per distanza)",
       filterPreferences: "Preferenze di filtro",
-      travelTimeCache: "Tempi di viaggio in cache (scadono dopo 30 giorni)",
+      travelTimeCache: "Tempi di viaggio in cache (scadono dopo 14 giorni)",
       languagePreference: "Preferenza di lingua",
       clearData: "Cancella dati locali",
       clearDataConfirm:

--- a/web-app/src/services/transport/cache.ts
+++ b/web-app/src/services/transport/cache.ts
@@ -14,10 +14,16 @@ import type { Coordinates } from "./types";
 /** Day types for Swiss public transport schedules */
 export type DayType = "weekday" | "saturday" | "sunday";
 
-/** Cache TTL: 30 days in milliseconds */
-export const TRAVEL_TIME_CACHE_TTL = 30 * 24 * 60 * 60 * 1000;
+/**
+ * Cache TTL: 14 days in milliseconds.
+ *
+ * Note: Using 14 days instead of 30 to stay within JavaScript's 32-bit
+ * signed integer limit for setTimeout (~24.8 days max). Values above
+ * ~2.147 billion ms cause silent clamping to 1ms.
+ */
+export const TRAVEL_TIME_CACHE_TTL = 14 * 24 * 60 * 60 * 1000;
 
-/** Cache stale time: 30 days (TanStack Query config) */
+/** Cache stale time: 14 days (TanStack Query config) */
 export const TRAVEL_TIME_STALE_TIME = TRAVEL_TIME_CACHE_TTL;
 
 /** Garbage collection time: same as TTL */


### PR DESCRIPTION
## Summary

- Fixed 32-bit integer overflow in travel time cache TTL that caused `TimeoutOverflowWarning` during tests
- Reduced cache TTL from 30 days to 14 days to stay within JavaScript's setTimeout limit (~24.8 days max)
- Updated all user-facing documentation and translations to reflect the new 14-day cache duration

## Changes

- `src/services/transport/cache.ts`: Changed `TRAVEL_TIME_CACHE_TTL` from 30 days (2.59B ms) to 14 days (1.21B ms) with explanatory comment
- `src/hooks/useTravelTime.test.tsx`: Updated mock values to match new TTL
- `src/hooks/useTravelTimeFilter.test.tsx`: Updated mock values to match new TTL
- `src/i18n/locales/en.ts`: Updated cache info and data retention strings (30 → 14 days)
- `src/i18n/locales/de.ts`: Updated cache info and data retention strings (30 → 14 Tage)
- `src/i18n/locales/fr.ts`: Updated cache info and data retention strings (30 → 14 jours)
- `src/i18n/locales/it.ts`: Updated cache info and data retention strings (30 → 14 giorni)
- `docs/DATA_RETENTION.md`: Updated travel time cache retention from 7 days to 14 days

## Test Plan

- [x] All 2396 unit tests pass
- [x] No `TimeoutOverflowWarning` messages in test output
- [x] ESLint passes with 0 warnings
- [ ] Verify Settings page displays correct cache duration in all 4 languages
- [ ] Verify travel time caching still works correctly in the app
