### PR TITLE
feat(debug): add live dashboard fetch diagnostic to debug panel

### DIFF
--- a/web-app/src/components/debug/AssociationDebugPanel.tsx
+++ b/web-app/src/components/debug/AssociationDebugPanel.tsx
@@ -831,7 +831,7 @@ function LiveDashboardFetch() {
 
           {!result.activeParty && result.rawMatch && (
             <div style={{ marginTop: "8px" }}>
-              <strong>Raw Match (first 500 chars):</strong>
+              <strong>Raw Match (first {RAW_MATCH_PREVIEW_LENGTH} chars):</strong>
               <pre
                 style={{
                   fontSize: "8px",

--- a/web-app/src/components/debug/AssociationDebugPanel.tsx
+++ b/web-app/src/components/debug/AssociationDebugPanel.tsx
@@ -10,7 +10,12 @@
  * 3. Ensure styles work regardless of app theme/CSS state
  */
 import { useAuthStore, type Occupation } from "@/stores/auth";
-import { type AttributeValue, extractActivePartyFromHtml } from "@/utils/active-party-parser";
+import {
+  type AttributeValue,
+  extractActivePartyFromHtml,
+  ACTIVE_PARTY_PATTERN,
+  VUE_ACTIVE_PARTY_PATTERN,
+} from "@/utils/active-party-parser";
 import { useShallow } from "zustand/react/shallow";
 import { useState, useEffect, useCallback, useId } from "react";
 
@@ -685,9 +690,8 @@ function HydrationTimeline({
   );
 }
 
-/** Regex patterns from active-party-parser.ts */
-const ACTIVE_PARTY_PATTERN = /window\.activeParty\s*=\s*JSON\.parse\s*\(\s*'((?:[^'\\]|\\.)*)'\s*\)/;
-const VUE_ACTIVE_PARTY_PATTERN = /:active-party="\$convertFromBackendToFrontend\((\{.+?\})\)"/s;
+/** Maximum characters to show in raw match preview */
+const RAW_MATCH_PREVIEW_LENGTH = 500;
 
 interface FetchResult {
   status: "idle" | "loading" | "success" | "error";
@@ -724,9 +728,9 @@ function LiveDashboardFetch() {
       const scriptMatch = ACTIVE_PARTY_PATTERN.exec(html);
       const vueMatch = VUE_ACTIVE_PARTY_PATTERN.exec(html);
       if (scriptMatch?.[1]) {
-        rawMatch = scriptMatch[1].substring(0, 500);
+        rawMatch = scriptMatch[1].substring(0, RAW_MATCH_PREVIEW_LENGTH);
       } else if (vueMatch?.[1]) {
-        rawMatch = vueMatch[1].substring(0, 500);
+        rawMatch = vueMatch[1].substring(0, RAW_MATCH_PREVIEW_LENGTH);
       }
 
       setResult({
@@ -752,6 +756,7 @@ function LiveDashboardFetch() {
         <button
           onClick={handleFetch}
           disabled={result.status === "loading"}
+          aria-busy={result.status === "loading"}
           style={{
             padding: "6px 12px",
             fontSize: "10px",

--- a/web-app/src/utils/active-party-parser.ts
+++ b/web-app/src/utils/active-party-parser.ts
@@ -114,8 +114,10 @@ const ActivePartySchema = z
  * character is consumed by exactly one branch, preventing catastrophic backtracking.
  * The outer * quantifier cannot cause exponential behavior because the inner alternation
  * is mutually exclusive (either a non-special char OR an escape sequence).
+ *
+ * @internal Exported for use in debug panel diagnostics
  */
-const ACTIVE_PARTY_PATTERN =
+export const ACTIVE_PARTY_PATTERN =
   /window\.activeParty\s*=\s*JSON\.parse\s*\(\s*'((?:[^'\\]|\\.)*)'\s*\)/;
 
 /**
@@ -128,8 +130,10 @@ const ACTIVE_PARTY_PATTERN =
  * - Quotes inside JSON are HTML-encoded as &quot;, so }" cannot appear inside JSON string values
  * - The /s flag allows . to match newlines for multi-line JSON
  * - Greedy matching would incorrectly extend to later })" sequences elsewhere in the HTML
+ *
+ * @internal Exported for use in debug panel diagnostics
  */
-const VUE_ACTIVE_PARTY_PATTERN =
+export const VUE_ACTIVE_PARTY_PATTERN =
   /:active-party="\$convertFromBackendToFrontend\((\{.+?\})\)"/s;
 
 /**


### PR DESCRIPTION
## Summary

- Added live dashboard fetch diagnostic to the association debug panel to help diagnose why the dropdown is not showing when eligibleAttributeValues and groupedEligibleAttributeValues are null
- Addressed code review feedback: removed duplicated regex patterns, added named constants, improved accessibility

## Changes

- Added `LiveDashboardFetch` component to debug panel that:
  - Fetches the dashboard HTML directly with credentials
  - Tests both regex patterns (script and Vue) against the HTML
  - Shows HTTP status, HTML length, and pattern match results
  - Displays parsed activeParty data if successful
  - Shows raw match content for debugging if parsing fails
  - Provides helpful error message if neither pattern matches
- Exported `ACTIVE_PARTY_PATTERN` and `VUE_ACTIVE_PARTY_PATTERN` from active-party-parser.ts to avoid duplication
- Added `RAW_MATCH_PREVIEW_LENGTH` constant for magic number (500)
- Used constant in UI text for consistency ("Raw Match (first {RAW_MATCH_PREVIEW_LENGTH} chars)")
- Added `aria-busy` attribute to fetch button for screen reader accessibility

## Test Plan

- [ ] Open the app with `?debug=associations` in the URL
- [ ] Scroll to the "Live Dashboard Fetch" section and expand it
- [ ] Click "Fetch Dashboard Now" button
- [ ] Verify the diagnostic output shows HTTP status, pattern matching results
- [ ] If activeParty is found, verify the parsed JSON is displayed
- [ ] If patterns don't match, verify the warning message is shown
- [ ] Verify screen readers announce loading state when button is clicked
