### PR TITLE
feat(validation): align player data as LastName Initial. DOB

### DIFF
--- a/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
@@ -118,18 +118,22 @@ describe("AddPlayerSheet", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("displays player list with formatted names", () => {
+  it("displays player list with aligned columns", () => {
     render(<AddPlayerSheet {...defaultProps} />, { wrapper: createWrapper() });
-    // Players are shown as "LastName Initial. dd.mm.yy"
-    expect(screen.getByText("Müller M. 15.05.90")).toBeInTheDocument();
-    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
+    // Players are shown in aligned columns: LastName | Initial | DOB
+    expect(screen.getByText("Müller")).toBeInTheDocument();
+    expect(screen.getByText("M.")).toBeInTheDocument();
+    expect(screen.getByText("15.05.90")).toBeInTheDocument();
+    expect(screen.getByText("Schmidt")).toBeInTheDocument();
+    expect(screen.getByText("A.")).toBeInTheDocument();
+    expect(screen.getByText("22.08.95")).toBeInTheDocument();
   });
 
   it("filters out already nominated players", () => {
     render(<AddPlayerSheet {...defaultProps} />, { wrapper: createWrapper() });
-    expect(screen.getByText("Müller M. 15.05.90")).toBeInTheDocument();
+    expect(screen.getByText("Müller")).toBeInTheDocument();
     // Weber Thomas is already nominated, so should not appear
-    expect(screen.queryByText(/Weber/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Weber")).not.toBeInTheDocument();
   });
 
   it("filters out excluded players", () => {
@@ -137,8 +141,8 @@ describe("AddPlayerSheet", () => {
       <AddPlayerSheet {...defaultProps} excludePlayerIds={["indoor-1"]} />,
       { wrapper: createWrapper() },
     );
-    expect(screen.queryByText(/Müller/)).not.toBeInTheDocument();
-    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
+    expect(screen.queryByText("Müller")).not.toBeInTheDocument();
+    expect(screen.getByText("Schmidt")).toBeInTheDocument();
   });
 
   it("calls onClose when backdrop is clicked", () => {
@@ -198,8 +202,8 @@ describe("AddPlayerSheet", () => {
       vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
     });
 
-    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
-    expect(screen.queryByText(/Müller/)).not.toBeInTheDocument();
+    expect(screen.getByText("Schmidt")).toBeInTheDocument();
+    expect(screen.queryByText("Müller")).not.toBeInTheDocument();
   });
 
   it("performs case-insensitive search", () => {
@@ -212,7 +216,7 @@ describe("AddPlayerSheet", () => {
       vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
     });
 
-    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
+    expect(screen.getByText("Schmidt")).toBeInTheDocument();
   });
 
   it("shows no results message when search has no matches", () => {
@@ -251,18 +255,20 @@ describe("AddPlayerSheet", () => {
       wrapper: createWrapper(),
     });
 
-    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const playerButton = screen.getByText("Müller").closest("button");
     fireEvent.click(playerButton!);
 
     expect(onAddPlayer).toHaveBeenCalledTimes(1);
     expect(onAddPlayer).toHaveBeenCalledWith(mockPlayers[0]);
   });
 
-  it("displays formatted player info with date of birth", () => {
+  it("displays player info in aligned columns with date of birth", () => {
     render(<AddPlayerSheet {...defaultProps} />, { wrapper: createWrapper() });
-    // Players are displayed as "LastName Initial. dd.mm.yy"
-    expect(screen.getByText("Müller M. 15.05.90")).toBeInTheDocument();
-    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
+    // Players are displayed in aligned columns
+    expect(screen.getByText("Müller")).toBeInTheDocument();
+    expect(screen.getByText("15.05.90")).toBeInTheDocument();
+    expect(screen.getByText("Schmidt")).toBeInTheDocument();
+    expect(screen.getByText("22.08.95")).toBeInTheDocument();
   });
 
   it("has proper accessibility attributes", () => {
@@ -378,7 +384,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       wrapper: createWrapper(),
     });
 
-    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const playerButton = screen.getByText("Müller").closest("button");
     fireEvent.click(playerButton!);
 
     expect(onClose).not.toHaveBeenCalled();
@@ -388,7 +394,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
   it("shows checkmark on added player", () => {
     render(<AddPlayerSheet {...defaultProps} />, { wrapper: createWrapper() });
 
-    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const playerButton = screen.getByText("Müller").closest("button");
     fireEvent.click(playerButton!);
 
     expect(playerButton).toHaveAttribute("aria-pressed", "true");
@@ -401,12 +407,12 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
 
     expect(screen.queryByText(/added/i)).not.toBeInTheDocument();
 
-    const maxButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const maxButton = screen.getByText("Müller").closest("button");
     fireEvent.click(maxButton!);
 
     expect(screen.getByText("1 added")).toBeInTheDocument();
 
-    const annaButton = screen.getByText("Schmidt A. 22.08.95").closest("button");
+    const annaButton = screen.getByText("Schmidt").closest("button");
     fireEvent.click(annaButton!);
 
     expect(screen.getByText("2 added")).toBeInTheDocument();
@@ -418,10 +424,10 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       wrapper: createWrapper(),
     });
 
-    const maxButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const maxButton = screen.getByText("Müller").closest("button");
     fireEvent.click(maxButton!);
 
-    const annaButton = screen.getByText("Schmidt A. 22.08.95").closest("button");
+    const annaButton = screen.getByText("Schmidt").closest("button");
     fireEvent.click(annaButton!);
 
     expect(onAddPlayer).toHaveBeenCalledTimes(2);
@@ -441,7 +447,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       { wrapper: createWrapper() },
     );
 
-    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const playerButton = screen.getByText("Müller").closest("button");
 
     // First click adds
     fireEvent.click(playerButton!);
@@ -466,7 +472,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       { wrapper: createWrapper() },
     );
 
-    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const playerButton = screen.getByText("Müller").closest("button");
     fireEvent.click(playerButton!);
 
     expect(screen.getByText("1 added")).toBeInTheDocument();
@@ -477,7 +483,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
     rerender(<AddPlayerSheet {...defaultProps} onClose={onClose} isOpen={true} />);
 
     expect(screen.queryByText(/added/i)).not.toBeInTheDocument();
-    const newPlayerButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const newPlayerButton = screen.getByText("Müller").closest("button");
     expect(newPlayerButton).not.toBeDisabled();
   });
 
@@ -487,17 +493,17 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       { wrapper: createWrapper() },
     );
 
-    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
+    const playerButton = screen.getByText("Müller").closest("button");
     fireEvent.click(playerButton!);
 
     rerender(
       <AddPlayerSheet {...defaultProps} excludePlayerIds={["indoor-1"]} />,
     );
 
-    expect(screen.getByText("Müller M. 15.05.90")).toBeInTheDocument();
+    expect(screen.getByText("Müller")).toBeInTheDocument();
     // Button is still enabled to allow toggling (removal)
-    expect(screen.getByText("Müller M. 15.05.90").closest("button")).toBeEnabled();
-    expect(screen.getByText("Müller M. 15.05.90").closest("button")).toHaveAttribute(
+    expect(screen.getByText("Müller").closest("button")).toBeEnabled();
+    expect(screen.getByText("Müller").closest("button")).toHaveAttribute(
       "aria-pressed",
       "true",
     );

--- a/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
@@ -118,16 +118,18 @@ describe("AddPlayerSheet", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("displays player list", () => {
+  it("displays player list with formatted names", () => {
     render(<AddPlayerSheet {...defaultProps} />, { wrapper: createWrapper() });
-    expect(screen.getByText("Müller Max")).toBeInTheDocument();
-    expect(screen.getByText("Schmidt Anna")).toBeInTheDocument();
+    // Players are shown as "LastName Initial. dd.mm.yy"
+    expect(screen.getByText("Müller M. 15.05.90")).toBeInTheDocument();
+    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
   });
 
   it("filters out already nominated players", () => {
     render(<AddPlayerSheet {...defaultProps} />, { wrapper: createWrapper() });
-    expect(screen.getByText("Müller Max")).toBeInTheDocument();
-    expect(screen.queryByText("Weber Thomas")).not.toBeInTheDocument();
+    expect(screen.getByText("Müller M. 15.05.90")).toBeInTheDocument();
+    // Weber Thomas is already nominated, so should not appear
+    expect(screen.queryByText(/Weber/)).not.toBeInTheDocument();
   });
 
   it("filters out excluded players", () => {
@@ -135,8 +137,8 @@ describe("AddPlayerSheet", () => {
       <AddPlayerSheet {...defaultProps} excludePlayerIds={["indoor-1"]} />,
       { wrapper: createWrapper() },
     );
-    expect(screen.queryByText("Müller Max")).not.toBeInTheDocument();
-    expect(screen.getByText("Schmidt Anna")).toBeInTheDocument();
+    expect(screen.queryByText(/Müller/)).not.toBeInTheDocument();
+    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
   });
 
   it("calls onClose when backdrop is clicked", () => {
@@ -196,8 +198,8 @@ describe("AddPlayerSheet", () => {
       vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
     });
 
-    expect(screen.getByText("Schmidt Anna")).toBeInTheDocument();
-    expect(screen.queryByText("Müller Max")).not.toBeInTheDocument();
+    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
+    expect(screen.queryByText(/Müller/)).not.toBeInTheDocument();
   });
 
   it("performs case-insensitive search", () => {
@@ -210,7 +212,7 @@ describe("AddPlayerSheet", () => {
       vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
     });
 
-    expect(screen.getByText("Schmidt Anna")).toBeInTheDocument();
+    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
   });
 
   it("shows no results message when search has no matches", () => {
@@ -249,18 +251,18 @@ describe("AddPlayerSheet", () => {
       wrapper: createWrapper(),
     });
 
-    const playerButton = screen.getByText("Müller Max").closest("button");
+    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
     fireEvent.click(playerButton!);
 
     expect(onAddPlayer).toHaveBeenCalledTimes(1);
     expect(onAddPlayer).toHaveBeenCalledWith(mockPlayers[0]);
   });
 
-  it("displays date of birth for players", () => {
+  it("displays formatted player info with date of birth", () => {
     render(<AddPlayerSheet {...defaultProps} />, { wrapper: createWrapper() });
-    // DOB is shown in DD.MM.YY format
-    expect(screen.getByText("15.05.90")).toBeInTheDocument();
-    expect(screen.getByText("22.08.95")).toBeInTheDocument();
+    // Players are displayed as "LastName Initial. dd.mm.yy"
+    expect(screen.getByText("Müller M. 15.05.90")).toBeInTheDocument();
+    expect(screen.getByText("Schmidt A. 22.08.95")).toBeInTheDocument();
   });
 
   it("has proper accessibility attributes", () => {
@@ -376,7 +378,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       wrapper: createWrapper(),
     });
 
-    const playerButton = screen.getByText("Müller Max").closest("button");
+    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
     fireEvent.click(playerButton!);
 
     expect(onClose).not.toHaveBeenCalled();
@@ -386,7 +388,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
   it("shows checkmark on added player", () => {
     render(<AddPlayerSheet {...defaultProps} />, { wrapper: createWrapper() });
 
-    const playerButton = screen.getByText("Müller Max").closest("button");
+    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
     fireEvent.click(playerButton!);
 
     expect(playerButton).toHaveAttribute("aria-pressed", "true");
@@ -399,12 +401,12 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
 
     expect(screen.queryByText(/added/i)).not.toBeInTheDocument();
 
-    const maxButton = screen.getByText("Müller Max").closest("button");
+    const maxButton = screen.getByText("Müller M. 15.05.90").closest("button");
     fireEvent.click(maxButton!);
 
     expect(screen.getByText("1 added")).toBeInTheDocument();
 
-    const annaButton = screen.getByText("Schmidt Anna").closest("button");
+    const annaButton = screen.getByText("Schmidt A. 22.08.95").closest("button");
     fireEvent.click(annaButton!);
 
     expect(screen.getByText("2 added")).toBeInTheDocument();
@@ -416,10 +418,10 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       wrapper: createWrapper(),
     });
 
-    const maxButton = screen.getByText("Müller Max").closest("button");
+    const maxButton = screen.getByText("Müller M. 15.05.90").closest("button");
     fireEvent.click(maxButton!);
 
-    const annaButton = screen.getByText("Schmidt Anna").closest("button");
+    const annaButton = screen.getByText("Schmidt A. 22.08.95").closest("button");
     fireEvent.click(annaButton!);
 
     expect(onAddPlayer).toHaveBeenCalledTimes(2);
@@ -439,7 +441,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       { wrapper: createWrapper() },
     );
 
-    const playerButton = screen.getByText("Müller Max").closest("button");
+    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
 
     // First click adds
     fireEvent.click(playerButton!);
@@ -464,7 +466,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       { wrapper: createWrapper() },
     );
 
-    const playerButton = screen.getByText("Müller Max").closest("button");
+    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
     fireEvent.click(playerButton!);
 
     expect(screen.getByText("1 added")).toBeInTheDocument();
@@ -475,7 +477,7 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
     rerender(<AddPlayerSheet {...defaultProps} onClose={onClose} isOpen={true} />);
 
     expect(screen.queryByText(/added/i)).not.toBeInTheDocument();
-    const newPlayerButton = screen.getByText("Müller Max").closest("button");
+    const newPlayerButton = screen.getByText("Müller M. 15.05.90").closest("button");
     expect(newPlayerButton).not.toBeDisabled();
   });
 
@@ -485,17 +487,17 @@ describe("AddPlayerSheet - Multi-Player Selection", () => {
       { wrapper: createWrapper() },
     );
 
-    const playerButton = screen.getByText("Müller Max").closest("button");
+    const playerButton = screen.getByText("Müller M. 15.05.90").closest("button");
     fireEvent.click(playerButton!);
 
     rerender(
       <AddPlayerSheet {...defaultProps} excludePlayerIds={["indoor-1"]} />,
     );
 
-    expect(screen.getByText("Müller Max")).toBeInTheDocument();
+    expect(screen.getByText("Müller M. 15.05.90")).toBeInTheDocument();
     // Button is still enabled to allow toggling (removal)
-    expect(screen.getByText("Müller Max").closest("button")).toBeEnabled();
-    expect(screen.getByText("Müller Max").closest("button")).toHaveAttribute(
+    expect(screen.getByText("Müller M. 15.05.90").closest("button")).toBeEnabled();
+    expect(screen.getByText("Müller M. 15.05.90").closest("button")).toHaveAttribute(
       "aria-pressed",
       "true",
     );

--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -6,7 +6,7 @@ import { usePossiblePlayerNominations } from "@/hooks/usePlayerNominations";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { ResponsiveSheet } from "@/components/ui/ResponsiveSheet";
 import { Check, X, Plus } from "@/components/ui/icons";
-import { formatRosterEntries } from "@/utils/date-helpers";
+import { formatRosterEntries, getMaxLastNameWidth } from "@/utils/date-helpers";
 
 // Delay before focusing search input to ensure the sheet animation has started
 const FOCUS_DELAY_MS = 100;
@@ -80,15 +80,10 @@ export function AddPlayerSheet({
   }, [filteredPlayers]);
 
   // Calculate max last name width for column alignment
-  const maxLastNameWidth = useMemo(() => {
-    let maxLen = 0;
-    for (const entry of formattedEntries.values()) {
-      if (entry.lastName.length > maxLen) {
-        maxLen = entry.lastName.length;
-      }
-    }
-    return maxLen;
-  }, [formattedEntries]);
+  const maxLastNameWidth = useMemo(
+    () => getMaxLastNameWidth(formattedEntries),
+    [formattedEntries],
+  );
 
   const handleClose = useCallback(() => {
     setSearchQuery("");
@@ -204,6 +199,16 @@ export function AddPlayerSheet({
               {filteredPlayers.map((player) => {
                 const playerId = player.indoorPlayer?.__identity ?? "";
                 const isAdded = sessionAddedIds.has(playerId);
+                const entry = formattedEntries.get(playerId);
+                const lastName =
+                  entry?.lastName ||
+                  player.indoorPlayer?.person?.lastName ||
+                  "";
+                const firstInitial = entry?.firstInitial || "";
+                const dob = entry?.dob || "";
+                const textColorClass = isAdded
+                  ? "text-success-700 dark:text-success-400"
+                  : "text-text-primary dark:text-text-primary-dark";
 
                 return (
                   <li key={player.__identity}>
@@ -221,31 +226,20 @@ export function AddPlayerSheet({
                       `}
                     >
                       <div className="flex-1 min-w-0">
-                        {(() => {
-                          const entry = formattedEntries.get(playerId);
-                          const lastName = entry?.lastName || player.indoorPlayer?.person?.lastName || "";
-                          const firstInitial = entry?.firstInitial || "";
-                          const dob = entry?.dob || "";
-                          const textColorClass = isAdded
-                            ? "text-success-700 dark:text-success-400"
-                            : "text-text-primary dark:text-text-primary-dark";
-                          return (
-                            <div className="flex items-baseline text-sm font-mono">
-                              <span
-                                className={`font-medium ${textColorClass}`}
-                                style={{ minWidth: `${maxLastNameWidth}ch` }}
-                              >
-                                {lastName}
-                              </span>
-                              <span className={`ml-2 w-[3ch] ${textColorClass}`}>
-                                {firstInitial}
-                              </span>
-                              <span className="ml-2 text-text-muted dark:text-text-muted-dark tabular-nums">
-                                {dob}
-                              </span>
-                            </div>
-                          );
-                        })()}
+                        <div className="flex items-baseline text-sm font-mono">
+                          <span
+                            className={`font-medium ${textColorClass}`}
+                            style={{ minWidth: `${maxLastNameWidth}ch` }}
+                          >
+                            {lastName}
+                          </span>
+                          <span className={`ml-2 w-[3ch] ${textColorClass}`}>
+                            {firstInitial}
+                          </span>
+                          <span className="ml-2 text-text-muted dark:text-text-muted-dark tabular-nums">
+                            {dob}
+                          </span>
+                        </div>
                       </div>
                       {isAdded ? (
                         <span className="relative flex-shrink-0 ml-2 w-5 h-5">

--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -6,7 +6,7 @@ import { usePossiblePlayerNominations } from "@/hooks/usePlayerNominations";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { ResponsiveSheet } from "@/components/ui/ResponsiveSheet";
 import { Check, X, Plus } from "@/components/ui/icons";
-import { formatDOB } from "@/utils/date-helpers";
+import { formatRosterEntries } from "@/utils/date-helpers";
 
 // Delay before focusing search input to ensure the sheet animation has started
 const FOCUS_DELAY_MS = 100;
@@ -67,6 +67,17 @@ export function AddPlayerSheet({
       return fullName.includes(query) || firstName.includes(query) || lastName.includes(query);
     });
   }, [players, debouncedQuery, excludePlayerIds, sessionAddedIds]);
+
+  // Compute formatted display strings for filtered players (handles duplicate detection)
+  const formattedEntries = useMemo(() => {
+    const playersData = filteredPlayers.map((player) => ({
+      id: player.indoorPlayer?.__identity ?? "",
+      firstName: player.indoorPlayer?.person?.firstName,
+      lastName: player.indoorPlayer?.person?.lastName,
+      birthday: player.indoorPlayer?.person?.birthday,
+    }));
+    return formatRosterEntries(playersData);
+  }, [filteredPlayers]);
 
   const handleClose = useCallback(() => {
     setSearchQuery("");
@@ -198,7 +209,7 @@ export function AddPlayerSheet({
                         }
                       `}
                     >
-                      <div className="flex-1 min-w-0 flex items-center gap-2">
+                      <div className="flex-1 min-w-0">
                         <span
                           className={`font-medium truncate ${
                             isAdded
@@ -206,11 +217,8 @@ export function AddPlayerSheet({
                               : "text-text-primary dark:text-text-primary-dark"
                           }`}
                         >
-                          {player.indoorPlayer?.person?.lastName ?? ""}{" "}
-                          {player.indoorPlayer?.person?.firstName ?? ""}
-                        </span>
-                        <span className="text-xs text-text-muted dark:text-text-muted-dark flex-shrink-0">
-                          {formatDOB(player.indoorPlayer?.person?.birthday)}
+                          {formattedEntries.get(playerId)?.displayString ||
+                            `${player.indoorPlayer?.person?.lastName ?? ""} ${player.indoorPlayer?.person?.firstName ?? ""}`}
                         </span>
                       </div>
                       {isAdded ? (

--- a/web-app/src/components/features/validation/AddPlayerSheet.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.tsx
@@ -68,7 +68,7 @@ export function AddPlayerSheet({
     });
   }, [players, debouncedQuery, excludePlayerIds, sessionAddedIds]);
 
-  // Compute formatted display strings for filtered players (handles duplicate detection)
+  // Compute formatted display data for filtered players (handles duplicate detection)
   const formattedEntries = useMemo(() => {
     const playersData = filteredPlayers.map((player) => ({
       id: player.indoorPlayer?.__identity ?? "",
@@ -78,6 +78,17 @@ export function AddPlayerSheet({
     }));
     return formatRosterEntries(playersData);
   }, [filteredPlayers]);
+
+  // Calculate max last name width for column alignment
+  const maxLastNameWidth = useMemo(() => {
+    let maxLen = 0;
+    for (const entry of formattedEntries.values()) {
+      if (entry.lastName.length > maxLen) {
+        maxLen = entry.lastName.length;
+      }
+    }
+    return maxLen;
+  }, [formattedEntries]);
 
   const handleClose = useCallback(() => {
     setSearchQuery("");
@@ -210,16 +221,31 @@ export function AddPlayerSheet({
                       `}
                     >
                       <div className="flex-1 min-w-0">
-                        <span
-                          className={`font-medium truncate ${
-                            isAdded
-                              ? "text-success-700 dark:text-success-400"
-                              : "text-text-primary dark:text-text-primary-dark"
-                          }`}
-                        >
-                          {formattedEntries.get(playerId)?.displayString ||
-                            `${player.indoorPlayer?.person?.lastName ?? ""} ${player.indoorPlayer?.person?.firstName ?? ""}`}
-                        </span>
+                        {(() => {
+                          const entry = formattedEntries.get(playerId);
+                          const lastName = entry?.lastName || player.indoorPlayer?.person?.lastName || "";
+                          const firstInitial = entry?.firstInitial || "";
+                          const dob = entry?.dob || "";
+                          const textColorClass = isAdded
+                            ? "text-success-700 dark:text-success-400"
+                            : "text-text-primary dark:text-text-primary-dark";
+                          return (
+                            <div className="flex items-baseline text-sm font-mono">
+                              <span
+                                className={`font-medium ${textColorClass}`}
+                                style={{ minWidth: `${maxLastNameWidth}ch` }}
+                              >
+                                {lastName}
+                              </span>
+                              <span className={`ml-2 w-[3ch] ${textColorClass}`}>
+                                {firstInitial}
+                              </span>
+                              <span className="ml-2 text-text-muted dark:text-text-muted-dark tabular-nums">
+                                {dob}
+                              </span>
+                            </div>
+                          );
+                        })()}
                       </div>
                       {isAdded ? (
                         <span className="relative flex-shrink-0 ml-2 w-5 h-5">

--- a/web-app/src/components/features/validation/PlayerListItem.test.tsx
+++ b/web-app/src/components/features/validation/PlayerListItem.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { PlayerListItem } from "./PlayerListItem";
+import { PlayerListItem, type PlayerDisplayData } from "./PlayerListItem";
 import type { RosterPlayer } from "@/hooks/useNominationList";
 
 function createMockPlayer(overrides: Partial<RosterPlayer> = {}): RosterPlayer {
@@ -13,21 +13,34 @@ function createMockPlayer(overrides: Partial<RosterPlayer> = {}): RosterPlayer {
   };
 }
 
+function createDisplayData(overrides: Partial<PlayerDisplayData> = {}): PlayerDisplayData {
+  return {
+    lastName: "Doe",
+    firstInitial: "J.",
+    dob: "01.01.90",
+    ...overrides,
+  };
+}
+
 describe("PlayerListItem", () => {
-  it("renders player name", () => {
+  it("renders player name in aligned columns", () => {
     const player = createMockPlayer({ displayName: "Max" });
+    const displayData = createDisplayData({ lastName: "Max", firstInitial: "M.", dob: "01.01.90" });
 
     render(
       <PlayerListItem
         player={player}
-        formattedDisplay="Max M. 01.01.90"
+        displayData={displayData}
+        maxLastNameWidth={10}
         isMarkedForRemoval={false}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("Max M. 01.01.90")).toBeInTheDocument();
+    expect(screen.getByText("Max")).toBeInTheDocument();
+    expect(screen.getByText("M.")).toBeInTheDocument();
+    expect(screen.getByText("01.01.90")).toBeInTheDocument();
   });
 
   it("shows license category badge when provided", () => {
@@ -36,7 +49,8 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
-        formattedDisplay="Doe J. 01.01.90"
+        displayData={createDisplayData()}
+        maxLastNameWidth={10}
         isMarkedForRemoval={false}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
@@ -52,7 +66,8 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
-        formattedDisplay="Doe J. 01.01.90"
+        displayData={createDisplayData()}
+        maxLastNameWidth={10}
         isMarkedForRemoval={false}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
@@ -69,7 +84,8 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
-        formattedDisplay="Doe J. 01.01.90"
+        displayData={createDisplayData()}
+        maxLastNameWidth={10}
         isMarkedForRemoval={false}
         onRemove={onRemove}
         onUndoRemoval={vi.fn()}
@@ -88,7 +104,8 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
-        formattedDisplay="Doe J. 01.01.90"
+        displayData={createDisplayData()}
+        maxLastNameWidth={10}
         isMarkedForRemoval={true}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
@@ -105,7 +122,8 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
-        formattedDisplay="Doe J. 01.01.90"
+        displayData={createDisplayData()}
+        maxLastNameWidth={10}
         isMarkedForRemoval={true}
         onRemove={vi.fn()}
         onUndoRemoval={onUndoRemoval}
@@ -120,20 +138,21 @@ describe("PlayerListItem", () => {
 
   it("applies strikethrough styling when marked for removal", () => {
     const player = createMockPlayer();
-    const formattedDisplay = "Doe J. 01.01.90";
+    const displayData = createDisplayData({ lastName: "Doe" });
 
     render(
       <PlayerListItem
         player={player}
-        formattedDisplay={formattedDisplay}
+        displayData={displayData}
+        maxLastNameWidth={10}
         isMarkedForRemoval={true}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
       />,
     );
 
-    const nameElement = screen.getByText(formattedDisplay);
-    expect(nameElement).toHaveClass("line-through");
+    const lastNameElement = screen.getByText("Doe");
+    expect(lastNameElement).toHaveClass("line-through");
   });
 
   it("hides badges when marked for removal", () => {
@@ -144,7 +163,8 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
-        formattedDisplay="Doe J. 01.01.90"
+        displayData={createDisplayData()}
+        maxLastNameWidth={10}
         isMarkedForRemoval={true}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
@@ -152,5 +172,24 @@ describe("PlayerListItem", () => {
     );
 
     expect(screen.queryByText("SEN")).not.toBeInTheDocument();
+  });
+
+  it("aligns last names based on maxLastNameWidth", () => {
+    const player = createMockPlayer();
+    const displayData = createDisplayData({ lastName: "Doe" });
+
+    render(
+      <PlayerListItem
+        player={player}
+        displayData={displayData}
+        maxLastNameWidth={12}
+        isMarkedForRemoval={false}
+        onRemove={vi.fn()}
+        onUndoRemoval={vi.fn()}
+      />,
+    );
+
+    const lastNameElement = screen.getByText("Doe");
+    expect(lastNameElement).toHaveStyle({ minWidth: "12ch" });
   });
 });

--- a/web-app/src/components/features/validation/PlayerListItem.test.tsx
+++ b/web-app/src/components/features/validation/PlayerListItem.test.tsx
@@ -20,13 +20,14 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
+        formattedDisplay="Max M. 01.01.90"
         isMarkedForRemoval={false}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("Max")).toBeInTheDocument();
+    expect(screen.getByText("Max M. 01.01.90")).toBeInTheDocument();
   });
 
   it("shows license category badge when provided", () => {
@@ -35,6 +36,7 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
+        formattedDisplay="Doe J. 01.01.90"
         isMarkedForRemoval={false}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
@@ -50,6 +52,7 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
+        formattedDisplay="Doe J. 01.01.90"
         isMarkedForRemoval={false}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
@@ -66,6 +69,7 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
+        formattedDisplay="Doe J. 01.01.90"
         isMarkedForRemoval={false}
         onRemove={onRemove}
         onUndoRemoval={vi.fn()}
@@ -84,6 +88,7 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
+        formattedDisplay="Doe J. 01.01.90"
         isMarkedForRemoval={true}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
@@ -100,6 +105,7 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
+        formattedDisplay="Doe J. 01.01.90"
         isMarkedForRemoval={true}
         onRemove={vi.fn()}
         onUndoRemoval={onUndoRemoval}
@@ -114,17 +120,19 @@ describe("PlayerListItem", () => {
 
   it("applies strikethrough styling when marked for removal", () => {
     const player = createMockPlayer();
+    const formattedDisplay = "Doe J. 01.01.90";
 
     render(
       <PlayerListItem
         player={player}
+        formattedDisplay={formattedDisplay}
         isMarkedForRemoval={true}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}
       />,
     );
 
-    const nameElement = screen.getByText(player.displayName);
+    const nameElement = screen.getByText(formattedDisplay);
     expect(nameElement).toHaveClass("line-through");
   });
 
@@ -136,6 +144,7 @@ describe("PlayerListItem", () => {
     render(
       <PlayerListItem
         player={player}
+        formattedDisplay="Doe J. 01.01.90"
         isMarkedForRemoval={true}
         onRemove={vi.fn()}
         onUndoRemoval={vi.fn()}

--- a/web-app/src/components/features/validation/PlayerListItem.tsx
+++ b/web-app/src/components/features/validation/PlayerListItem.tsx
@@ -1,19 +1,12 @@
 import { Badge } from "@/components/ui/Badge";
 import type { RosterPlayer } from "@/hooks/useNominationList";
 import { Trash2, Undo2 } from "@/components/ui/icons";
-import { formatDOB } from "@/utils/date-helpers";
 import { useTranslation } from "@/hooks/useTranslation";
-
-/** Format player name as "LastName FirstName" */
-function formatPlayerName(player: RosterPlayer): string {
-  if (player.lastName && player.firstName) {
-    return `${player.lastName} ${player.firstName}`;
-  }
-  return player.displayName;
-}
 
 interface PlayerListItemProps {
   player: RosterPlayer;
+  /** Pre-formatted display string (e.g., "Müller M. 01.01.90") */
+  formattedDisplay: string;
   isMarkedForRemoval: boolean;
   onRemove?: () => void;
   onUndoRemoval?: () => void;
@@ -23,6 +16,7 @@ interface PlayerListItemProps {
 
 export function PlayerListItem({
   player,
+  formattedDisplay,
   isMarkedForRemoval,
   onRemove,
   onUndoRemoval,
@@ -37,7 +31,7 @@ export function PlayerListItem({
       }`}
     >
       <div className="flex items-center gap-3 min-w-0 flex-1">
-        {/* Player name and DOB */}
+        {/* Player name and DOB in aligned format */}
         <span
           className={`text-sm truncate ${
             isMarkedForRemoval
@@ -45,13 +39,8 @@ export function PlayerListItem({
               : "text-text-primary dark:text-text-primary-dark"
           }`}
         >
-          {formatPlayerName(player)}
+          {formattedDisplay}
         </span>
-        {player.birthday && !isMarkedForRemoval && (
-          <span className="text-xs text-text-muted dark:text-text-muted-dark flex-shrink-0">
-            {formatDOB(player.birthday)}
-          </span>
-        )}
 
         {/* Badges */}
         <div className="flex items-center gap-1.5 flex-shrink-0">

--- a/web-app/src/components/features/validation/PlayerListItem.tsx
+++ b/web-app/src/components/features/validation/PlayerListItem.tsx
@@ -3,10 +3,19 @@ import type { RosterPlayer } from "@/hooks/useNominationList";
 import { Trash2, Undo2 } from "@/components/ui/icons";
 import { useTranslation } from "@/hooks/useTranslation";
 
+/** Structured player display data for aligned columns */
+export interface PlayerDisplayData {
+  lastName: string;
+  firstInitial: string;
+  dob: string;
+}
+
 interface PlayerListItemProps {
   player: RosterPlayer;
-  /** Pre-formatted display string (e.g., "Müller M. 01.01.90") */
-  formattedDisplay: string;
+  /** Structured display data for column alignment */
+  displayData: PlayerDisplayData;
+  /** Maximum last name width in the list (for alignment) */
+  maxLastNameWidth: number;
   isMarkedForRemoval: boolean;
   onRemove?: () => void;
   onUndoRemoval?: () => void;
@@ -16,13 +25,18 @@ interface PlayerListItemProps {
 
 export function PlayerListItem({
   player,
-  formattedDisplay,
+  displayData,
+  maxLastNameWidth,
   isMarkedForRemoval,
   onRemove,
   onUndoRemoval,
   readOnly = false,
 }: PlayerListItemProps) {
   const { t } = useTranslation();
+
+  const textColorClass = isMarkedForRemoval
+    ? "line-through text-text-subtle dark:text-text-subtle-dark"
+    : "text-text-primary dark:text-text-primary-dark";
 
   return (
     <div
@@ -31,16 +45,25 @@ export function PlayerListItem({
       }`}
     >
       <div className="flex items-center gap-3 min-w-0 flex-1">
-        {/* Player name and DOB in aligned format */}
-        <span
-          className={`text-sm truncate ${
-            isMarkedForRemoval
-              ? "line-through text-text-subtle dark:text-text-subtle-dark"
-              : "text-text-primary dark:text-text-primary-dark"
-          }`}
-        >
-          {formattedDisplay}
-        </span>
+        {/* Player name and DOB in aligned columns using tabular numbers */}
+        <div className="flex items-baseline text-sm font-mono">
+          <span
+            className={textColorClass}
+            style={{ minWidth: `${maxLastNameWidth}ch` }}
+          >
+            {displayData.lastName}
+          </span>
+          <span className={`ml-2 w-[3ch] ${textColorClass}`}>
+            {displayData.firstInitial}
+          </span>
+          <span
+            className={`ml-2 text-text-muted dark:text-text-muted-dark tabular-nums ${
+              isMarkedForRemoval ? "line-through" : ""
+            }`}
+          >
+            {displayData.dob}
+          </span>
+        </div>
 
         {/* Badges */}
         <div className="flex items-center gap-1.5 flex-shrink-0">

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -10,7 +10,7 @@ import { PlayerListItem } from "./PlayerListItem";
 import { AddPlayerSheet } from "./AddPlayerSheet";
 import { UserPlus, AlertCircle, RefreshCw } from "@/components/ui/icons";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import { formatRosterEntries } from "@/utils/date-helpers";
+import { formatRosterEntries, getMaxLastNameWidth } from "@/utils/date-helpers";
 
 interface RosterVerificationPanelProps {
   team: "home" | "away";
@@ -130,15 +130,10 @@ export function RosterVerificationPanel({
   );
 
   // Calculate max last name width for column alignment
-  const maxLastNameWidth = useMemo(() => {
-    let maxLen = 0;
-    for (const entry of formattedEntries.values()) {
-      if (entry.lastName.length > maxLen) {
-        maxLen = entry.lastName.length;
-      }
-    }
-    return maxLen;
-  }, [formattedEntries]);
+  const maxLastNameWidth = useMemo(
+    () => getMaxLastNameWidth(formattedEntries),
+    [formattedEntries],
+  );
 
   // Calculate visible player count (excluding removed)
   const visiblePlayerCount = allPlayers.filter(

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import type { PossibleNomination, NominationList } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import {
@@ -10,6 +10,7 @@ import { PlayerListItem } from "./PlayerListItem";
 import { AddPlayerSheet } from "./AddPlayerSheet";
 import { UserPlus, AlertCircle, RefreshCw } from "@/components/ui/icons";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { formatRosterEntries } from "@/utils/date-helpers";
 
 interface RosterVerificationPanelProps {
   team: "home" | "away";
@@ -122,6 +123,12 @@ export function RosterVerificationPanel({
     return a.displayName.localeCompare(b.displayName);
   });
 
+  // Compute formatted display strings for all players (handles duplicate detection)
+  const formattedEntries = useMemo(
+    () => formatRosterEntries(allPlayers),
+    [allPlayers],
+  );
+
   // Calculate visible player count (excluding removed)
   const visiblePlayerCount = allPlayers.filter(
     (p) => !removedPlayerIds.has(p.id),
@@ -191,6 +198,10 @@ export function RosterVerificationPanel({
             <PlayerListItem
               key={player.id}
               player={player}
+              formattedDisplay={
+                formattedEntries.get(player.id)?.displayString ||
+                player.displayName
+              }
               isMarkedForRemoval={removedPlayerIds.has(player.id)}
               onRemove={readOnly ? undefined : () => handleRemovePlayer(player.id)}
               onUndoRemoval={readOnly ? undefined : () => handleUndoRemoval(player.id)}

--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -123,11 +123,22 @@ export function RosterVerificationPanel({
     return a.displayName.localeCompare(b.displayName);
   });
 
-  // Compute formatted display strings for all players (handles duplicate detection)
+  // Compute formatted display data for all players (handles duplicate detection)
   const formattedEntries = useMemo(
     () => formatRosterEntries(allPlayers),
     [allPlayers],
   );
+
+  // Calculate max last name width for column alignment
+  const maxLastNameWidth = useMemo(() => {
+    let maxLen = 0;
+    for (const entry of formattedEntries.values()) {
+      if (entry.lastName.length > maxLen) {
+        maxLen = entry.lastName.length;
+      }
+    }
+    return maxLen;
+  }, [formattedEntries]);
 
   // Calculate visible player count (excluding removed)
   const visiblePlayerCount = allPlayers.filter(
@@ -194,20 +205,25 @@ export function RosterVerificationPanel({
         </div>
       ) : (
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
-          {allPlayers.map((player) => (
-            <PlayerListItem
-              key={player.id}
-              player={player}
-              formattedDisplay={
-                formattedEntries.get(player.id)?.displayString ||
-                player.displayName
-              }
-              isMarkedForRemoval={removedPlayerIds.has(player.id)}
-              onRemove={readOnly ? undefined : () => handleRemovePlayer(player.id)}
-              onUndoRemoval={readOnly ? undefined : () => handleUndoRemoval(player.id)}
-              readOnly={readOnly}
-            />
-          ))}
+          {allPlayers.map((player) => {
+            const entry = formattedEntries.get(player.id);
+            return (
+              <PlayerListItem
+                key={player.id}
+                player={player}
+                displayData={{
+                  lastName: entry?.lastName || player.lastName || player.displayName,
+                  firstInitial: entry?.firstInitial || "",
+                  dob: entry?.dob || "",
+                }}
+                maxLastNameWidth={maxLastNameWidth}
+                isMarkedForRemoval={removedPlayerIds.has(player.id)}
+                onRemove={readOnly ? undefined : () => handleRemovePlayer(player.id)}
+                onUndoRemoval={readOnly ? undefined : () => handleUndoRemoval(player.id)}
+                readOnly={readOnly}
+              />
+            );
+          })}
         </div>
       )}
 

--- a/web-app/src/utils/date-helpers.ts
+++ b/web-app/src/utils/date-helpers.ts
@@ -243,3 +243,22 @@ export function formatRosterEntries(
 
   return result;
 }
+
+/**
+ * Calculates the maximum last name width from formatted roster entries.
+ * Used for column alignment in player lists.
+ *
+ * @param entries - Map of formatted roster entries
+ * @returns Maximum last name character length
+ */
+export function getMaxLastNameWidth(
+  entries: Map<string, FormattedRosterEntry>,
+): number {
+  let maxLen = 0;
+  for (const entry of entries.values()) {
+    if (entry.lastName.length > maxLen) {
+      maxLen = entry.lastName.length;
+    }
+  }
+  return maxLen;
+}

--- a/web-app/src/utils/date-helpers.ts
+++ b/web-app/src/utils/date-helpers.ts
@@ -119,3 +119,127 @@ export function groupByWeek<T>(
 
   return groups;
 }
+
+/**
+ * Player data for roster formatting.
+ */
+export interface RosterPlayerData {
+  id: string;
+  firstName?: string;
+  lastName?: string;
+  birthday?: string | null;
+}
+
+/**
+ * Formatted player entry with abbreviated first name.
+ */
+export interface FormattedRosterEntry {
+  lastName: string;
+  firstInitial: string;
+  dob: string;
+  displayString: string;
+}
+
+/**
+ * Computes the minimum number of first name letters needed to distinguish
+ * players with the same last name.
+ *
+ * @param players - Array of players with the same last name
+ * @returns Map of player ID to required initial length
+ */
+function computeInitialLengths(
+  players: RosterPlayerData[],
+): Map<string, number> {
+  const result = new Map<string, number>();
+
+  // Start with 1 character for everyone
+  for (const player of players) {
+    result.set(player.id, 1);
+  }
+
+  // If only one player or no duplicates possible, we're done
+  if (players.length <= 1) {
+    return result;
+  }
+
+  // Group by first letter to find conflicts
+  const byFirstLetter = new Map<string, RosterPlayerData[]>();
+  for (const player of players) {
+    const firstLetter = (player.firstName ?? "").charAt(0).toUpperCase();
+    const existing = byFirstLetter.get(firstLetter) ?? [];
+    existing.push(player);
+    byFirstLetter.set(firstLetter, existing);
+  }
+
+  // For groups with conflicts, use 2 letters
+  for (const group of byFirstLetter.values()) {
+    if (group.length > 1) {
+      for (const player of group) {
+        result.set(player.id, 2);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Formats player roster entries with abbreviated first names and DOB.
+ * Uses 1 letter for first name by default, 2 letters if there are duplicate
+ * last names with the same first initial.
+ *
+ * Format: "LastName X. dd.mm.yy" or "LastName Xy. dd.mm.yy" for duplicates
+ *
+ * @param players - Array of players to format
+ * @returns Map of player ID to formatted entry data
+ */
+export function formatRosterEntries(
+  players: RosterPlayerData[],
+): Map<string, FormattedRosterEntry> {
+  const result = new Map<string, FormattedRosterEntry>();
+
+  // Group players by last name (case-insensitive)
+  const byLastName = new Map<string, RosterPlayerData[]>();
+  for (const player of players) {
+    const lastName = (player.lastName ?? "").toLowerCase();
+    const existing = byLastName.get(lastName) ?? [];
+    existing.push(player);
+    byLastName.set(lastName, existing);
+  }
+
+  // Compute required initial lengths for each group
+  const initialLengths = new Map<string, number>();
+  for (const group of byLastName.values()) {
+    const groupLengths = computeInitialLengths(group);
+    for (const [id, length] of groupLengths) {
+      initialLengths.set(id, length);
+    }
+  }
+
+  // Format each player
+  for (const player of players) {
+    const lastName = player.lastName ?? "";
+    const firstName = player.firstName ?? "";
+    const initialLength = initialLengths.get(player.id) ?? 1;
+    const firstInitial =
+      firstName.length > 0
+        ? firstName.slice(0, initialLength).charAt(0).toUpperCase() +
+          firstName.slice(1, initialLength).toLowerCase() +
+          "."
+        : "";
+    const dob = formatDOB(player.birthday);
+
+    const displayString = [lastName, firstInitial, dob]
+      .filter(Boolean)
+      .join(" ");
+
+    result.set(player.id, {
+      lastName,
+      firstInitial,
+      dob,
+      displayString,
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Align player roster entries in a compact, readable format with consistent columns
- Use abbreviated first names with automatic duplicate detection
- Apply monospace font for proper column alignment across all players

## Changes

### New Display Format

Players are now displayed in aligned columns:

    Müller   M.  15.05.90  [SEN]
    Schmidt  A.  22.08.95  [JUN]
    Weber    T.  01.12.88  [SEN]

When players share the same last name and first initial, 2-letter initials are used:

    Müller   Ma. 15.05.90  [SEN]
    Müller   Mi. 22.03.92  [JUN]

### Implementation Details

**New utility function** (`src/utils/date-helpers.ts`):
- `formatRosterEntries()` - Computes formatted display data for player lists
- Detects duplicate last names and uses 2-letter initials when same first letter
- Returns structured data: `{ lastName, firstInitial, dob, displayString }`

**Updated components**:
- `PlayerListItem` - Accepts structured `displayData` and `maxLastNameWidth` props
- `RosterVerificationPanel` - Calculates max last name width and passes structured data
- `AddPlayerSheet` - Same aligned column layout for player search/add dialog

**CSS approach**:
- Monospace font (`font-mono`) for consistent character widths
- Dynamic `minWidth` using `ch` units based on longest last name
- Fixed-width column (3ch) for initials
- Tabular numbers for DOB alignment

## Test plan

- [x] Verify players display in aligned columns in roster list
- [x] Verify AddPlayerSheet shows same aligned format
- [x] Verify duplicate detection uses 2-letter initials correctly
- [x] Verify strikethrough styling works for removed players
- [x] All unit tests pass (2392 tests)
- [x] Build succeeds
