### PR TITLE
refactor(logging): use logger utility in AppShell for consistent logging

### DIFF
--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { getOccupationLabelKey } from "@/utils/occupation-labels";
 import { getApiClient } from "@/api/client";
 import { toast } from "@/stores/toast";
+import { createLogger } from "@/utils/logger";
 import {
   Volleyball,
   ClipboardList,
@@ -18,6 +19,8 @@ import {
 } from "@/components/ui/icons";
 import type { LucideIcon } from "lucide-react";
 import { TourModeBanner } from "@/components/tour/TourModeBanner";
+
+const log = createLogger("AppShell");
 
 // Lazy-load debug panel to avoid bundle size impact in production
 const AssociationDebugPanel = lazy(() =>
@@ -146,7 +149,7 @@ export function AppShell() {
         setActiveOccupation(previousOccupationId ?? id);
         // Show error toast to user
         toast.error(t("common.switchAssociationFailed"));
-        console.error("Failed to switch association:", error);
+        log.error("Failed to switch association:", error);
       }
     } finally {
       // Only clear switching state if this is still the latest request


### PR DESCRIPTION
## Summary

- Replaced direct `console.error` call with the project's logger utility in AppShell.tsx for consistent logging behavior across the codebase

## Changes

- Added import for `createLogger` from `@/utils/logger`
- Created a logger instance: `const log = createLogger("AppShell")`
- Replaced `console.error("Failed to switch association:", error)` with `log.error("Failed to switch association:", error)`

## Test Plan

- [ ] Verify lint passes with no warnings (`npm run lint -- --max-warnings 0`)
- [ ] Verify all tests pass (`npm test`)
- [ ] Test association switching in demo mode - error logging should only appear in development builds
- [ ] Verify production builds don't show debug logs when switching associations fails
