### PR TITLE
feat(settings): add experimental section with OCR POC link

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'web-app/**'
+      - 'ocr-poc/**'
       - '.github/workflows/deploy-pr-preview.yml'
 permissions:
   contents: write
@@ -25,7 +26,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+          cache-dependency-path: |
+            web-app/package-lock.json
+            ocr-poc/package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Cache generated API types
@@ -52,6 +55,18 @@ jobs:
           VITE_OJP_API_KEY: ${{ secrets.VITE_OJP_API_KEY }}
       - name: Add .nojekyll for GitHub Pages
         run: touch dist/.nojekyll
+      # Build OCR POC
+      - name: Install OCR POC dependencies
+        run: npm ci
+        working-directory: ocr-poc
+      - name: Lint OCR POC
+        run: npm run lint
+        working-directory: ocr-poc
+      - name: Build OCR POC
+        run: npm run build
+        working-directory: ocr-poc
+        env:
+          VITE_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/ocr-poc/
       # Download existing gh-pages content to preserve main site and other PR previews
       - name: Download existing gh-pages content
         run: |
@@ -71,9 +86,12 @@ jobs:
           if [ -d "${{ github.workspace }}/gh-pages-current" ]; then
             rsync -a --exclude='.git' ${{ github.workspace }}/gh-pages-current/ ${{ github.workspace }}/deploy/
           fi
