### PR TITLE
fix(auth): reject login for users without referee role

### DIFF
--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -169,6 +169,7 @@ const de: Translations = {
     loginInfo: "Verwenden Sie Ihre VolleyManager-Anmeldeinformationen.",
     privacyNote: "Ihr Passwort wird niemals gespeichert.",
     loadingDemo: "Demo-Modus wird geladen...",
+    noRefereeRole: "Diese App ist nur für Schiedsrichter. Ihr Konto hat keine Schiedsrichter-Rolle im VolleyManager.",
   },
   occupations: {
     referee: "Schiedsrichter",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -169,6 +169,7 @@ const en: Translations = {
     loginInfo: "Use your VolleyManager credentials to login.",
     privacyNote: "Your password is never stored.",
     loadingDemo: "Loading demo mode...",
+    noRefereeRole: "This app is for referees only. Your account has no referee role in VolleyManager.",
   },
   occupations: {
     referee: "Referee",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -169,6 +169,7 @@ const fr: Translations = {
     loginInfo: "Utilisez vos identifiants VolleyManager pour vous connecter.",
     privacyNote: "Votre mot de passe n'est jamais stocké.",
     loadingDemo: "Chargement du mode démo...",
+    noRefereeRole: "Cette application est réservée aux arbitres. Votre compte n'a pas de rôle d'arbitre dans VolleyManager.",
   },
   occupations: {
     referee: "Arbitre",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -169,6 +169,7 @@ const it: Translations = {
     loginInfo: "Usa le tue credenziali VolleyManager per accedere.",
     privacyNote: "La tua password non viene mai memorizzata.",
     loadingDemo: "Caricamento modalità demo...",
+    noRefereeRole: "Questa app è riservata agli arbitri. Il tuo account non ha un ruolo arbitro in VolleyManager.",
   },
   occupations: {
     referee: "Arbitro",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -61,6 +61,7 @@ export interface Translations {
     loginInfo: string;
     privacyNote: string;
     loadingDemo: string;
+    noRefereeRole: string;
   };
   occupations: {
     referee: string;

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import { useNavigate } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
-import { useAuthStore } from "@/stores/auth";
+import { useAuthStore, NO_REFEREE_ROLE_ERROR_KEY } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Button } from "@/components/ui/Button";
@@ -189,7 +189,9 @@ export function LoginPage() {
             {error && (
               <div className="p-3 rounded-lg bg-danger-50 dark:bg-danger-900/20 border border-danger-200 dark:border-danger-800">
                 <p className="text-sm text-danger-600 dark:text-danger-400">
-                  {error}
+                  {error === NO_REFEREE_ROLE_ERROR_KEY
+                    ? t("auth.noRefereeRole")
+                    : error}
                 </p>
               </div>
             )}

--- a/web-app/src/stores/auth.test.ts
+++ b/web-app/src/stores/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { useAuthStore } from "./auth";
+import { useAuthStore, NO_REFEREE_ROLE_ERROR_KEY } from "./auth";
 import { setCsrfToken, clearSession } from "@/api/client";
 
 // Mock the API client
@@ -512,7 +512,7 @@ describe("useAuthStore", () => {
       expect(result).toBe(false);
       const { status, error } = useAuthStore.getState();
       expect(status).toBe("error");
-      expect(error).toContain("This app is for referees only");
+      expect(error).toBe(NO_REFEREE_ROLE_ERROR_KEY);
       expect(clearSession).toHaveBeenCalled();
       // Should have made 3 calls: login page + auth POST + logout
       expect(mockFetch).toHaveBeenCalledTimes(3);
@@ -545,7 +545,7 @@ describe("useAuthStore", () => {
       expect(result).toBe(false);
       const { status, error } = useAuthStore.getState();
       expect(status).toBe("error");
-      expect(error).toContain("no referee role");
+      expect(error).toBe(NO_REFEREE_ROLE_ERROR_KEY);
       expect(clearSession).toHaveBeenCalled();
     });
 

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -77,6 +77,13 @@ const LOGOUT_URL = `${API_BASE}/logout`;
 const SESSION_CHECK_TIMEOUT_MS = 10_000;
 
 /**
+ * Error message for users without a referee role.
+ * This app is designed for referees only - users with only player/admin roles cannot use it.
+ */
+const NO_REFEREE_ROLE_ERROR =
+  "This app is for referees only. Your account has no referee role in VolleyManager.";
+
+/**
  * Derives user occupations and active occupation ID from active party data.
  * Used during login and session restoration to populate the association dropdown.
  *
@@ -178,6 +185,19 @@ export const useAuthStore = create<AuthState>()(
               currentState.activeOccupationId,
             );
 
+            // Reject users without referee role - this app is for referees only
+            if (user.occupations.length === 0) {
+              // Invalidate the server session
+              try {
+                await fetch(LOGOUT_URL, { credentials: "include", redirect: "manual" });
+              } catch {
+                // Ignore logout errors - we're rejecting the login anyway
+              }
+              clearSession();
+              set({ status: "error", error: NO_REFEREE_ROLE_ERROR });
+              return false;
+            }
+
             set({
               status: "authenticated",
               csrfToken: existingCsrfToken,
@@ -208,6 +228,19 @@ export const useAuthStore = create<AuthState>()(
               currentState.user,
               currentState.activeOccupationId,
             );
+
+            // Reject users without referee role - this app is for referees only
+            if (user.occupations.length === 0) {
+              // Invalidate the server session
+              try {
+                await fetch(LOGOUT_URL, { credentials: "include", redirect: "manual" });
+              } catch {
+                // Ignore logout errors - we're rejecting the login anyway
+              }
+              clearSession();
+              set({ status: "error", error: NO_REFEREE_ROLE_ERROR });
+              return false;
+            }
 
             set({
               status: "authenticated",


### PR DESCRIPTION
## Summary

- Reject login for users who don't have a referee role in VolleyManager
- This app is designed for referees only - users with only player, club admin, or association admin roles cannot use it
- When rejected, users see a clear error message explaining they need a referee role

## Changes

- Add `noRefereeRole` translation key in all 4 languages (de, en, fr, it)
- Add validation check in `auth.ts` login flow:
  - Checks if parsed occupations array is empty after filtering to referee-only roles
  - Invalidates the server session by calling logout endpoint
  - Clears local session state
  - Returns error with translated message
- Handle both login paths (fresh login and resume existing session)
- Add comprehensive tests for referee role validation:
  - Test rejection when user has only player roles
  - Test rejection when already-authenticated user has no referee role  
  - Test acceptance when user has referee role
- Update existing tests to include referee role in mock dashboard HTML

## Test Plan

- [ ] Verify lint passes: `npm run lint`
- [ ] Verify all tests pass: `npm test`
- [ ] Verify build succeeds: `npm run build`
- [ ] Manual test: Log in with a user that has a referee role - should succeed
- [ ] Manual test: Log in with a user that only has player/admin roles - should see error message and remain on login page
- [ ] Verify error message displays correctly in all 4 languages
