### PR TITLE
refactor(tour): simplify guided tours and make descriptions concise

### DIFF
--- a/web-app/src/components/tour/TourSpotlight.tsx
+++ b/web-app/src/components/tour/TourSpotlight.tsx
@@ -124,6 +124,11 @@ export function TourSpotlight({
     if (!target) return;
 
     const element = target as HTMLElement;
+
+    // Scroll element into view if it's not visible
+    // Use smooth scrolling and center the element in the viewport
+    element.scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest" });
+
     // Store original styles in local variables for cleanup
     const originalPosition = element.style.position;
     const originalZIndex = element.style.zIndex;

--- a/web-app/src/components/tour/definitions/exchange.ts
+++ b/web-app/src/components/tour/definitions/exchange.ts
@@ -19,14 +19,6 @@ export const exchangeTour: TourDefinition = {
       placement: "bottom",
       completionEvent: { type: "swipe" },
     },
-    {
-      id: "filter",
-      targetSelector: "[data-tour='exchange-filter']",
-      titleKey: "tour.exchange.filter.title",
-      descriptionKey: "tour.exchange.filter.description",
-      placement: "bottom",
-      completionEvent: { type: "click" },
-    },
   ],
 };
 

--- a/web-app/src/components/tour/definitions/exchange.ts
+++ b/web-app/src/components/tour/definitions/exchange.ts
@@ -19,6 +19,14 @@ export const exchangeTour: TourDefinition = {
       placement: "bottom",
       completionEvent: { type: "swipe" },
     },
