### PR TITLE
fix(parser): iterate through all :active-party matches to skip form permissions

### DIFF
--- a/web-app/src/components/debug/AssociationDebugPanel.tsx
+++ b/web-app/src/components/debug/AssociationDebugPanel.tsx
@@ -718,13 +718,21 @@ function LiveDashboardFetch() {
       );
 
       const html = await response.text();
+
+      // Reset lastIndex for global regexes before each use
+      ACTIVE_PARTY_PATTERN.lastIndex = 0;
+      VUE_ACTIVE_PARTY_PATTERN.lastIndex = 0;
+
       const hasScriptPattern = ACTIVE_PARTY_PATTERN.test(html);
       const hasVuePattern = VUE_ACTIVE_PARTY_PATTERN.test(html);
 
       // Use diagnostic extraction for detailed info
       const diagnostic = extractActivePartyWithDiagnostics(html);
 
-      // Get raw match for debugging
+      // Get raw match for debugging - reset lastIndex again after .test() advanced it
+      ACTIVE_PARTY_PATTERN.lastIndex = 0;
+      VUE_ACTIVE_PARTY_PATTERN.lastIndex = 0;
+
       let rawMatch: string | undefined;
       const scriptMatch = ACTIVE_PARTY_PATTERN.exec(html);
       const vueMatch = VUE_ACTIVE_PARTY_PATTERN.exec(html);
@@ -848,8 +856,8 @@ function LiveDashboardFetch() {
                 <div style={{ marginBottom: "4px", color: "#ff6b6b" }}>
                   <strong>Validation Errors:</strong>
                   <ul style={{ margin: "4px 0", paddingLeft: "16px" }}>
-                    {result.diagnostic.zodValidationErrors.map((err, i) => (
-                      <li key={i}>{err}</li>
+                    {result.diagnostic.zodValidationErrors.map((err) => (
+                      <li key={err}>{err}</li>
                     ))}
                   </ul>
                 </div>

--- a/web-app/src/utils/active-party-parser.ts
+++ b/web-app/src/utils/active-party-parser.ts
@@ -273,7 +273,10 @@ function tryVuePatternMatches(
   let match: RegExpExecArray | null;
 
   while ((match = pattern.exec(html)) !== null) {
-    const activeParty = tryParseMatch(match[1], result, "vue", true);
+    const encodedJson = match[1];
+    if (!encodedJson) continue;
+
+    const activeParty = tryParseMatch(encodedJson, result, "vue", true);
     if (activeParty) {
       return activeParty;
     }
@@ -369,8 +372,10 @@ export function extractActivePartyFromHtml(html: string): ActiveParty | null {
     VUE_ACTIVE_PARTY_PATTERN.lastIndex = 0;
 
     while ((vueMatch = VUE_ACTIVE_PARTY_PATTERN.exec(html)) !== null) {
+      const encodedJson = vueMatch[1];
+      if (!encodedJson) continue;
+
       try {
-        const encodedJson = vueMatch[1];
         const decodedJson = decodeHtmlEntities(encodedJson);
         const parsed: unknown = JSON.parse(decodedJson);
 
@@ -391,8 +396,10 @@ export function extractActivePartyFromHtml(html: string): ActiveParty | null {
     VUE_PARTY_PATTERN.lastIndex = 0;
 
     while ((vueMatch = VUE_PARTY_PATTERN.exec(html)) !== null) {
+      const encodedJson = vueMatch[1];
+      if (!encodedJson) continue;
+
       try {
-        const encodedJson = vueMatch[1];
         const decodedJson = decodeHtmlEntities(encodedJson);
         const parsed: unknown = JSON.parse(decodedJson);
 


### PR DESCRIPTION
## Summary

- Fix dropdown menu not appearing by iterating through all `:active-party` Vue attributes to find the correct one
- The production dashboard has multiple `:active-party` attributes - form permission objects (with `_permissions`) and actual user party data (with `eligibleAttributeValues`)
- Previously, the parser only matched the first `:active-party` attribute, which was the form permissions, not the user's association data
- Add enhanced diagnostics to debug panel showing pattern matching, JSON parsing, and Zod validation details

## Changes

- Add global flag (`g`) to regex patterns to find ALL occurrences
- Add `looksLikeActiveParty()` function to identify objects with expected fields (`eligibleAttributeValues`, `groupedEligibleAttributeValues`, `eligibleRoles`, etc.)
- Iterate through all matches and skip non-activeParty objects (form permissions)
- Add `VUE_PARTY_PATTERN` to also check `:party` attribute as fallback
- Add `extractActivePartyWithDiagnostics()` for detailed parsing info in debug panel
- Update debug panel to show: pattern matched, raw match length, JSON.parse status, top-level keys, Zod validation errors

## Test plan

- [ ] Open debug panel with `?debug=associations`
- [ ] Click "Fetch Dashboard Now" in the "Live Dashboard Fetch" section
- [ ] Verify "activeParty Parsed: ✓ YES" appears
- [ ] Verify "Top-level Keys" shows expected fields like `groupedEligibleAttributeValues`
- [ ] Verify dropdown menu appears in the app header for users with multiple associations
