### PR TITLE
feat(ocr-poc): add ImageCapture component for camera/file upload

### DIFF
--- a/ocr-poc/src/components/ImageCapture.js
+++ b/ocr-poc/src/components/ImageCapture.js
@@ -1,0 +1,314 @@
+/**
+ * ImageCapture Component
+ *
+ * Provides two methods for capturing images:
+ * 1. Camera capture - Opens rear camera with live preview
+ * 2. File upload - Accepts image files from device
+ *
+ * Designed for mobile-first with large touch targets and
+ * graceful degradation when camera is unavailable.
+ */
+
+/**
+ * @typedef {Object} ImageCaptureOptions
+ * @property {HTMLElement} container - Container element to render into
+ * @property {(blob: Blob) => void} onCapture - Callback when image is captured
+ */
+
+export class ImageCapture {
+  /** @type {HTMLElement} */
+  #container;
+
+  /** @type {(blob: Blob) => void} */
+  #onCapture;
+
+  /** @type {MediaStream | null} */
+  #stream = null;
+
+  /** @type {HTMLVideoElement | null} */
+  #videoElement = null;
+
+  /** @type {boolean} */
+  #isCameraActive = false;
+
+  /** @type {boolean} */
+  #cameraPermissionDenied = false;
+
+  /**
+   * Ideal video constraints for high-resolution capture
+   * 1920x1080 provides good OCR quality while being widely supported
+   */
+  static VIDEO_CONSTRAINTS = {
+    facingMode: 'environment',
+    width: { ideal: 1920 },
+    height: { ideal: 1080 },
+  };
+
+  /**
+   * @param {ImageCaptureOptions} options
+   */
+  constructor({ container, onCapture }) {
+    this.#container = container;
+    this.#onCapture = onCapture;
+    this.#render();
+  }
+
+  /**
+   * Render the component UI
+   */
+  #render() {
+    this.#container.innerHTML = `
+      <div class="image-capture">
+        <div class="image-capture__buttons">
+          <button
+            type="button"
+            class="btn btn-primary btn-lg image-capture__btn"
+            id="btn-camera"
+            aria-label="Open camera to capture image"
+          >
+            <svg class="image-capture__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/>
+              <circle cx="12" cy="13" r="4"/>
+            </svg>
+            <span>Use Camera</span>
+          </button>
+          <button
+            type="button"
+            class="btn btn-secondary btn-lg image-capture__btn"
+            id="btn-upload"
+            aria-label="Upload image from device"
+          >
+            <svg class="image-capture__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+              <polyline points="17 8 12 3 7 8"/>
+              <line x1="12" y1="3" x2="12" y2="15"/>
+            </svg>
+            <span>Upload Image</span>
+          </button>
+        </div>
+
+        <input
+          type="file"
+          id="file-input"
+          class="image-capture__file-input"
+          accept="image/*"
+          aria-hidden="true"
+        />
+
+        <div id="camera-container" class="image-capture__camera" hidden>
+          <video
+            id="camera-preview"
+            class="image-capture__video"
+            autoplay
+            playsinline
+            muted
+          ></video>
+          <div class="image-capture__camera-controls">
+            <button
+              type="button"
+              class="btn btn-secondary image-capture__btn"
+              id="btn-cancel-camera"
+              aria-label="Cancel camera capture"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary image-capture__capture-btn"
+              id="btn-take-photo"
+              aria-label="Take photo"
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <circle cx="12" cy="12" r="10"/>
+              </svg>
+            </button>
+            <div class="image-capture__spacer"></div>
+          </div>
+        </div>
+
+        <div id="permission-message" class="image-capture__message" hidden>
+          <svg class="image-capture__message-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="12" y1="8" x2="12" y2="12"/>
+            <line x1="12" y1="16" x2="12.01" y2="16"/>
+          </svg>
+          <p>Camera access was denied. Please use the upload button to select an image instead.</p>
+        </div>
+      </div>
+    `;
+
+    this.#bindEvents();
+  }
+
+  /**
+   * Bind event listeners to UI elements
+   */
+  #bindEvents() {
+    const cameraBtn = this.#container.querySelector('#btn-camera');
+    const uploadBtn = this.#container.querySelector('#btn-upload');
+    const fileInput = this.#container.querySelector('#file-input');
+    const cancelBtn = this.#container.querySelector('#btn-cancel-camera');
+    const takePhotoBtn = this.#container.querySelector('#btn-take-photo');
+
+    cameraBtn?.addEventListener('click', () => this.#openCamera());
+    uploadBtn?.addEventListener('click', () => fileInput?.click());
+    fileInput?.addEventListener('change', (e) => this.#handleFileSelect(e));
+    cancelBtn?.addEventListener('click', () => this.#closeCamera());
+    takePhotoBtn?.addEventListener('click', () => this.#capturePhoto());
+  }
+
+  /**
+   * Open the camera and start the preview
+   */
+  async #openCamera() {
+    if (this.#cameraPermissionDenied) {
+      this.#showPermissionMessage();
+      return;
+    }
+
+    try {
+      this.#stream = await navigator.mediaDevices.getUserMedia({
+        video: ImageCapture.VIDEO_CONSTRAINTS,
+        audio: false,
+      });
+
+      const cameraContainer = this.#container.querySelector('#camera-container');
+      const buttonsContainer = this.#container.querySelector('.image-capture__buttons');
+      this.#videoElement = this.#container.querySelector('#camera-preview');
+
+      if (this.#videoElement && this.#stream) {
+        this.#videoElement.srcObject = this.#stream;
+        await this.#videoElement.play();
+      }
+
+      buttonsContainer?.setAttribute('hidden', '');
+      cameraContainer?.removeAttribute('hidden');
+      this.#isCameraActive = true;
+    } catch (error) {
+      console.error('Camera access error:', error);
+      this.#handleCameraError(error);
+    }
+  }
+
+  /**
+   * Handle camera access errors
+   * @param {Error} error
+   */
+  #handleCameraError(error) {
+    if (
+      error.name === 'NotAllowedError' ||
+      error.name === 'PermissionDeniedError'
+    ) {
+      this.#cameraPermissionDenied = true;
+      this.#showPermissionMessage();
+    } else if (error.name === 'NotFoundError') {
+      // No camera available
+      this.#showPermissionMessage();
+    } else {
+      // Other errors - show message and fall back to upload
+      this.#showPermissionMessage();
+    }
+  }
+
+  /**
+   * Show the permission denied message
+   */
+  #showPermissionMessage() {
+    const message = this.#container.querySelector('#permission-message');
+    message?.removeAttribute('hidden');
+
+    // Hide message after 5 seconds
+    setTimeout(() => {
+      message?.setAttribute('hidden', '');
+    }, 5000);
+  }
+
+  /**
+   * Close the camera and stop the stream
+   */
+  #closeCamera() {
+    if (this.#stream) {
+      this.#stream.getTracks().forEach((track) => track.stop());
+      this.#stream = null;
+    }
+
+    if (this.#videoElement) {
+      this.#videoElement.srcObject = null;
+    }
+
+    const cameraContainer = this.#container.querySelector('#camera-container');
+    const buttonsContainer = this.#container.querySelector('.image-capture__buttons');
+
+    cameraContainer?.setAttribute('hidden', '');
+    buttonsContainer?.removeAttribute('hidden');
+    this.#isCameraActive = false;
+  }
+
+  /**
+   * Capture a photo from the video stream
+   */
+  async #capturePhoto() {
+    if (!this.#videoElement || !this.#isCameraActive) {
+      return;
+    }
+
+    const video = this.#videoElement;
+    const canvas = document.createElement('canvas');
+
+    // Use actual video dimensions for best quality
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      console.error('Could not get canvas context');
+      return;
+    }
+
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+    // Convert to blob with high quality JPEG
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          this.#closeCamera();
+          this.#onCapture(blob);
+        }
+      },
+      'image/jpeg',
+      0.92
+    );
+  }
+
+  /**
+   * Handle file selection from input
+   * @param {Event} event
+   */
+  #handleFileSelect(event) {
+    const input = event.target;
+    if (!(input instanceof HTMLInputElement) || !input.files?.length) {
+      return;
+    }
+
+    const file = input.files[0];
+
+    // Validate it's an image
+    if (!file.type.startsWith('image/')) {
+      console.error('Selected file is not an image');
+      return;
+    }
+
+    this.#onCapture(file);
+
+    // Reset input so the same file can be selected again
+    input.value = '';
+  }
+
+  /**
+   * Clean up resources when component is destroyed
+   */
+  destroy() {
+    this.#closeCamera();
+    this.#container.innerHTML = '';
+  }
+}

--- a/ocr-poc/src/components/ImageCapture.js
+++ b/ocr-poc/src/components/ImageCapture.js
@@ -15,6 +15,12 @@
  * @property {(blob: Blob) => void} onCapture - Callback when image is captured
  */
 
+/** How long to display the permission denied message */
+const PERMISSION_MESSAGE_DISPLAY_MS = 5000;
+
+/** JPEG quality for captured photos (0-1 scale) */
+const JPEG_QUALITY = 0.92;
+
 export class ImageCapture {
   /** @type {HTMLElement} */
   #container;
@@ -34,10 +40,7 @@ export class ImageCapture {
   /** @type {boolean} */
   #cameraPermissionDenied = false;
 
-  /**
-   * Ideal video constraints for high-resolution capture
-   * 1920x1080 provides good OCR quality while being widely supported
-   */
+  /** 1920x1080 provides good OCR quality while being widely supported */
   static VIDEO_CONSTRAINTS = {
     facingMode: 'environment',
     width: { ideal: 1920 },
@@ -53,9 +56,6 @@ export class ImageCapture {
     this.#render();
   }
 
-  /**
-   * Render the component UI
-   */
   #render() {
     this.#container.innerHTML = `
       <div class="image-capture">
@@ -140,9 +140,6 @@ export class ImageCapture {
     this.#bindEvents();
   }
 
-  /**
-   * Bind event listeners to UI elements
-   */
   #bindEvents() {
     const cameraBtn = this.#container.querySelector('#btn-camera');
     const uploadBtn = this.#container.querySelector('#btn-upload');
@@ -157,9 +154,6 @@ export class ImageCapture {
     takePhotoBtn?.addEventListener('click', () => this.#capturePhoto());
   }
 
-  /**
-   * Open the camera and start the preview
-   */
   async #openCamera() {
     if (this.#cameraPermissionDenied) {
       this.#showPermissionMessage();
@@ -190,10 +184,7 @@ export class ImageCapture {
     }
   }
 
-  /**
-   * Handle camera access errors
-   * @param {Error} error
-   */
+  /** @param {Error} error */
   #handleCameraError(error) {
     if (
       error.name === 'NotAllowedError' ||
@@ -210,22 +201,15 @@ export class ImageCapture {
     }
   }
 
-  /**
-   * Show the permission denied message
-   */
   #showPermissionMessage() {
     const message = this.#container.querySelector('#permission-message');
     message?.removeAttribute('hidden');
 
-    // Hide message after 5 seconds
     setTimeout(() => {
       message?.setAttribute('hidden', '');
-    }, 5000);
+    }, PERMISSION_MESSAGE_DISPLAY_MS);
   }
 
