### PR TITLE
fix(debug): add propertyRenderConfiguration to debug panel API calls

### DIFF
--- a/web-app/src/components/debug/DebugPanel.tsx
+++ b/web-app/src/components/debug/DebugPanel.tsx
@@ -578,6 +578,20 @@ function ExchangeDebugSection({ userId, isDemoMode }: { userId?: string; isDemoM
         "searchConfiguration[offset]": "0",
         "searchConfiguration[limit]": "10",
       });
+      // Add minimal propertyRenderConfiguration - required by the API
+      // Note: parent objects must be listed before nested properties
+      const properties = [
+        "status",
+        "submittedByPerson",
+        "submittedByPerson.__identity",
+        "submittedByPerson.displayName",
+        "refereeGame",
+        "refereeGame.game",
+        "refereeGame.game.startingDateTime",
+      ];
+      properties.forEach((prop, index) => {
+        bodyParams.append(`propertyRenderConfiguration[${index}]`, prop);
+      });
       if (csrfToken) {
         bodyParams.append("__csrfToken", csrfToken);
       }


### PR DESCRIPTION
## Summary

- Fixed debug panel API calls that were failing with 500 Internal Server Errors
- The debug panel was missing the required `propertyRenderConfiguration` parameter that the main app includes in its API requests

## Changes

- Added `propertyRenderConfiguration` array to the exchange debug section API call in `DebugPanel.tsx`
- Included parent objects before nested properties (e.g., `submittedByPerson` before `submittedByPerson.__identity`) following the API's requirements

## Test Plan

- [ ] Open the debug panel in the app (add `?debug` to URL)
- [ ] Expand the "Exchange Debug" section
- [ ] Click "Fetch Exchanges (Live API)" button
- [ ] Verify the API call succeeds and returns exchange data instead of a 500 error
- [ ] Verify matching/non-matching exchanges are displayed correctly based on user ID
