### PR TITLE
fix(auth): fetch dashboard when already logged in to get activeParty

### DIFF
--- a/web-app/src/stores/auth.test.ts
+++ b/web-app/src/stores/auth.test.ts
@@ -276,9 +276,18 @@ describe("useAuthStore", () => {
     it("handles already authenticated user (login page has CSRF token)", async () => {
       // When user has existing valid session, /login redirects to authenticated page
       // The browser follows the redirect, and we get a page with CSRF token
+      // First fetch: login page (with existing CSRF token)
       mockFetch.mockResolvedValueOnce({
         ok: true,
         redirected: true,
+        text: () =>
+          Promise.resolve(
+            createDashboardHtml("existing-session-csrf-token-1234"),
+          ),
+      });
+      // Second fetch: dashboard to get activeParty data
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
         text: () =>
           Promise.resolve(
             createDashboardHtml("existing-session-csrf-token-1234"),
@@ -292,8 +301,8 @@ describe("useAuthStore", () => {
       expect(setCsrfToken).toHaveBeenCalledWith(
         "existing-session-csrf-token-1234",
       );
-      // Should only have made 1 call (login page fetch detected existing session)
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // Should have made 2 calls: login page fetch + dashboard fetch for activeParty
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it("handles stale session by proceeding with normal login", async () => {

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -156,8 +156,19 @@ export const useAuthStore = create<AuthState>()(
           const existingCsrfToken = extractCsrfTokenFromPage(html);
 
           if (existingCsrfToken) {
-            // Already logged in - parse activeParty from current page
-            const activeParty = extractActivePartyFromHtml(html);
+            // Already logged in - the login page redirect doesn't contain activeParty data
+            // We need to fetch the dashboard explicitly to get the user's associations
+            const dashboardResponse = await fetch(
+              `${API_BASE}/sportmanager.volleyball/main/dashboard`,
+              { credentials: "include" },
+            );
+
+            let activeParty = null;
+            if (dashboardResponse.ok) {
+              const dashboardHtml = await dashboardResponse.text();
+              activeParty = extractActivePartyFromHtml(dashboardHtml);
+            }
+
             setCsrfToken(existingCsrfToken);
 
             const currentState = get();


### PR DESCRIPTION
## Summary

- Fixed association dropdown not appearing for users with existing server sessions
- When a user has valid session cookies but cleared VolleyKit localStorage, the login flow now correctly fetches activeParty data from the dashboard

## Changes

- **web-app/src/stores/auth.ts**: Modified the "already logged in" branch in `login()` to explicitly fetch the dashboard page when an existing CSRF token is detected. Previously, it was parsing the login page redirect (which goes to homepage, not dashboard), which contains no activeParty data.

- **web-app/src/stores/auth.test.ts**: Updated test "handles already authenticated user (login page has CSRF token)" to mock both fetch calls:
  1. Login page fetch (detects existing session via CSRF token)
  2. Dashboard fetch (to get activeParty data for associations dropdown)

## Test Plan

- [ ] Clear VolleyKit localStorage while logged into volleymanager.volleyball.ch
- [ ] Open VolleyKit and attempt to log in
- [ ] Verify the associations dropdown appears (for users with multiple associations)
- [ ] Verify all 2449 unit tests pass
- [ ] Verify production build succeeds
