### PR TITLE
fix(auth): preserve attribute values when checkSession fetches page without activeParty

### DIFF
--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -321,9 +321,17 @@ export const useAuthStore = create<AuthState>()(
                 set({
                   status: "authenticated",
                   csrfToken: csrfToken ?? currentState.csrfToken,
-                  eligibleAttributeValues: activeParty?.eligibleAttributeValues ?? null,
-                  groupedEligibleAttributeValues: activeParty?.groupedEligibleAttributeValues ?? null,
-                  eligibleRoles: activeParty?.eligibleRoles ?? null,
+                  // Preserve existing attribute values if new values are missing
+                  // This prevents the association dropdown from disappearing when
+                  // checkSession fetches a page without activeParty data
+                  eligibleAttributeValues:
+                    activeParty?.eligibleAttributeValues ??
+                    currentState.eligibleAttributeValues,
+                  groupedEligibleAttributeValues:
+                    activeParty?.groupedEligibleAttributeValues ??
+                    currentState.groupedEligibleAttributeValues,
+                  eligibleRoles:
+                    activeParty?.eligibleRoles ?? currentState.eligibleRoles,
                   user,
                   activeOccupationId,
                 });


### PR DESCRIPTION
## Summary

- Fixed race condition causing associations dropdown to disappear after login for multi-association users
- The bug occurred because `checkSession()` would nullify `groupedEligibleAttributeValues` when fetching a dashboard page that didn't contain activeParty data

## Changes

- **web-app/src/stores/auth.ts**: Modified `checkSession()` to preserve existing `eligibleAttributeValues`, `groupedEligibleAttributeValues`, and `eligibleRoles` when new values are missing (similar to how `csrfToken` is already preserved)
- **web-app/src/stores/auth.test.ts**: Added test case "preserves groupedEligibleAttributeValues when dashboard has no activeParty data"

## Root Cause

After login, the app navigates to "/" which triggers `checkSession()` in `ProtectedRoute`. If the dashboard response doesn't contain activeParty data, the previous code would set:

    groupedEligibleAttributeValues: activeParty?.groupedEligibleAttributeValues ?? null

This overwrote the valid data stored during login, causing `hasMultipleAssociations()` to return false and hiding the dropdown.

## Test Plan

- [ ] Clear localStorage and login with a multi-association user
- [ ] Verify the associations dropdown appears after login
- [ ] Navigate between pages and verify dropdown persists
- [ ] Refresh the page and verify dropdown still appears
- [ ] Run `npm test -- --run src/stores/auth.test.ts` - all 27 tests pass
- [ ] Run `npm run lint` - no warnings
- [ ] Run `npm run build` - builds successfully
