### PR TITLE
fix(api): handle public_transport mode and null values in compensation validation

### DIFF
--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -1696,7 +1696,8 @@ components:
           example: 96317
         transportationMode:
           type: string
-          enum: [car, train, other]
+          enum: [car, train, public_transport, other]
+          nullable: true
           example: "car"
         paymentValueDate:
           type: string

--- a/web-app/src/api/validation.test.ts
+++ b/web-app/src/api/validation.test.ts
@@ -113,6 +113,36 @@ describe("compensationRecordSchema with dateSchema", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("accepts compensation with public_transport transportationMode", () => {
+    const result = compensationRecordSchema.safeParse({
+      ...validCompensationBase,
+      convocationCompensation: {
+        transportationMode: "public_transport",
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts compensation with null transportationMode", () => {
+    const result = compensationRecordSchema.safeParse({
+      ...validCompensationBase,
+      convocationCompensation: {
+        transportationMode: null,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts compensation with null distanceFormatted", () => {
+    const result = compensationRecordSchema.safeParse({
+      ...validCompensationBase,
+      convocationCompensation: {
+        distanceFormatted: null,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("personSearchResultSchema", () => {

--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -232,12 +232,15 @@ const convocationCompensationSchema = z
     publicTransportExpenses: z.number().optional().nullable(),
     travelExpensesPercentageWeighting: z.number().optional(),
     distanceInMetres: z.number().optional(),
-    transportationMode: z.enum(["car", "train", "other"]).optional(),
+    transportationMode: z
+      .enum(["car", "train", "public_transport", "other"])
+      .optional()
+      .nullable(),
     paymentValueDate: dateSchema,
     gameCompensationFormatted: z.string().optional(),
     travelExpensesFormatted: z.string().optional(),
     costFormatted: z.string().optional(),
-    distanceFormatted: z.string().optional(),
+    distanceFormatted: z.string().optional().nullable(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary

- Fix API validation errors on the compensation tab for associations that use public transport mode

## Changes

- Add `public_transport` to the `transportationMode` enum in `convocationCompensationSchema`
- Make `transportationMode` nullable (API returns null for some records)
- Make `distanceFormatted` nullable (API returns null when distance data is incomplete)

## Test Plan

- [ ] Switch to an association that previously showed validation errors
- [ ] Open the Compensations tab
- [ ] Verify compensation records load without "Invalid API response" errors
- [ ] Verify records with public_transport mode display correctly
- [ ] Verify records with null distance values display correctly
