### PR TITLE
test(hooks): add unit tests for useSettings hook

### DIFF
--- a/web-app/src/hooks/useSettings.test.tsx
+++ b/web-app/src/hooks/useSettings.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useAssociationSettings, useActiveSeason } from "./useSettings";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFunction = (...args: any[]) => any;
+
+// Mock dependencies
+vi.mock("@/api/client", () => ({
+  api: {
+    getAssociationSettings: vi.fn(),
+    getActiveSeason: vi.fn(),
+  },
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn((selector: AnyFunction) =>
+    selector({ isDemoMode: false, activeOccupationId: "occupation-123" }),
+  ),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useAssociationSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches association settings when not in demo mode", async () => {
+    const mockSettings = {
+      hoursAfterGameStartForRefereeToEditGameList: 6,
+    };
+
+    const { api } = await import("@/api/client");
+    vi.mocked(api.getAssociationSettings).mockResolvedValue(mockSettings);
+
+    const { result } = renderHook(() => useAssociationSettings(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(api.getAssociationSettings).toHaveBeenCalled();
+    expect(result.current.data).toEqual(mockSettings);
+  });
+
+  it("is disabled in demo mode", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: true, activeOccupationId: null }),
+    );
+
+    const { api } = await import("@/api/client");
+
+    const { result } = renderHook(() => useAssociationSettings(), {
+      wrapper: createWrapper(),
+    });
+
+    // Wait a tick to ensure query would have been called if enabled
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(result.current.isPending).toBe(true);
+    expect(api.getAssociationSettings).not.toHaveBeenCalled();
+  });
+
+  it("includes activeOccupationId in query key for cache invalidation on association switch", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    const { api } = await import("@/api/client");
+
+    const mockSettings = {
+      hoursAfterGameStartForRefereeToEditGameList: 6,
+    };
+    vi.mocked(api.getAssociationSettings).mockResolvedValue(mockSettings);
+
+    // First render with one occupation
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false, activeOccupationId: "occupation-1" }),
+    );
+
+    const wrapper1 = createWrapper();
+    const { result: result1 } = renderHook(() => useAssociationSettings(), {
+      wrapper: wrapper1,
+    });
+
+    await waitFor(() => {
+      expect(result1.current.isSuccess).toBe(true);
+    });
+
+    expect(api.getAssociationSettings).toHaveBeenCalledTimes(1);
+
+    // Second render with different occupation - should trigger new fetch
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false, activeOccupationId: "occupation-2" }),
+    );
+
+    const wrapper2 = createWrapper();
+    const { result: result2 } = renderHook(() => useAssociationSettings(), {
+      wrapper: wrapper2,
+    });
+
+    await waitFor(() => {
+      expect(result2.current.isSuccess).toBe(true);
+    });
+
+    // API should be called again because the occupation changed
+    expect(api.getAssociationSettings).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles API errors gracefully", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false, activeOccupationId: "occupation-123" }),
+    );
+
+    const { api } = await import("@/api/client");
+    vi.mocked(api.getAssociationSettings).mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    const { result } = renderHook(() => useAssociationSettings(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.message).toBe("Network error");
+  });
+});
+
+describe("useActiveSeason", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches active season when not in demo mode", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false, activeOccupationId: "occupation-123" }),
+    );
+
+    const mockSeason = {
+      __identity: "season-1",
+      seasonStartDate: "2024-09-01",
+      seasonEndDate: "2025-06-30",
+    };
+
+    const { api } = await import("@/api/client");
+    vi.mocked(api.getActiveSeason).mockResolvedValue(mockSeason);
+
+    const { result } = renderHook(() => useActiveSeason(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(api.getActiveSeason).toHaveBeenCalled();
+    expect(result.current.data).toEqual(mockSeason);
+  });
+
+  it("is disabled in demo mode", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: true, activeOccupationId: null }),
+    );
+
+    const { api } = await import("@/api/client");
+
+    const { result } = renderHook(() => useActiveSeason(), {
+      wrapper: createWrapper(),
+    });
+
+    // Wait a tick to ensure query would have been called if enabled
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(result.current.isPending).toBe(true);
+    expect(api.getActiveSeason).not.toHaveBeenCalled();
+  });
+
+  it("includes activeOccupationId in query key for cache invalidation on association switch", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    const { api } = await import("@/api/client");
+
+    const mockSeason = {
+      __identity: "season-1",
+      seasonStartDate: "2024-09-01",
+      seasonEndDate: "2025-06-30",
+    };
+    vi.mocked(api.getActiveSeason).mockResolvedValue(mockSeason);
+
+    // First render with one occupation
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false, activeOccupationId: "occupation-1" }),
+    );
+
+    const wrapper1 = createWrapper();
+    const { result: result1 } = renderHook(() => useActiveSeason(), {
+      wrapper: wrapper1,
+    });
+
+    await waitFor(() => {
+      expect(result1.current.isSuccess).toBe(true);
+    });
+
+    expect(api.getActiveSeason).toHaveBeenCalledTimes(1);
+
+    // Second render with different occupation - should trigger new fetch
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false, activeOccupationId: "occupation-2" }),
+    );
+
+    const wrapper2 = createWrapper();
+    const { result: result2 } = renderHook(() => useActiveSeason(), {
+      wrapper: wrapper2,
+    });
+
+    await waitFor(() => {
+      expect(result2.current.isSuccess).toBe(true);
+    });
+
+    // API should be called again because the occupation changed
+    expect(api.getActiveSeason).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles API errors gracefully", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({ isDemoMode: false, activeOccupationId: "occupation-123" }),
+    );
+
+    const { api } = await import("@/api/client");
+    vi.mocked(api.getActiveSeason).mockRejectedValue(
+      new Error("API unavailable"),
+    );
+
+    const { result } = renderHook(() => useActiveSeason(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.message).toBe("API unavailable");
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for the `useSettings.ts` hook which previously had 0% test coverage
- Tests cover both `useAssociationSettings` and `useActiveSeason` hooks

## Changes

- Created `web-app/src/hooks/useSettings.test.tsx` with 8 comprehensive tests:
  - `useAssociationSettings`: fetches settings when not in demo mode
  - `useAssociationSettings`: is disabled in demo mode  
  - `useAssociationSettings`: includes activeOccupationId in query key for cache invalidation
  - `useAssociationSettings`: handles API errors gracefully
  - `useActiveSeason`: fetches active season when not in demo mode
  - `useActiveSeason`: is disabled in demo mode
  - `useActiveSeason`: includes activeOccupationId in query key for cache invalidation
  - `useActiveSeason`: handles API errors gracefully

## Test Plan

- [x] All 8 new tests pass locally
- [x] ESLint passes with no warnings
- [x] TypeScript build completes successfully
- [ ] CI pipeline passes
