### PR TITLE
fix(validation): request scoresheet parent before nested closedAt property

### DIFF
--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -47,7 +47,10 @@ export const ASSIGNMENT_PROPERTIES = [
   // Compensation lock flags for editability check
   "convocationCompensation.paymentDone",
   "convocationCompensation.lockPayoutOnSiteCompensation",
-  // Validation status for swipe button color
+  // Validation status for swipe button color.
+  // Parent object must be requested before nested property to ensure
+  // the API populates the nested structure correctly.
+  "refereeGame.game.scoresheet",
   "refereeGame.game.scoresheet.closedAt",
 ];
 


### PR DESCRIPTION
## Summary

- Fixed safe mode incorrectly blocking the validation modal for already validated games in production
- The API requires parent objects to be requested before nested properties to properly populate the response structure

## Changes

- Added `refereeGame.game.scoresheet` to `ASSIGNMENT_PROPERTIES` before `refereeGame.game.scoresheet.closedAt`
- This ensures the API returns the complete scoresheet object structure, allowing `isGameAlreadyValidated` to correctly identify validated games

## Test Plan

- [ ] Enable safe mode in Settings
- [ ] Navigate to the "Validation Closed" tab on the Assignments page
- [ ] Click "Validate" on an already validated game (grey validate button)
- [ ] Verify the validation modal opens successfully (read-only view)
- [ ] Verify that clicking "Validate" on non-validated games is still blocked with the safe mode warning
