### PR TITLE
feat(ocr-poc): add SheetTypeSelector component with state machine flow

### DIFF
--- a/ocr-poc/src/components/SheetTypeSelector.js
+++ b/ocr-poc/src/components/SheetTypeSelector.js
@@ -1,0 +1,146 @@
+/**
+ * SheetTypeSelector Component
+ *
+ * Allows the user to specify the type of scoresheet they captured:
+ * - Electronic/Printed: Screenshots or printed forms
+ * - Handwritten: Physical forms filled by hand
+ *
+ * This distinction helps optimize OCR processing for different text styles.
+ */
+
+/**
+ * @typedef {'electronic' | 'handwritten'} SheetType
+ */
+
+/**
+ * @typedef {Object} SheetSelection
+ * @property {SheetType} type - The selected sheet type
+ * @property {Blob} imageBlob - The captured image
+ */
+
+/**
+ * @typedef {Object} SheetTypeSelectorOptions
+ * @property {HTMLElement} container - Container element to render into
+ * @property {Blob} imageBlob - The captured image to display
+ * @property {(selection: SheetSelection) => void} onSelect - Callback when type is selected
+ * @property {() => void} [onBack] - Optional callback to go back to capture
+ */
+
+export class SheetTypeSelector {
+  /** @type {HTMLElement} */
+  #container;
+
+  /** @type {Blob} */
+  #imageBlob;
+
+  /** @type {(selection: SheetSelection) => void} */
+  #onSelect;
+
+  /** @type {(() => void) | undefined} */
+  #onBack;
+
+  /** @type {string | null} */
+  #previewUrl = null;
+
+  /**
+   * @param {SheetTypeSelectorOptions} options
+   */
+  constructor({ container, imageBlob, onSelect, onBack }) {
+    this.#container = container;
+    this.#imageBlob = imageBlob;
+    this.#onSelect = onSelect;
+    this.#onBack = onBack;
+    this.#render();
+  }
+
+  #render() {
+    // Create object URL for thumbnail preview
+    this.#previewUrl = URL.createObjectURL(this.#imageBlob);
+
+    this.#container.innerHTML = `
+      <div class="sheet-type-selector">
+        <div class="sheet-type-selector__preview">
+          <img
+            src="${this.#previewUrl}"
+            alt="Captured scoresheet"
+            class="sheet-type-selector__thumbnail"
+          />
+        </div>
+
+        <h3 class="sheet-type-selector__title">What type of scoresheet is this?</h3>
+
+        <div class="sheet-type-selector__options">
+          <button
+            type="button"
+            class="sheet-type-selector__option"
+            id="btn-electronic"
+            aria-describedby="desc-electronic"
+          >
+            <span class="sheet-type-selector__option-icon" aria-hidden="true">🖥️</span>
+            <span class="sheet-type-selector__option-label">Electronic / Printed</span>
+            <span class="sheet-type-selector__option-desc" id="desc-electronic">
+              Screenshots or printed forms with typed text
+            </span>
+          </button>
+
+          <button
+            type="button"
+            class="sheet-type-selector__option"
+            id="btn-handwritten"
+            aria-describedby="desc-handwritten"
+          >
+            <span class="sheet-type-selector__option-icon" aria-hidden="true">✍️</span>
+            <span class="sheet-type-selector__option-label">Handwritten</span>
+            <span class="sheet-type-selector__option-desc" id="desc-handwritten">
+              Physical forms filled in by hand
+            </span>
+          </button>
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-secondary btn-block sheet-type-selector__back"
+          id="btn-back"
+        >
+          ← Capture Different Image
+        </button>
+      </div>
+    `;
+
+    this.#bindEvents();
+  }
+
+  #bindEvents() {
+    const electronicBtn = this.#container.querySelector('#btn-electronic');
+    const handwrittenBtn = this.#container.querySelector('#btn-handwritten');
+    const backBtn = this.#container.querySelector('#btn-back');
+
+    electronicBtn?.addEventListener('click', () => this.#handleSelect('electronic'));
+    handwrittenBtn?.addEventListener('click', () => this.#handleSelect('handwritten'));
+    backBtn?.addEventListener('click', () => this.#handleBack());
+  }
+
+  /**
+   * @param {SheetType} type
+   */
+  #handleSelect(type) {
+    this.#onSelect({
+      type,
+      imageBlob: this.#imageBlob,
+    });
+  }
+
+  #handleBack() {
+    if (this.#onBack) {
+      this.#onBack();
+    }
+  }
+
+  destroy() {
+    if (this.#previewUrl) {
+      URL.revokeObjectURL(this.#previewUrl);
+      this.#previewUrl = null;
+    }
+    this.#container.innerHTML = '';
+  }
+}

--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -47,6 +47,9 @@ let imageCapture = null;
 /** @type {SheetTypeSelector | null} */
 let sheetTypeSelector = null;
 
+/** @type {string | null} Object URL for processing state preview image */
+let processingPreviewUrl = null;
+
 /* ==============================================
  * STATE MACHINE
  * ============================================== */
@@ -90,7 +93,10 @@ function cleanupState(state) {
       }
       break;
     case 'processing':
-      // Future: Clean up OCR processing
+      if (processingPreviewUrl) {
+        URL.revokeObjectURL(processingPreviewUrl);
+        processingPreviewUrl = null;
+      }
       break;
   }
 }
@@ -102,6 +108,7 @@ function cleanupState(state) {
 function renderState(state) {
   const contentContainer = document.getElementById('content-container');
   if (!contentContainer) {
+    console.error('Content container not found, cannot render state:', state);
     return;
   }
 
@@ -192,7 +199,8 @@ function renderProcessingState(container) {
   // Show the captured image
   const preview = document.getElementById('result-preview');
   if (preview && appContext.capturedImage) {
-    preview.src = URL.createObjectURL(appContext.capturedImage);
+    processingPreviewUrl = URL.createObjectURL(appContext.capturedImage);
+    preview.src = processingPreviewUrl;
   }
 
   // Bind start over button
@@ -231,11 +239,7 @@ function handleSheetTypeSelect(selection) {
  * Handle going back to capture from type selection
  */
 function handleBackToCapture() {
-  // Revoke the captured image URL to prevent memory leak
-  if (appContext.capturedImage) {
-    // Note: The SheetTypeSelector component handles its own URL cleanup
-  }
-
+  // SheetTypeSelector component handles its own URL cleanup via destroy()
   transition('capture', { capturedImage: null, sheetType: null });
 }
 

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -425,3 +425,89 @@ body {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
+
+/* ==============================================
+ * SHEET TYPE SELECTOR COMPONENT
+ * ============================================== */
+
+.sheet-type-selector {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.sheet-type-selector__preview {
+  display: flex;
+  justify-content: center;
+}
+
+.sheet-type-selector__thumbnail {
+  max-width: 100%;
+  max-height: 200px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-default);
+  object-fit: contain;
+  background-color: var(--color-gray-100);
+}
+
+.sheet-type-selector__title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  text-align: center;
+  color: var(--color-text-primary);
+}
+
+.sheet-type-selector__options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.sheet-type-selector__option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg);
+  background-color: var(--color-surface-subtle);
+  border: 2px solid var(--color-border-default);
+  border-radius: var(--radius-xl);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease, transform 0.1s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.sheet-type-selector__option:hover {
+  border-color: var(--color-primary-400);
+  background-color: var(--color-primary-50);
+}
+
+.sheet-type-selector__option:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}
+
+.sheet-type-selector__option:active {
+  transform: scale(0.98);
+}
+
+.sheet-type-selector__option-icon {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.sheet-type-selector__option-label {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.sheet-type-selector__option-desc {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.sheet-type-selector__back {
+  margin-top: var(--spacing-sm);
+}


### PR DESCRIPTION
## Summary

- Add SheetTypeSelector component to let users specify if their scoresheet is electronic/printed or handwritten
- Implement a simple state machine to manage the app flow between capture, type selection, and processing states
- Users can select photos from their library via the existing "Upload Image" button (no `capture` attribute restricts to camera-only)

## Changes

- `ocr-poc/src/components/SheetTypeSelector.js`: New component showing captured image thumbnail with two large buttons for electronic/handwritten selection
- `ocr-poc/src/main.js`: Refactored to use state machine pattern with `transition()` function managing capture → select-type → processing flow
- `ocr-poc/src/style.css`: Added styles for SheetTypeSelector including option buttons, thumbnail preview, and back button

## Test Plan

- [ ] Capture image via camera → verify SheetTypeSelector appears with thumbnail
- [ ] Upload image from library → verify SheetTypeSelector appears with thumbnail
- [ ] Select "Electronic / Printed" → verify console logs selection and processing state shows
- [ ] Select "Handwritten" → verify console logs selection and processing state shows
- [ ] Click "Capture Different Image" → verify returns to capture state
- [ ] Click "Start Over" from processing state → verify returns to capture state
- [ ] Test on mobile device to confirm photo library selection works
