### PR TITLE
fix(validation): sort roster players by last name alphabetically

### DIFF
--- a/web-app/src/components/features/validation/RosterVerificationPanel.tsx
+++ b/web-app/src/components/features/validation/RosterVerificationPanel.tsx
@@ -120,7 +120,9 @@ export function RosterVerificationPanel({
   const allPlayers = [...players, ...addedPlayers].sort((a, b) => {
     if (a.isNewlyAdded && !b.isNewlyAdded) return 1;
     if (!a.isNewlyAdded && b.isNewlyAdded) return -1;
-    return a.displayName.localeCompare(b.displayName);
+    const lastNameA = a.lastName ?? a.displayName;
+    const lastNameB = b.lastName ?? b.displayName;
+    return lastNameA.localeCompare(lastNameB);
   });
 
   // Compute formatted display data for all players (handles duplicate detection)


### PR DESCRIPTION
## Summary

- Sort players in team roster verification panels by last name alphabetically for easier lookup

## Changes

- Modified `RosterVerificationPanel.tsx` to sort players by `lastName` instead of `displayName`
- Added fallback to `displayName` when `lastName` is not available
- Newly added players still appear at the end of the list (existing behavior preserved)

## Test Plan

- [ ] Open the validation wizard for a game
- [ ] Verify home team roster shows players sorted alphabetically by last name
- [ ] Verify away team roster shows players sorted alphabetically by last name
- [ ] Add a new player and verify they appear at the end of the list
- [ ] Verify players with missing lastName still appear in the list (sorted by displayName)
