### PR TITLE
fix(api): only detect stale session when redirected to login page

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -191,6 +191,23 @@ describe("API Client", () => {
         "Unexpected HTML response (expected JSON)",
       );
     });
+
+    it("does not treat HTML response as stale session for login-like paths", async () => {
+      // Paths like /api/v2/login-history or /user/login-preferences should NOT
+      // be treated as login page redirects - only exact /login matches should.
+      setCsrfToken("some-token");
+
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse("<html>Login history page</html>", {
+          contentType: "text/html; charset=UTF-8",
+          url: "https://example.com/api/v2/login-history",
+        }),
+      );
+
+      await expect(api.searchAssignments({})).rejects.toThrow(
+        "Unexpected HTML response (expected JSON)",
+      );
+    });
   });
 
   describe("searchAssignments", () => {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -143,9 +143,18 @@ async function apiRequest<T>(
   // Detect stale session: when the API returns HTML instead of JSON with status 200,
   // it means the session expired and the server is returning a login page.
   // This commonly happens with TYPO3 Neos/Flow backends that don't return proper 401.
+  // Only treat as stale if we were actually redirected to a login page, to avoid
+  // false positives on valid sessions that happen to receive HTML responses.
   if (contentType.includes("text/html")) {
-    clearSession();
-    throw new Error("Session expired. Please log in again.");
+    const isLoginPage = response.url.toLowerCase().includes("/login");
+    if (isLoginPage) {
+      clearSession();
+      throw new Error("Session expired. Please log in again.");
+    }
+    // Non-login HTML response - treat as an API error, not auth failure
+    throw new Error(
+      `${method} ${endpoint}: Unexpected HTML response (expected JSON)`,
+    );
   }
 
   try {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -146,7 +146,10 @@ async function apiRequest<T>(
   // Only treat as stale if we were actually redirected to a login page, to avoid
   // false positives on valid sessions that happen to receive HTML responses.
   if (contentType.includes("text/html")) {
-    const isLoginPage = response.url.toLowerCase().includes("/login");
+    // Check if pathname ends with "/login" to avoid false positives on paths
+    // like "/api/v2/login-history" or "/user/login-preferences"
+    const pathname = new URL(response.url).pathname.toLowerCase();
+    const isLoginPage = pathname === "/login" || pathname.endsWith("/login");
     if (isLoginPage) {
       clearSession();
       throw new Error("Session expired. Please log in again.");


### PR DESCRIPTION
## Summary

- Fixed false positive stale session detection that was incorrectly logging out users with valid sessions
- The previous implementation treated any HTML response as a stale session, but now it only triggers when the response URL contains "/login" (indicating actual redirect to login page)

## Changes

- `web-app/src/api/client.ts`: Updated stale session detection to check `response.url` for "/login" before treating HTML responses as auth failures
- `web-app/src/api/client.test.ts`: Added `url` option to mock response helper and updated tests to cover both login page redirects and non-login HTML responses

## Test Plan

- [ ] Log in with valid credentials and verify normal API calls work without being logged out
- [ ] Let session expire naturally and verify you're redirected to login when making API calls
- [ ] Verify that HTML error responses from non-login URLs show an error message but don't log you out
- [ ] Run `npm test` - all 2445 tests pass
- [ ] Run `npm run lint` - no warnings
- [ ] Run `npm run build` - builds successfully
