### PR TITLE
feat(validation): add vertical swipe-to-dismiss for wizard

### DIFF
--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -130,6 +130,7 @@ function ValidateGameModalComponent({
           totalSteps={wizard.totalSteps}
           onSwipeNext={wizard.goNext}
           onSwipePrevious={wizard.goBack}
+          onDismiss={wizard.attemptClose}
           swipeEnabled={wizard.isSwipeEnabled}
         >
           <div className="max-h-80 overflow-y-auto">

--- a/web-app/src/components/ui/WizardStepContainer.tsx
+++ b/web-app/src/components/ui/WizardStepContainer.tsx
@@ -20,6 +20,18 @@ const SWIPE_THRESHOLD_RATIO = 0.3;
  */
 const TRANSITION_DURATION_MS = 300;
 
+/**
+ * Minimum opacity during dismiss swipe gesture.
+ * Prevents content from becoming invisible while still providing visual feedback.
+ */
+const MINIMUM_DISMISS_OPACITY = 0.3;
+
+/**
+ * Distance in pixels at which opacity reaches minimum during dismiss swipe.
+ * Higher values = slower opacity reduction; lower values = faster reduction.
+ */
+const OPACITY_REDUCTION_DISTANCE_PX = 200;
+
 /** Animation phases for step transitions */
 type AnimationPhase = "idle" | "exiting" | "entering";
 
@@ -152,6 +164,7 @@ export function WizardStepContainer({
 
   // Use vertical swipe dismiss hook
   // Allows users to swipe up/down on step content to dismiss the wizard
+  // Share containerRef with horizontal swipe hook for scroll detection
   const {
     translateY,
     isDragging: isDraggingVertical,
@@ -159,6 +172,7 @@ export function WizardStepContainer({
   } = useVerticalSwipeDismiss({
     enabled: swipeEnabled && !!onDismiss,
     onDismiss,
+    containerRef,
   });
 
   // Combine horizontal and vertical gesture handlers
@@ -255,7 +269,10 @@ export function WizardStepContainer({
   // Calculate opacity reduction during vertical swipe (visual dismiss feedback)
   // Full opacity at translateY=0, reducing as user swipes further
   const dismissOpacity = isDraggingVertical
-    ? Math.max(0.3, 1 - Math.abs(translateY) / 200)
+    ? Math.max(
+        MINIMUM_DISMISS_OPACITY,
+        1 - Math.abs(translateY) / OPACITY_REDUCTION_DISTANCE_PX,
+      )
     : 1;
 
   return (

--- a/web-app/src/hooks/useVerticalSwipeDismiss.test.ts
+++ b/web-app/src/hooks/useVerticalSwipeDismiss.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { canElementScroll } from "./useVerticalSwipeDismiss";
+
+/**
+ * Helper to create a mock scrollable element with specified scroll properties.
+ * JSDOM doesn't calculate scroll dimensions, so we mock them directly.
+ */
+function createMockScrollableElement(
+  parent: HTMLElement,
+  options: {
+    overflowY?: string;
+    scrollTop?: number;
+    scrollHeight?: number;
+    clientHeight?: number;
+  },
+): HTMLDivElement {
+  const element = document.createElement("div");
+  parent.appendChild(element);
+
+  // Mock getComputedStyle to return the overflow value
+  const originalGetComputedStyle = window.getComputedStyle;
+  vi.spyOn(window, "getComputedStyle").mockImplementation((el) => {
+    if (el === element) {
+      return {
+        ...originalGetComputedStyle(el),
+        overflowY: options.overflowY ?? "visible",
+      } as CSSStyleDeclaration;
+    }
+    return originalGetComputedStyle(el);
+  });
+
+  // Mock scroll properties
+  Object.defineProperty(element, "scrollTop", {
+    value: options.scrollTop ?? 0,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    value: options.scrollHeight ?? 100,
+    configurable: true,
+  });
+  Object.defineProperty(element, "clientHeight", {
+    value: options.clientHeight ?? 100,
+    configurable: true,
+  });
+
+  return element;
+}
+
+describe("canElementScroll", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    vi.restoreAllMocks();
+  });
+
+  describe("null and invalid inputs", () => {
+    it("returns false when element is null", () => {
+      expect(canElementScroll(null, container, "down")).toBe(false);
+    });
+
+    it("returns false when container is null", () => {
+      const element = document.createElement("div");
+      container.appendChild(element);
+      expect(canElementScroll(element, null, "down")).toBe(false);
+    });
+
+    it("returns false when element is not an HTMLElement", () => {
+      const textNode = document.createTextNode("text");
+      expect(canElementScroll(textNode, container, "down")).toBe(false);
+    });
+
+    it("returns false when both element and container are null", () => {
+      expect(canElementScroll(null, null, "down")).toBe(false);
+    });
+  });
+
+  describe("scrollable element detection - can scroll down", () => {
+    it("returns true when element can scroll down (scrollTop at 0, content overflows)", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 0,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(true);
+    });
+
+    it("returns false when element cannot scroll down (already at bottom)", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 200, // scrollHeight - clientHeight
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(false);
+    });
+
+    it("returns false when content does not overflow (scrollHeight equals clientHeight)", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 0,
+        scrollHeight: 100,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(false);
+    });
+  });
+
+  describe("scrollable element detection - can scroll up", () => {
+    it("returns true when element can scroll up (scrollTop > 1)", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 50,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "up")).toBe(true);
+    });
+
+    it("returns false when element cannot scroll up (at top)", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 0,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "up")).toBe(false);
+    });
+  });
+
+  describe("non-scrollable elements", () => {
+    it("returns false for element with overflow: visible", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "visible",
+        scrollTop: 0,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(false);
+    });
+
+    it("returns false for element with overflow: hidden", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "hidden",
+        scrollTop: 0,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(false);
+    });
+  });
+
+  describe("overflow styles", () => {
+    it("detects overflow: scroll", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "scroll",
+        scrollTop: 0,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(true);
+    });
+
+    it("detects overflow: auto", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 0,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(true);
+    });
+  });
+
+  describe("nested scrollable containers", () => {
+    it("finds scrollable ancestor of deep child", () => {
+      // Create a scrollable parent
+      const scrollableParent = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 0,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      // Create a non-scrollable child inside the scrollable parent
+      const deepChild = document.createElement("div");
+      scrollableParent.appendChild(deepChild);
+
+      expect(canElementScroll(deepChild, container, "down")).toBe(true);
+    });
+
+    it("stops at container boundary and returns false if no scrollable found", () => {
+      const nonScrollableChild = document.createElement("div");
+      container.appendChild(nonScrollableChild);
+
+      // Mock getComputedStyle for the non-scrollable child
+      vi.spyOn(window, "getComputedStyle").mockImplementation(() => {
+        return { overflowY: "visible" } as CSSStyleDeclaration;
+      });
+
+      expect(canElementScroll(nonScrollableChild, container, "down")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("scroll boundary conditions with 1px tolerance", () => {
+    it("returns true when more than 1px from bottom", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 197, // 3px from max (300 - 100 = 200)
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(true);
+    });
+
+    it("returns false when within 1px of bottom", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 199.5, // 0.5px from max
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "down")).toBe(false);
+    });
+
+    it("returns true when more than 1px from top", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 2,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "up")).toBe(true);
+    });
+
+    it("returns false when within 1px of top", () => {
+      const element = createMockScrollableElement(container, {
+        overflowY: "auto",
+        scrollTop: 0.5,
+        scrollHeight: 300,
+        clientHeight: 100,
+      });
+
+      expect(canElementScroll(element, container, "up")).toBe(false);
+    });
+  });
+
+  describe("element is same as container", () => {
+    it("returns false when element equals container (loop does not execute)", () => {
+      expect(canElementScroll(container, container, "down")).toBe(false);
+    });
+  });
+});

