### PR TITLE
fix(cache): include activeOccupationId in query keys for association switching

### DIFF
--- a/web-app/src/api/queryKeys.ts
+++ b/web-app/src/api/queryKeys.ts
@@ -36,11 +36,16 @@ export const queryKeys = {
     all: ["assignments"] as const,
     /** Parent key for all list queries */
     lists: () => [...queryKeys.assignments.all, "list"] as const,
-    /** Specific list query with search configuration */
+    /**
+     * Specific list query with search configuration.
+     * @param config - Search configuration filters and sorting
+     * @param associationKey - In demo mode: demoAssociationCode. In production: activeOccupationId.
+     *                         This ensures cache invalidation when switching associations.
+     */
     list: (
       config?: SearchConfiguration,
-      demoAssociationCode?: string | null,
-    ) => [...queryKeys.assignments.lists(), config, demoAssociationCode] as const,
+      associationKey?: string | null,
+    ) => [...queryKeys.assignments.lists(), config, associationKey] as const,
     /** Parent key for all detail queries */
     details: () => [...queryKeys.assignments.all, "detail"] as const,
     /** Specific assignment detail query */
@@ -68,11 +73,15 @@ export const queryKeys = {
     all: ["compensations"] as const,
     /** Parent key for all list queries */
     lists: () => [...queryKeys.compensations.all, "list"] as const,
-    /** Specific list query with search configuration */
+    /**
+     * Specific list query with search configuration.
+     * @param config - Search configuration filters and sorting
+     * @param associationKey - In demo mode: demoAssociationCode. In production: activeOccupationId.
+     */
     list: (
       config?: SearchConfiguration,
-      demoAssociationCode?: string | null,
-    ) => [...queryKeys.compensations.lists(), config, demoAssociationCode] as const,
+      associationKey?: string | null,
+    ) => [...queryKeys.compensations.lists(), config, associationKey] as const,
   },
 
   /**
@@ -83,11 +92,15 @@ export const queryKeys = {
     all: ["exchanges"] as const,
     /** Parent key for all list queries */
     lists: () => [...queryKeys.exchanges.all, "list"] as const,
-    /** Specific list query with search configuration */
+    /**
+     * Specific list query with search configuration.
+     * @param config - Search configuration filters and sorting
+     * @param associationKey - In demo mode: demoAssociationCode. In production: activeOccupationId.
+     */
     list: (
       config?: SearchConfiguration,
-      demoAssociationCode?: string | null,
-    ) => [...queryKeys.exchanges.lists(), config, demoAssociationCode] as const,
+      associationKey?: string | null,
+    ) => [...queryKeys.exchanges.lists(), config, associationKey] as const,
   },
 
   /**
@@ -96,8 +109,12 @@ export const queryKeys = {
   seasons: {
     /** Base key - invalidates ALL season queries */
     all: ["seasons"] as const,
-    /** Active season query */
-    active: () => [...queryKeys.seasons.all, "active"] as const,
+    /**
+     * Active season query.
+     * @param associationKey - In demo mode: demoAssociationCode. In production: activeOccupationId.
+     */
+    active: (associationKey?: string | null) =>
+      [...queryKeys.seasons.all, "active", associationKey] as const,
   },
 
   /**
@@ -106,8 +123,12 @@ export const queryKeys = {
   settings: {
     /** Base key - invalidates ALL settings queries */
     all: ["settings"] as const,
