### PR TITLE
feat(settings): display user name and Swiss Volley number in profile section

### DIFF
--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -317,6 +317,7 @@ const de: Translations = {
   settings: {
     title: "Einstellungen",
     profile: "Profil",
+    svNumber: "SV-Nummer",
     language: "Sprache",
     homeLocation: {
       title: "Heimatstandort",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -315,6 +315,7 @@ const en: Translations = {
   settings: {
     title: "Settings",
     profile: "Profile",
+    svNumber: "SV Number",
     language: "Language",
     homeLocation: {
       title: "Home Location",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -316,6 +316,7 @@ const fr: Translations = {
   settings: {
     title: "Paramètres",
     profile: "Profil",
+    svNumber: "N° SV",
     language: "Langue",
     homeLocation: {
       title: "Emplacement domicile",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -314,6 +314,7 @@ const it: Translations = {
   settings: {
     title: "Impostazioni",
     profile: "Profilo",
+    svNumber: "N. SV",
     language: "Lingua",
     homeLocation: {
       title: "Posizione casa",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -197,6 +197,7 @@ export interface Translations {
   settings: {
     title: string;
     profile: string;
+    svNumber: string;
     language: string;
     homeLocation: {
       title: string;

--- a/web-app/src/pages/SettingsPage.test.tsx
+++ b/web-app/src/pages/SettingsPage.test.tsx
@@ -54,9 +54,12 @@ function mockAuthStore(overrides = {}) {
     isDemoMode: false,
     ...overrides,
   };
-  vi.mocked(authStore.useAuthStore).mockReturnValue(
-    state as ReturnType<typeof authStore.useAuthStore>,
-  );
+  vi.mocked(authStore.useAuthStore).mockImplementation((selector?: unknown) => {
+    if (typeof selector === "function") {
+      return selector(state);
+    }
+    return state as ReturnType<typeof authStore.useAuthStore>;
+  });
 }
 
 function mockSettingsStore(overrides = {}) {


### PR DESCRIPTION
## Summary

- Display user's first name, last name, and Swiss Volley (SV) number in the profile section on the Settings page
- Fetch profile data from the person API endpoint since auth store doesn't populate name fields

## Changes

- Extended `ProfileSection.tsx` to fetch `firstName`, `lastName`, `svNumber`, and `profilePicture` from the person API
- Added local state for firstName/lastName to display values fetched from API
- Only show the name row when firstName or lastName is available
- Added `svNumber` translation key to i18n types and all 4 locale files:
  - English: "SV Number"
  - German: "SV-Nummer"
  - French: "N° SV"
  - Italian: "N. SV"
- Demo mode displays placeholder values (firstName: "Demo", lastName: "User", svNumber: 12345)

## Test Plan

- [ ] Login to the app and navigate to Settings page
- [ ] Verify the profile section shows the user's profile picture (or initials fallback)
- [ ] Verify the user's first and last name are displayed
- [ ] Verify the SV number is displayed below the name
- [ ] Verify email is displayed if available
- [ ] Test in demo mode - verify placeholder name and SV number (12345) are shown
- [ ] Test all 4 languages to verify correct translations for "SV Number"
- [ ] Verify the initials in the avatar circle match the fetched name
