### PR TITLE
perf(ci): cache node_modules for faster CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Audit dependencies
         run: npm audit --audit-level=high --omit=dev
@@ -47,10 +56,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Cache generated API types
@@ -82,10 +97,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Cache generated API types
@@ -117,10 +138,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Cache generated API types
@@ -160,10 +187,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Download build artifact
@@ -196,10 +229,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Download build artifact
@@ -254,10 +293,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Download build artifact


### PR DESCRIPTION
## Summary

- Cache node_modules directory in CI for faster builds when dependencies haven't changed
- Replace npm download cache (which only caches ~/.npm) with direct node_modules caching
- Skip npm ci entirely when cache hits, saving ~30-60 seconds per job

## Changes

- Added node_modules caching to all 7 CI jobs (audit, lint, test, build, bundle-size, e2e, lighthouse)
- Cache key based on package-lock.json hash ensures cache invalidation when dependencies change
- Conditional npm ci step only runs when cache misses
- Removed redundant `cache: 'npm'` option from setup-node since we now cache node_modules directly

## Test Plan

- [ ] Verify CI workflow runs successfully on first run (cache miss - should run npm ci)
- [ ] Verify subsequent runs with same package-lock.json use cached node_modules (cache hit - should skip npm ci)
- [ ] Verify cache is invalidated when package-lock.json changes
- [ ] Confirm all jobs still complete successfully with cached dependencies
