### PR TITLE
fix(layout): make top bar sticky to match bottom bar behavior

### DIFF
--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -117,8 +117,8 @@ export function AppShell() {
 
   return (
     <div className="flex flex-col flex-1 bg-surface-page dark:bg-surface-page-dark">
-      {/* Header */}
-      <header className="bg-surface-card dark:bg-surface-card-dark shadow-sm border-b border-border-default dark:border-border-default-dark">
+      {/* Header - fixed to always stay visible */}
+      <header className="bg-surface-card dark:bg-surface-card-dark shadow-sm border-b border-border-default dark:border-border-default-dark fixed top-0 left-0 right-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-14">
             <div className="flex items-center gap-2">
@@ -194,6 +194,9 @@ export function AppShell() {
           </div>
         </div>
       </header>
+
+      {/* Spacer to account for fixed header height (h-14 = 3.5rem = 56px) */}
+      <div className="h-14" aria-hidden="true" />
 
       {/* Demo mode banner */}
       {isDemoMode && (

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -118,7 +118,7 @@ export function AppShell() {
   return (
     <div className="flex flex-col flex-1 bg-surface-page dark:bg-surface-page-dark">
       {/* Header - fixed to always stay visible */}
-      <header className="bg-surface-card dark:bg-surface-card-dark shadow-sm border-b border-border-default dark:border-border-default-dark fixed top-0 left-0 right-0 z-50">
+      <header className="bg-surface-card dark:bg-surface-card-dark shadow-sm border-b border-border-default dark:border-border-default-dark fixed top-0 left-0 right-0 z-50 safe-area-inset-top">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-14">
             <div className="flex items-center gap-2">
@@ -195,8 +195,8 @@ export function AppShell() {
         </div>
       </header>
 
-      {/* Spacer to account for fixed header height (h-14 = 3.5rem = 56px) */}
-      <div className="h-14" aria-hidden="true" />
+      {/* Spacer to account for fixed header height plus safe area inset */}
+      <div className="header-spacer" aria-hidden="true" />
 
       {/* Demo mode banner */}
       {isDemoMode && (

--- a/web-app/src/index.css
+++ b/web-app/src/index.css
@@ -140,8 +140,17 @@
 /* Utility classes */
 @layer utilities {
   /* Safe area padding for iOS devices with notch/home indicator */
+  .safe-area-inset-top {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+
   .safe-area-inset-bottom {
     padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+
+  /* Spacer that accounts for fixed header height (h-14 = 3.5rem) plus safe area */
+  .header-spacer {
+    height: calc(3.5rem + env(safe-area-inset-top, 0px));
   }
 }
 


### PR DESCRIPTION
## Summary

- Make the top bar (header) sticky/fixed to match the bottom navigation bar behavior

## Changes

- Added fixed positioning classes (`fixed top-0 left-0 right-0 z-50`) to the header in `AppShell.tsx`
- Added a spacer div with `h-14` to account for the fixed header height and prevent content overlap

## Test Plan

- [ ] Scroll down on any page and verify the top bar stays fixed at the top
- [ ] Verify the bottom bar is still fixed at the bottom
- [ ] Verify content is not hidden behind the fixed header (demo mode banner, tour banner, and main content should all be visible)
- [ ] Test on mobile viewport to ensure proper behavior
- [ ] Verify the occupation dropdown in the header still works correctly when fixed
