### PR TITLE
fix(exchange): use extractCoordinates for travel time badge

### DIFF
--- a/web-app/src/hooks/useTravelTimeFilter.ts
+++ b/web-app/src/hooks/useTravelTimeFilter.ts
@@ -21,6 +21,7 @@ import {
   type Coordinates,
   type TravelTimeResult,
 } from "@/services/transport";
+import { extractCoordinates } from "@/utils/geo-location";
 import type { GameExchange } from "@/api/client";
 
 interface HallInfo {
@@ -46,8 +47,7 @@ function getHallInfo(exchange: GameExchange): HallInfo | null {
   if (!hall?.__identity) return null;
 
   const geoLocation = hall.primaryPostalAddress?.geographicalLocation;
-  const lat = geoLocation?.latitude;
-  const lon = geoLocation?.longitude;
+  const coords = extractCoordinates(geoLocation);
 
   // Extract game start time for optimal connection selection
   const startingDateTime = exchange.refereeGame?.game?.startingDateTime;
@@ -55,7 +55,7 @@ function getHallInfo(exchange: GameExchange): HallInfo | null {
 
   return {
     id: hall.__identity,
-    coords: lat != null && lon != null ? { latitude: lat, longitude: lon } : null,
+    coords,
     gameStartTime,
   };
 }


### PR DESCRIPTION
## Summary

- Fixed travel time badge not appearing in production when halls only have Plus Codes (no direct lat/lon coordinates)
- The issue was that `useTravelTimeFilter` hook was directly checking `latitude`/`longitude` instead of using the `extractCoordinates` utility that supports Plus Code fallback

## Changes

- Updated `web-app/src/hooks/useTravelTimeFilter.ts`:
  - Imported `extractCoordinates` from `@/utils/geo-location`
  - Modified `getHallInfo()` to use `extractCoordinates(geoLocation)` instead of directly accessing `geoLocation?.latitude` and `geoLocation?.longitude`

## Root Cause

Commit 9777596 added Plus Code support for the **distance badge** in `ExchangePage.tsx` and `ExchangeCard.tsx`, but the **travel time calculation** in `useTravelTimeFilter.ts` was not updated. When the API returns a hall with only a Plus Code (no direct coordinates), the travel time badge wouldn't show because `coords` was `null`.

## Test Plan

- [x] Enable travel time feature in settings
- [x] Set a home address
- [x] View exchange tab with games at venues that only have Plus Codes (no direct lat/lon)
- [x] Verify travel time badge now appears alongside the distance badge
- [x] Verify existing functionality still works for venues with direct coordinates
