### PR TITLE
fix(auth): associations dropdown not appearing for multi-association user

### DIFF
--- a/web-app/src/utils/active-party-parser.ts
+++ b/web-app/src/utils/active-party-parser.ts
@@ -13,7 +13,7 @@ import { logger } from "@/utils/logger";
  * Represents an inflated association value with full details.
  */
 export interface InflatedAssociationValue {
-  __identity: string;
+  __identity?: string; // Some inflatedValue objects don't have __identity
   name?: string;
   shortName?: string;
   /** Association identifier code (e.g., "912000" for SVRZ) */
@@ -67,7 +67,7 @@ export interface ActiveParty {
 
 // Zod schemas for runtime validation of parsed JSON
 const InflatedValueSchema = z.object({
-  __identity: z.string(),
+  __identity: z.string().optional(), // Some inflatedValue objects don't have __identity
   name: z.string().optional(),
   shortName: z.string().optional(),
   identifier: z.string().optional(),


### PR DESCRIPTION
## Summary

- Fix associations dropdown not appearing for users with multiple associations
- Root cause: Zod schema validation was too strict, causing the entire activeParty parsing to fail silently

## Changes

- Make `__identity` optional in `InflatedValueSchema` Zod schema (`active-party-parser.ts:70`)
- Make `__identity` optional in `InflatedAssociationValue` TypeScript interface (`active-party-parser.ts:16`)

## Root Cause Analysis

Some `inflatedValue` objects in the API response don't have `__identity` (e.g., boolean role flags). The strict Zod schema required `__identity: z.string()`, which caused:

1. One item in `groupedEligibleAttributeValues` failed validation
2. Zod's `safeParse` returned `{ success: false }` for the entire array
3. `extractActivePartyFromHtml` returned `null`
4. `deriveUserWithOccupations` received `null` and returned 0 occupations
5. The dropdown never appeared (requires >= 2 occupations)

## Test Plan

- [ ] Clear localStorage and log in with an account that has multiple associations
- [ ] Verify the associations dropdown appears in the header
- [ ] Verify switching associations works correctly
- [ ] Run existing tests: `npm test -- --run active-party-parser`
