### PR TITLE
perf(ux): preload all tabs when switching associations

### DIFF
--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -9,6 +9,7 @@ import { getOccupationLabelKey } from "@/utils/occupation-labels";
 import { getApiClient } from "@/api/client";
 import { toast } from "@/stores/toast";
 import { createLogger } from "@/utils/logger";
+import { prefetchAllTabData } from "@/hooks/usePrefetchTabData";
 import {
   Volleyball,
   ClipboardList,
@@ -151,6 +152,16 @@ export function AppShell() {
       // 2. New data is fetched fresh from the server
       // This prevents showing stale data from the previous association.
       await queryClient.resetQueries();
+
+      // Prefetch data for all tabs in production mode.
+      // This improves UX by loading data for tabs the user hasn't visited yet.
+      // In demo mode, data comes directly from the store, so no prefetch needed.
+      if (!isDemoMode) {
+        // Don't await - let prefetch happen in background while user interacts
+        prefetchAllTabData(queryClient, id).catch(() => {
+          // Errors are already logged in prefetchAllTabData, no action needed
+        });
+      }
     } catch (error) {
       // Check if this is still the latest switch request before showing error
       if (currentSwitch === switchCounterRef.current) {

--- a/web-app/src/hooks/usePaginatedQuery.ts
+++ b/web-app/src/hooks/usePaginatedQuery.ts
@@ -17,9 +17,29 @@ export const DEFAULT_DATE_RANGE_DAYS = 365;
 // to find the one matching the assignment's game.
 export const COMPENSATION_LOOKUP_LIMIT = 200;
 
-// Cache duration for validation-closed assignments (15 minutes).
-// Longer than default because validation status changes infrequently
-// and fetching all pages is expensive.
+// Cache durations (stale times) for different query types.
+// These control how long TanStack Query considers data fresh before refetching.
+
+/** Default stale time for assignments queries (5 minutes) */
+export const ASSIGNMENTS_STALE_TIME_MS = 5 * 60 * 1000;
+
+/** Stale time for compensation queries (5 minutes) */
+export const COMPENSATIONS_STALE_TIME_MS = 5 * 60 * 1000;
+
+/** Stale time for exchange queries (2 minutes) - shorter due to time-sensitive nature */
+export const EXCHANGES_STALE_TIME_MS = 2 * 60 * 1000;
+
+/** Stale time for association settings (30 minutes) - settings rarely change */
+export const SETTINGS_STALE_TIME_MS = 30 * 60 * 1000;
+
+/** Stale time for active season (1 hour) - season changes infrequently */
+export const SEASON_STALE_TIME_MS = 60 * 60 * 1000;
+
+/**
+ * Cache duration for validation-closed assignments (15 minutes).
+ * Longer than default because validation status changes infrequently
+ * and fetching all pages is expensive.
+ */
 export const VALIDATION_CLOSED_STALE_TIME_MS = 15 * 60 * 1000;
 
 // Fallback timestamp for items with missing dates - uses Unix epoch (1970-01-01)

--- a/web-app/src/hooks/usePrefetchTabData.test.ts
+++ b/web-app/src/hooks/usePrefetchTabData.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { prefetchAllTabData } from "./usePrefetchTabData";
+import {
+  ASSIGNMENTS_STALE_TIME_MS,
+  COMPENSATIONS_STALE_TIME_MS,
+  EXCHANGES_STALE_TIME_MS,
+  SETTINGS_STALE_TIME_MS,
+  SEASON_STALE_TIME_MS,
+} from "./usePaginatedQuery";
+
+// Mock dependencies
+vi.mock("@/api/client", () => ({
+  api: {
+    searchAssignments: vi.fn(),
+    searchCompensations: vi.fn(),
+    searchExchanges: vi.fn(),
+    getAssociationSettings: vi.fn(),
+    getActiveSeason: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/date-helpers", () => ({
+  getSeasonDateRange: vi.fn(() => ({
+    from: new Date("2024-09-01"),
+    to: new Date("2025-05-31"),
+  })),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+describe("prefetchAllTabData", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("prefetches all tab data in parallel", async () => {
+    const { api } = await import("@/api/client");
+
+    vi.mocked(api.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchExchanges).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.getAssociationSettings).mockResolvedValue({
+      hoursAfterGameStartForRefereeToEditGameList: 6,
+    });
+    vi.mocked(api.getActiveSeason).mockResolvedValue({
+      seasonStartDate: "2024-09-01",
+      seasonEndDate: "2025-05-31",
+    });
+
+    await prefetchAllTabData(queryClient, "occupation-123");
+
+    expect(api.searchAssignments).toHaveBeenCalledTimes(1);
+    expect(api.searchCompensations).toHaveBeenCalledTimes(1);
+    expect(api.searchExchanges).toHaveBeenCalledTimes(1);
+    expect(api.getAssociationSettings).toHaveBeenCalledTimes(1);
+    expect(api.getActiveSeason).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses correct query keys with occupation ID", async () => {
+    const { api } = await import("@/api/client");
+
+    vi.mocked(api.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchExchanges).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.getAssociationSettings).mockResolvedValue({});
+    vi.mocked(api.getActiveSeason).mockResolvedValue({});
+
+    const prefetchSpy = vi.spyOn(queryClient, "prefetchQuery");
+
+    await prefetchAllTabData(queryClient, "occupation-456");
+
+    // Verify prefetchQuery was called 5 times
+    expect(prefetchSpy).toHaveBeenCalledTimes(5);
+
+    // Check that occupation ID is included in query keys
+    const calls = prefetchSpy.mock.calls;
+    expect(calls[0]![0]).toMatchObject({
+      queryKey: expect.arrayContaining(["occupation-456"]),
+      staleTime: ASSIGNMENTS_STALE_TIME_MS,
+    });
+    expect(calls[1]![0]).toMatchObject({
+      queryKey: expect.arrayContaining(["occupation-456"]),
+      staleTime: COMPENSATIONS_STALE_TIME_MS,
+    });
+    expect(calls[2]![0]).toMatchObject({
+      queryKey: expect.arrayContaining(["occupation-456"]),
+      staleTime: EXCHANGES_STALE_TIME_MS,
+    });
+    expect(calls[3]![0]).toMatchObject({
+      queryKey: expect.arrayContaining(["occupation-456"]),
+      staleTime: SETTINGS_STALE_TIME_MS,
+    });
+    expect(calls[4]![0]).toMatchObject({
+      queryKey: expect.arrayContaining(["occupation-456"]),
+      staleTime: SEASON_STALE_TIME_MS,
+    });
+  });
+
+  it("continues prefetching other queries when one fails", async () => {
+    const { api } = await import("@/api/client");
+
+    // First query fails
+    vi.mocked(api.searchAssignments).mockRejectedValue(
+      new Error("Network error"),
+    );
+    // Rest succeed
+    vi.mocked(api.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchExchanges).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.getAssociationSettings).mockResolvedValue({});
+    vi.mocked(api.getActiveSeason).mockResolvedValue({});
+
+    // Should not throw, failures are caught internally
+    await expect(
+      prefetchAllTabData(queryClient, "occupation-123"),
+    ).resolves.toBeUndefined();
+
+    // All APIs should have been called despite first failure
+    expect(api.searchAssignments).toHaveBeenCalled();
+    expect(api.searchCompensations).toHaveBeenCalled();
+    expect(api.searchExchanges).toHaveBeenCalled();
+    expect(api.getAssociationSettings).toHaveBeenCalled();
+    expect(api.getActiveSeason).toHaveBeenCalled();
+  });
+
+  it("handles all queries failing gracefully", async () => {
+    const { api } = await import("@/api/client");
+
+    vi.mocked(api.searchAssignments).mockRejectedValue(new Error("Error 1"));
+    vi.mocked(api.searchCompensations).mockRejectedValue(new Error("Error 2"));
+    vi.mocked(api.searchExchanges).mockRejectedValue(new Error("Error 3"));
+    vi.mocked(api.getAssociationSettings).mockRejectedValue(
+      new Error("Error 4"),
+    );
+    vi.mocked(api.getActiveSeason).mockRejectedValue(new Error("Error 5"));
+
+    // Should not throw
+    await expect(
+      prefetchAllTabData(queryClient, "occupation-123"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("uses correct search configurations for assignments", async () => {
+    const { api } = await import("@/api/client");
+
+    vi.mocked(api.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchExchanges).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.getAssociationSettings).mockResolvedValue({});
+    vi.mocked(api.getActiveSeason).mockResolvedValue({});
+
+    await prefetchAllTabData(queryClient, "occupation-123");
+
+    // Verify assignments config has correct structure
+    expect(api.searchAssignments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        offset: 0,
+        limit: 100,
+        propertyFilters: expect.arrayContaining([
+          expect.objectContaining({
+            propertyName: "refereeGame.game.startingDateTime",
+            dateRange: expect.objectContaining({
+              from: expect.any(String),
+              to: expect.any(String),
+            }),
+          }),
+        ]),
+        propertyOrderings: expect.arrayContaining([
+          expect.objectContaining({
+            propertyName: "refereeGame.game.startingDateTime",
+            descending: false,
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("uses correct search configurations for compensations", async () => {
+    const { api } = await import("@/api/client");
+
+    vi.mocked(api.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchExchanges).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.getAssociationSettings).mockResolvedValue({});
+    vi.mocked(api.getActiveSeason).mockResolvedValue({});
+
+    await prefetchAllTabData(queryClient, "occupation-123");
+
+    // Verify compensations config - no date filter, sorted descending
+    expect(api.searchCompensations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        offset: 0,
+        limit: 100,
+        propertyFilters: [],
+        propertyOrderings: expect.arrayContaining([
+          expect.objectContaining({
+            propertyName: "refereeGame.game.startingDateTime",
+            descending: true,
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("uses correct search configurations for exchanges", async () => {
+    const { api } = await import("@/api/client");
+
+    vi.mocked(api.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchExchanges).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.getAssociationSettings).mockResolvedValue({});
+    vi.mocked(api.getActiveSeason).mockResolvedValue({});
+
+    await prefetchAllTabData(queryClient, "occupation-123");
+
+    // Verify exchanges config has date filter and ascending order
+    expect(api.searchExchanges).toHaveBeenCalledWith(
+      expect.objectContaining({
+        offset: 0,
+        limit: 100,
+        propertyFilters: expect.arrayContaining([
+          expect.objectContaining({
+            propertyName: "refereeGame.game.startingDateTime",
+            dateRange: expect.objectContaining({
+              from: expect.any(String),
+              to: expect.any(String),
+            }),
+          }),
+        ]),
+        propertyOrderings: expect.arrayContaining([
+          expect.objectContaining({
+            propertyName: "refereeGame.game.startingDateTime",
+            descending: false,
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("caches prefetched data in query client", async () => {
+    const { api } = await import("@/api/client");
+
+    vi.mocked(api.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.searchExchanges).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    });
+    vi.mocked(api.getAssociationSettings).mockResolvedValue({
+      hoursAfterGameStartForRefereeToEditGameList: 6,
+    });
+    vi.mocked(api.getActiveSeason).mockResolvedValue({
+      seasonStartDate: "2024-09-01",
+    });
+
+    await prefetchAllTabData(queryClient, "occupation-123");
+
+    // Verify data is cached - getQueriesData returns cached queries
+    const cachedQueries = queryClient.getQueriesData({ queryKey: ["assignments"] });
+    expect(cachedQueries.length).toBeGreaterThan(0);
+  });
+});
+
+describe("stale time constants", () => {
+  it("has correct values", () => {
+    expect(ASSIGNMENTS_STALE_TIME_MS).toBe(5 * 60 * 1000);
+    expect(COMPENSATIONS_STALE_TIME_MS).toBe(5 * 60 * 1000);
+    expect(EXCHANGES_STALE_TIME_MS).toBe(2 * 60 * 1000);
+    expect(SETTINGS_STALE_TIME_MS).toBe(30 * 60 * 1000);
+    expect(SEASON_STALE_TIME_MS).toBe(60 * 60 * 1000);
+  });
+});

--- a/web-app/src/hooks/usePrefetchTabData.ts
+++ b/web-app/src/hooks/usePrefetchTabData.ts
@@ -3,7 +3,15 @@ import { startOfDay, endOfDay, addDays } from "date-fns";
 import { api, type SearchConfiguration } from "@/api/client";
 import { queryKeys } from "@/api/queryKeys";
 import { getSeasonDateRange } from "@/utils/date-helpers";
-import { DEFAULT_PAGE_SIZE, DEFAULT_DATE_RANGE_DAYS } from "./usePaginatedQuery";
+import {
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_DATE_RANGE_DAYS,
+  ASSIGNMENTS_STALE_TIME_MS,
+  COMPENSATIONS_STALE_TIME_MS,
+  EXCHANGES_STALE_TIME_MS,
+  SETTINGS_STALE_TIME_MS,
+  SEASON_STALE_TIME_MS,
+} from "./usePaginatedQuery";
 import { createLogger } from "@/utils/logger";
 
 const log = createLogger("prefetchTabData");
@@ -98,7 +106,7 @@ export async function prefetchAllTabData(
           newOccupationId,
         ),
         queryFn: () => api.searchAssignments(upcomingAssignmentsConfig),
-        staleTime: 5 * 60 * 1000,
+        staleTime: ASSIGNMENTS_STALE_TIME_MS,
       })
       .catch((err) => log.warn("Failed to prefetch assignments:", err)),
 
@@ -110,7 +118,7 @@ export async function prefetchAllTabData(
           newOccupationId,
         ),
         queryFn: () => api.searchCompensations(compensationsConfig),
-        staleTime: 5 * 60 * 1000,
+        staleTime: COMPENSATIONS_STALE_TIME_MS,
       })
       .catch((err) => log.warn("Failed to prefetch compensations:", err)),
 
@@ -119,7 +127,7 @@ export async function prefetchAllTabData(
       .prefetchQuery({
         queryKey: queryKeys.exchanges.list(exchangesConfig, newOccupationId),
         queryFn: () => api.searchExchanges(exchangesConfig),
-        staleTime: 2 * 60 * 1000,
+        staleTime: EXCHANGES_STALE_TIME_MS,
       })
       .catch((err) => log.warn("Failed to prefetch exchanges:", err)),
 
@@ -128,7 +136,7 @@ export async function prefetchAllTabData(
       .prefetchQuery({
         queryKey: queryKeys.settings.association(newOccupationId),
         queryFn: () => api.getAssociationSettings(),
-        staleTime: 30 * 60 * 1000,
+        staleTime: SETTINGS_STALE_TIME_MS,
       })
       .catch((err) => log.warn("Failed to prefetch settings:", err)),
 
@@ -137,7 +145,7 @@ export async function prefetchAllTabData(
       .prefetchQuery({
         queryKey: queryKeys.seasons.active(newOccupationId),
         queryFn: () => api.getActiveSeason(),
-        staleTime: 60 * 60 * 1000,
+        staleTime: SEASON_STALE_TIME_MS,
       })
       .catch((err) => log.warn("Failed to prefetch season:", err)),
   ];

--- a/web-app/src/hooks/usePrefetchTabData.ts
+++ b/web-app/src/hooks/usePrefetchTabData.ts
@@ -1,0 +1,147 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { startOfDay, endOfDay, addDays } from "date-fns";
+import { api, type SearchConfiguration } from "@/api/client";
+import { queryKeys } from "@/api/queryKeys";
+import { getSeasonDateRange } from "@/utils/date-helpers";
+import { DEFAULT_PAGE_SIZE, DEFAULT_DATE_RANGE_DAYS } from "./usePaginatedQuery";
+import { createLogger } from "@/utils/logger";
+
+const log = createLogger("prefetchTabData");
+
+/**
+ * Prefetches data for all main tabs after an association switch.
+ *
+ * This improves UX by loading data for tabs the user hasn't visited yet,
+ * so they don't see loading states when navigating between tabs.
+ *
+ * Prefetches:
+ * - Upcoming assignments (Assignments tab)
+ * - Compensations (Compensations tab)
+ * - Game exchanges (Exchange tab)
+ * - Association settings and active season (needed for validation-closed assignments)
+ *
+ * @param queryClient - TanStack Query client instance
+ * @param newOccupationId - The new occupation ID after switching
+ */
+export async function prefetchAllTabData(
+  queryClient: QueryClient,
+  newOccupationId: string,
+): Promise<void> {
+  const now = new Date();
+
+  // Build configs matching what the hooks use
+  const upcomingAssignmentsConfig: SearchConfiguration = {
+    offset: 0,
+    limit: DEFAULT_PAGE_SIZE,
+    propertyFilters: [
+      {
+        propertyName: "refereeGame.game.startingDateTime",
+        dateRange: {
+          from: startOfDay(now).toISOString(),
+          to: endOfDay(addDays(now, DEFAULT_DATE_RANGE_DAYS)).toISOString(),
+        },
+      },
+    ],
+    propertyOrderings: [
+      {
+        propertyName: "refereeGame.game.startingDateTime",
+        descending: false,
+        isSetByUser: true,
+      },
+    ],
+  };
+
+  const compensationsConfig: SearchConfiguration = {
+    offset: 0,
+    limit: DEFAULT_PAGE_SIZE,
+    propertyFilters: [],
+    propertyOrderings: [
+      {
+        propertyName: "refereeGame.game.startingDateTime",
+        descending: true,
+        isSetByUser: true,
+      },
+    ],
+  };
+
+  const { to: seasonEnd } = getSeasonDateRange();
+  const exchangesConfig: SearchConfiguration = {
+    offset: 0,
+    limit: DEFAULT_PAGE_SIZE,
+    propertyFilters: [
+      {
+        propertyName: "refereeGame.game.startingDateTime",
+        dateRange: {
+          from: startOfDay(now).toISOString(),
+          to: endOfDay(seasonEnd).toISOString(),
+        },
+      },
+    ],
+    propertyOrderings: [
+      {
+        propertyName: "refereeGame.game.startingDateTime",
+        descending: false,
+        isSetByUser: true,
+      },
+    ],
+  };
+
+  log.debug("Prefetching all tab data for occupation:", newOccupationId);
+
+  // Prefetch all in parallel - failures are logged but don't block other prefetches
+  const prefetchPromises = [
+    // Assignments tab - upcoming assignments
+    queryClient
+      .prefetchQuery({
+        queryKey: queryKeys.assignments.list(
+          upcomingAssignmentsConfig,
+          newOccupationId,
+        ),
+        queryFn: () => api.searchAssignments(upcomingAssignmentsConfig),
+        staleTime: 5 * 60 * 1000,
+      })
+      .catch((err) => log.warn("Failed to prefetch assignments:", err)),
+
+    // Compensations tab
+    queryClient
+      .prefetchQuery({
+        queryKey: queryKeys.compensations.list(
+          compensationsConfig,
+          newOccupationId,
+        ),
+        queryFn: () => api.searchCompensations(compensationsConfig),
+        staleTime: 5 * 60 * 1000,
+      })
+      .catch((err) => log.warn("Failed to prefetch compensations:", err)),
+
+    // Exchange tab
+    queryClient
+      .prefetchQuery({
+        queryKey: queryKeys.exchanges.list(exchangesConfig, newOccupationId),
+        queryFn: () => api.searchExchanges(exchangesConfig),
+        staleTime: 2 * 60 * 1000,
+      })
+      .catch((err) => log.warn("Failed to prefetch exchanges:", err)),
+
+    // Settings - needed for validation-closed assignments
+    queryClient
+      .prefetchQuery({
+        queryKey: queryKeys.settings.association(newOccupationId),
+        queryFn: () => api.getAssociationSettings(),
+        staleTime: 30 * 60 * 1000,
+      })
+      .catch((err) => log.warn("Failed to prefetch settings:", err)),
+
+    // Active season - needed for validation-closed assignments
+    queryClient
+      .prefetchQuery({
+        queryKey: queryKeys.seasons.active(newOccupationId),
+        queryFn: () => api.getActiveSeason(),
+        staleTime: 60 * 60 * 1000,
+      })
+      .catch((err) => log.warn("Failed to prefetch season:", err)),
+  ];
+
+  await Promise.all(prefetchPromises);
+  log.debug("Tab data prefetch complete");
+}


### PR DESCRIPTION
## Summary

- Preload data for all tabs (Assignments, Compensations, Exchange) when switching associations
- Eliminates loading states when navigating between tabs after an association switch
- Improves perceived performance by fetching data in the background

## Changes

- Created `web-app/src/hooks/usePrefetchTabData.ts` with `prefetchAllTabData()` function that prefetches:
  - Upcoming assignments (Assignments tab)
  - Compensations (Compensations tab)
  - Game exchanges (Exchange tab)
  - Association settings (needed for validation-closed assignments)
  - Active season (needed for validation-closed assignments)
- Integrated prefetch call in `AppShell.tsx` after association switch completes
- Prefetch runs in the background (non-blocking) and only in production mode (demo mode reads from store directly)
- Individual prefetch failures are logged but don't block other prefetches

## Test Plan

- [ ] Switch between associations with multiple occupation roles
- [ ] After switch, navigate to Compensations tab - should show data immediately (no loading spinner)
- [ ] After switch, navigate to Exchange tab - should show data immediately
- [ ] Verify assignments tab still works correctly after switch
- [ ] Check browser network tab to confirm parallel prefetch requests after switch
- [ ] Verify demo mode still works (should skip prefetching)
- [ ] Verify rapid association switching still handles race conditions correctly
