### PR TITLE
perf(exchanges): fetch only future exchanges instead of entire season

### DIFF
--- a/web-app/src/hooks/useExchanges.ts
+++ b/web-app/src/hooks/useExchanges.ts
@@ -44,13 +44,11 @@ export function useGameExchanges(status: ExchangeStatus = "all") {
 
   // Only fetch future exchanges - past games are irrelevant for both
   // "open" (can't take over past games) and "applied" (user only cares about upcoming).
-  const { fromDate, toDate } = useMemo(() => {
-    const { to } = getSeasonDateRange();
-    return {
-      fromDate: startOfDay(new Date()).toISOString(),
-      toDate: endOfDay(to).toISOString(),
-    };
-  }, []);
+  // No useMemo: the calculation is trivial, and we need fresh dates if the app
+  // stays open overnight (the query key change will trigger a refetch).
+  const { to: seasonEnd } = getSeasonDateRange();
+  const fromDate = startOfDay(new Date()).toISOString();
+  const toDate = endOfDay(seasonEnd).toISOString();
 
   // Build property filters: always include date range, optionally include status
   const propertyFilters = useMemo(() => {

--- a/web-app/src/hooks/useExchanges.ts
+++ b/web-app/src/hooks/useExchanges.ts
@@ -42,12 +42,12 @@ export function useGameExchanges(status: ExchangeStatus = "all") {
   // Use appropriate key for cache invalidation when switching associations
   const associationKey = isDemoMode ? demoAssociationCode : activeOccupationId;
 
-  // Memoize season date range. The season only changes once per year,
-  // so this is stable for the entire session.
+  // Only fetch future exchanges - past games are irrelevant for both
+  // "open" (can't take over past games) and "applied" (user only cares about upcoming).
   const { fromDate, toDate } = useMemo(() => {
-    const { from, to } = getSeasonDateRange();
+    const { to } = getSeasonDateRange();
     return {
-      fromDate: startOfDay(from).toISOString(),
+      fromDate: startOfDay(new Date()).toISOString(),
       toDate: endOfDay(to).toISOString(),
     };
   }, []);


### PR DESCRIPTION
## Summary

- Optimize exchange tab loading by fetching only future exchanges instead of the entire volleyball season

## Changes

- Modified `useExchanges.ts` to use today's date as the start of the date range filter instead of the season start (September 1st)
- This reduces the API query window from ~9 months to only upcoming games until end of season

## Test Plan

- [ ] Open the Exchange tab and verify it loads faster
- [ ] Verify "Open" tab shows only future open exchanges
- [ ] Verify "My Applications" tab shows only future applications
- [ ] Confirm no past exchanges appear (which is expected - they're irrelevant)
- [ ] Test at different times during the season to ensure date calculation works correctly
