### PR TITLE
fix(compensation): load existing kilometers and reason when editing assignment compensation

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.test.tsx
+++ b/web-app/src/components/features/EditCompensationModal.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { EditCompensationModal } from "./EditCompensationModal";
 import type { CompensationRecord, Assignment } from "@/api/client";
 import { getApiClient } from "@/api/client";
+import { COMPENSATION_LOOKUP_LIMIT } from "@/hooks/usePaginatedQuery";
 import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import * as useConvocationsModule from "@/hooks/useConvocations";
@@ -265,7 +266,7 @@ describe("EditCompensationModal", () => {
       expect(reasonInput).toHaveValue("Detour via highway");
 
       // Verify the API was called correctly
-      expect(mockSearchCompensations).toHaveBeenCalledWith({ limit: 100 });
+      expect(mockSearchCompensations).toHaveBeenCalledWith({ limit: COMPENSATION_LOOKUP_LIMIT });
       expect(mockGetCompensationDetails).toHaveBeenCalledWith("found-comp-id");
     });
 

--- a/web-app/src/components/features/EditCompensationModal.test.tsx
+++ b/web-app/src/components/features/EditCompensationModal.test.tsx
@@ -75,6 +75,7 @@ function createMockAssignment(
     refereeGame: {
       game: {
         __identity: "game-1",
+        number: 12345,
         startingDateTime: "2025-12-15T14:00:00Z",
         encounter: {
           teamHome: { name: "VBC Zürich" },
@@ -98,6 +99,7 @@ describe("EditCompensationModal", () => {
   const mockMutate = vi.fn();
   const mockAssignmentMutate = vi.fn();
   const mockGetCompensationDetails = vi.fn();
+  const mockSearchCompensations = vi.fn();
   const mockGetAssignmentCompensation = vi.fn();
 
   beforeEach(() => {
@@ -162,6 +164,7 @@ describe("EditCompensationModal", () => {
 
     (getApiClient as Mock).mockReturnValue({
       getCompensationDetails: mockGetCompensationDetails,
+      searchCompensations: mockSearchCompensations,
     });
 
     mockGetCompensationDetails.mockResolvedValue({
@@ -170,6 +173,9 @@ describe("EditCompensationModal", () => {
         correctionReason: "",
       },
     });
+
+    // Default: return empty compensations list
+    mockSearchCompensations.mockResolvedValue({ items: [] });
   });
 
   describe("rendering", () => {
@@ -221,9 +227,25 @@ describe("EditCompensationModal", () => {
       });
     });
 
-    it("renders form immediately when only assignment provided (no API fetch)", async () => {
-      // When only assignment is provided (no compensation), there's no compensationId
-      // so the API fetch is skipped and the form renders immediately
+    it("fetches and pre-fills existing compensation data for assignment in production mode", async () => {
+      // Mock searchCompensations to return a compensation with matching game number
+      mockSearchCompensations.mockResolvedValue({
+        items: [
+          {
+            refereeGame: { game: { number: 12345 } },
+            convocationCompensation: { __identity: "found-comp-id" },
+          },
+        ],
+      });
+
+      // Mock getCompensationDetails to return existing values
+      mockGetCompensationDetails.mockResolvedValue({
+        convocationCompensation: {
+          distanceInMetres: 32500,
+          correctionReason: "Detour via highway",
+        },
+      });
+
       render(
         <EditCompensationModal
           assignment={createMockAssignment()}
@@ -233,11 +255,47 @@ describe("EditCompensationModal", () => {
         { wrapper: createWrapper() },
       );
 
-      // Form should render immediately without waiting for API
-      // Query with hidden: true because the backdrop has aria-hidden
-      expect(screen.getByRole("dialog", { hidden: true })).toBeInTheDocument();
-      expect(screen.getByLabelText("Kilometers")).toBeInTheDocument();
-      expect(screen.getByText("Save")).toBeInTheDocument();
+      // Wait for the form to load with pre-filled data
+      await waitFor(() => {
+        const kmInput = screen.getByLabelText("Kilometers");
+        expect(kmInput).toHaveValue("32.5");
+      });
+
+      const reasonInput = screen.getByLabelText("Reason");
+      expect(reasonInput).toHaveValue("Detour via highway");
+
+      // Verify the API was called correctly
+      expect(mockSearchCompensations).toHaveBeenCalledWith({ limit: 100 });
+      expect(mockGetCompensationDetails).toHaveBeenCalledWith("found-comp-id");
+    });
+
+    it("shows empty form when no compensation exists for assignment", async () => {
+      // Mock searchCompensations to return no matching compensation
+      mockSearchCompensations.mockResolvedValue({ items: [] });
+
+      render(
+        <EditCompensationModal
+          assignment={createMockAssignment()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+        { wrapper: createWrapper() },
+      );
+
+      // Wait for loading to complete
+      await waitFor(() => {
+        expect(screen.getByLabelText("Kilometers")).toBeInTheDocument();
+      });
+
+      // Form should be empty since no compensation was found
+      const kmInput = screen.getByLabelText("Kilometers");
+      expect(kmInput).toHaveValue("");
+
+      const reasonInput = screen.getByLabelText("Reason");
+      expect(reasonInput).toHaveValue("");
+
+      // Compensation details should not be fetched since no compensation was found
+      expect(mockGetCompensationDetails).not.toHaveBeenCalled();
     });
 
     it("returns null when neither assignment nor compensation provided", () => {


### PR DESCRIPTION
## Summary

- Fixed a bug where the compensation modal did not pre-fill existing kilometers and correction reason values when editing compensation for a future game from the assignments page in production mode

## Changes

- **web-app/src/components/features/EditCompensationModal.tsx**:
  - Added `useQueryClient` hook and `queryKeys` import for cache lookup
  - Added helper function `findCompensationInCache()` to search cached compensations by game number
  - Extended the data fetching `useEffect` to handle assignment edits in production mode:
    - Looks up compensation record by matching game number in the TanStack Query cache
    - Falls back to fetching compensations from the API if not cached
    - Fetches detailed compensation data once the compensation ID is found
    - Pre-fills the form with existing `distanceInMetres` (converted to km) and `correctionReason`

- **web-app/src/components/features/EditCompensationModal.test.tsx**:
  - Added `number` field to mock assignment's game object
  - Added `mockSearchCompensations` mock for the API client
  - Added test: "fetches and pre-fills existing compensation data for assignment in production mode"
  - Added test: "shows empty form when no compensation exists for assignment"

## Test Plan

- [ ] Open the app in production mode (not demo mode)
- [ ] Navigate to the Assignments page
- [ ] Find a future game that has existing compensation data (kilometers and/or reason already saved)
- [ ] Open the edit compensation modal for that assignment
- [ ] Verify the kilometers field is pre-filled with the existing value
- [ ] Verify the reason field is pre-filled with the existing correction reason
- [ ] Verify saving the form still works correctly
- [ ] Run unit tests: `npm test -- src/components/features/EditCompensationModal.test.tsx`
