### PR TITLE
fix(debug): fix API calls in debug panel and add copy functionality

### DIFF
--- a/web-app/src/components/debug/DebugPanel.tsx
+++ b/web-app/src/components/debug/DebugPanel.tsx
@@ -206,11 +206,6 @@ function copyToClipboard(text: string): Promise<boolean> {
   }
 }
 
-/** Copy JSON data to clipboard as formatted string */
-function copyJsonToClipboard(data: unknown): Promise<boolean> {
-  return copyToClipboard(JSON.stringify(data, null, 2));
-}
-
 export function DebugPanel() {
   const [persistedState, setPersistedState] = useState<PersistedState | null>(null);
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(["identity", "status"]));
@@ -563,6 +558,7 @@ interface ExchangeFetchResult {
 
 function ExchangeDebugSection({ userId, isDemoMode }: { userId?: string; isDemoMode: boolean }) {
   const [result, setResult] = useState<ExchangeFetchResult>({ status: "idle" });
+  const { copied, handleCopy } = useCopyWithFeedback();
 
   const handleFetch = async () => {
     if (isDemoMode) {
@@ -651,18 +647,19 @@ function ExchangeDebugSection({ userId, isDemoMode }: { userId?: string; isDemoM
         </button>
         {result.status === "success" && result.rawResponse !== undefined && (
           <button
-            onClick={() => { copyJsonToClipboard(result.rawResponse); }}
+            onClick={() => handleCopy(JSON.stringify(result.rawResponse, null, 2), "exchangeResponse")}
+            aria-label="Copy exchange response to clipboard"
             style={{
               padding: "6px 12px",
               fontSize: "10px",
               cursor: "pointer",
-              backgroundColor: "#1a1a2e",
-              border: "1px solid #444",
-              color: "#888",
+              backgroundColor: copied === "exchangeResponse" ? "#0a2e0a" : "#1a1a2e",
+              border: `1px solid ${copied === "exchangeResponse" ? "#1a5e1a" : "#444"}`,
+              color: copied === "exchangeResponse" ? "#4eff4e" : "#888",
               borderRadius: "4px",
             }}
           >
-            Copy Response
+            {copied === "exchangeResponse" ? "Copied!" : "Copy Response"}
           </button>
         )}
       </div>
@@ -894,18 +891,19 @@ function PersonDetailsSection({ isDemoMode, userId }: { isDemoMode: boolean; use
         </button>
         {result.status === "success" && result.rawResponse !== undefined && (
           <button
-            onClick={() => { copyJsonToClipboard(result.rawResponse); }}
+            onClick={() => handleCopy(JSON.stringify(result.rawResponse, null, 2), "profileResponse")}
+            aria-label="Copy profile response to clipboard"
             style={{
               padding: "6px 12px",
               fontSize: "10px",
               cursor: "pointer",
-              backgroundColor: "#1a1a2e",
-              border: "1px solid #444",
-              color: "#888",
+              backgroundColor: copied === "profileResponse" ? "#0a2e0a" : "#1a1a2e",
+              border: `1px solid ${copied === "profileResponse" ? "#1a5e1a" : "#444"}`,
+              color: copied === "profileResponse" ? "#4eff4e" : "#888",
               borderRadius: "4px",
             }}
           >
-            Copy Response
+            {copied === "profileResponse" ? "Copied!" : "Copy Response"}
           </button>
         )}
       </div>
@@ -1386,6 +1384,7 @@ interface FetchResult {
 
 function LiveDashboardFetch() {
   const [result, setResult] = useState<FetchResult>({ status: "idle" });
+  const { copied, handleCopy } = useCopyWithFeedback();
 
   const handleFetch = async () => {
     setResult({ status: "loading" });
@@ -1438,12 +1437,6 @@ function LiveDashboardFetch() {
     }
   };
 
-  const handleCopyActiveParty = async () => {
-    if (result.diagnostic?.activeParty) {
-      await copyToClipboard(JSON.stringify(result.diagnostic.activeParty, null, 2));
-    }
-  };
-
   return (
     <div>
       <div style={{ marginBottom: "8px", display: "flex", gap: "8px" }}>
@@ -1465,18 +1458,19 @@ function LiveDashboardFetch() {
         </button>
         {result.status === "success" && result.diagnostic?.activeParty && (
           <button
-            onClick={handleCopyActiveParty}
+            onClick={() => handleCopy(JSON.stringify(result.diagnostic?.activeParty, null, 2), "activeParty")}
+            aria-label="Copy activeParty data to clipboard"
             style={{
               padding: "6px 12px",
               fontSize: "10px",
               cursor: "pointer",
-              backgroundColor: "#1a1a2e",
-              border: "1px solid #444",
-              color: "#888",
+              backgroundColor: copied === "activeParty" ? "#0a2e0a" : "#1a1a2e",
+              border: `1px solid ${copied === "activeParty" ? "#1a5e1a" : "#444"}`,
+              color: copied === "activeParty" ? "#4eff4e" : "#888",
               borderRadius: "4px",
             }}
           >
-            Copy activeParty
+            {copied === "activeParty" ? "Copied!" : "Copy activeParty"}
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Fixed API errors in the debug panel for My Profile (500) and Exchanges (403)
- Added copy buttons with visual feedback to easily copy API responses for debugging
- Improved accessibility with aria-label attributes on copy buttons

## Changes

- **My Profile API fix**: Added required `person[__identity]` query parameter and `propertyRenderConfiguration[]` to fetch proper profile data
- **Exchanges API fix**: Added CSRF token (`__csrfToken`) to POST request body to fix 403 authorization error
- **Copy functionality with feedback**: Added "Copy Response" buttons using `useCopyWithFeedback()` hook that shows "Copied!" confirmation state
- **Accessibility**: Added `aria-label` attributes to all new copy buttons
- **Cleanup**: Removed obsolete "Dropdown Should Show" status banner and unused `copyJsonToClipboard` helper

## Test Plan

- [ ] Open debug panel in production with `?debug` URL parameter
- [ ] Click "Fetch My Profile (Live API)" - should return profile data without 500 error
- [ ] Click "Fetch Exchanges (Live API)" - should return exchanges without 403 error
- [ ] Click "Copy Response" button - should show "Copied!" with green highlight for 2 seconds
- [ ] Click "Copy activeParty" button on Live Dashboard Fetch - should show same feedback
- [ ] Verify dropdown status banner is no longer displayed
