### PR TITLE
fix(api): use primaryPostalAddress instead of postalAddress

### DIFF
--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -110,11 +110,11 @@ const hallSchema = z
     __identity: uuidSchema.optional(),
     name: z.string().optional(),
     shortName: z.string().optional().nullable(),
-    postalAddress: z
+    primaryPostalAddress: z
       .object({
-        streetAddress: z.string().optional(),
+        combinedAddress: z.string().optional(),
         postalCode: z.string().optional(),
-        locality: z.string().optional(),
+        city: z.string().optional(),
       })
       .passthrough()
       .optional(),

--- a/web-app/src/hooks/useAssignments.test.tsx
+++ b/web-app/src/hooks/useAssignments.test.tsx
@@ -459,7 +459,7 @@ describe("useAssignmentDetails", () => {
         "refereeGame.game.encounter.teamHome",
         "refereeGame.game.encounter.teamAway",
         "refereeGame.game.hall",
-        "refereeGame.game.hall.postalAddress",
+        "refereeGame.game.hall.primaryPostalAddress",
       ]),
     );
   });

--- a/web-app/src/hooks/useAssignments.ts
+++ b/web-app/src/hooks/useAssignments.ts
@@ -376,7 +376,7 @@ export function useAssignmentDetails(assignmentId: string | null) {
         "refereeGame.game.encounter.teamHome",
         "refereeGame.game.encounter.teamAway",
         "refereeGame.game.hall",
-        "refereeGame.game.hall.postalAddress",
+        "refereeGame.game.hall.primaryPostalAddress",
       ]),
     enabled: !!assignmentId,
     staleTime: 10 * 60 * 1000,


### PR DESCRIPTION
## Summary

- Fixed missing postal code and city in production by correcting the API property name from `postalAddress` to `primaryPostalAddress`

## Changes

- **web-app/src/hooks/useAssignments.ts**: Changed property request from `refereeGame.game.hall.postalAddress` to `refereeGame.game.hall.primaryPostalAddress` in `useAssignmentDetails`
- **web-app/src/api/validation.ts**: Updated hall schema to use `primaryPostalAddress` with correct field names (`city` instead of `locality`, `combinedAddress` instead of `streetAddress`)
- **web-app/src/hooks/useAssignments.test.tsx**: Updated test assertion to match the corrected property name

## Test Plan

- [ ] Verify postal code and city appear in assignment details in production
- [ ] Check that address displays correctly in AssignmentCard expanded view
- [ ] Confirm Google Maps and native maps links work with the full address
- [ ] Test SBB transport connection button uses correct city name
