### PR TITLE
fix(validation): request scorer birthday from API for validated games

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -368,6 +368,8 @@ export const api = {
       "scoresheet.game.__identity",
       "scoresheet.isSimpleScoresheet",
       "scoresheet.writerPerson",
+      "scoresheet.writerPerson.displayName",
+      "scoresheet.writerPerson.birthday",
       "scoresheet.file",
       "scoresheet.hasFile",
       "scoresheet.closedAt",


### PR DESCRIPTION
## Summary

- Fixed scorer date of birth not being displayed for already validated games in the validation wizard

## Changes

- Added `scoresheet.writerPerson.displayName` and `scoresheet.writerPerson.birthday` to the property render configuration in `getGameWithScoresheet()` API call (`web-app/src/api/client.ts:371-372`)

## Test Plan

- [ ] Open a game that has already been validated
- [ ] Navigate to step 3 (scorer) in the validation wizard
- [ ] Verify the scorer's date of birth is displayed alongside their name
- [ ] Verify the display works for games that are not yet validated (no regression)
