### PR TITLE
fix(pwa): prevent redirect loop for OCR POC on production

### DIFF
--- a/web-app/404.html
+++ b/web-app/404.html
@@ -13,6 +13,13 @@
         const search = window.location.search;
         const hash = window.location.hash;
 
+        // Don't redirect for subdirectory apps - they have their own index.html
+        // The ocr-poc is a separate Vite app deployed as a subdirectory
+        if (fullPath.includes('/ocr-poc/') || fullPath.endsWith('/ocr-poc')) {
+          // Let the browser handle this normally (will 404 or load the actual ocr-poc app)
+          return;
+        }
+
         // Detect the base path from the current URL
         // For PR previews: /volleykit/pr-123/some-route -> base is /volleykit/pr-123/
         // For main site: /volleykit/some-route -> base is /volleykit/

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -197,6 +197,8 @@ export default defineConfig(({ mode }) => {
             /\/logout$/,
             // Don't intercept PR preview routes - let them load their own assets
             /\/pr-\d+/,
+            // Don't intercept OCR POC routes - it's a separate app
+            /\/ocr-poc/,
           ],
           // Runtime caching for API responses
           runtimeCaching: [


### PR DESCRIPTION
## Summary

- Fix OCR POC redirect issue in production where navigating to the POC always redirected back to the main app
- The issue was caused by the main app's service worker and 404.html SPA fallback intercepting requests to /ocr-poc/

## Changes

- Add `/ocr-poc/` pattern to `navigateFallbackDenylist` in `web-app/vite.config.ts` to prevent the service worker from intercepting navigation to the POC
- Update `web-app/404.html` to skip the SPA redirect for paths containing `/ocr-poc/`, allowing the browser to load the actual OCR POC app

## Test Plan

- [ ] Deploy to production and verify https://takishima.github.io/volleykit/ocr-poc/ loads correctly
- [ ] Verify the main app still works normally at https://takishima.github.io/volleykit/
- [ ] Verify the OCR POC link in Settings > Experimental section opens the POC correctly
- [ ] Test direct navigation to /volleykit/ocr-poc/ in a fresh browser (no service worker cached)
- [ ] Test navigation after the service worker is installed
