### PR TITLE
fix(tour): show dummy data immediately to prevent empty state race condition

### DIFF
--- a/web-app/src/components/tour/definitions/exchange.ts
+++ b/web-app/src/components/tour/definitions/exchange.ts
@@ -56,19 +56,25 @@ export const TOUR_DUMMY_EXCHANGE: TourDummyExchange = {
     game: {
       __identity: "tour-dummy-game-exchange",
       gameNumber: "67890",
-      plannedStartDateTime: getFutureDate(),
-      teamHome: {
-        __identity: "tour-dummy-team-home-exchange",
-        name: "VBC Anleitung",
-      },
-      teamAway: {
-        __identity: "tour-dummy-team-away-exchange",
-        name: "SC Hilfe",
+      startingDateTime: getFutureDate(),
+      encounter: {
+        __identity: "tour-dummy-encounter-exchange",
+        teamHome: {
+          __identity: "tour-dummy-team-home-exchange",
+          name: "VBC Anleitung",
+        },
+        teamAway: {
+          __identity: "tour-dummy-team-away-exchange",
+          name: "SC Hilfe",
+        },
       },
       hall: {
         __identity: "tour-dummy-hall-exchange",
         name: "Turnhalle Tutorial",
-        city: "Bern",
+        primaryPostalAddress: {
+          __identity: "tour-dummy-address-exchange",
+          city: "Bern",
+        },
       },
     },
   },

--- a/web-app/src/components/tour/definitions/types.ts
+++ b/web-app/src/components/tour/definitions/types.ts
@@ -138,19 +138,25 @@ export interface TourDummyExchange {
     game: {
       __identity: string;
       gameNumber: string;
-      plannedStartDateTime: string;
-      teamHome: {
+      startingDateTime: string;
+      encounter: {
         __identity: string;
-        name: string;
-      };
-      teamAway: {
-        __identity: string;
-        name: string;
+        teamHome: {
+          __identity: string;
+          name: string;
+        };
+        teamAway: {
+          __identity: string;
+          name: string;
+        };
       };
       hall: {
         __identity: string;
         name: string;
-        city: string;
+        primaryPostalAddress: {
+          __identity: string;
+          city: string;
+        };
       };
     };
   };

--- a/web-app/src/hooks/useTour.ts
+++ b/web-app/src/hooks/useTour.ts
@@ -15,6 +15,9 @@ interface UseTourReturn {
   isActive: boolean;
   // Whether tour mode is active (for showing dummy data)
   isTourMode: boolean;
+  // Whether to show dummy data (true during auto-start delay AND when tour is active)
+  // Use this for data filtering to avoid race condition with empty states
+  showDummyData: boolean;
   // Start this tour manually
   startTour: () => void;
   // End the current tour
@@ -49,6 +52,12 @@ export function useTour(
   const isActive = isTourActive(tourId);
   const isTourMode = activeTour === tourId;
   const shouldShow = shouldShowTour(tourId);
+
+  // showDummyData is true when:
+  // 1. The tour is actively running (isTourMode), OR
+  // 2. The tour will auto-start (shouldShow && autoStart) - covers the 500ms delay window
+  // This prevents the race condition where empty states are shown before the tour starts
+  const showDummyData = isTourMode || (shouldShow && autoStart);
 
   // Reset hasAutoStarted when tours are reset (shouldShow changes from false to true)
   useEffect(() => {
@@ -87,6 +96,7 @@ export function useTour(
   return {
     isActive,
     isTourMode,
+    showDummyData,
     startTour,
     endTour,
     currentStep,

--- a/web-app/src/pages/AssignmentsPage.test.tsx
+++ b/web-app/src/pages/AssignmentsPage.test.tsx
@@ -5,8 +5,8 @@ import type { Assignment } from "@/api/client";
 import type { UseQueryResult } from "@tanstack/react-query";
 import * as useConvocations from "@/hooks/useConvocations";
 
-vi.mock("@/hooks/useConvocations");
-vi.mock("@/hooks/useTour", () => ({
+// Mock useTour to disable tour mode during tests (see src/test/mocks.ts for shared pattern)
+const mockUseTour = vi.hoisted(() => ({
   useTour: () => ({
     isActive: false,
     isTourMode: false,
@@ -18,6 +18,9 @@ vi.mock("@/hooks/useTour", () => ({
     shouldShow: false,
   }),
 }));
+
+vi.mock("@/hooks/useConvocations");
+vi.mock("@/hooks/useTour", () => mockUseTour);
 vi.mock("@/hooks/useAssignmentActions", () => ({
   useAssignmentActions: () => ({
     editCompensationModal: {

--- a/web-app/src/pages/AssignmentsPage.test.tsx
+++ b/web-app/src/pages/AssignmentsPage.test.tsx
@@ -6,6 +6,18 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import * as useConvocations from "@/hooks/useConvocations";
 
 vi.mock("@/hooks/useConvocations");
+vi.mock("@/hooks/useTour", () => ({
+  useTour: () => ({
+    isActive: false,
+    isTourMode: false,
+    showDummyData: false,
+    startTour: vi.fn(),
+    endTour: vi.fn(),
+    currentStep: 0,
+    nextStep: vi.fn(),
+    shouldShow: false,
+  }),
+}));
 vi.mock("@/hooks/useAssignmentActions", () => ({
   useAssignmentActions: () => ({
     editCompensationModal: {

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -52,7 +52,8 @@ export function AssignmentsPage() {
   const { t } = useTranslation();
 
   // Initialize tour for this page (triggers auto-start on first visit)
-  const { isTourMode } = useTour("assignments");
+  // Use showDummyData to show dummy data immediately, avoiding race condition with empty states
+  const { showDummyData } = useTour("assignments");
 
   const {
     editCompensationModal,
@@ -84,17 +85,17 @@ export function AssignmentsPage() {
   const refetch =
     activeTab === "upcoming" ? refetchUpcoming : refetchValidationClosed;
 
-  // When tour is active, show ONLY the dummy assignment to ensure tour works
-  // regardless of whether tabs have real data
+  // When tour is active (or about to auto-start), show ONLY the dummy assignment
+  // to ensure tour works regardless of whether tabs have real data
   const data = useMemo(() => {
-    if (isTourMode) {
+    if (showDummyData) {
       // Safe cast: TourDummyAssignment provides all fields used by AssignmentCard and
       // eligibility checks (refereePosition, refereeGame, convocationCompensation)
       const tourAssignment = TOUR_DUMMY_ASSIGNMENT as unknown as Assignment;
       return [tourAssignment];
     }
     return rawData;
-  }, [isTourMode, rawData]);
+  }, [showDummyData, rawData]);
 
   // Group assignments by week for visual separation
   const groupedData = useMemo(() => {

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -215,7 +215,8 @@ export function AssignmentsPage() {
         }
         className="space-y-3"
       >
-        {isLoading && <LoadingState message={t("assignments.loading")} />}
+        {/* Skip loading state when showing dummy tour data (we already have data to show) */}
+        {isLoading && !showDummyData && <LoadingState message={t("assignments.loading")} />}
 
         {error && (
           <ErrorState
@@ -228,7 +229,7 @@ export function AssignmentsPage() {
           />
         )}
 
-        {!isLoading && !error && data && data.length === 0 && (
+        {(!isLoading || showDummyData) && !error && data && data.length === 0 && (
           <EmptyState
             icon={activeTab === "upcoming" ? "calendar" : "lock"}
             title={
@@ -244,7 +245,7 @@ export function AssignmentsPage() {
           />
         )}
 
-        {!isLoading && !error && groupedData.length > 0 && (
+        {(!isLoading || showDummyData) && !error && groupedData.length > 0 && (
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
             {groupedData.map((group, groupIndex) => {
               // Track global item index for tour data attribute

--- a/web-app/src/pages/CompensationsPage.test.tsx
+++ b/web-app/src/pages/CompensationsPage.test.tsx
@@ -6,6 +6,18 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import * as useConvocations from "@/hooks/useConvocations";
 
 vi.mock("@/hooks/useConvocations");
+vi.mock("@/hooks/useTour", () => ({
+  useTour: () => ({
+    isActive: false,
+    isTourMode: false,
+    showDummyData: false,
+    startTour: vi.fn(),
+    endTour: vi.fn(),
+    currentStep: 0,
+    nextStep: vi.fn(),
+    shouldShow: false,
+  }),
+}));
 vi.mock("@/hooks/useCompensationActions", () => ({
   useCompensationActions: () => ({
     editCompensationModal: {

--- a/web-app/src/pages/CompensationsPage.test.tsx
+++ b/web-app/src/pages/CompensationsPage.test.tsx
@@ -5,8 +5,8 @@ import type { CompensationRecord } from "@/api/client";
 import type { UseQueryResult } from "@tanstack/react-query";
 import * as useConvocations from "@/hooks/useConvocations";
 
-vi.mock("@/hooks/useConvocations");
-vi.mock("@/hooks/useTour", () => ({
+// Mock useTour to disable tour mode during tests (see src/test/mocks.ts for shared pattern)
+const mockUseTour = vi.hoisted(() => ({
   useTour: () => ({
     isActive: false,
     isTourMode: false,
@@ -18,6 +18,9 @@ vi.mock("@/hooks/useTour", () => ({
     shouldShow: false,
   }),
 }));
+
+vi.mock("@/hooks/useConvocations");
+vi.mock("@/hooks/useTour", () => mockUseTour);
 vi.mock("@/hooks/useCompensationActions", () => ({
   useCompensationActions: () => ({
     editCompensationModal: {

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -48,22 +48,23 @@ export function CompensationsPage() {
   const { editCompensationModal, handleGeneratePDF } = useCompensationActions();
 
   // Initialize tour for this page (triggers auto-start on first visit)
-  const { isTourMode } = useTour("compensations");
+  // Use showDummyData to show dummy data immediately, avoiding race condition with empty states
+  const { showDummyData } = useTour("compensations");
 
   // Single data fetch based on current filter (like ExchangePage pattern)
   const paidFilter = useMemo(() => filterToPaidFilter(filter), [filter]);
   const { data: rawData, isLoading, error, refetch } = useCompensations(paidFilter);
 
-  // When tour is active, show ONLY the dummy compensation to ensure tour works
-  // regardless of whether tabs have real data
+  // When tour is active (or about to auto-start), show ONLY the dummy compensation
+  // to ensure tour works regardless of whether tabs have real data
   const data = useMemo(() => {
-    if (isTourMode) {
+    if (showDummyData) {
       // Safe cast: TourDummyCompensation provides all fields used by CompensationCard
       const tourCompensation = TOUR_DUMMY_COMPENSATION as unknown as CompensationRecord;
       return [tourCompensation];
     }
     return rawData;
-  }, [isTourMode, rawData]);
+  }, [showDummyData, rawData]);
 
   // Group compensations by week for visual separation
   const groupedData = useMemo(() => {

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -123,7 +123,8 @@ export function CompensationsPage() {
   };
 
   const renderContent = () => {
-    if (isLoading) {
+    // Skip loading state when showing dummy tour data (we already have data to show)
+    if (isLoading && !showDummyData) {
       return <LoadingState message={t("compensations.loading")} />;
     }
 

--- a/web-app/src/pages/ExchangePage.test.tsx
+++ b/web-app/src/pages/ExchangePage.test.tsx
@@ -12,6 +12,18 @@ vi.mock("@/hooks/useConvocations");
 vi.mock("@/stores/auth");
 vi.mock("@/stores/demo");
 vi.mock("@/stores/settings");
+vi.mock("@/hooks/useTour", () => ({
+  useTour: () => ({
+    isActive: false,
+    isTourMode: false,
+    showDummyData: false,
+    startTour: vi.fn(),
+    endTour: vi.fn(),
+    currentStep: 0,
+    nextStep: vi.fn(),
+    shouldShow: false,
+  }),
+}));
 vi.mock("@/hooks/useActiveAssociation", () => ({
   useActiveAssociationCode: () => "TEST",
 }));

--- a/web-app/src/pages/ExchangePage.test.tsx
+++ b/web-app/src/pages/ExchangePage.test.tsx
@@ -8,11 +8,8 @@ import * as authStore from "@/stores/auth";
 import * as demoStore from "@/stores/demo";
 import * as settingsStore from "@/stores/settings";
 
-vi.mock("@/hooks/useConvocations");
-vi.mock("@/stores/auth");
-vi.mock("@/stores/demo");
-vi.mock("@/stores/settings");
-vi.mock("@/hooks/useTour", () => ({
+// Mock useTour to disable tour mode during tests (see src/test/mocks.ts for shared pattern)
+const mockUseTour = vi.hoisted(() => ({
   useTour: () => ({
     isActive: false,
     isTourMode: false,
@@ -24,6 +21,12 @@ vi.mock("@/hooks/useTour", () => ({
     shouldShow: false,
   }),
 }));
+
+vi.mock("@/hooks/useConvocations");
+vi.mock("@/stores/auth");
+vi.mock("@/stores/demo");
+vi.mock("@/stores/settings");
+vi.mock("@/hooks/useTour", () => mockUseTour);
 vi.mock("@/hooks/useActiveAssociation", () => ({
   useActiveAssociationCode: () => "TEST",
 }));

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -47,7 +47,8 @@ export function ExchangePage() {
   const { t } = useTranslation();
 
   // Initialize tour for this page (triggers auto-start on first visit)
-  const { isTourMode } = useTour("exchange");
+  // Use showDummyData to show dummy data immediately, avoiding race condition with empty states
+  const { showDummyData } = useTour("exchange");
 
   const isDemoMode = useAuthStore((state) => state.isDemoMode);
   const { userRefereeLevel, userRefereeLevelGradationValue } = useDemoStore(
@@ -119,9 +120,9 @@ export function ExchangePage() {
 
   // Filter exchanges by user's referee level and distance when filters are enabled
   const filteredData = useMemo(() => {
-    // When tour is active, show ONLY the dummy exchange to ensure tour works
-    // regardless of whether tabs have real data
-    if (isTourMode) {
+    // When tour is active (or about to auto-start), show ONLY the dummy exchange
+    // to ensure tour works regardless of whether tabs have real data
+    if (showDummyData) {
       // Safe cast: TourDummyExchange provides all fields used by ExchangeCard
       const tourExchange = TOUR_DUMMY_EXCHANGE as unknown as GameExchange;
       return [{ exchange: tourExchange, distanceKm: null }];
@@ -185,7 +186,7 @@ export function ExchangePage() {
 
     return result;
   }, [
-    isTourMode,
+    showDummyData,
     exchangesWithDistance,
     levelFilterEnabled,
     statusFilter,

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -305,7 +305,8 @@ export function ExchangePage() {
     ) : undefined;
 
   const renderContent = () => {
-    if (isLoading) {
+    // Skip loading state when showing dummy tour data (we already have data to show)
+    if (isLoading && !showDummyData) {
       return <LoadingState message={t("exchange.loading")} />;
     }
 

--- a/web-app/src/test/mocks.ts
+++ b/web-app/src/test/mocks.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared mock patterns for tests.
+ *
+ * Due to Vitest's hoisting of vi.mock(), these cannot be directly imported
+ * into test files. Instead, use vi.hoisted() to define mocks inline.
+ *
+ * Example usage in test files:
+ *
+ * ```typescript
+ * // Mock useTour to disable tour mode during tests
+ * const mockUseTour = vi.hoisted(() => ({
+ *   useTour: () => ({
+ *     isActive: false,
+ *     isTourMode: false,
+ *     showDummyData: false,
+ *     startTour: vi.fn(),
+ *     endTour: vi.fn(),
+ *     currentStep: 0,
+ *     nextStep: vi.fn(),
+ *     shouldShow: false,
+ *   }),
+ * }));
+ *
+ * vi.mock("@/hooks/useTour", () => mockUseTour);
+ * ```
+ */
+
+/**
+ * Default values for useTour mock.
+ * Copy this pattern into test files using vi.hoisted().
+ */
+export const USE_TOUR_MOCK_DEFAULTS = {
+  isActive: false,
+  isTourMode: false,
+  showDummyData: false,
+  currentStep: 0,
+  shouldShow: false,
+} as const;


### PR DESCRIPTION
## Summary

- Fixed race condition where guided tour wouldn't work when tabs had no real data
- The tour now shows dummy data immediately when it's about to auto-start, not just when actively running

## Changes

- Added `showDummyData` property to `useTour` hook that is true when either:
  - The tour is actively running (`isTourMode`), OR
  - The tour will auto-start (`shouldShow && autoStart`)
- Updated `AssignmentsPage` to use `showDummyData` instead of `isTourMode` for data filtering
- Updated `CompensationsPage` to use `showDummyData` instead of `isTourMode` for data filtering
- Updated `ExchangePage` to use `showDummyData` instead of `isTourMode` for data filtering
- Added `useTour` mock to page test files to prevent tour interference in tests

## Test Plan

- [ ] Clear localStorage to reset tour state (`localStorage.removeItem('volleykit-tour')`)
- [ ] Navigate to Assignments page with no real assignments - verify dummy assignment shows immediately
- [ ] Navigate to Compensations page with no real compensations - verify dummy compensation shows immediately  
- [ ] Navigate to Exchange page with no real exchanges - verify dummy exchange shows immediately
- [ ] Verify tour spotlight correctly highlights the dummy items
- [ ] Complete a tour and verify real data (or empty state) shows afterward
- [ ] Run `npm test` - all tests pass
- [ ] Run `npm run build` - build succeeds
