### PR TITLE
feat(validation): display scorer date of birth in validation wizard

### DIFF
--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -525,7 +525,8 @@ export const mockApi = {
     const scorerToShow = validatedData?.scorer ?? pendingScorer;
 
     // Build mock game details with scoresheet and nomination lists
-    const gameDetails: GameDetails = {
+    // Cast to allow extended writerPerson type with birthday (demo mode only)
+    const gameDetails = {
       __identity: gameId,
       // Include group info for scoresheet requirements
       ...(group && {
@@ -544,6 +545,7 @@ export const mockApi = {
           writerPerson: {
             __identity: scorerToShow.__identity,
             displayName: scorerToShow.displayName,
+            birthday: scorerToShow.birthday,
           },
         }),
         // Only validated games have closedAt
@@ -554,7 +556,7 @@ export const mockApi = {
       },
       nominationListOfTeamHome: gameNominations?.home ?? undefined,
       nominationListOfTeamAway: gameNominations?.away ?? undefined,
-    };
+    } as GameDetails;
 
     return gameDetails;
   },
@@ -634,14 +636,17 @@ export const mockApi = {
 
     const store = useDemoStore.getState();
 
-    // Find the scorer's display name from the scorers list
+    // Find the scorer's info from the scorers list
     const scorer = store.scorers.find((s) => s.__identity === scorerPersonId);
     const scorerDisplayName = scorer?.displayName ?? "Unknown Scorer";
+    // Convert null to undefined for type compatibility
+    const scorerBirthday = scorer?.birthday ?? undefined;
 
     // Persist pending scorer selection to demo store
     store.setPendingScorer(gameId, {
       __identity: scorerPersonId,
       displayName: scorerDisplayName,
+      birthday: scorerBirthday,
     });
 
     // In demo mode, return a mock updated scoresheet
@@ -666,15 +671,18 @@ export const mockApi = {
 
     const store = useDemoStore.getState();
 
-    // Find the scorer's display name from the scorers list
+    // Find the scorer's info from the scorers list
     const scorer = store.scorers.find((s) => s.__identity === scorerPersonId);
     const scorerDisplayName = scorer?.displayName ?? "Unknown Scorer";
+    // Convert null to undefined for type compatibility
+    const scorerBirthday = scorer?.birthday ?? undefined;
 
     // Mark the game as validated in the store
     store.markGameValidated(gameId, {
       scorer: {
         __identity: scorerPersonId,
         displayName: scorerDisplayName,
+        birthday: scorerBirthday,
       },
       scoresheetFileId: fileResourceId,
     });

--- a/web-app/src/components/features/validation/ScorerPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerPanel.tsx
@@ -9,6 +9,8 @@ interface ScorerPanelProps {
   readOnly?: boolean;
   /** Scorer name to display in read-only mode when no scorer data is available */
   readOnlyScorerName?: string;
+  /** Scorer birthday to display in read-only mode when no scorer data is available */
+  readOnlyScorerBirthday?: string;
 }
 
 /**
@@ -21,6 +23,7 @@ export function ScorerPanel({
   initialScorer = null,
   readOnly = false,
   readOnlyScorerName,
+  readOnlyScorerBirthday,
 }: ScorerPanelProps) {
   const [selectedScorer, setSelectedScorer] =
     useState<ValidatedPersonSearchResult | null>(initialScorer);
@@ -44,6 +47,7 @@ export function ScorerPanel({
       onScorerSelect={handleScorerSelect}
       readOnly={readOnly}
       readOnlyScorerName={readOnlyScorerName}
+      readOnlyScorerBirthday={readOnlyScorerBirthday}
     />
   );
 }

--- a/web-app/src/components/features/validation/ScorerSearchPanel.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.tsx
@@ -35,6 +35,8 @@ interface ScorerSearchPanelProps {
   readOnly?: boolean;
   /** Scorer name to display in read-only mode when no scorer data is available */
   readOnlyScorerName?: string;
+  /** Scorer birthday to display in read-only mode when no scorer data is available */
+  readOnlyScorerBirthday?: string;
 }
 
 /**
@@ -46,6 +48,7 @@ export function ScorerSearchPanel({
   onScorerSelect,
   readOnly = false,
   readOnlyScorerName,
+  readOnlyScorerBirthday,
 }: ScorerSearchPanelProps) {
   const { t, tInterpolate } = useTranslation();
   const [searchQuery, setSearchQuery] = useState("");
@@ -146,6 +149,7 @@ export function ScorerSearchPanel({
           <SelectedScorerCard
             scorer={selectedScorer}
             displayName={readOnlyScorerName}
+            displayBirthday={readOnlyScorerBirthday}
             readOnly
           />
         ) : (

--- a/web-app/src/components/features/validation/SelectedScorerCard.test.tsx
+++ b/web-app/src/components/features/validation/SelectedScorerCard.test.tsx
@@ -58,4 +58,87 @@ describe("SelectedScorerCard", () => {
 
     expect(screen.queryByText("15.03.85")).not.toBeInTheDocument();
   });
+
+  describe("displayBirthday fallback prop", () => {
+    it("displays birthday from displayBirthday prop when scorer is not available", () => {
+      render(
+        <SelectedScorerCard
+          displayName="Jane Doe"
+          displayBirthday="1990-06-20T00:00:00+00:00"
+          readOnly
+        />,
+      );
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.getByText("DOB: 20.06.90")).toBeInTheDocument();
+    });
+
+    it("displays birthday from displayBirthday when scorer has no birthday", () => {
+      const scorerWithoutBirthday = { ...mockScorer, birthday: undefined };
+      render(
+        <SelectedScorerCard
+          scorer={scorerWithoutBirthday}
+          displayBirthday="1988-12-01T00:00:00+00:00"
+          onClear={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("DOB: 01.12.88")).toBeInTheDocument();
+    });
+
+    it("prefers scorer.birthday over displayBirthday prop", () => {
+      render(
+        <SelectedScorerCard
+          scorer={mockScorer}
+          displayBirthday="1999-01-01T00:00:00+00:00"
+          onClear={vi.fn()}
+        />,
+      );
+
+      // Should show scorer's birthday (15.03.85), not displayBirthday
+      expect(screen.getByText("DOB: 15.03.85")).toBeInTheDocument();
+      expect(screen.queryByText("DOB: 01.01.99")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("metadata row visibility", () => {
+    it("shows metadata row with only birthday when no association ID", () => {
+      const scorerWithBirthdayOnly = {
+        ...mockScorer,
+        associationId: undefined,
+        birthday: "1992-07-15T00:00:00+00:00",
+      };
+      render(
+        <SelectedScorerCard scorer={scorerWithBirthdayOnly} onClear={vi.fn()} />,
+      );
+
+      // Should show birthday but not ID
+      expect(screen.getByText("DOB: 15.07.92")).toBeInTheDocument();
+      expect(screen.queryByText(/ID:/)).not.toBeInTheDocument();
+    });
+
+    it("shows metadata row with only association ID when no birthday", () => {
+      const scorerWithIdOnly = { ...mockScorer, birthday: undefined };
+      render(<SelectedScorerCard scorer={scorerWithIdOnly} onClear={vi.fn()} />);
+
+      expect(screen.getByText("ID: 12345")).toBeInTheDocument();
+      expect(screen.queryByText(/DOB:/)).not.toBeInTheDocument();
+    });
+
+    it("hides metadata row when neither association ID nor birthday present", () => {
+      const scorerWithNoMetadata = {
+        ...mockScorer,
+        associationId: undefined,
+        birthday: undefined,
+      };
+      render(
+        <SelectedScorerCard scorer={scorerWithNoMetadata} onClear={vi.fn()} />,
+      );
+
+      // Only the name should be visible, no metadata row
+      expect(screen.getByText("Hans Müller")).toBeInTheDocument();
+      expect(screen.queryByText(/ID:/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/DOB:/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/web-app/src/components/features/validation/SelectedScorerCard.tsx
+++ b/web-app/src/components/features/validation/SelectedScorerCard.tsx
@@ -8,6 +8,8 @@ interface SelectedScorerCardProps {
   scorer?: ValidatedPersonSearchResult | null;
   /** Fallback display name to use when scorer data is not available */
   displayName?: string;
+  /** Fallback birthday to use when scorer data is not available */
+  displayBirthday?: string;
   /** Callback to clear the selection */
   onClear?: () => void;
   /** When true, hides the clear button */
@@ -20,6 +22,7 @@ interface SelectedScorerCardProps {
 export function SelectedScorerCard({
   scorer,
   displayName,
+  displayBirthday,
   onClear,
   readOnly = false,
 }: SelectedScorerCardProps) {
@@ -27,6 +30,8 @@ export function SelectedScorerCard({
 
   // Use scorer displayName if available, otherwise use the displayName prop
   const name = scorer?.displayName ?? displayName ?? "";
+  // Use scorer birthday if available, otherwise use the displayBirthday prop
+  const birthday = scorer?.birthday ?? displayBirthday;
 
   return (
     <div className="mb-4 p-4 bg-primary-50 dark:bg-primary-900/20 rounded-lg border border-primary-200 dark:border-primary-800">
@@ -35,12 +40,12 @@ export function SelectedScorerCard({
           <div className="font-medium text-text-primary dark:text-text-primary-dark">
             {name}
           </div>
-          {scorer && (
+          {(scorer?.associationId || birthday) && (
             <div className="flex items-center gap-3 text-sm text-text-muted dark:text-text-muted-dark">
-              {scorer.associationId && <span>ID: {scorer.associationId}</span>}
-              {scorer.birthday && (
+              {scorer?.associationId && <span>ID: {scorer.associationId}</span>}
+              {birthday && (
                 <span>
-                  {t("common.dob")}: {formatDOB(scorer.birthday)}
+                  {t("common.dob")}: {formatDOB(birthday)}
                 </span>
               )}
             </div>

--- a/web-app/src/components/features/validation/StepRenderer.tsx
+++ b/web-app/src/components/features/validation/StepRenderer.tsx
@@ -112,12 +112,13 @@ export function StepRenderer({
           onScorerChange={handlers.setScorer}
           readOnly={validation.isValidated}
           readOnlyScorerName={validation.validatedInfo?.scorerName}
+          readOnlyScorerBirthday={validation.validatedInfo?.scorerBirthday}
           initialScorer={
             validation.pendingScorer
               ? {
                   __identity: validation.pendingScorer.__identity,
                   displayName: validation.pendingScorer.displayName,
-                  birthday: "",
+                  birthday: validation.pendingScorer.birthday ?? "",
                 }
               : null
           }

--- a/web-app/src/hooks/useValidationState.ts
+++ b/web-app/src/hooks/useValidationState.ts
@@ -99,20 +99,29 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
   const validatedInfo = useMemo<ValidatedGameInfo | null>(() => {
     const scoresheet = gameDetailsQuery.data?.scoresheet;
     if (!scoresheet?.closedAt) return null;
+    // Cast to include birthday which is available in demo mode
+    const writerPerson = scoresheet.writerPerson as
+      | { displayName?: string; birthday?: string }
+      | undefined;
     return {
       validatedAt: scoresheet.closedAt,
-      scorerName: scoresheet.writerPerson?.displayName ?? "Unknown",
+      scorerName: writerPerson?.displayName ?? "Unknown",
+      scorerBirthday: writerPerson?.birthday,
       hasScoresheet: !!scoresheet.hasFile,
     };
   }, [gameDetailsQuery.data]);
 
   const pendingScorer = useMemo<PendingScorerData | null>(() => {
     if (isValidated) return null;
-    const writerPerson = gameDetailsQuery.data?.scoresheet?.writerPerson;
+    // Cast to include birthday which is available in demo mode
+    const writerPerson = gameDetailsQuery.data?.scoresheet?.writerPerson as
+      | { __identity?: string; displayName?: string; birthday?: string }
+      | undefined;
     if (!writerPerson?.__identity) return null;
     return {
       __identity: writerPerson.__identity,
       displayName: writerPerson.displayName ?? "Unknown",
+      birthday: writerPerson.birthday,
     };
   }, [gameDetailsQuery.data, isValidated]);
 

--- a/web-app/src/hooks/validation/types.ts
+++ b/web-app/src/hooks/validation/types.ts
@@ -60,6 +60,7 @@ export interface PanelCompletionStatus {
 export interface ValidatedGameInfo {
   validatedAt: string;
   scorerName: string;
+  scorerBirthday?: string;
   hasScoresheet: boolean;
 }
 
@@ -69,6 +70,7 @@ export interface ValidatedGameInfo {
 export interface PendingScorerData {
   __identity: string;
   displayName: string;
+  birthday?: string;
 }
 
 /**

--- a/web-app/src/stores/demo/types.ts
+++ b/web-app/src/stores/demo/types.ts
@@ -30,6 +30,7 @@ export interface ValidatedGameData {
   scorer: {
     __identity: string;
     displayName: string;
+    birthday?: string;
   };
   scoresheetFileId?: string;
   homeRosterClosed: boolean;
@@ -40,6 +41,7 @@ export interface ValidatedGameData {
 export interface PendingScorerData {
   __identity: string;
   displayName: string;
+  birthday?: string;
 }
 
 // Compensation edits for assignments (stored separately since assignments
@@ -156,7 +158,7 @@ export interface DemoState
   markGameValidated: (
     gameId: string,
     data: {
-      scorer: { __identity: string; displayName: string };
+      scorer: { __identity: string; displayName: string; birthday?: string };
       scoresheetFileId?: string;
     },
   ) => void;
@@ -164,7 +166,7 @@ export interface DemoState
   getValidatedGameData: (gameId: string) => ValidatedGameData | null;
   setPendingScorer: (
     gameId: string,
-    scorer: { __identity: string; displayName: string },
+    scorer: { __identity: string; displayName: string; birthday?: string },
   ) => void;
   getPendingScorer: (gameId: string) => PendingScorerData | null;
   clearPendingScorer: (gameId: string) => void;

--- a/web-app/src/stores/demo/validation.ts
+++ b/web-app/src/stores/demo/validation.ts
@@ -15,7 +15,7 @@ export interface ValidationSlice extends DemoValidationState {
   markGameValidated: (
     gameId: string,
     data: {
-      scorer: { __identity: string; displayName: string };
+      scorer: { __identity: string; displayName: string; birthday?: string };
       scoresheetFileId?: string;
     },
   ) => void;
@@ -23,7 +23,7 @@ export interface ValidationSlice extends DemoValidationState {
   getValidatedGameData: (gameId: string) => ValidatedGameData | null;
   setPendingScorer: (
     gameId: string,
-    scorer: { __identity: string; displayName: string },
+    scorer: { __identity: string; displayName: string; birthday?: string },
   ) => void;
   getPendingScorer: (gameId: string) => PendingScorerData | null;
   clearPendingScorer: (gameId: string) => void;
@@ -41,7 +41,7 @@ export const createValidationSlice: StateCreator<
   markGameValidated: (
     gameId: string,
     data: {
-      scorer: { __identity: string; displayName: string };
+      scorer: { __identity: string; displayName: string; birthday?: string };
       scoresheetFileId?: string;
     },
   ) =>
@@ -68,7 +68,7 @@ export const createValidationSlice: StateCreator<
 
   setPendingScorer: (
     gameId: string,
-    scorer: { __identity: string; displayName: string },
+    scorer: { __identity: string; displayName: string; birthday?: string },
   ) =>
     set((state) => ({
       pendingScorers: {


### PR DESCRIPTION
Add date of birth display for scorers in the validation wizard's scorer
panel, both when selecting a scorer and when viewing a validated game.

- Add birthday field to ValidatedGameData and PendingScorerData types
- Add scorerBirthday to ValidatedGameInfo for validated games
- Update mock-api to store and return scorer birthday
- Update useValidationState to extract birthday from game details
- Pass birthday through StepRenderer to ScorerPanel/ScorerSearchPanel
- Update SelectedScorerCard to show birthday when scorer data or
  displayBirthday prop is available