--- a/web-app/src/hooks/useVerticalSwipeDismiss.ts
+++ b/web-app/src/hooks/useVerticalSwipeDismiss.ts
@@ -1,0 +1,293 @@
+import { useState, useRef, useCallback } from "react";
+
+/**
+ * Minimum movement in pixels before determining swipe direction.
+ * Prevents micro-movements from being interpreted as swipes.
+ */
+const DIRECTION_THRESHOLD_PX = 10;
+
+/**
+ * Minimum vertical swipe distance as ratio of container height to trigger dismiss.
+ * 25% threshold balances ease of intentional swipes vs preventing accidental dismissals.
+ */
+const DISMISS_THRESHOLD_RATIO = 0.25;
+
+/**
+ * Maximum translateY as multiplier of threshold (adds resistance at edges).
+ */
+const MAX_SWIPE_MULTIPLIER = 1.5;
+
+/** Direction determined by initial gesture movement */
+type SwipeDirection = "horizontal" | "vertical" | null;
+
+/**
+ * Checks if an element or any of its parents (up to container) is a scrollable element
+ * that can scroll in the given vertical direction.
+ */
+function canElementScroll(
+  element: EventTarget | null,
+  container: HTMLElement | null,
+  direction: "up" | "down",
+): boolean {
+  if (!element || !(element instanceof HTMLElement) || !container) {
+    return false;
+  }
+
+  let current: HTMLElement | null = element;
+
+  while (current && current !== container) {
+    const { overflowY } = getComputedStyle(current);
+    const isScrollable = overflowY === "auto" || overflowY === "scroll";
+
+    if (isScrollable) {
+      const { scrollTop, scrollHeight, clientHeight } = current;
+      const canScrollDown = scrollTop + clientHeight < scrollHeight - 1;
+      const canScrollUp = scrollTop > 1;
+
+      if (direction === "down" && canScrollDown) return true;
+      if (direction === "up" && canScrollUp) return true;
+    }
+
+    current = current.parentElement;
+  }
+
+  return false;
+}
+
+interface UseVerticalSwipeDismissOptions {
+  /** Whether swipe gestures are enabled (default: true) */
+  enabled?: boolean;
+  /** Called when dismiss gesture is triggered */
+  onDismiss?: () => void;
+}
+
+interface UseVerticalSwipeDismissReturn {
+  /** Ref to attach to the swipeable container element */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Current vertical translation in pixels */
+  translateY: number;
+  /** Whether user is currently dragging vertically */
+  isDragging: boolean;
+  /** Touch and mouse event handlers to spread on the container */
+  handlers: {
+    onTouchStart: (e: React.TouchEvent) => void;
+    onTouchMove: (e: React.TouchEvent) => void;
+    onTouchEnd: () => void;
+    onMouseDown: (e: React.MouseEvent) => void;
+    onMouseMove: (e: React.MouseEvent) => void;
+    onMouseUp: () => void;
+    onMouseLeave: () => void;
+  };
+}
+
+/**
+ * Hook for handling vertical swipe-to-dismiss gestures.
+ *
+ * Allows users to swipe up or down on content to dismiss a modal or wizard.
+ * Works alongside horizontal swipe gestures (each gesture is either horizontal OR vertical).
+ *
+ * @example
+ * ```tsx
+ * function MyDismissableContent({ onClose }) {
+ *   const { containerRef, translateY, isDragging, handlers } = useVerticalSwipeDismiss({
+ *     onDismiss: onClose,
+ *   });
+ *
+ *   return (
+ *     <div ref={containerRef} {...handlers}>
+ *       <div style={{
+ *         transform: `translateY(${translateY}px)`,
+ *         opacity: 1 - Math.abs(translateY) / 300,
+ *       }}>
+ *         Content that can be swiped away
+ *       </div>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useVerticalSwipeDismiss(
+  options: UseVerticalSwipeDismissOptions = {},
+): UseVerticalSwipeDismissReturn {
+  const { enabled = true, onDismiss } = options;
+
+  const [translateY, setTranslateY] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const directionRef = useRef<SwipeDirection>(null);
+  const touchActiveRef = useRef(false);
+  const mouseActiveRef = useRef(false);
+  const currentTranslateRef = useRef(0);
+  // Track the element where the gesture started (for scroll detection)
+  const touchTargetRef = useRef<EventTarget | null>(null);
+  // Track if we've decided to let the browser handle scrolling
+  const isScrollingRef = useRef(false);
+
+  const resetPosition = useCallback(() => {
+    setTranslateY(0);
+    currentTranslateRef.current = 0;
+  }, []);
+
+  const handleDragStart = useCallback(
+    (clientX: number, clientY: number, target: EventTarget | null) => {
+      if (!enabled) return;
+
+      startXRef.current = clientX;
+      startYRef.current = clientY;
+      directionRef.current = null;
+      currentTranslateRef.current = 0;
+      touchTargetRef.current = target;
+      isScrollingRef.current = false;
+      setIsDragging(true);
+    },
+    [enabled],
+  );
+
+  const handleDragMove = useCallback(
+    (clientX: number, clientY: number, preventDefault: () => void) => {
+      if (!enabled || isScrollingRef.current) return;
+
+      const diffX = clientX - startXRef.current;
+      const diffY = clientY - startYRef.current;
+
+      // Determine swipe direction on first significant movement
+      if (directionRef.current === null) {
+        if (
+          Math.abs(diffX) > DIRECTION_THRESHOLD_PX ||
+          Math.abs(diffY) > DIRECTION_THRESHOLD_PX
+        ) {
+          directionRef.current =
+            Math.abs(diffY) > Math.abs(diffX) ? "vertical" : "horizontal";
+
+          // If vertical, check if we should let the browser handle scrolling
+          if (directionRef.current === "vertical") {
+            const scrollDirection = diffY > 0 ? "up" : "down";
+            // If the element can scroll in this direction, let browser handle it
+            if (
+              canElementScroll(
+                touchTargetRef.current,
+                containerRef.current,
+                scrollDirection,
+              )
+            ) {
+              isScrollingRef.current = true;
+              setIsDragging(false);
+              return;
+            }
+          }
+        }
+      }
+
+      // Only handle vertical swipes (when not scrolling)
+      if (directionRef.current === "vertical" && !isScrollingRef.current) {
+        preventDefault();
+
+        // Get container height for threshold calculation
+        const containerHeight = containerRef.current?.offsetHeight ?? 300;
+        const threshold = containerHeight * DISMISS_THRESHOLD_RATIO;
+        const maxSwipe = threshold * MAX_SWIPE_MULTIPLIER;
+
+        // Apply resistance at edges
+        const clampedTranslate = Math.max(-maxSwipe, Math.min(maxSwipe, diffY));
+
+        currentTranslateRef.current = clampedTranslate;
+        setTranslateY(clampedTranslate);
+      }
+    },
+    [enabled],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    // Reset scrolling flag
+    isScrollingRef.current = false;
+    touchTargetRef.current = null;
+
+    if (directionRef.current !== "vertical") {
+      directionRef.current = null;
+      setIsDragging(false);
+      return;
+    }
+
+    const finalTranslateY = currentTranslateRef.current;
+    const containerHeight = containerRef.current?.offsetHeight ?? 300;
+    const threshold = containerHeight * DISMISS_THRESHOLD_RATIO;
+
+    // Check if swipe exceeded threshold (in either direction)
+    if (Math.abs(finalTranslateY) > threshold && onDismiss) {
+      onDismiss();
+    }
+
+    // Always reset position (dismiss handler closes the modal)
+    resetPosition();
+    directionRef.current = null;
+    setIsDragging(false);
+  }, [onDismiss, resetPosition]);
+
+  // Touch event handlers
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      touchActiveRef.current = true;
+      handleDragStart(touch.clientX, touch.clientY, e.target);
+    },
+    [handleDragStart],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!touchActiveRef.current) return;
+      const touch = e.touches[0];
+      if (!touch) return;
+      handleDragMove(touch.clientX, touch.clientY, () => e.preventDefault());
+    },
+    [handleDragMove],
+  );
+
+  const handleTouchEnd = useCallback(() => {
+    if (!touchActiveRef.current) return;
+    touchActiveRef.current = false;
+    handleDragEnd();
+  }, [handleDragEnd]);
+
+  // Mouse event handlers
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      mouseActiveRef.current = true;
+      handleDragStart(e.clientX, e.clientY, e.target);
+    },
+    [handleDragStart],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!mouseActiveRef.current) return;
+      handleDragMove(e.clientX, e.clientY, () => e.preventDefault());
+    },
+    [handleDragMove],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    if (!mouseActiveRef.current) return;
+    mouseActiveRef.current = false;
+    handleDragEnd();
+  }, [handleDragEnd]);
+
+  return {
+    containerRef,
+    translateY,
+    isDragging,
+    handlers: {
+      onTouchStart: handleTouchStart,
+      onTouchMove: handleTouchMove,
+      onTouchEnd: handleTouchEnd,
+      onMouseDown: handleMouseDown,
+      onMouseMove: handleMouseMove,
+      onMouseUp: handleMouseUp,
+      onMouseLeave: handleMouseUp,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add vertical swipe-to-dismiss gesture for the game validation wizard
- Users can now swipe up or down on wizard step content to dismiss the modal
- Smart scroll detection ensures the gesture doesn't interfere with scrollable content (roster panels)

## Changes

- **New hook**: `useVerticalSwipeDismiss.ts` - Handles vertical swipe gestures with scroll-aware logic
  - Detects scrollable containers and only captures swipe when content can't scroll further in that direction
  - 25% threshold of container height required to trigger dismiss
  - Visual feedback via opacity reduction during swipe
- **WizardStepContainer.tsx**: Integrated vertical swipe dismiss alongside existing horizontal step navigation
  - Combined gesture handlers for both horizontal (step navigation) and vertical (dismiss) swipes
  - Added translateY transform and opacity feedback during vertical drag
- **ValidateGameModal.tsx**: Connected `wizard.attemptClose` to the new `onDismiss` prop

## Test Plan

- [x] Open the validation wizard on a game
- [x] On a step with scrollable content (roster panel with many players), verify scrolling still works normally
- [ ] At the top of scrollable content, swipe down - should start dismiss gesture
- [ ] At the bottom of scrollable content, swipe up - should start dismiss gesture
- [ ] Swipe past threshold (25% of wizard height) - wizard should dismiss
- [ ] Swipe less than threshold - wizard should snap back
- [ ] Verify opacity reduces during the swipe gesture (visual feedback)
- [ ] If there are unsaved changes, verify the unsaved changes dialog appears
- [ ] Test on mobile device with touch gestures
- [ ] Test with zoom locked on mobile
