### PR TITLE
fix(auth): use non-greedy regex for activeParty extraction

### DIFF
--- a/web-app/src/utils/active-party-parser.ts
+++ b/web-app/src/utils/active-party-parser.ts
@@ -118,13 +118,14 @@ const ACTIVE_PARTY_PATTERN =
  * This is the format used in production VolleyManager pages.
  * Captures the JSON object inside the $convertFromBackendToFrontend() call.
  *
- * Uses greedy matching because the JSON object contains nested braces.
- * The pattern is safe because:
- * - Quotes inside JSON are HTML-encoded as &quot;, so )" only appears at the end
- * - The /s flag allows . to match newlines
+ * Uses non-greedy matching (.+?) to stop at the first })" sequence after the opening brace.
+ * This is correct because:
+ * - Quotes inside JSON are HTML-encoded as &quot;, so }" cannot appear inside JSON string values
+ * - The /s flag allows . to match newlines for multi-line JSON
+ * - Greedy matching would incorrectly extend to later })" sequences elsewhere in the HTML
  */
 const VUE_ACTIVE_PARTY_PATTERN =
-  /:active-party="\$convertFromBackendToFrontend\((\{.+\})\)"/s;
+  /:active-party="\$convertFromBackendToFrontend\((\{.+?\})\)"/s;
 
 /**
  * Decode HTML entities in a string.


### PR DESCRIPTION
## Summary

- Fixed the association dropdown not appearing for users with multiple associations
- The root cause was a greedy regex pattern that captured too much content when parsing the `:active-party` Vue attribute from dashboard HTML

## Changes

- Changed `VUE_ACTIVE_PARTY_PATTERN` regex from greedy (`.+`) to non-greedy (`.+?`) matching in `web-app/src/utils/active-party-parser.ts`
- Updated the comment to explain why non-greedy matching is correct for this use case

The greedy regex was matching from the first `{` to the LAST `})"` in the entire HTML document (53,189 chars), instead of stopping at the actual end of the JSON object (33,756 chars). This caused JSON parsing to fail silently, resulting in empty `occupations`, `groupedEligibleAttributeValues`, and `eligibleAttributeValues` arrays.

## Test Plan

- [ ] Log in with real credentials (not demo mode)
- [ ] Verify the association dropdown appears in the header for users with multiple associations
- [ ] Verify switching between associations works correctly
- [ ] Run the bookmarklet on the app to confirm parsing now succeeds:
    javascript:(function(){var s=JSON.parse(localStorage.getItem('volleykit-auth'));alert('Occupations: '+(s?.state?.user?.occupations?.length||0));})();
- [ ] All existing tests pass (28 active-party-parser tests, 39 parseOccupations tests)
