### PR TITLE
fix(ui): display postal code and city in address display

### DIFF
--- a/web-app/src/stores/demo-generators.ts
+++ b/web-app/src/stores/demo-generators.ts
@@ -75,10 +75,14 @@ function createAddress({
   longitude,
   plusCode,
 }: AddressParams) {
-  const combinedAddress =
-    street && houseNumber
-      ? `${street} ${houseNumber}, ${postalCode} ${city}`
-      : `${postalCode} ${city}`;
+  // Build streetAndHouseNumber if both parts are available
+  const streetAndHouseNumber =
+    street && houseNumber ? `${street} ${houseNumber}` : undefined;
+
+  // combinedAddress in real API often just contains street, but we build full here
+  const combinedAddress = streetAndHouseNumber
+    ? `${streetAndHouseNumber}, ${postalCode} ${city}`
+    : `${postalCode} ${city}`;
 
   return {
     __identity: id,
@@ -86,6 +90,7 @@ function createAddress({
     ...(houseNumber && { houseNumber }),
     postalCode,
     city,
+    ...(streetAndHouseNumber && { streetAndHouseNumber }),
     combinedAddress,
     ...(latitude !== undefined &&
       longitude !== undefined && {

--- a/web-app/src/utils/maps-url.test.ts
+++ b/web-app/src/utils/maps-url.test.ts
@@ -17,12 +17,13 @@ describe("maps-url", () => {
       expect(buildFullAddress(undefined)).toBeNull();
     });
 
-    it("returns combinedAddress when available", () => {
+    it("builds address from components when all are available", () => {
       const address: PostalAddress = {
         combinedAddress: "Sportstrasse 1, 8000 Zürich",
         streetAndHouseNumber: "Sportstrasse 1",
         postalCodeAndCity: "8000 Zürich",
       };
+      // Should build from components, result happens to match combinedAddress
       expect(buildFullAddress(address)).toBe("Sportstrasse 1, 8000 Zürich");
     });
 
@@ -67,13 +68,32 @@ describe("maps-url", () => {
       expect(buildFullAddress({})).toBeNull();
     });
 
-    it("prefers combinedAddress over individual components", () => {
+    it("builds from components even when combinedAddress differs", () => {
       const address: PostalAddress = {
-        combinedAddress: "Full Combined Address",
-        streetAndHouseNumber: "Different Street",
-        postalCodeAndCity: "Different City",
+        combinedAddress: "Different Combined Address",
+        streetAndHouseNumber: "Musterstrasse 1",
+        postalCodeAndCity: "8000 Zürich",
       };
-      expect(buildFullAddress(address)).toBe("Full Combined Address");
+      // Components take precedence - builds full address from street + postalCodeAndCity
+      expect(buildFullAddress(address)).toBe("Musterstrasse 1, 8000 Zürich");
+    });
+
+    it("handles API case where combinedAddress only has street", () => {
+      // Real API data: combinedAddress matches streetAndHouseNumber (no postal info)
+      const address: PostalAddress = {
+        combinedAddress: "Steingrubenweg 30",
+        streetAndHouseNumber: "Steingrubenweg 30",
+        postalCode: "4125",
+        city: "Riehen",
+      };
+      expect(buildFullAddress(address)).toBe("Steingrubenweg 30, 4125 Riehen");
+    });
+
+    it("returns combinedAddress when only it is available", () => {
+      const address: PostalAddress = {
+        combinedAddress: "Full Address Here",
+      };
+      expect(buildFullAddress(address)).toBe("Full Address Here");
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixed postal code and city not being displayed in address fields for exchange cards and assignment cards
- The API returns `combinedAddress` containing only the street address (e.g., "Steingrubenweg 30"), not the full address with postal code and city

## Changes

- Updated `buildFullAddress()` in `web-app/src/utils/maps-url.ts` to build the full address from components (`streetAndHouseNumber`, `postalCode`, `city`) when available, instead of blindly trusting `combinedAddress`
- Added `streetAndHouseNumber` field to mock address generator in `web-app/src/stores/demo-generators.ts` for consistency with real API data
- Updated tests in `web-app/src/utils/maps-url.test.ts` to reflect the new behavior and added a test case matching the real API response format

## Test Plan

- [ ] View exchange cards in the Exchange tab - addresses should now show postal code and city (e.g., "Steingrubenweg 30, 4125 Riehen")
- [ ] View assignment cards in the Assignments tab - addresses should display full address with postal code and city
- [ ] Verify demo mode still works correctly with the updated mock data
- [ ] Confirm maps links still work correctly with the full address