-    /** Association settings query */
-    association: () => [...queryKeys.settings.all, "association"] as const,
+    /**
+     * Association settings query.
+     * @param associationKey - In demo mode: demoAssociationCode. In production: activeOccupationId.
+     */
+    association: (associationKey?: string | null) =>
+      [...queryKeys.settings.all, "association", associationKey] as const,
   },
 
   /**

--- a/web-app/src/hooks/useCompensations.ts
+++ b/web-app/src/hooks/useCompensations.ts
@@ -43,10 +43,14 @@ export type CompensationErrorKey =
  */
 export function useCompensations(paidFilter?: boolean) {
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
   const demoAssociationCode = useDemoStore(
     (state) => state.activeAssociationCode,
   );
   const apiClient = getApiClient(isDemoMode);
+
+  // Use appropriate key for cache invalidation when switching associations
+  const associationKey = isDemoMode ? demoAssociationCode : activeOccupationId;
 
   const config: SearchConfiguration = {
     offset: 0,
@@ -70,10 +74,7 @@ export function useCompensations(paidFilter?: boolean) {
   };
 
   return useQuery({
-    queryKey: queryKeys.compensations.list(
-      config,
-      isDemoMode ? demoAssociationCode : null,
-    ),
+    queryKey: queryKeys.compensations.list(config, associationKey),
     queryFn: () => apiClient.searchCompensations(config),
     select: (data) => data.items ?? EMPTY_COMPENSATIONS,
     staleTime: 5 * 60 * 1000,

--- a/web-app/src/hooks/useExchanges.ts
+++ b/web-app/src/hooks/useExchanges.ts
@@ -27,10 +27,14 @@ export type ExchangeStatus = "open" | "applied" | "closed" | "all";
  */
 export function useGameExchanges(status: ExchangeStatus = "all") {
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
   const demoAssociationCode = useDemoStore(
     (state) => state.activeAssociationCode,
   );
   const apiClient = getApiClient(isDemoMode);
+
+  // Use appropriate key for cache invalidation when switching associations
+  const associationKey = isDemoMode ? demoAssociationCode : activeOccupationId;
 
   const config: SearchConfiguration = {
     offset: 0,
@@ -49,10 +53,7 @@ export function useGameExchanges(status: ExchangeStatus = "all") {
   };
 
   return useQuery({
-    queryKey: queryKeys.exchanges.list(
-      config,
-      isDemoMode ? demoAssociationCode : null,
-    ),
+    queryKey: queryKeys.exchanges.list(config, associationKey),
     queryFn: () => apiClient.searchExchanges(config),
     select: (data) => data.items ?? EMPTY_EXCHANGES,
     staleTime: 2 * 60 * 1000,

--- a/web-app/src/hooks/useSettings.ts
+++ b/web-app/src/hooks/useSettings.ts
@@ -8,15 +8,17 @@ import { queryKeys } from "@/api/queryKeys";
  * Settings include deadline hours for validation and other configuration.
  *
  * Note: Disabled in demo mode as demo data doesn't need these settings.
+ * Includes activeOccupationId in the query key to refetch when switching associations.
  */
 export function useAssociationSettings(): UseQueryResult<
   AssociationSettings,
   Error
 > {
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
 
   return useQuery({
-    queryKey: queryKeys.settings.association(),
+    queryKey: queryKeys.settings.association(activeOccupationId),
     queryFn: () => api.getAssociationSettings(),
     staleTime: 30 * 60 * 1000, // 30 minutes - settings rarely change
     enabled: !isDemoMode,
@@ -28,12 +30,14 @@ export function useAssociationSettings(): UseQueryResult<
  * Used to determine date ranges for assignment queries.
  *
  * Note: Disabled in demo mode as demo data uses fixed date ranges.
+ * Includes activeOccupationId in the query key to refetch when switching associations.
  */
 export function useActiveSeason(): UseQueryResult<Season, Error> {
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
 
   return useQuery({
-    queryKey: queryKeys.seasons.active(),
+    queryKey: queryKeys.seasons.active(activeOccupationId),
     queryFn: () => api.getActiveSeason(),
     staleTime: 60 * 60 * 1000, // 1 hour - season rarely changes
     enabled: !isDemoMode,


### PR DESCRIPTION
## Summary

- Fixed association switching in production mode not fetching/showing correct data
- Query keys now include `activeOccupationId` to properly invalidate cache when switching associations

## Changes

- **web-app/src/api/queryKeys.ts**: Updated query key functions for assignments, compensations, exchanges, settings, and seasons to accept an `associationKey` parameter (used for cache invalidation)
- **web-app/src/hooks/useAssignments.ts**: Added `activeOccupationId` from auth store and pass it to query key in production mode
- **web-app/src/hooks/useCompensations.ts**: Added `activeOccupationId` from auth store and pass it to query key in production mode
- **web-app/src/hooks/useExchanges.ts**: Added `activeOccupationId` from auth store and pass it to query key in production mode
- **web-app/src/hooks/useSettings.ts**: Added `activeOccupationId` to association settings and active season query keys

## Test Plan

- [ ] Login with an account that has multiple associations
- [ ] Switch between associations using the dropdown in the header
- [ ] Verify assignments list updates to show the correct association's assignments
- [ ] Verify compensations page shows the correct association's data
- [ ] Verify exchange page shows the correct association's exchanges
- [ ] Verify demo mode still works correctly (switching associations should regenerate data)
- [ ] Run `npm run lint` - passes with 0 warnings
- [ ] Run `npm test` - all 2462 tests pass
- [ ] Run `npm run build` - builds successfully
