### PR TITLE
fix(exchanges): add missing submittedByPerson properties for filtering

### DIFF
--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -63,6 +63,11 @@ export const EXCHANGE_PROPERTIES = [
   "refereeGame.game.startingDateTime",
   "refereeGame.game.playingWeekday",
   "submittedAt",
+  // Parent object must be requested before nested properties
+  "submittedByPerson",
+  "submittedByPerson.__identity",
+  "submittedByPerson.firstName",
+  "submittedByPerson.lastName",
   "submittedByPerson.displayName",
   "submittingType",
   "status",


### PR DESCRIPTION
## Summary

- Fixed bug where exchanges submitted by the current user were not appearing in the "Mine" tab on the Exchange page
- The API was not returning `submittedByPerson.__identity` because it wasn't included in the property configuration, causing the client-side filtering to fail

## Changes

- Added missing properties to `EXCHANGE_PROPERTIES` in `web-app/src/api/property-configs.ts`:
  - `submittedByPerson` (parent object, required before nested properties)
  - `submittedByPerson.__identity` (used for "mine" filtering in useExchanges.ts)
  - `submittedByPerson.firstName` (used in ExchangeCard for submitter name display)
  - `submittedByPerson.lastName` (used in ExchangeCard for submitter name display)

## Test Plan

- [ ] Log in to the app with an account that has submitted an exchange
- [ ] Navigate to the Exchange page
- [ ] Verify your submitted exchanges appear in the "Mine" tab
- [ ] Verify the submitter name is correctly highlighted in the exchange card details
- [ ] Use the debug panel (add ?debug to URL) → Exchange Debug → Fetch Exchanges to verify `submittedByPerson.__identity` is now returned by the API
