### PR TITLE
fix(exchange): show distance badge when only plus code is available

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -14,6 +14,7 @@
         "lucide-react": "^0.562.0",
         "ojp-sdk-next": "^0.21.1",
         "pdf-lib": "^1.17.1",
+        "pluscodes": "^3.0.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-router-dom": "^7.10.1",
@@ -8824,6 +8825,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pluscodes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pluscodes/-/pluscodes-3.0.1.tgz",
+      "integrity": "sha512-2KxZx0q7Rgo2OURGUQXtF7cTjx9jzQKKqMmcHgpP4d37PbATgTeL96+pcot6HTFkuSt1y0jgaVj60nq2tJbk4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -27,7 +27,7 @@
     {
       "name": "Main App Bundle",
       "path": "dist/assets/index-*.js",
-      "limit": "135 kB",
+      "limit": "136 kB",
       "gzip": true
     },
     {
@@ -67,6 +67,7 @@
     "lucide-react": "^0.562.0",
     "ojp-sdk-next": "^0.21.1",
     "pdf-lib": "^1.17.1",
+    "pluscodes": "^3.0.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-router-dom": "^7.10.1",

--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { getPositionLabel } from "@/utils/position-labels";
 import { buildMapsUrls } from "@/utils/maps-url";
+import { extractCoordinates } from "@/utils/geo-location";
 import { useSettingsStore } from "@/stores/settings";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { useSbbUrl } from "@/hooks/useSbbUrl";
@@ -105,9 +106,7 @@ function AssignmentCardComponent({
 
   // Extract hall coordinates and ID for travel time queries
   const geoLocation = game?.hall?.primaryPostalAddress?.geographicalLocation;
-  const hallCoords = geoLocation?.latitude !== undefined && geoLocation?.longitude !== undefined
-    ? { latitude: geoLocation.latitude, longitude: geoLocation.longitude }
-    : null;
+  const hallCoords = extractCoordinates(geoLocation);
   const hallId = game?.hall?.__identity;
   const gameStartingDateTime = game?.startingDateTime;
 

--- a/web-app/src/components/features/ExchangeCard.tsx
+++ b/web-app/src/components/features/ExchangeCard.tsx
@@ -7,6 +7,7 @@ import type { GameExchange } from "@/api/client";
 import { useDateLocale } from "@/hooks/useDateFormat";
 import { useTranslation } from "@/hooks/useTranslation";
 import { buildMapsUrls } from "@/utils/maps-url";
+import { extractCoordinates } from "@/utils/geo-location";
 import { getPositionLabel } from "@/utils/position-labels";
 import { useSettingsStore } from "@/stores/settings";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
@@ -99,9 +100,7 @@ function ExchangeCardComponent({
 
   // Extract hall coordinates and ID for travel time queries
   const geoLocation = game?.hall?.primaryPostalAddress?.geographicalLocation;
-  const hallCoords = geoLocation?.latitude !== undefined && geoLocation?.longitude !== undefined
-    ? { latitude: geoLocation.latitude, longitude: geoLocation.longitude }
-    : null;
+  const hallCoords = extractCoordinates(geoLocation);
   const hallId = game?.hall?.__identity;
   const gameStartingDateTime = game?.startingDateTime;
 

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from "@/stores/auth";
 import { useSettingsStore } from "@/stores/settings";
 import { createExchangeActions } from "@/utils/exchange-actions";
 import { calculateDistanceKm } from "@/utils/distance";
+import { extractCoordinates } from "@/utils/geo-location";
 import { ExchangeCard } from "@/components/features/ExchangeCard";
 import { SwipeableCard } from "@/components/ui/SwipeableCard";
 import { WeekSeparator } from "@/components/ui/WeekSeparator";
@@ -109,16 +110,15 @@ export function ExchangePage() {
     return data.map((exchange) => {
       const geoLocation =
         exchange.refereeGame?.game?.hall?.primaryPostalAddress?.geographicalLocation;
-      const lat = geoLocation?.latitude;
-      const lon = geoLocation?.longitude;
+      const hallCoords = extractCoordinates(geoLocation);
 
-      if (lat == null || lon == null) {
+      if (!hallCoords) {
         return { exchange, distanceKm: null };
       }
 
       const distanceKm = calculateDistanceKm(
         { latitude: homeLocation.latitude, longitude: homeLocation.longitude },
-        { latitude: lat, longitude: lon },
+        hallCoords,
       );
 
       return { exchange, distanceKm };

--- a/web-app/src/utils/geo-location.test.ts
+++ b/web-app/src/utils/geo-location.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { extractCoordinates } from "./geo-location";
+
+describe("extractCoordinates", () => {
+  describe("with direct coordinates", () => {
+    it("returns coordinates when both latitude and longitude are present", () => {
+      const result = extractCoordinates({
+        latitude: 47.3769,
+        longitude: 8.5417,
+      });
+
+      expect(result).toEqual({
+        latitude: 47.3769,
+        longitude: 8.5417,
+      });
+    });
+
+    it("prioritizes direct coordinates over plus code", () => {
+      const result = extractCoordinates({
+        latitude: 47.3769,
+        longitude: 8.5417,
+        plusCode: "8FV9HMQ5+F5", // Would decode to different coordinates
+      });
+
+      expect(result).toEqual({
+        latitude: 47.3769,
+        longitude: 8.5417,
+      });
+    });
+
+    it("handles zero coordinates correctly", () => {
+      const result = extractCoordinates({
+        latitude: 0,
+        longitude: 0,
+      });
+
+      expect(result).toEqual({
+        latitude: 0,
+        longitude: 0,
+      });
+    });
+  });
+
+  describe("with plus code fallback", () => {
+    it("decodes plus code when lat/lon are missing", () => {
+      // Plus code for Riehen, Switzerland: 8FV9HMQ5+F5
+      const result = extractCoordinates({
+        plusCode: "8FV9HMQ5+F5",
+      });
+
+      expect(result).not.toBeNull();
+      // Verify coordinates are in the expected area (Riehen is near Basel)
+      expect(result?.latitude).toBeCloseTo(47.571, 1);
+      expect(result?.longitude).toBeCloseTo(7.664, 1);
+    });
+
+    it("decodes plus code when latitude is missing", () => {
+      const result = extractCoordinates({
+        longitude: 8.5417,
+        plusCode: "8FV9HMQ5+F5",
+      });
+
+      // Should use plus code since lat is missing
+      expect(result?.latitude).toBeCloseTo(47.571, 1);
+    });
+
+    it("decodes plus code when longitude is missing", () => {
+      const result = extractCoordinates({
+        latitude: 47.3769,
+        plusCode: "8FV9HMQ5+F5",
+      });
+
+      // Should use plus code since lon is missing
+      expect(result?.longitude).toBeCloseTo(7.664, 1);
+    });
+
+    it("returns null for invalid plus code", () => {
+      const result = extractCoordinates({
+        plusCode: "invalid-code",
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("with no location data", () => {
+    it("returns null for null input", () => {
+      expect(extractCoordinates(null)).toBeNull();
+    });
+
+    it("returns null for undefined input", () => {
+      expect(extractCoordinates(undefined)).toBeNull();
+    });
+
+    it("returns null for empty object", () => {
+      expect(extractCoordinates({})).toBeNull();
+    });
+
+    it("returns null when only identity is present", () => {
+      const result = extractCoordinates({
+        // No lat, lon, or plusCode
+      } as { latitude?: number; longitude?: number; plusCode?: string });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("real-world API examples", () => {
+    it("handles Turnhalle Hinter Gärten (Riehen) from API", () => {
+      // Real example from the API where only plusCode is available
+      const result = extractCoordinates({
+        plusCode: "8FV9HMQ5+F5",
+      });
+
+      expect(result).not.toBeNull();
+      // Verify we get reasonable Swiss coordinates
+      expect(result?.latitude).toBeGreaterThan(45);
+      expect(result?.latitude).toBeLessThan(48);
+      expect(result?.longitude).toBeGreaterThan(5);
+      expect(result?.longitude).toBeLessThan(11);
+    });
+
+    it("handles hall with full coordinates from API", () => {
+      // Example with both lat/lon and plusCode
+      const result = extractCoordinates({
+        latitude: 47.462187,
+        longitude: 8.577813,
+        plusCode: "8FVCFH6H+V4",
+      });
+
+      // Should use direct coordinates
+      expect(result).toEqual({
+        latitude: 47.462187,
+        longitude: 8.577813,
+      });
+    });
+  });
+});

--- a/web-app/src/utils/geo-location.ts
+++ b/web-app/src/utils/geo-location.ts
@@ -1,0 +1,74 @@
+/**
+ * Utilities for extracting geographic coordinates from various sources.
+ *
+ * Supports:
+ * - Direct latitude/longitude values
+ * - Plus Code (Open Location Code) decoding as fallback
+ *
+ * Note: Uses the `pluscodes` package for Plus Code decoding. This package
+ * was chosen for its small size (~0.4 KB gzipped), zero dependencies, and
+ * TypeScript support. Alternative: `open-location-code` (Google's official
+ * library) has similar features but slightly larger bundle impact.
+ */
+
+import { decode as decodePlusCode } from "pluscodes";
+import type { components } from "@/api/schema";
+import type { Coordinates } from "./distance";
+
+/**
+ * Geographic location data from the API schema.
+ * Using the schema type ensures this stays in sync with API changes.
+ */
+type GeographicalLocation = components["schemas"]["GeographicalLocation"];
+
+/**
+ * Extracts coordinates from a geographical location object.
+ *
+ * Priority:
+ * 1. Use direct latitude/longitude if both are present
+ * 2. Decode Plus Code if available and lat/lon are missing
+ *
+ * @param geoLocation - Geographic location object from the API
+ * @returns Coordinates object or null if no location can be determined
+ *
+ * @example
+ * ```ts
+ * // With direct coordinates
+ * extractCoordinates({ latitude: 47.3769, longitude: 8.5417 })
+ * // Returns { latitude: 47.3769, longitude: 8.5417 }
+ *
+ * // With Plus Code only
+ * extractCoordinates({ plusCode: "8FV9HMQ5+F5" })
+ * // Returns { latitude: 47.xxx, longitude: 7.xxx }
+ *
+ * // With no location data
+ * extractCoordinates({ })
+ * // Returns null
+ * ```
+ */
+export function extractCoordinates(
+  geoLocation: GeographicalLocation | null | undefined,
+): Coordinates | null {
+  if (!geoLocation) return null;
+
+  // Priority 1: Use direct coordinates if available
+  if (geoLocation.latitude != null && geoLocation.longitude != null) {
+    return {
+      latitude: geoLocation.latitude,
+      longitude: geoLocation.longitude,
+    };
+  }
+
+  // Priority 2: Decode Plus Code as fallback
+  if (geoLocation.plusCode) {
+    const decoded = decodePlusCode(geoLocation.plusCode);
+    if (decoded) {
+      return {
+        latitude: decoded.latitude,
+        longitude: decoded.longitude,
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Fixed missing distance badge in exchange items when the sports hall only has a Plus Code (no direct latitude/longitude coordinates)
- Added fallback to decode Plus Codes (Open Location Code) to coordinates when lat/lon are not available from the API

## Changes

- Added `pluscodes` npm package (v3.0.1) for decoding Plus Codes to coordinates
- Created new `extractCoordinates` utility in `src/utils/geo-location.ts` that:
  - Uses direct lat/lon if available
  - Falls back to decoding Plus Code when coordinates are missing
  - Uses API schema type (`components["schemas"]["GeographicalLocation"]`) for type safety
  - Includes documentation on package choice (small size, zero dependencies, TypeScript support)
- Updated `ExchangePage.tsx` to use the new utility for distance calculations
- Updated `ExchangeCard.tsx` and `AssignmentCard.tsx` to use the utility for SBB travel time lookups
- Added comprehensive unit tests for the geo-location utility (13 tests)
- Increased main bundle size limit from 135 KB to 136 KB to accommodate the new dependency (~0.4 KB gzipped)

## Test Plan

- [ ] Verify distance badge appears on exchange items where the hall only has a Plus Code (e.g., "Turnhalle Hinter Gärten" with plusCode "8FV9HMQ5+F5")
- [ ] Verify distance badge still works for halls with direct lat/lon coordinates
- [ ] Verify distance filtering still works correctly
- [ ] Verify travel time badge and SBB button work for halls with Plus Code only
- [ ] Run `npm run build && npm run size` to verify bundle limits pass
- [ ] Run `npm test` to verify all tests pass
