### PR TITLE
feat(validation): display DOB label with date in scorer display

### DIFF
--- a/web-app/src/components/features/validation/ScorerResultsList.tsx
+++ b/web-app/src/components/features/validation/ScorerResultsList.tsx
@@ -102,7 +102,9 @@ export function ScorerResultsList({
                     <span>ID: {scorer.associationId}</span>
                   )}
                   {scorer.birthday && (
-                    <span>{formatDOB(scorer.birthday)}</span>
+                    <span>
+                      {t("common.dob")}: {formatDOB(scorer.birthday)}
+                    </span>
                   )}
                 </div>
               </div>

--- a/web-app/src/components/features/validation/SelectedScorerCard.test.tsx
+++ b/web-app/src/components/features/validation/SelectedScorerCard.test.tsx
@@ -26,11 +26,11 @@ describe("SelectedScorerCard", () => {
     expect(screen.getByText("ID: 12345")).toBeInTheDocument();
   });
 
-  it("displays formatted birthday", () => {
+  it("displays formatted birthday with DOB label", () => {
     render(<SelectedScorerCard scorer={mockScorer} onClear={vi.fn()} />);
 
-    // formatDOB returns DD.MM.YY format (Swiss format)
-    expect(screen.getByText("15.03.85")).toBeInTheDocument();
+    // formatDOB returns DD.MM.YY format (Swiss format) with DOB label
+    expect(screen.getByText("DOB: 15.03.85")).toBeInTheDocument();
   });
 
   it("calls onClear when clear button is clicked", () => {

--- a/web-app/src/components/features/validation/SelectedScorerCard.tsx
+++ b/web-app/src/components/features/validation/SelectedScorerCard.tsx
@@ -38,7 +38,11 @@ export function SelectedScorerCard({
           {scorer && (
             <div className="flex items-center gap-3 text-sm text-text-muted dark:text-text-muted-dark">
               {scorer.associationId && <span>ID: {scorer.associationId}</span>}
-              {scorer.birthday && <span>{formatDOB(scorer.birthday)}</span>}
+              {scorer.birthday && (
+                <span>
+                  {t("common.dob")}: {formatDOB(scorer.birthday)}
+                </span>
+              )}
             </div>
           )}
         </div>

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -151,6 +151,7 @@ const de: Translations = {
     wizardProgress: "Assistentenfortschritt",
     stepIndicatorCurrent: "(aktuell)",
     stepIndicatorDone: "(erledigt)",
+    dob: "Geb.",
   },
   auth: {
     login: "Anmelden",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -151,6 +151,7 @@ const en: Translations = {
     wizardProgress: "Wizard progress",
     stepIndicatorCurrent: "(current)",
     stepIndicatorDone: "(done)",
+    dob: "DOB",
   },
   auth: {
     login: "Login",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -151,6 +151,7 @@ const fr: Translations = {
     wizardProgress: "Progression de l'assistant",
     stepIndicatorCurrent: "(actuel)",
     stepIndicatorDone: "(terminé)",
+    dob: "DDN",
   },
   auth: {
     login: "Connexion",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -151,6 +151,7 @@ const it: Translations = {
     wizardProgress: "Progresso procedura guidata",
     stepIndicatorCurrent: "(corrente)",
     stepIndicatorDone: "(completato)",
+    dob: "DDN",
   },
   auth: {
     login: "Accesso",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -43,6 +43,7 @@ export interface Translations {
     wizardProgress: string;
     stepIndicatorCurrent: string;
     stepIndicatorDone: string;
+    dob: string;
   };
   auth: {
     login: string;


### PR DESCRIPTION
## Summary

- Added "DOB:" label prefix to date of birth display in scorer validation wizard
- Verified fuzzy search correctly matches firstName, lastName, and yearOfBirth

## Changes

- `SelectedScorerCard.tsx`: Added DOB label prefix before formatted birthday
- `ScorerResultsList.tsx`: Added DOB label prefix before formatted birthday  
- `i18n/types.ts`: Added `dob` translation key to common section
- `locales/de.ts`: Added German translation "Geb." (Geburtstag)
- `locales/en.ts`: Added English translation "DOB"
- `locales/fr.ts`: Added French translation "DDN" (Date de Naissance)
- `locales/it.ts`: Added Italian translation "DDN" (Data di Nascita)
- `SelectedScorerCard.test.tsx`: Updated test to expect "DOB: 15.03.85" format

## Test Plan

- [ ] Open validation wizard for a game
- [ ] Search for a scorer and verify DOB is displayed as "DOB: dd.mm.yy" in results list
- [ ] Select a scorer and verify DOB is displayed as "DOB: dd.mm.yy" in selected card
- [ ] Test search by last name only (e.g., "müller")
- [ ] Test search by first and last name (e.g., "hans müller")
- [ ] Test search with year of birth (e.g., "müller 1985")
- [ ] Verify all language translations display correctly (de, en, fr, it)
