### PR TITLE
feat(validation): allow viewing validated games in safe mode

### DIFF
--- a/web-app/src/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/hooks/useAssignmentActions.test.ts
@@ -414,7 +414,7 @@ describe("useAssignmentActions", () => {
       expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
     });
 
-    it("should block validate game when safe mode is enabled", () => {
+    it("should block validate game when safe mode is enabled for unvalidated games", () => {
       const { result } = renderHook(() => useAssignmentActions());
 
       act(() => {
@@ -423,6 +423,31 @@ describe("useAssignmentActions", () => {
 
       expect(result.current.validateGameModal.isOpen).toBe(false);
       expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
+    });
+
+    it("should allow validate game when safe mode is enabled for already validated games", () => {
+      const validatedAssignment: Assignment = {
+        ...mockAssignment,
+        refereeGame: {
+          ...mockAssignment.refereeGame,
+          game: {
+            ...mockAssignment.refereeGame?.game,
+            scoresheet: {
+              closedAt: "2025-12-15T20:00:00Z",
+            },
+          },
+        },
+      } as Assignment;
+
+      const { result } = renderHook(() => useAssignmentActions());
+
+      act(() => {
+        result.current.validateGameModal.open(validatedAssignment);
+      });
+
+      expect(result.current.validateGameModal.isOpen).toBe(true);
+      expect(result.current.validateGameModal.assignment).toBe(validatedAssignment);
+      expect(toast.warning).not.toHaveBeenCalled();
     });
 
     it("should not block operations in demo mode even with safe mode enabled", () => {

--- a/web-app/src/hooks/useAssignmentActions.ts
+++ b/web-app/src/hooks/useAssignmentActions.ts
@@ -1,7 +1,11 @@
 import { useState, useCallback } from "react";
 import type { Assignment } from "@/api/client";
 import { createLogger } from "@/utils/logger";
-import { getTeamNames, isGameReportEligible } from "@/utils/assignment-helpers";
+import {
+  getTeamNames,
+  isGameReportEligible,
+  isGameAlreadyValidated,
+} from "@/utils/assignment-helpers";
 import { useDemoStore } from "@/stores/demo";
 import { useLanguageStore } from "@/stores/language";
 import { toast } from "@/stores/toast";
@@ -58,7 +62,10 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
 
   const openValidateGame = useCallback(
     (assignment: Assignment) => {
+      // Allow viewing already validated games in safe mode (read-only)
+      const isAlreadyValidated = isGameAlreadyValidated(assignment);
       if (
+        !isAlreadyValidated &&
         guard({
           context: "useAssignmentActions",
           action: "game validation",

--- a/web-app/src/utils/assignment-helpers.test.ts
+++ b/web-app/src/utils/assignment-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_VALIDATION_DEADLINE_HOURS,
   isValidationClosed,
   isGamePast,
+  isGameAlreadyValidated,
 } from "./assignment-helpers";
 import type { Assignment } from "@/api/client";
 
@@ -199,6 +200,72 @@ describe("assignment-helpers", () => {
     it("should return true for games from yesterday", () => {
       const gameStart = new Date("2025-01-14T18:00:00Z").toISOString();
       expect(isGamePast(gameStart)).toBe(true);
+    });
+  });
+
+  describe("isGameAlreadyValidated", () => {
+    it("should return true when scoresheet has closedAt set", () => {
+      const assignment: Partial<Assignment> = {
+        refereeGame: {
+          game: {
+            scoresheet: {
+              closedAt: "2025-01-15T20:00:00Z",
+            },
+          },
+        },
+      } as Assignment;
+
+      expect(isGameAlreadyValidated(assignment as Assignment)).toBe(true);
+    });
+
+    it("should return false when scoresheet closedAt is null", () => {
+      const assignment: Partial<Assignment> = {
+        refereeGame: {
+          game: {
+            scoresheet: {
+              closedAt: null,
+            },
+          },
+        },
+      } as Assignment;
+
+      expect(isGameAlreadyValidated(assignment as Assignment)).toBe(false);
+    });
+
+    it("should return false when scoresheet closedAt is undefined", () => {
+      const assignment: Partial<Assignment> = {
+        refereeGame: {
+          game: {
+            scoresheet: {},
+          },
+        },
+      } as Assignment;
+
+      expect(isGameAlreadyValidated(assignment as Assignment)).toBe(false);
+    });
+
+    it("should return false when scoresheet is missing", () => {
+      const assignment: Partial<Assignment> = {
+        refereeGame: {
+          game: {},
+        },
+      } as Assignment;
+
+      expect(isGameAlreadyValidated(assignment as Assignment)).toBe(false);
+    });
+
+    it("should return false when game is missing", () => {
+      const assignment: Partial<Assignment> = {
+        refereeGame: {},
+      } as Assignment;
+
+      expect(isGameAlreadyValidated(assignment as Assignment)).toBe(false);
+    });
+
+    it("should return false when refereeGame is missing", () => {
+      const assignment: Partial<Assignment> = {} as Assignment;
+
+      expect(isGameAlreadyValidated(assignment as Assignment)).toBe(false);
     });
   });
 });

--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -157,3 +157,16 @@ export function isGamePast(gameStartTime: string | undefined | null): boolean {
   const gameStart = parseGameStartTime(gameStartTime);
   return gameStart !== null && new Date() > gameStart;
 }
+
+/**
+ * Checks if a game has already been validated (scoresheet closed).
+ *
+ * A validated game has its scoresheet's closedAt field set, indicating
+ * that validation was completed and the game data is now read-only.
+ *
+ * @param assignment - The referee assignment to check
+ * @returns true if the game has been validated (closedAt is set), false otherwise
+ */
+export function isGameAlreadyValidated(assignment: Assignment): boolean {
+  return !!assignment.refereeGame?.game?.scoresheet?.closedAt;
+}


### PR DESCRIPTION
## Summary

- Allow viewing already validated games in the validation wizard even when safe mode is enabled
- Since validated games are read-only (no mutations possible), it's safe to display them without risking unintended API changes

## Changes

- Add `isGameAlreadyValidated()` helper function in `assignment-helpers.ts` that checks if `scoresheet.closedAt` is set
- Update `useAssignmentActions.ts` to skip the safe mode guard when opening the validation wizard for already validated games
- Add comprehensive tests for the new helper function (6 test cases covering all edge cases)
- Add test case verifying validated games can be opened in safe mode

## Test Plan

- [ ] Enable safe mode in settings (production mode, not demo mode)
- [ ] Verify that clicking "Validate" on an unvalidated game still shows the safe mode blocked toast
- [ ] Verify that clicking "Validate" on an already validated game opens the validation wizard
- [ ] Confirm the validation wizard displays in read-only mode for validated games
- [ ] Run `npm test` - all 2398 tests pass
- [ ] Run `npm run lint` - no warnings
