### PR TITLE
fix(exchanges): add missing date filter to exchange search API

### DIFF
--- a/web-app/src/hooks/useConvocations.test.tsx
+++ b/web-app/src/hooks/useConvocations.test.tsx
@@ -308,7 +308,7 @@ describe("useConvocations - API Client Routing", () => {
       );
     });
 
-    it("should call API without filter when status is all", async () => {
+    it("should call API with only date filter when status is all", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({ isDemoMode: false } as ReturnType<
           typeof authStore.useAuthStore.getState
@@ -328,9 +328,18 @@ describe("useConvocations - API Client Routing", () => {
         expect(result.current.isFetching).toBe(false);
       });
 
+      // When status is "all", only the date filter should be present (no status filter)
       expect(mockApi.searchExchanges).toHaveBeenCalledWith(
         expect.objectContaining({
-          propertyFilters: [],
+          propertyFilters: [
+            expect.objectContaining({
+              propertyName: "refereeGame.game.startingDateTime",
+              dateRange: expect.objectContaining({
+                from: expect.any(String),
+                to: expect.any(String),
+              }),
+            }),
+          ],
         }),
       );
     });

--- a/web-app/src/hooks/useExchanges.ts
+++ b/web-app/src/hooks/useExchanges.ts
@@ -15,42 +15,7 @@ import { useAuthStore } from "@/stores/auth";
 import { useDemoStore } from "@/stores/demo";
 import { queryKeys } from "@/api/queryKeys";
 import { DEFAULT_PAGE_SIZE } from "./usePaginatedQuery";
-
-// Volleyball season months (0-indexed): September = 8, May = 4
-const SEASON_START_MONTH = 8; // September
-const SEASON_END_MONTH = 4; // May
-
-/**
- * Calculate the current volleyball season date range.
- * A season runs from beginning of September to end of May of the following year.
- *
- * @returns Object with season start and end dates
- */
-function getSeasonDateRange(): { from: Date; to: Date } {
-  const now = new Date();
-  const currentMonth = now.getMonth();
-  const currentYear = now.getFullYear();
-
-  let seasonStartYear: number;
-  let seasonEndYear: number;
-
-  if (currentMonth >= SEASON_START_MONTH) {
-    // September-December: season is current year to next year
-    seasonStartYear = currentYear;
-    seasonEndYear = currentYear + 1;
-  } else {
-    // January-August: season is previous year to current year
-    seasonStartYear = currentYear - 1;
-    seasonEndYear = currentYear;
-  }
-
-  // Season starts September 1st
-  const seasonStart = new Date(seasonStartYear, SEASON_START_MONTH, 1);
-  // Season ends May 31st
-  const seasonEnd = new Date(seasonEndYear, SEASON_END_MONTH + 1, 0); // Day 0 of June = May 31st
-
-  return { from: seasonStart, to: seasonEnd };
-}
+import { getSeasonDateRange } from "@/utils/date-helpers";
 
 // Stable empty array for React Query selectors to prevent unnecessary re-renders.
 const EMPTY_EXCHANGES: GameExchange[] = [];

--- a/web-app/src/utils/date-helpers.ts
+++ b/web-app/src/utils/date-helpers.ts
@@ -262,3 +262,50 @@ export function getMaxLastNameWidth(
   }
   return maxLen;
 }
+
+// Volleyball season months (0-indexed): September = 8, May = 4
+const SEASON_START_MONTH = 8; // September
+const SEASON_END_MONTH = 4; // May
+
+/**
+ * Calculate the current volleyball season date range.
+ * A season runs from beginning of September to end of May of the following year.
+ *
+ * Season boundaries:
+ * - September 1st to December 31st: current year → next year (e.g., Sept 2025 - May 2026)
+ * - January 1st to August 31st: previous year → current year (e.g., Sept 2024 - May 2025)
+ *
+ * Note: If the app remains open across a season boundary (Aug 31 → Sept 1),
+ * the user will need to refresh to see the new season. This is acceptable
+ * for a PWA where users typically close/reopen the app regularly.
+ *
+ * @param referenceDate - Date to calculate season for (defaults to current date)
+ * @returns Object with season start and end dates
+ */
+export function getSeasonDateRange(referenceDate: Date = new Date()): {
+  from: Date;
+  to: Date;
+} {
+  const currentMonth = referenceDate.getMonth();
+  const currentYear = referenceDate.getFullYear();
+
+  let seasonStartYear: number;
+  let seasonEndYear: number;
+
+  if (currentMonth >= SEASON_START_MONTH) {
+    // September-December: season is current year to next year
+    seasonStartYear = currentYear;
+    seasonEndYear = currentYear + 1;
+  } else {
+    // January-August: season is previous year to current year
+    seasonStartYear = currentYear - 1;
+    seasonEndYear = currentYear;
+  }
+
+  // Season starts September 1st
+  const seasonStart = new Date(seasonStartYear, SEASON_START_MONTH, 1);
+  // Season ends May 31st (day 0 of June = last day of May)
+  const seasonEnd = new Date(seasonEndYear, SEASON_END_MONTH + 1, 0);
+
+  return { from: seasonStart, to: seasonEnd };
+}


### PR DESCRIPTION
## Summary

- Fixed the exchange tab showing no assignments in production by adding the missing date range filter to the exchange search API
- Updated to use volleyball season dates (September to May) instead of an arbitrary rolling window

## Changes

- Added `getSeasonDateRange()` helper function in `web-app/src/hooks/useExchanges.ts`
  - Calculates current season: Sept 1st to May 31st
  - Sept-Dec: uses current year to next year (e.g., Sept 2025 - May 2026)
  - Jan-Aug: uses previous year to current year (e.g., Sept 2024 - May 2025)
- Added date range filter to `useGameExchanges` hook (required by the API)
- Added `useMemo` for date range and property filters to prevent unnecessary re-renders
- Updated test in `useConvocations.test.tsx` to verify date filter is always present

## Root Cause

The exchange search API (`/api/refereegameexchange/search`) requires a `refereeGame.game.startingDateTime` date range filter. Without it, the API returns an empty list. The assignments endpoint worked correctly because it already included this date filter.

## Test Plan

- [ ] Deploy to production and verify exchanges appear on the Exchange tab
- [ ] Verify "Open" tab shows available exchanges within the current season
- [ ] Verify "My Applications" tab shows applied exchanges
- [ ] Verify filtering by status still works correctly
- [ ] Test in January (should show Sept previous year to May current year)
- [ ] Test in October (should show Sept current year to May next year)

