### PR TITLE
fix(debug): correct API call parameters and add Accept header

### DIFF
--- a/web-app/src/components/debug/DebugPanel.tsx
+++ b/web-app/src/components/debug/DebugPanel.tsx
@@ -575,8 +575,8 @@ function ExchangeDebugSection({ userId, isDemoMode }: { userId?: string; isDemoM
       // Fetch exchanges from the API
       const csrfToken = getCsrfToken();
       const bodyParams = new URLSearchParams({
-        "configuration[offset]": "0",
-        "configuration[limit]": "10",
+        "searchConfiguration[offset]": "0",
+        "searchConfiguration[limit]": "10",
       });
       if (csrfToken) {
         bodyParams.append("__csrfToken", csrfToken);
@@ -588,6 +588,7 @@ function ExchangeDebugSection({ userId, isDemoMode }: { userId?: string; isDemoM
           method: "POST",
           credentials: "include",
           headers: {
+            Accept: "application/json",
             "Content-Type": "application/x-www-form-urlencoded",
           },
           body: bodyParams,
@@ -846,6 +847,9 @@ function PersonDetailsSection({ isDemoMode, userId }: { isDemoMode: boolean; use
         {
           method: "GET",
           credentials: "include",
+          headers: {
+            Accept: "application/json",
+          },
         }
       );
 


### PR DESCRIPTION
## Summary

- Fix 500 errors when using debug panel API fetch buttons
- Align debug panel API calls with main API client implementation

## Changes

- Fix exchange search parameter name: `configuration` → `searchConfiguration` (matches `api.searchExchanges()`)
- Add `Accept: application/json` header to exchange search POST request
- Add `Accept: application/json` header to person details GET request

## Test Plan

- [ ] Open app with `?debug` URL parameter
- [ ] Expand "Exchange Debug" section and click "Fetch Exchanges (Live API)"
- [ ] Verify request succeeds and shows exchange data (no 500 error)
- [ ] Expand "My Profile (API)" section and click "Fetch My Profile (Live API)"
- [ ] Verify request succeeds and shows person details (no 500 error)
- [ ] Run `npm run lint` - passes with 0 warnings
- [ ] Run `npm test` - all tests pass
