### PR TITLE
fix(parser): accept primitive values for inflatedValue in activeParty

### DIFF
--- a/web-app/src/components/debug/AssociationDebugPanel.tsx
+++ b/web-app/src/components/debug/AssociationDebugPanel.tsx
@@ -14,6 +14,7 @@ import {
   type AttributeValue,
   type ActivePartyDiagnostic,
   extractActivePartyWithDiagnostics,
+  isInflatedObject,
   ACTIVE_PARTY_PATTERN,
   VUE_ACTIVE_PARTY_PATTERN,
 } from "@/utils/active-party-parser";
@@ -539,7 +540,7 @@ function GroupedValuesTable({ values }: { values: AttributeValue[] | null }) {
                 <td style={{ padding: "2px" }}>{index}</td>
                 <td style={{ padding: "2px" }}>{av.__identity?.substring(0, 12) ?? "(none)"}</td>
                 <td style={{ padding: "2px" }}>{av.roleIdentifier?.split(":").pop() ?? "(none)"}</td>
-                <td style={{ padding: "2px", color: "#00d4ff" }}>{av.inflatedValue?.shortName ?? "(none)"}</td>
+                <td style={{ padding: "2px", color: "#00d4ff" }}>{isInflatedObject(av.inflatedValue) ? av.inflatedValue.shortName : "(none)"}</td>
                 <td style={{ padding: "2px" }}>{isAssoc ? "Assoc" : (av.type?.substring(0, 15) ?? "(none)")}</td>
                 <td style={{ padding: "2px" }}>{isValid ? "✓" : "✗"}</td>
               </tr>

--- a/web-app/src/utils/parseOccupations.ts
+++ b/web-app/src/utils/parseOccupations.ts
@@ -10,7 +10,10 @@
  */
 import type { Occupation } from "@/stores/auth";
 import type { components } from "@/api/schema";
-import type { AttributeValue as ActivePartyAttributeValue } from "@/utils/active-party-parser";
+import {
+  isInflatedObject,
+  type AttributeValue as ActivePartyAttributeValue,
+} from "@/utils/active-party-parser";
 
 type AttributeValue = components["schemas"]["AttributeValue"];
 
@@ -169,8 +172,10 @@ export function parseOccupationFromActiveParty(
   }
 
   // Extract association code: prefer shortName, fall back to derived from name
+  // inflatedValue can be an object or primitive (boolean/null/string/number)
+  const inflated = isInflatedObject(attr.inflatedValue) ? attr.inflatedValue : undefined;
   const associationCode =
-    attr.inflatedValue?.shortName ?? deriveAssociationCodeFromName(attr.inflatedValue?.name);
+    inflated?.shortName ?? deriveAssociationCodeFromName(inflated?.name);
 
   return {
     id: attr.__identity,


### PR DESCRIPTION
## Summary

- Fixed Zod validation errors when parsing activeParty data from VolleyManager HTML pages
- The `inflatedValue` field in `eligibleAttributeValues` and `groupedEligibleAttributeValues` can be primitive values (boolean, null, string, number) in addition to objects, which was causing validation to fail

## Changes

- Updated `InflatedValueSchema` in `active-party-parser.ts` to accept a union of object and primitive types
- Added `.passthrough()` to the object schema to allow additional unknown properties from the API
- Added `isInflatedObject()` type guard helper function for safe property access on the union type
- Updated `AttributeValue` interface to reflect the union type for `inflatedValue`
- Updated `hasMultipleAssociations()` to use the type guard when accessing `inflatedValue.__identity`
- Updated `parseOccupationFromActiveParty()` in `parseOccupations.ts` to use the type guard
- Updated `AssociationDebugPanel.tsx` to use the type guard when displaying `shortName`
- Added comprehensive test cases for primitive `inflatedValue` scenarios (boolean, null, string, number)
- Added tests for the `isInflatedObject()` helper function

## Test Plan

- [ ] Verify login works for users whose activeParty data contains primitive `inflatedValue` fields
- [ ] Verify association dropdown displays correctly for users with multiple associations
- [ ] Verify the debug panel (`?debug=associations`) shows correct data
- [ ] Run `npm test` - all 2457 tests pass
- [ ] Run `npm run build` - TypeScript compilation succeeds
- [ ] Run `npm run lint` - no warnings