-  /**
-   * Close the camera and stop the stream
-   */
   #closeCamera() {
     if (this.#stream) {
       this.#stream.getTracks().forEach((track) => track.stop());
@@ -244,9 +228,6 @@ export class ImageCapture {
     this.#isCameraActive = false;
   }
 
-  /**
-   * Capture a photo from the video stream
-   */
   async #capturePhoto() {
     if (!this.#videoElement || !this.#isCameraActive) {
       return;
@@ -267,7 +248,6 @@ export class ImageCapture {
 
     ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
 
-    // Convert to blob with high quality JPEG
     canvas.toBlob(
       (blob) => {
         if (blob) {
@@ -276,14 +256,11 @@ export class ImageCapture {
         }
       },
       'image/jpeg',
-      0.92
+      JPEG_QUALITY
     );
   }
 
-  /**
-   * Handle file selection from input
-   * @param {Event} event
-   */
+  /** @param {Event} event */
   #handleFileSelect(event) {
     const input = event.target;
     if (!(input instanceof HTMLInputElement) || !input.files?.length) {
@@ -304,9 +281,6 @@ export class ImageCapture {
     input.value = '';
   }
 
-  /**
-   * Clean up resources when component is destroyed
-   */
   destroy() {
     this.#closeCamera();
     this.#container.innerHTML = '';

--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -14,8 +14,10 @@ import './style.css';
 import { ImageCapture } from './components/ImageCapture.js';
 
 /** @type {ImageCapture | null} */
-// eslint-disable-next-line no-unused-vars -- Retained for potential cleanup via destroy()
 let imageCapture = null;
+
+/** @type {string | null} */
+let currentPreviewUrl = null;
 
 /**
  * Initialize the application
@@ -87,24 +89,35 @@ function handleImageCapture(blob) {
   const previewImage = document.getElementById('preview-image');
 
   if (previewContainer && previewImage) {
-    // Revoke previous object URL if exists
-    if (previewImage.src && previewImage.src.startsWith('blob:')) {
-      URL.revokeObjectURL(previewImage.src);
+    // Revoke previous object URL to prevent memory leak
+    if (currentPreviewUrl) {
+      URL.revokeObjectURL(currentPreviewUrl);
     }
 
-    // Create new object URL and display
-    const objectUrl = URL.createObjectURL(blob);
-    previewImage.src = objectUrl;
+    currentPreviewUrl = URL.createObjectURL(blob);
+    previewImage.src = currentPreviewUrl;
     previewContainer.removeAttribute('hidden');
   }
 }
 
-/**
- * Handle reference list loading (placeholder)
- */
 function handleLoadReference() {
   console.log('Reference list loading not yet implemented');
 }
+
+/** Clean up resources to prevent memory leaks */
+function cleanup() {
+  if (currentPreviewUrl) {
+    URL.revokeObjectURL(currentPreviewUrl);
+    currentPreviewUrl = null;
+  }
+  if (imageCapture) {
+    imageCapture.destroy();
+    imageCapture = null;
+  }
+}
+
+// Clean up on page unload
+window.addEventListener('pagehide', cleanup);
 
 // Initialize when DOM is ready
 if (document.readyState === 'loading') {

--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -11,6 +11,11 @@
  */
 
 import './style.css';
+import { ImageCapture } from './components/ImageCapture.js';
+
+/** @type {ImageCapture | null} */
+// eslint-disable-next-line no-unused-vars -- Retained for potential cleanup via destroy()
+let imageCapture = null;
 
 /**
  * Initialize the application
@@ -27,15 +32,19 @@ function init() {
   app.innerHTML = `
     <div class="container">
       <div class="card">
-        <h2 class="text-center mb-md">Welcome</h2>
+        <h2 class="text-center mb-md">Capture Scoresheet</h2>
         <p class="text-muted text-center mb-lg">
-          This app will help you scan volleyball scoresheets and extract player information.
+          Take a photo or upload an image of the scoresheet to extract player information.
         </p>
 
-        <div class="flex flex-col gap-md">
-          <button class="btn btn-primary btn-block btn-lg" id="btn-capture" disabled aria-label="Capture Scoresheet - coming soon">
-            Capture Scoresheet
-          </button>
+        <div id="image-capture-container"></div>
+
+        <div id="preview-container" class="image-capture__preview mt-lg" hidden>
+          <img id="preview-image" class="image-capture__thumbnail" alt="Captured scoresheet preview" />
+          <span class="image-capture__preview-label">Captured image preview</span>
+        </div>
+
+        <div class="mt-lg">
           <button class="btn btn-secondary btn-block" id="btn-reference" disabled aria-label="Load Reference List - coming soon">
             Load Reference List
           </button>
@@ -48,24 +57,46 @@ function init() {
     </div>
   `;
 
-  // Set up event listeners for future functionality
-  const captureBtn = document.getElementById('btn-capture');
-  const referenceBtn = document.getElementById('btn-reference');
-
-  if (captureBtn) {
-    captureBtn.addEventListener('click', handleCapture);
+  // Initialize ImageCapture component
+  const captureContainer = document.getElementById('image-capture-container');
+  if (captureContainer) {
+    imageCapture = new ImageCapture({
+      container: captureContainer,
+      onCapture: handleImageCapture,
+    });
   }
 
+  // Set up event listeners for future functionality
+  const referenceBtn = document.getElementById('btn-reference');
   if (referenceBtn) {
     referenceBtn.addEventListener('click', handleLoadReference);
   }
 }
 
 /**
- * Handle scoresheet capture (placeholder)
+ * Handle captured image
+ * @param {Blob} blob - The captured image as a Blob
  */
-function handleCapture() {
-  console.log('Capture functionality not yet implemented');
+function handleImageCapture(blob) {
+  console.log('Image captured:', blob);
+  console.log('  Type:', blob.type);
+  console.log('  Size:', (blob.size / 1024).toFixed(2), 'KB');
+
+  // Show thumbnail preview
+  const previewContainer = document.getElementById('preview-container');
+  const previewImage = document.getElementById('preview-image');
+
+  if (previewContainer && previewImage) {
+    // Revoke previous object URL if exists
+    if (previewImage.src && previewImage.src.startsWith('blob:')) {
+      URL.revokeObjectURL(previewImage.src);
+    }
+
+    // Create new object URL and display
+    const objectUrl = URL.createObjectURL(blob);
+    previewImage.src = objectUrl;
+    previewContainer.removeAttribute('hidden');
+  }
 }
 
 /**

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -287,3 +287,141 @@ body {
     padding: var(--spacing-xl);
   }
 }
+
+/* ==============================================
+ * IMAGE CAPTURE COMPONENT
+ * ============================================== */
+
+.image-capture {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.image-capture__buttons {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.image-capture__btn {
+  min-height: 48px; /* Touch-friendly target size */
+}
+
+.image-capture__icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.image-capture__file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Camera preview container */
+.image-capture__camera {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  background-color: var(--color-gray-900);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.image-capture__video {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background-color: var(--color-gray-800);
+}
+
+.image-capture__camera-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md);
+  background-color: var(--color-gray-900);
+}
+
+.image-capture__capture-btn {
+  width: 64px;
+  height: 64px;
+  padding: 0;
+  border-radius: 50%;
+  background-color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.image-capture__capture-btn svg {
+  width: 48px;
+  height: 48px;
+  color: var(--color-danger-500);
+}
+
+.image-capture__capture-btn:hover:not(:disabled) {
+  background-color: var(--color-gray-100);
+}
+
+.image-capture__capture-btn:active {
+  transform: scale(0.95);
+}
+
+.image-capture__spacer {
+  width: 80px; /* Match cancel button approximate width for centering */
+}
+
+/* Permission denied message */
+.image-capture__message {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+  background-color: var(--color-warning-500);
+  color: var(--color-gray-900);
+  border-radius: var(--radius-lg);
+}
+
+.image-capture__message-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  stroke: currentColor;
+}
+
+.image-capture__message p {
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Preview thumbnail */
+.image-capture__preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.image-capture__thumbnail {
+  max-width: 100%;
+  max-height: 300px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-default);
+  object-fit: contain;
+  background-color: var(--color-gray-100);
+}
+
+.image-capture__preview-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}


### PR DESCRIPTION
## Summary

- Add ImageCapture ES module class component for capturing scoresheet images via camera or file upload
- Integrate ImageCapture into main.js with blob logging and thumbnail preview display

## Changes

- **ocr-poc/src/components/ImageCapture.js**: New ES module class with:
  - Camera capture using rear camera (facingMode: 'environment') at 1920x1080 resolution
  - File upload accepting image/* files
  - Live video preview with capture button
  - Graceful permission denial handling with fallback message
  - destroy() method for cleanup

- **ocr-poc/src/style.css**: Added ImageCapture component styles:
  - Mobile-friendly touch targets (min 48px)
  - Camera preview container with controls
  - Permission denied warning message
  - Thumbnail preview styling

- **ocr-poc/src/main.js**: Updated to:
  - Import and instantiate ImageCapture component
  - Log captured blob details to console (type, size)
  - Display thumbnail preview of captured images

## Test Plan

- [ ] Open the app on a mobile device with camera
- [ ] Tap "Use Camera" and grant camera permission - verify live preview appears
- [ ] Tap the capture button - verify image is captured and thumbnail shows
- [ ] Tap "Upload Image" and select a file - verify thumbnail shows
- [ ] Deny camera permission - verify warning message appears and file upload still works
- [ ] Verify touch targets are at least 48px on mobile
- [ ] Check console logs show blob type and size after capture
- [ ] Run `npm run lint` - passes with no warnings
- [ ] Run `npm run build` - builds successfully
