### PR TITLE
feat(compensations): add filters for current season and future items

### DIFF
--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -42,6 +42,7 @@ export { SlidersHorizontal } from "lucide-react";
 export { CheckCircle } from "lucide-react";
 export { AlertTriangle } from "lucide-react";
 export { Calendar } from "lucide-react";
+export { Clock } from "lucide-react";
 export { Lock } from "lucide-react";
 export { Inbox } from "lucide-react";
 export { Info } from "lucide-react";

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -246,8 +246,6 @@ const de: Translations = {
       "Entschädigungseintrag nicht gefunden. Das Spiel liegt möglicherweise zu weit in der Zukunft.",
     compensationMissingId:
       "Entschädigungseintrag hat keine Kennung. Bitte versuchen Sie es später erneut.",
-    filters: "Filter",
-    currentSeasonOnly: "Aktuelle Saison",
     hideFutureItems: "Zukünftige ausblenden",
   },
   exchange: {

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -246,6 +246,7 @@ const de: Translations = {
       "Entschädigungseintrag nicht gefunden. Das Spiel liegt möglicherweise zu weit in der Zukunft.",
     compensationMissingId:
       "Entschädigungseintrag hat keine Kennung. Bitte versuchen Sie es später erneut.",
+    filters: "Filter",
     hideFutureItems: "Zukünftige ausblenden",
   },
   exchange: {

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -246,6 +246,9 @@ const de: Translations = {
       "Entschädigungseintrag nicht gefunden. Das Spiel liegt möglicherweise zu weit in der Zukunft.",
     compensationMissingId:
       "Entschädigungseintrag hat keine Kennung. Bitte versuchen Sie es später erneut.",
+    filters: "Filter",
+    currentSeasonOnly: "Aktuelle Saison",
+    hideFutureItems: "Zukünftige ausblenden",
   },
   exchange: {
     title: "Tauschbörse",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -246,6 +246,9 @@ const en: Translations = {
       "Compensation record not found. The game may be too far in the future.",
     compensationMissingId:
       "Compensation record is missing an identifier. Please try again later.",
+    filters: "Filters",
+    currentSeasonOnly: "Current season",
+    hideFutureItems: "Hide future",
   },
   exchange: {
     title: "Exchange",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -246,8 +246,6 @@ const en: Translations = {
       "Compensation record not found. The game may be too far in the future.",
     compensationMissingId:
       "Compensation record is missing an identifier. Please try again later.",
-    filters: "Filters",
-    currentSeasonOnly: "Current season",
     hideFutureItems: "Hide future",
   },
   exchange: {

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -246,6 +246,7 @@ const en: Translations = {
       "Compensation record not found. The game may be too far in the future.",
     compensationMissingId:
       "Compensation record is missing an identifier. Please try again later.",
+    filters: "Filters",
     hideFutureItems: "Hide future",
   },
   exchange: {

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -246,6 +246,9 @@ const fr: Translations = {
       "Enregistrement d'indemnité introuvable. Le match est peut-être trop éloigné dans le futur.",
     compensationMissingId:
       "L'enregistrement d'indemnité n'a pas d'identifiant. Veuillez réessayer plus tard.",
+    filters: "Filtres",
+    currentSeasonOnly: "Saison actuelle",
+    hideFutureItems: "Masquer futurs",
   },
   exchange: {
     title: "Bourse aux échanges",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -246,6 +246,7 @@ const fr: Translations = {
       "Enregistrement d'indemnité introuvable. Le match est peut-être trop éloigné dans le futur.",
     compensationMissingId:
       "L'enregistrement d'indemnité n'a pas d'identifiant. Veuillez réessayer plus tard.",
+    filters: "Filtres",
     hideFutureItems: "Masquer futurs",
   },
   exchange: {

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -246,8 +246,6 @@ const fr: Translations = {
       "Enregistrement d'indemnité introuvable. Le match est peut-être trop éloigné dans le futur.",
     compensationMissingId:
       "L'enregistrement d'indemnité n'a pas d'identifiant. Veuillez réessayer plus tard.",
-    filters: "Filtres",
-    currentSeasonOnly: "Saison actuelle",
     hideFutureItems: "Masquer futurs",
   },
   exchange: {

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -244,8 +244,6 @@ const it: Translations = {
       "Record di compenso non trovato. La partita potrebbe essere troppo lontana nel futuro.",
     compensationMissingId:
       "Il record di compenso non ha un identificatore. Riprova più tardi.",
-    filters: "Filtri",
-    currentSeasonOnly: "Stagione corrente",
     hideFutureItems: "Nascondi futuri",
   },
   exchange: {

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -244,6 +244,9 @@ const it: Translations = {
       "Record di compenso non trovato. La partita potrebbe essere troppo lontana nel futuro.",
     compensationMissingId:
       "Il record di compenso non ha un identificatore. Riprova più tardi.",
+    filters: "Filtri",
+    currentSeasonOnly: "Stagione corrente",
+    hideFutureItems: "Nascondi futuri",
   },
   exchange: {
     title: "Borsa scambi",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -244,6 +244,7 @@ const it: Translations = {
       "Record di compenso non trovato. La partita potrebbe essere troppo lontana nel futuro.",
     compensationMissingId:
       "Il record di compenso non ha un identificatore. Riprova più tardi.",
+    filters: "Filtri",
     hideFutureItems: "Nascondi futuri",
   },
   exchange: {

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -130,6 +130,9 @@ export interface Translations {
     assignmentNotFoundInCache: string;
     compensationNotFound: string;
     compensationMissingId: string;
+    filters: string;
+    currentSeasonOnly: string;
+    hideFutureItems: string;
   };
   exchange: {
     title: string;

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -130,8 +130,6 @@ export interface Translations {
     assignmentNotFoundInCache: string;
     compensationNotFound: string;
     compensationMissingId: string;
-    filters: string;
-    currentSeasonOnly: string;
     hideFutureItems: string;
   };
   exchange: {

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -130,6 +130,7 @@ export interface Translations {
     assignmentNotFoundInCache: string;
     compensationNotFound: string;
     compensationMissingId: string;
+    filters: string;
     hideFutureItems: string;
   };
   exchange: {

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -5,7 +5,7 @@ import { CompensationCard } from "@/components/features/CompensationCard";
 import { SwipeableCard } from "@/components/ui/SwipeableCard";
 import { WeekSeparator } from "@/components/ui/WeekSeparator";
 import { FilterChip } from "@/components/ui/FilterChip";
-import { Calendar, Clock } from "@/components/ui/icons";
+import { Clock } from "@/components/ui/icons";
 import { groupByWeek, getSeasonDateRange } from "@/utils/date-helpers";
 import {
   LoadingState,
@@ -56,12 +56,7 @@ export function CompensationsPage() {
   );
 
   // Filter store for persisted filters
-  const {
-    currentSeasonOnly,
-    hideFutureItems,
-    toggleCurrentSeasonOnly,
-    toggleHideFutureItems,
-  } = useCompensationFiltersStore();
+  const { hideFutureItems, toggleHideFutureItems } = useCompensationFiltersStore();
 
   // Initialize tour for this page (triggers auto-start on first visit)
   // Use showDummyData to show dummy data immediately, avoiding race condition with empty states
@@ -87,7 +82,7 @@ export function CompensationsPage() {
 
     if (!rawData) return rawData;
 
-    // Apply additional filters
+    // Apply filters - always filter to current season since the app is only useful for current season
     const now = new Date();
     return rawData.filter((record) => {
       const dateString = record.refereeGame?.game?.startingDateTime;
@@ -95,23 +90,19 @@ export function CompensationsPage() {
 
       const gameDate = parseISO(dateString);
 
-      // Filter by current season (Sept 1 - May 31)
-      if (currentSeasonOnly) {
-        if (gameDate < seasonRange.from || gameDate > seasonRange.to) {
-          return false;
-        }
+      // Always filter by current season (Sept 1 - May 31)
+      if (gameDate < seasonRange.from || gameDate > seasonRange.to) {
+        return false;
       }
 
-      // Filter out future items
-      if (hideFutureItems) {
-        if (gameDate > now) {
-          return false;
-        }
+      // Filter out future items (user preference)
+      if (hideFutureItems && gameDate > now) {
+        return false;
       }
 
       return true;
     });
-  }, [showDummyData, rawData, currentSeasonOnly, hideFutureItems, seasonRange]);
+  }, [showDummyData, rawData, hideFutureItems, seasonRange]);
 
   // Group compensations by week for visual separation
   const groupedData = useMemo(() => {
@@ -264,15 +255,8 @@ export function CompensationsPage() {
         ariaLabel={t("compensations.title")}
       />
 
-      {/* Additional filters */}
+      {/* Filter to hide future items */}
       <div className="flex flex-wrap gap-2">
-        <FilterChip
-          active={currentSeasonOnly}
-          onToggle={toggleCurrentSeasonOnly}
-          icon={<Calendar className="w-full h-full" />}
-          label={t("compensations.currentSeasonOnly")}
-          showIconWhenActive
-        />
         <FilterChip
           active={hideFutureItems}
           onToggle={toggleHideFutureItems}

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -71,6 +71,9 @@ export function CompensationsPage() {
   // Calculate season date range for filtering
   const seasonRange = useMemo(() => getSeasonDateRange(), []);
 
+  // Memoize current date to avoid recreating on every render
+  const now = useMemo(() => new Date(), []);
+
   // When tour is active (or about to auto-start), show ONLY the dummy compensation
   // to ensure tour works regardless of whether tabs have real data
   const data = useMemo(() => {
@@ -83,7 +86,6 @@ export function CompensationsPage() {
     if (!rawData) return rawData;
 
     // Apply filters - always filter to current season since the app is only useful for current season
-    const now = new Date();
     return rawData.filter((record) => {
       const dateString = record.refereeGame?.game?.startingDateTime;
       if (!dateString) return true; // Keep items without dates
@@ -102,7 +104,7 @@ export function CompensationsPage() {
 
       return true;
     });
-  }, [showDummyData, rawData, hideFutureItems, seasonRange]);
+  }, [showDummyData, rawData, hideFutureItems, seasonRange, now]);
 
   // Group compensations by week for visual separation
   const groupedData = useMemo(() => {
@@ -256,7 +258,11 @@ export function CompensationsPage() {
       />
 
       {/* Filter to hide future items */}
-      <div className="flex flex-wrap gap-2">
+      <div
+        role="group"
+        aria-label={t("compensations.filters")}
+        className="flex flex-wrap gap-2"
+      >
         <FilterChip
           active={hideFutureItems}
           onToggle={toggleHideFutureItems}

--- a/web-app/src/stores/compensationFilters.test.ts
+++ b/web-app/src/stores/compensationFilters.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useCompensationFiltersStore } from "./compensationFilters";
+
+describe("CompensationFilters Store", () => {
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear();
+    // Reset store state to defaults
+    useCompensationFiltersStore.setState({ hideFutureItems: false });
+  });
+
+  it("initializes with hideFutureItems set to false", () => {
+    const { hideFutureItems } = useCompensationFiltersStore.getState();
+    expect(hideFutureItems).toBe(false);
+  });
+
+  it("toggles hideFutureItems when toggleHideFutureItems is called", () => {
+    const { toggleHideFutureItems } = useCompensationFiltersStore.getState();
+
+    // Initially false
+    expect(useCompensationFiltersStore.getState().hideFutureItems).toBe(false);
+
+    // Toggle to true
+    toggleHideFutureItems();
+    expect(useCompensationFiltersStore.getState().hideFutureItems).toBe(true);
+
+    // Toggle back to false
+    toggleHideFutureItems();
+    expect(useCompensationFiltersStore.getState().hideFutureItems).toBe(false);
+  });
+
+  it("persists hideFutureItems to localStorage", () => {
+    const { toggleHideFutureItems } = useCompensationFiltersStore.getState();
+
+    toggleHideFutureItems();
+
+    // Check that localStorage was updated
+    const stored = localStorage.getItem("volleykit-compensation-filters");
+    expect(stored).toBeTruthy();
+
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      expect(parsed.state.hideFutureItems).toBe(true);
+    }
+  });
+
+  it("restores state from localStorage on initialization", () => {
+    // Simulate persisted state
+    localStorage.setItem(
+      "volleykit-compensation-filters",
+      JSON.stringify({ state: { hideFutureItems: true }, version: 0 }),
+    );
+
+    // Force store to rehydrate from localStorage
+    useCompensationFiltersStore.persist.rehydrate();
+
+    expect(useCompensationFiltersStore.getState().hideFutureItems).toBe(true);
+  });
+});

--- a/web-app/src/stores/compensationFilters.ts
+++ b/web-app/src/stores/compensationFilters.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface CompensationFiltersState {
+  /** Filter to show only items from the current volleyball season (Sept-May) */
+  currentSeasonOnly: boolean;
+  /** Filter to hide items with game dates in the future */
+  hideFutureItems: boolean;
+  /** Toggle current season filter */
+  toggleCurrentSeasonOnly: () => void;
+  /** Toggle hide future items filter */
+  toggleHideFutureItems: () => void;
+}
+
+export const useCompensationFiltersStore = create<CompensationFiltersState>()(
+  persist(
+    (set) => ({
+      currentSeasonOnly: true,
+      hideFutureItems: false,
+      toggleCurrentSeasonOnly: () =>
+        set((state) => ({ currentSeasonOnly: !state.currentSeasonOnly })),
+      toggleHideFutureItems: () =>
+        set((state) => ({ hideFutureItems: !state.hideFutureItems })),
+    }),
+    {
+      name: "volleykit-compensation-filters",
+      partialize: (state) => ({
+        currentSeasonOnly: state.currentSeasonOnly,
+        hideFutureItems: state.hideFutureItems,
+      }),
+    },
+  ),
+);

--- a/web-app/src/stores/compensationFilters.ts
+++ b/web-app/src/stores/compensationFilters.ts
@@ -2,12 +2,8 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 interface CompensationFiltersState {
-  /** Filter to show only items from the current volleyball season (Sept-May) */
-  currentSeasonOnly: boolean;
   /** Filter to hide items with game dates in the future */
   hideFutureItems: boolean;
-  /** Toggle current season filter */
-  toggleCurrentSeasonOnly: () => void;
   /** Toggle hide future items filter */
   toggleHideFutureItems: () => void;
 }
@@ -15,17 +11,13 @@ interface CompensationFiltersState {
 export const useCompensationFiltersStore = create<CompensationFiltersState>()(
   persist(
     (set) => ({
-      currentSeasonOnly: true,
       hideFutureItems: false,
-      toggleCurrentSeasonOnly: () =>
-        set((state) => ({ currentSeasonOnly: !state.currentSeasonOnly })),
       toggleHideFutureItems: () =>
         set((state) => ({ hideFutureItems: !state.hideFutureItems })),
     }),
     {
       name: "volleykit-compensation-filters",
       partialize: (state) => ({
-        currentSeasonOnly: state.currentSeasonOnly,
         hideFutureItems: state.hideFutureItems,
       }),
     },


### PR DESCRIPTION
## Summary

- Add filtering to Compensations page to show only current season items and optionally hide future items
- Current season filtering (Sept 1 - May 31) is always applied since the app is only useful for current season data
- "Hide future" filter is a user preference persisted to localStorage

## Changes

- Add `compensationFilters` Zustand store with localStorage persistence (`web-app/src/stores/compensationFilters.ts`)
- Add client-side filtering in CompensationsPage to always filter by current volleyball season (Sept 1 - May 31)
- Add "Hide future" FilterChip toggle for hiding future-dated items (user preference)
- Add `Clock` icon export to `icons.tsx`
- Add i18n translation key `compensations.hideFutureItems` in all 4 languages (de, en, fr, it)

## Test Plan

- [ ] Navigate to the Compensations tab
- [ ] Verify items from previous seasons are not shown (they are automatically filtered out)
- [ ] Toggle "Hide future" on and verify future-dated items are hidden
- [ ] Refresh the page and verify "Hide future" preference is preserved
- [ ] Switch between Unpaid/Paid/All tabs and verify filtering applies to all tabs
- [ ] Test in all 4 languages (de, en, fr, it) to verify translations