-          # Add/update this PR's preview
+          # Add/update this PR's preview (web-app)
           mkdir -p ${{ github.workspace }}/deploy/pr-${{ github.event.pull_request.number }}
           cp -r dist/* ${{ github.workspace }}/deploy/pr-${{ github.event.pull_request.number }}/
+          # Add/update OCR POC preview
+          mkdir -p ${{ github.workspace }}/deploy/pr-${{ github.event.pull_request.number }}/ocr-poc
+          cp -r ${{ github.workspace }}/ocr-poc/dist/* ${{ github.workspace }}/deploy/pr-${{ github.event.pull_request.number }}/ocr-poc/
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -86,8 +104,10 @@ jobs:
         with:
           script: |
             const previewUrl = `https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/`;
+            const ocrPocUrl = `${previewUrl}ocr-poc/`;
             const body = `## 🚀 PR Preview Deployed!\n\n` +
               `Your preview is ready at: ${previewUrl}\n\n` +
+              `**OCR POC:** ${ocrPocUrl}\n\n` +
               `> This preview will be updated on each push to this PR.\n\n` +
               `**Demo Mode Only:** This preview runs in demo mode with sample data. Real authentication is disabled for security.`;
 

--- a/web-app/src/components/features/settings/ExperimentalSection.tsx
+++ b/web-app/src/components/features/settings/ExperimentalSection.tsx
@@ -2,7 +2,10 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 
-const OCR_POC_URL = "/ocr-poc/";
+// Build OCR POC URL relative to the app's base path
+// In dev: BASE_URL is "/" → "/ocr-poc/"
+// In PR preview: BASE_URL is "/volleykit/pr-123/" → "/volleykit/pr-123/ocr-poc/"
+const OCR_POC_URL = `${import.meta.env.BASE_URL}ocr-poc/`;
 
 export function ExperimentalSection() {
   const { t } = useTranslation();

--- a/web-app/src/components/features/settings/ExperimentalSection.tsx
+++ b/web-app/src/components/features/settings/ExperimentalSection.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from "@/hooks/useTranslation";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+
+const OCR_POC_URL = "/ocr-poc/";
+
+export function ExperimentalSection() {
+  const { t } = useTranslation();
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
+          {t("settings.experimental.title")}
+        </h2>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t("settings.experimental.description")}
+        </p>
+
+        <div className="border-t border-border-subtle dark:border-border-subtle-dark pt-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <p className="font-medium text-text-primary dark:text-text-primary-dark">
+                {t("settings.experimental.ocrPoc")}
+              </p>
+              <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                {t("settings.experimental.ocrPocDescription")}
+              </p>
+            </div>
+            <Button
+              variant="secondary"
+              onClick={() => window.open(OCR_POC_URL, "_blank", "noopener,noreferrer")}
+              aria-label={t("settings.experimental.openOcrPoc")}
+            >
+              {t("settings.experimental.openOcrPoc")}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/src/components/features/settings/index.ts
+++ b/web-app/src/components/features/settings/index.ts
@@ -9,3 +9,4 @@ export { AccessibilitySection } from "./AccessibilitySection";
 export { SafeModeSection } from "./SafeModeSection";
 export { UpdateSection } from "./UpdateSection";
 export { AboutSection } from "./AboutSection";
+export { ExperimentalSection } from "./ExperimentalSection";

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -420,6 +420,13 @@ const de: Translations = {
       "Ihre Demo-Daten werden im Browser gespeichert. Zurücksetzen, um mit neuen Demo-Daten zu starten.",
     resetDemoData: "Demo-Daten zurücksetzen",
     demoDataReset: "Demo-Daten wurden zurückgesetzt",
+    experimental: {
+      title: "Experimentell",
+      description: "Funktionen in Entwicklung. Kann instabil sein.",
+      ocrPoc: "Spielberichts-Scanner",
+      ocrPocDescription: "OCR-Tool zum Scannen von Volleyball-Spielberichten",
+      openOcrPoc: "Scanner öffnen",
+    },
   },
   pwa: {
     offlineReady: "App bereit für Offline-Nutzung",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -418,6 +418,13 @@ const en: Translations = {
       "Your demo data modifications are saved in your browser. Reset to start fresh with new demo data.",
     resetDemoData: "Reset Demo Data",
     demoDataReset: "Demo data has been reset",
+    experimental: {
+      title: "Experimental",
+      description: "Features under development. May be unstable.",
+      ocrPoc: "Scoresheet Scanner",
+      ocrPocDescription: "OCR tool for scanning volleyball scoresheets",
+      openOcrPoc: "Open Scanner",
+    },
   },
   pwa: {
     offlineReady: "App ready for offline use",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -419,6 +419,13 @@ const fr: Translations = {
       "Vos modifications de démonstration sont enregistrées dans le navigateur. Réinitialisez pour repartir avec de nouvelles données.",
     resetDemoData: "Réinitialiser les données",
     demoDataReset: "Données de démonstration réinitialisées",
+    experimental: {
+      title: "Expérimental",
+      description: "Fonctionnalités en développement. Peut être instable.",
+      ocrPoc: "Scanner de feuille de match",
+      ocrPocDescription: "Outil OCR pour scanner les feuilles de match de volleyball",
+      openOcrPoc: "Ouvrir le scanner",
+    },
   },
   pwa: {
     offlineReady: "Application prête pour le mode hors ligne",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -417,6 +417,13 @@ const it: Translations = {
       "Le modifiche ai dati demo vengono salvate nel browser. Reimposta per ricominciare con nuovi dati demo.",
     resetDemoData: "Reimposta dati demo",
     demoDataReset: "I dati demo sono stati reimpostati",
+    experimental: {
+      title: "Sperimentale",
+      description: "Funzionalità in sviluppo. Potrebbe essere instabile.",
+      ocrPoc: "Scanner foglio partita",
+      ocrPocDescription: "Strumento OCR per la scansione dei fogli partita di pallavolo",
+      openOcrPoc: "Apri scanner",
+    },
   },
   pwa: {
     offlineReady: "App pronta per l'uso offline",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -280,6 +280,13 @@ export interface Translations {
     demoDataDescription: string;
     resetDemoData: string;
     demoDataReset: string;
+    experimental: {
+      title: string;
+      description: string;
+      ocrPoc: string;
+      ocrPocDescription: string;
+      openOcrPoc: string;
+    };
   };
   pwa: {
     offlineReady: string;

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -16,6 +16,7 @@ import {
   AccessibilitySection,
   SafeModeSection,
   UpdateSection,
+  ExperimentalSection,
   AboutSection,
 } from "@/components/features/settings";
 
@@ -84,6 +85,8 @@ export function SettingsPage() {
       )}
 
       {__PWA_ENABLED__ && <UpdateSection />}
+
+      <ExperimentalSection />
 
       <AboutSection />
 


### PR DESCRIPTION
## Summary

- Add an "Experimental" section to the Settings page with a button to open the OCR POC (Scoresheet Scanner)
- Update PR deployment workflow to also build and deploy the ocr-poc alongside the main web-app

## Changes

- Add translation keys for experimental section in `web-app/src/i18n/types.ts`
- Add translations for all 4 languages (de, en, fr, it) in locale files
- Create new `ExperimentalSection` component at `web-app/src/components/features/settings/ExperimentalSection.tsx`
- Export component from settings index
- Add `ExperimentalSection` to `SettingsPage.tsx`
- Update `.github/workflows/deploy-pr-preview.yml` to:
  - Trigger on `ocr-poc/**` path changes
  - Install, lint, and build the ocr-poc
  - Deploy ocr-poc to `pr-{number}/ocr-poc/` path
  - Include OCR POC link in PR preview comment

## Test Plan

- [ ] Visit Settings page and verify the "Experimental" section appears
- [ ] Click "Open Scanner" button and verify it opens `/ocr-poc/` in a new tab
- [ ] Verify translations display correctly in all 4 languages (de, en, fr, it)
- [ ] Verify PR preview deploys both web-app and ocr-poc
- [ ] Verify OCR POC is accessible at `{preview-url}/ocr-poc/`