+    {
+      id: "filters",
+      targetSelector: "[data-tour='exchange-settings']",
+      titleKey: "tour.exchange.filters.title",
+      descriptionKey: "tour.exchange.filters.description",
+      placement: "bottom",
+      completionEvent: { type: "click" },
+    },
   ],
 };
 

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -21,78 +21,73 @@ const de: Translations = {
       welcome: {
         title: "Ihre Einsätze",
         description:
-          "Hier sehen Sie Ihre bevorstehenden Schiedsrichtereinsätze. Jede Karte zeigt die Spieldetails. Dieses Beispiel zeigt alle verfügbaren Aktionen.",
+          "Ihre bevorstehenden Schiedsrichtereinsätze. Dieses Beispiel zeigt alle verfügbaren Aktionen.",
       },
       swipeValidate: {
         title: "Nach links wischen",
         description:
-          "Wischen Sie nach links, um die Aktionsschaltflächen anzuzeigen. Validieren erscheint für 1. Schiedsrichter, Bearbeiten für bearbeitbare Entschädigungen und Bericht für NLA/NLB-Spiele. Bei Ihren Spielen werden je nach Rolle und Berechtigung möglicherweise weniger Schaltflächen angezeigt.",
+          "Nach links wischen für Aktionen: Validieren (1. SR), Entschädigung bearbeiten oder Bericht (NLA/NLB).",
       },
       swipeExchange: {
         title: "Nach rechts wischen",
         description:
-          "Wischen Sie nach rechts, um den Einsatz zur Börse anzubieten. Andere Schiedsrichter können das Spiel dann übernehmen. Dies ist für alle bevorstehenden Spiele verfügbar.",
+          "Nach rechts wischen, um den Einsatz zur Börse anzubieten.",
       },
       tapDetails: {
-        title: "Details anzeigen",
+        title: "Antippen für Details",
         description:
-          "Tippen Sie auf eine Karte, um sie zu erweitern und weitere Details zum Einsatz zu sehen.",
+          "Tippen Sie auf eine Karte für mehr Details.",
       },
     },
     compensations: {
       overview: {
         title: "Ihre Entschädigungen",
         description:
-          "Hier können Sie alle Ihre Schiedsrichterentschädigungen einsehen, einschliesslich Spielgebühren und Reisekosten.",
+          "Ihre Spielgebühren und Reisekosten.",
       },
       swipeEdit: {
         title: "Nach links wischen",
         description:
-          "Wischen Sie nach links, um die Aktionsschaltflächen anzuzeigen: Bearbeiten (Distanz anpassen oder Korrekturgrund hinzufügen) und PDF (Entschädigungsübersicht herunterladen).",
+          "Nach links wischen zum Bearbeiten oder PDF herunterladen.",
       },
       tapDetails: {
-        title: "Details anzeigen",
+        title: "Antippen für Details",
         description:
-          "Tippen Sie auf eine Karte, um sie zu erweitern und die vollständige Aufschlüsselung Ihrer Entschädigung zu sehen.",
+          "Tippen Sie auf eine Karte für die vollständige Aufschlüsselung.",
       },
     },
     exchange: {
       browse: {
-        title: "Verfügbare Tauschangebote",
+        title: "Tauschbörse",
         description:
-          "Hier sehen Sie Einsätze, die andere Schiedsrichter abgeben möchten. Übernehmen Sie einen, wenn er in Ihren Zeitplan passt!",
+          "Einsätze, die andere Schiedsrichter abgeben möchten. Übernehmen Sie einen, wenn er passt!",
       },
       apply: {
         title: "Wischen zum Bewerben",
         description:
-          "Wischen Sie nach links, um sich für den Tausch zu bewerben. Bei Genehmigung übernehmen Sie den Einsatz.",
-      },
-      filter: {
-        title: "Nach Niveau filtern",
-        description:
-          "Verwenden Sie diesen Schalter, um nur Spiele anzuzeigen, die Ihrem Schiedsrichterniveau entsprechen.",
+          "Nach links wischen, um sich zu bewerben.",
       },
     },
     settings: {
       language: {
-        title: "Sprache ändern",
+        title: "Sprache",
         description:
-          "Wählen Sie Ihre bevorzugte Sprache. Die App unterstützt Deutsch, Englisch, Französisch und Italienisch.",
+          "Wählen Sie Ihre bevorzugte Sprache.",
       },
       homeLocation: {
-        title: "Heimatstandort festlegen",
+        title: "Heimatstandort",
         description:
-          "Legen Sie Ihren Heimatstandort fest, um Tauschangebote nach Entfernung zu filtern. So finden Sie leichter Spiele in Ihrer Nähe.",
+          "Standort festlegen für Filter nach Entfernung und Reisezeit.",
       },
       arrivalTime: {
-        title: "Ankunftszeit-Einstellung",
+        title: "Ankunftszeit",
         description:
-          "Legen Sie fest, wie viele Minuten vor dem Spiel Sie ankommen möchten. Diese Einstellung wird für jeden Verband separat gespeichert.",
+          "Minuten vor Spielbeginn ankommen.",
       },
       complete: {
         title: "Tour abgeschlossen!",
         description:
-          "Sie haben die Einführung abgeschlossen. Sie können sie jederzeit in den Einstellungen neu starten.",
+          "Sie können die Touren jederzeit in den Einstellungen neu starten.",
       },
       tourSection: {
         title: "Einführungstouren",

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -67,6 +67,11 @@ const de: Translations = {
         description:
           "Nach links wischen, um sich zu bewerben.",
       },
+      filters: {
+        title: "Filtereinstellungen",
+        description:
+          "Tippen Sie auf das Zahnrad, um Entfernungs- und Reisezeitfilter anzupassen.",
+      },
     },
     settings: {
       language: {

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -21,78 +21,73 @@ const en: Translations = {
       welcome: {
         title: "Your Assignments",
         description:
-          "This is where you'll see your upcoming referee assignments. Each card shows the game details. This example shows all available actions.",
+          "Your upcoming referee assignments. This example shows all available actions.",
       },
       swipeValidate: {
-        title: "Try Swiping Left",
+        title: "Swipe Left",
         description:
-          "Swipe left on a card to reveal action buttons. Validate appears for 1st referees, Edit for editable compensations, and Report for NLA/NLB games. Your actual games may show fewer buttons based on your role and permissions.",
+          "Swipe left for actions: Validate (1st referee), Edit compensation, or Report (NLA/NLB).",
       },
       swipeExchange: {
-        title: "Try Swiping Right",
+        title: "Swipe Right",
         description:
-          "Swipe right on a card to put the assignment up for exchange. Other referees can then take over the game. This is available for all upcoming games.",
+          "Swipe right to offer this assignment for exchange.",
       },
       tapDetails: {
-        title: "View Details",
+        title: "Tap for Details",
         description:
-          "Tap on a card to expand it and see more details about the assignment.",
+          "Tap a card to expand and see more details.",
       },
     },
     compensations: {
       overview: {
         title: "Your Compensations",
         description:
-          "Here you can see all your referee compensations, including game fees and travel expenses.",
+          "Your game fees and travel expenses.",
       },
       swipeEdit: {
-        title: "Try Swiping Left",
+        title: "Swipe Left",
         description:
-          "Swipe left on a card to reveal action buttons: Edit (adjust distance or add correction reason) and PDF (download compensation summary).",
+          "Swipe left to edit distance or download PDF.",
       },
       tapDetails: {
-        title: "View Details",
+        title: "Tap for Details",
         description:
-          "Tap on a card to expand it and see the full breakdown of your compensation.",
+          "Tap a card to see the full breakdown.",
       },
     },
     exchange: {
       browse: {
-        title: "Available Exchanges",
+        title: "Exchange",
         description:
-          "Here you can see assignments that other referees want to give away. Take one if it fits your schedule!",
+          "Assignments other referees want to give away. Take one if it fits your schedule!",
       },
       apply: {
         title: "Swipe to Apply",
         description:
-          "Swipe left on a card to apply for the exchange. You'll take over the assignment if approved.",
-      },
-      filter: {
-        title: "Filter by Level",
-        description:
-          "Use this toggle to show only games that match your referee level.",
+          "Swipe left to apply for this exchange.",
       },
     },
     settings: {
       language: {
-        title: "Change Language",
+        title: "Language",
         description:
-          "Select your preferred language. The app supports German, English, French, and Italian.",
+          "Choose your preferred language.",
       },
       homeLocation: {
-        title: "Set Home Location",
+        title: "Home Location",
         description:
-          "Set your home location to filter exchange offers by distance. This helps you find games near you more easily.",
+          "Set your location to filter exchanges by distance and travel time.",
       },
       arrivalTime: {
-        title: "Arrival Time Setting",
+        title: "Arrival Time",
         description:
-          "Configure how many minutes before the game you want to arrive. This setting is saved separately for each association.",
+          "How many minutes before the game you want to arrive.",
       },
       complete: {
         title: "Tour Complete!",
         description:
-          "You've completed the guided tour. You can restart it anytime from the settings.",
+          "You can restart the tours anytime from settings.",
       },
       tourSection: {
         title: "Guided Tours",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -67,6 +67,11 @@ const en: Translations = {
         description:
           "Swipe left to apply for this exchange.",
       },
+      filters: {
+        title: "Filter Settings",
+        description:
+          "Tap the gear to customize distance and travel time filters.",
+      },
     },
     settings: {
       language: {

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -21,78 +21,73 @@ const fr: Translations = {
       welcome: {
         title: "Vos désignations",
         description:
-          "Ici vous verrez vos prochaines désignations d'arbitre. Chaque carte affiche les détails du match. Cet exemple montre toutes les actions disponibles.",
+          "Vos prochaines désignations d'arbitre. Cet exemple montre toutes les actions disponibles.",
       },
       swipeValidate: {
-        title: "Glissez vers la gauche",
+        title: "Glissez à gauche",
         description:
-          "Glissez vers la gauche pour révéler les boutons d'action. Valider apparaît pour le 1er arbitre, Modifier pour les indemnités modifiables, et Rapport pour les matchs NLA/NLB. Vos matchs réels peuvent afficher moins de boutons selon votre rôle et vos permissions.",
+          "Glissez à gauche pour : Valider (1er arbitre), modifier l'indemnité ou Rapport (NLA/NLB).",
       },
       swipeExchange: {
-        title: "Glissez vers la droite",
+        title: "Glissez à droite",
         description:
-          "Glissez vers la droite pour proposer la désignation à la bourse. D'autres arbitres pourront alors reprendre le match. Disponible pour tous les matchs à venir.",
+          "Glissez à droite pour proposer cette désignation à la bourse.",
       },
       tapDetails: {
-        title: "Voir les détails",
+        title: "Appuyez pour détails",
         description:
-          "Appuyez sur une carte pour la développer et voir plus de détails sur la désignation.",
+          "Appuyez sur une carte pour plus de détails.",
       },
     },
     compensations: {
       overview: {
         title: "Vos indemnités",
         description:
-          "Ici vous pouvez voir toutes vos indemnités d'arbitre, y compris les frais de match et les frais de déplacement.",
+          "Vos frais de match et de déplacement.",
       },
       swipeEdit: {
-        title: "Glissez pour modifier",
+        title: "Glissez à gauche",
         description:
-          "Glissez vers la gauche pour révéler le bouton de modification. Appuyez dessus pour ajuster la distance ou ajouter un motif de correction.",
+          "Glissez à gauche pour modifier ou télécharger le PDF.",
       },
       tapDetails: {
-        title: "Voir les détails",
+        title: "Appuyez pour détails",
         description:
-          "Appuyez sur une carte pour la développer et voir plus de détails sur l'indemnité.",
+          "Appuyez sur une carte pour le détail complet.",
       },
     },
     exchange: {
       browse: {
-        title: "Échanges disponibles",
+        title: "Bourse",
         description:
-          "Ici vous voyez les désignations que d'autres arbitres souhaitent céder. Reprenez-en une si elle convient à votre emploi du temps !",
+          "Désignations que d'autres arbitres souhaitent céder. Reprenez-en une si elle vous convient !",
       },
       apply: {
         title: "Glissez pour postuler",
         description:
-          "Glissez vers la gauche pour postuler à l'échange. Vous reprendrez la désignation si votre candidature est acceptée.",
-      },
-      filter: {
-        title: "Filtrer par niveau",
-        description:
-          "Utilisez ce bouton pour n'afficher que les matchs correspondant à votre niveau d'arbitre.",
+          "Glissez à gauche pour postuler à cet échange.",
       },
     },
     settings: {
       language: {
-        title: "Changer de langue",
+        title: "Langue",
         description:
-          "Sélectionnez votre langue préférée. L'application prend en charge l'allemand, l'anglais, le français et l'italien.",
+          "Choisissez votre langue préférée.",
       },
       homeLocation: {
-        title: "Définir l'emplacement",
+        title: "Emplacement",
         description:
-          "Définissez votre emplacement pour filtrer les échanges par distance. Cela vous aide à trouver plus facilement des matchs près de chez vous.",
+          "Définissez votre position pour filtrer par distance et temps de trajet.",
       },
       arrivalTime: {
-        title: "Paramètre d'heure d'arrivée",
+        title: "Heure d'arrivée",
         description:
-          "Configurez combien de minutes avant le match vous souhaitez arriver. Ce paramètre est enregistré séparément pour chaque association.",
+          "Minutes avant le match pour arriver.",
       },
       complete: {
         title: "Visite terminée !",
         description:
-          "Vous avez terminé la visite guidée. Vous pouvez la recommencer à tout moment depuis les paramètres.",
+          "Vous pouvez recommencer les visites à tout moment dans les paramètres.",
       },
       tourSection: {
         title: "Visites guidées",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -67,6 +67,11 @@ const fr: Translations = {
         description:
           "Glissez à gauche pour postuler à cet échange.",
       },
+      filters: {
+        title: "Paramètres des filtres",
+        description:
+          "Appuyez sur l'engrenage pour personnaliser les filtres de distance et temps de trajet.",
+      },
     },
     settings: {
       language: {

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -67,6 +67,11 @@ const it: Translations = {
         description:
           "Scorri a sinistra per candidarti a questo scambio.",
       },
+      filters: {
+        title: "Impostazioni filtri",
+        description:
+          "Tocca l'ingranaggio per personalizzare i filtri di distanza e tempo di viaggio.",
+      },
     },
     settings: {
       language: {

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -21,78 +21,73 @@ const it: Translations = {
       welcome: {
         title: "Le tue designazioni",
         description:
-          "Qui vedrai le tue prossime designazioni arbitrali. Ogni scheda mostra i dettagli della partita. Questo esempio mostra tutte le azioni disponibili.",
+          "Le tue prossime designazioni arbitrali. Questo esempio mostra tutte le azioni disponibili.",
       },
       swipeValidate: {
-        title: "Scorri verso sinistra",
+        title: "Scorri a sinistra",
         description:
-          "Scorri verso sinistra per rivelare i pulsanti d'azione. Valida appare per il 1° arbitro, Modifica per i compensi modificabili, e Rapporto per le partite NLA/NLB. Le tue partite reali potrebbero mostrare meno pulsanti in base al tuo ruolo e permessi.",
+          "Scorri a sinistra per: Valida (1° arbitro), modifica compenso o Rapporto (NLA/NLB).",
       },
       swipeExchange: {
-        title: "Scorri verso destra",
+        title: "Scorri a destra",
         description:
-          "Scorri verso destra per offrire la designazione alla borsa. Altri arbitri potranno quindi prendere in carico la partita. Disponibile per tutte le partite in programma.",
+          "Scorri a destra per offrire questa designazione alla borsa.",
       },
       tapDetails: {
-        title: "Visualizza dettagli",
+        title: "Tocca per dettagli",
         description:
-          "Tocca una scheda per espanderla e vedere maggiori dettagli sulla designazione.",
+          "Tocca una scheda per più dettagli.",
       },
     },
     compensations: {
       overview: {
         title: "I tuoi compensi",
         description:
-          "Qui puoi vedere tutti i tuoi compensi arbitrali, incluse le tariffe delle partite e le spese di viaggio.",
+          "Le tue tariffe partita e spese di viaggio.",
       },
       swipeEdit: {
-        title: "Scorri per modificare",
+        title: "Scorri a sinistra",
         description:
-          "Scorri verso sinistra per rivelare il pulsante di modifica. Toccalo per regolare la distanza o aggiungere un motivo di correzione.",
+          "Scorri a sinistra per modificare o scaricare PDF.",
       },
       tapDetails: {
-        title: "Visualizza dettagli",
+        title: "Tocca per dettagli",
         description:
-          "Tocca una scheda per espanderla e vedere maggiori dettagli sul compenso.",
+          "Tocca una scheda per il dettaglio completo.",
       },
     },
     exchange: {
       browse: {
-        title: "Scambi disponibili",
+        title: "Borsa",
         description:
-          "Qui puoi vedere le designazioni che altri arbitri vogliono cedere. Assumine una se si adatta ai tuoi impegni!",
+          "Designazioni che altri arbitri vogliono cedere. Assumine una se ti conviene!",
       },
       apply: {
         title: "Scorri per candidarti",
         description:
-          "Scorri verso sinistra per candidarti allo scambio. Assumerai la designazione se approvato.",
-      },
-      filter: {
-        title: "Filtra per livello",
-        description:
-          "Usa questo pulsante per mostrare solo le partite che corrispondono al tuo livello arbitrale.",
+          "Scorri a sinistra per candidarti a questo scambio.",
       },
     },
     settings: {
       language: {
-        title: "Cambia lingua",
+        title: "Lingua",
         description:
-          "Seleziona la tua lingua preferita. L'app supporta tedesco, inglese, francese e italiano.",
+          "Scegli la tua lingua preferita.",
       },
       homeLocation: {
-        title: "Imposta posizione",
+        title: "Posizione",
         description:
-          "Imposta la tua posizione per filtrare gli scambi per distanza. Questo ti aiuta a trovare più facilmente le partite vicino a te.",
+          "Imposta la tua posizione per filtrare per distanza e tempo di viaggio.",
       },
       arrivalTime: {
-        title: "Impostazione orario di arrivo",
+        title: "Orario di arrivo",
         description:
-          "Configura quanti minuti prima della partita vuoi arrivare. Questa impostazione viene salvata separatamente per ogni associazione.",
+          "Minuti di anticipo all'arrivo prima della partita.",
       },
       complete: {
         title: "Tour completato!",
         description:
-          "Hai completato il tour guidato. Puoi riavviarlo in qualsiasi momento dalle impostazioni.",
+          "Puoi riavviare i tour in qualsiasi momento dalle impostazioni.",
       },
       tourSection: {
         title: "Tour guidati",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -470,6 +470,10 @@ export interface Translations {
         title: string;
         description: string;
       };
+      filters: {
+        title: string;
+        description: string;
+      };
     };
     settings: {
       language: {

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -470,10 +470,6 @@ export interface Translations {
         title: string;
         description: string;
       };
-      filter: {
-        title: string;
-        description: string;
-      };
     };
     settings: {
       language: {


### PR DESCRIPTION
## Summary

- Complete assessment and update of guided tour functionality for all tabs
- Made tour descriptions shorter and more to the point
- Added filter settings step to Exchange tour (targeting the gear icon)
- Added auto-scroll behavior so tour highlights are always visible

## Changes

- **Exchange tour**: 3 steps
  1. Browse (auto) - overview of available exchanges
  2. Swipe to Apply (swipe) - apply for an exchange  
  3. Filter Settings (click) - tap gear icon to customize distance/travel time filters

- **Assignments tour**: 4 steps (unchanged count, shortened descriptions)
  - Welcome, swipe left, swipe right, tap for details

- **Compensations tour**: 3 steps (unchanged count, shortened descriptions)
  - Overview, swipe left, tap for details

- **Settings tour**: 4 steps (unchanged count, shortened descriptions)
  - Language, home location, arrival time, complete

- **Auto-scroll**: Tour spotlight now scrolls the page to center the highlighted element
  - Uses smooth scrolling animation
  - Ensures users always see the tour highlight even if they were scrolled elsewhere

- **Translations**: Updated all 4 languages (de, en, fr, it) with concise descriptions

## Test Plan

- [ ] Start fresh (clear localStorage or use incognito) and verify each tour auto-starts on first visit
- [ ] Verify Assignments tour: 4 steps work correctly with swipe/tap interactions
- [ ] Verify Compensations tour: 3 steps work correctly
- [ ] Verify Exchange tour: 3 steps work correctly (browse → swipe → filter settings gear)
- [ ] Verify Settings tour: 4 steps highlight correct elements
- [ ] Test scroll behavior: scroll down on a page, then trigger tour step - page should scroll to show highlight
- [ ] Test in all 4 languages to verify translations display correctly
- [ ] Verify tour can be restarted from Settings page
- [ ] Run `npm run lint` - passes with 0 warnings
- [ ] Run `npm test` - all 2528 tests pass
