### PR TITLE
fix(api): handle separate postalCode/city fields and add geographicalLocation to schema

### DIFF
--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -115,6 +115,14 @@ const hallSchema = z
         combinedAddress: z.string().optional(),
         postalCode: z.string().optional(),
         city: z.string().optional(),
+        geographicalLocation: z
+          .object({
+            plusCode: z.string().optional(),
+            latitude: z.number().optional(),
+            longitude: z.number().optional(),
+          })
+          .passthrough()
+          .optional(),
       })
       .passthrough()
       .optional(),
@@ -126,8 +134,7 @@ const gameSchema = z
   .object({
     __identity: uuidSchema.optional(),
     gameNumber: z.string().optional(),
-    startDate: dateTimeSchema,
-    endDate: dateTimeSchema,
+    startingDateTime: dateTimeSchema,
     teamHome: teamSchema.optional(),
     teamAway: teamSchema.optional(),
     hall: hallSchema.optional(),

--- a/web-app/src/components/features/AssignmentCard.test.tsx
+++ b/web-app/src/components/features/AssignmentCard.test.tsx
@@ -138,7 +138,8 @@ describe("AssignmentCard", () => {
 
       render(<AssignmentCard assignment={assignment} />);
 
-      expect(screen.getByText("Zürich")).toBeInTheDocument();
+      // City appears in the address link
+      expect(screen.getByRole("link", { name: /Zürich in maps/i })).toBeInTheDocument();
     });
 
     it("maintains consistent spacing when city is not available", () => {

--- a/web-app/src/utils/maps-url.test.ts
+++ b/web-app/src/utils/maps-url.test.ts
@@ -41,11 +41,26 @@ describe("maps-url", () => {
       expect(buildFullAddress(address)).toBeNull();
     });
 
-    it("returns null when only postal code is available", () => {
+    it("returns postalCodeAndCity when only that is available", () => {
       const address: PostalAddress = {
         postalCodeAndCity: "3000 Bern",
       };
-      expect(buildFullAddress(address)).toBeNull();
+      expect(buildFullAddress(address)).toBe("3000 Bern");
+    });
+
+    it("builds postalCodeAndCity from separate postalCode and city fields", () => {
+      const address: PostalAddress = {
+        postalCode: "8000",
+        city: "Zürich",
+      };
+      expect(buildFullAddress(address)).toBe("8000 Zürich");
+    });
+
+    it("returns city alone when only city is available", () => {
+      const address: PostalAddress = {
+        city: "Basel",
+      };
+      expect(buildFullAddress(address)).toBe("Basel");
     });
 
     it("returns null for empty object", () => {

--- a/web-app/src/utils/maps-url.ts
+++ b/web-app/src/utils/maps-url.ts
@@ -6,6 +6,7 @@ export interface PostalAddress {
   combinedAddress?: string;
   streetAndHouseNumber?: string;
   postalCodeAndCity?: string;
+  postalCode?: string;
   city?: string;
   geographicalLocation?: {
     plusCode?: string;
@@ -25,14 +26,29 @@ export interface MapsUrls {
 
 /**
  * Build the full address string from postal address components.
+ * Handles both combined fields (postalCodeAndCity) and separate fields (postalCode, city).
  */
 export function buildFullAddress(postalAddress: PostalAddress | null | undefined): string | null {
   if (!postalAddress) return null;
 
-  return postalAddress.combinedAddress
-    || (postalAddress.streetAndHouseNumber && postalAddress.postalCodeAndCity
-      ? `${postalAddress.streetAndHouseNumber}, ${postalAddress.postalCodeAndCity}`
-      : null);
+  // Prefer combinedAddress if available
+  if (postalAddress.combinedAddress) {
+    return postalAddress.combinedAddress;
+  }
+
+  // Build postalCodeAndCity from separate fields if not provided
+  const postalCodeAndCity = postalAddress.postalCodeAndCity
+    || (postalAddress.postalCode && postalAddress.city
+      ? `${postalAddress.postalCode} ${postalAddress.city}`
+      : postalAddress.city || null);
+
+  // If we have street and postal/city, combine them
+  if (postalAddress.streetAndHouseNumber && postalCodeAndCity) {
+    return `${postalAddress.streetAndHouseNumber}, ${postalCodeAndCity}`;
+  }
+
+  // Fall back to just postal code and city
+  return postalCodeAndCity;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix addresses missing postal code and city name in production
- Fix distance and travel time badges not showing on Exchange tab
- Update validation schema to properly parse API response fields

## Changes

- **web-app/src/utils/maps-url.ts**: Update `buildFullAddress` to handle separate `postalCode` and `city` fields when `combinedAddress` is not available (API returns them separately in search endpoints)
- **web-app/src/api/validation.ts**: 
  - Add `geographicalLocation` schema to `hallSchema` for distance/travel time badge support
  - Fix `gameSchema` to use `startingDateTime` instead of `startDate` to match actual API field names
- **web-app/src/utils/maps-url.test.ts**: Add tests for new address formatting behavior (separate postalCode/city, city-only fallback)
- **web-app/src/components/features/AssignmentCard.test.tsx**: Update test to use more specific selector to avoid false matches

## Test Plan

- [ ] Verify addresses display correctly with postal code and city (e.g., "8000 Zürich")
- [ ] Verify addresses display with just city name when postal code unavailable
- [ ] Verify distance badge shows on Exchange tab when home location is set
- [ ] Verify travel time badge shows on Exchange tab when transport is enabled
- [ ] Verify SBB link still works on Exchange tab
- [ ] Run `npm test` - all tests pass
- [ ] Run `npm run lint` - no warnings
