### PR TITLE
fix(compensations): check correct lock based on disbursement method

### DIFF
--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -47,6 +47,8 @@ export const ASSIGNMENT_PROPERTIES = [
   // Compensation lock flags for editability check
   "convocationCompensation.paymentDone",
   "convocationCompensation.lockPayoutOnSiteCompensation",
+  "convocationCompensation.lockPayoutCentralPayoutCompensation",
+  "convocationCompensation.methodOfDisbursementArbitration",
   // Validation status for swipe button color.
   // Parent object must be requested before nested property to ensure
   // the API populates the nested structure correctly.
@@ -144,6 +146,8 @@ export const COMPENSATION_PROPERTIES = [
   "convocationCompensation.transportationMode",
   "convocationCompensation.paymentDone",
   "convocationCompensation.lockPayoutOnSiteCompensation",
+  "convocationCompensation.lockPayoutCentralPayoutCompensation",
+  "convocationCompensation.methodOfDisbursementArbitration",
   "convocationCompensation.paymentValueDate",
   "convocationCompensation.paymentUpdatedByAssociation.name",
   "indoorAssociationReferee.indoorReferee.person.associationId",


### PR DESCRIPTION
## Summary

- Fixed incorrect editability check for SV (NLB/NLA) compensation records
- The app was showing "La modification n'est pas disponible pour cette région" for NLB games that should be editable

## Changes

- **web-app/src/api/property-configs.ts**: Added missing property requests for `lockPayoutCentralPayoutCompensation` and `methodOfDisbursementArbitration` to both assignment and compensation endpoints
- **web-app/src/utils/compensation-actions.ts**: Updated editability logic to check the correct lock flag based on the disbursement method:
  - `payout_on_site` → check `lockPayoutOnSiteCompensation`
  - `central_payout` → check `lockPayoutCentralPayoutCompensation`
  - Unknown method → check both locks (backwards compatibility)
- **web-app/src/utils/compensation-actions.test.ts**: Updated and added tests for the new disbursement-method-aware editability logic, including a specific test case for the NLB bug

## Root Cause

The previous code only checked `lockPayoutOnSiteCompensation` for all games. For NLB and other central payout games, this flag may be `true` (since they don't use on-site payout) while `lockPayoutCentralPayoutCompensation` is `false`, meaning the game should still be editable.

## Test Plan

- [ ] Verify NLB games with `methodOfDisbursementArbitration: "central_payout"` are editable when `lockPayoutCentralPayoutCompensation: false`
- [ ] Verify regional association games with `methodOfDisbursementArbitration: "payout_on_site"` still show the restriction when `lockPayoutOnSiteCompensation: true`
- [ ] Verify paid compensations are still non-editable regardless of disbursement method
- [ ] Run full test suite (2492 tests pass)


