### PR TITLE
fix(settings): request parent profilePicture before nested property

### DIFF
--- a/web-app/src/components/features/settings/ProfileSection.tsx
+++ b/web-app/src/components/features/settings/ProfileSection.tsx
@@ -12,13 +12,17 @@ interface ProfileSectionProps {
   user: UserProfile;
 }
 
-interface PersonProfileResponse {
+interface PersonProfile {
   profilePicture?: {
     publicResourceUri?: string;
   };
   svNumber?: number;
   firstName?: string;
   lastName?: string;
+}
+
+interface PersonProfileResponse {
+  person?: PersonProfile;
 }
 
 const DEMO_SV_NUMBER = 12345;
@@ -72,17 +76,18 @@ function ProfileSectionComponent({ user }: ProfileSectionProps) {
 
         if (response.ok) {
           const data: PersonProfileResponse = await response.json();
-          if (data.profilePicture?.publicResourceUri) {
-            setProfilePictureUrl(data.profilePicture.publicResourceUri);
+          const person = data.person;
+          if (person?.profilePicture?.publicResourceUri) {
+            setProfilePictureUrl(person.profilePicture.publicResourceUri);
           }
-          if (data.svNumber) {
-            setSvNumber(data.svNumber);
+          if (person?.svNumber) {
+            setSvNumber(person.svNumber);
           }
-          if (data.firstName) {
-            setFirstName(data.firstName);
+          if (person?.firstName) {
+            setFirstName(person.firstName);
           }
-          if (data.lastName) {
-            setLastName(data.lastName);
+          if (person?.lastName) {
+            setLastName(person.lastName);
           }
         }
       } catch (error) {

--- a/web-app/src/components/features/settings/ProfileSection.tsx
+++ b/web-app/src/components/features/settings/ProfileSection.tsx
@@ -54,13 +54,15 @@ function ProfileSectionComponent({ user }: ProfileSectionProps) {
       try {
         const params = new URLSearchParams();
         params.set("person[__identity]", user.id);
-        params.set("propertyRenderConfiguration[0]", "profilePicture.publicResourceUri");
-        params.set("propertyRenderConfiguration[1]", "svNumber");
-        params.set("propertyRenderConfiguration[2]", "firstName");
-        params.set("propertyRenderConfiguration[3]", "lastName");
+        // Parent objects must be requested before nested properties to avoid 500 errors
+        params.set("propertyRenderConfiguration[0]", "profilePicture");
+        params.set("propertyRenderConfiguration[1]", "profilePicture.publicResourceUri");
+        params.set("propertyRenderConfiguration[2]", "svNumber");
+        params.set("propertyRenderConfiguration[3]", "firstName");
+        params.set("propertyRenderConfiguration[4]", "lastName");
 
         const response = await fetch(
-          `${API_BASE}/sportmanager.volleyball/api%5Cperson/showWithNestedObjects?${params}`,
+          `${API_BASE}/sportmanager.volleyball/api%5cperson/showWithNestedObjects?${params}`,
           {
             credentials: "include",
             signal: controller.signal,


### PR DESCRIPTION
## Summary

- Fixed 500 Internal Server Error on the Settings page when fetching user profile data
- Fixed profile data not displaying (name, SV number, profile picture) due to incorrect response parsing

## Changes

- Added `profilePicture` to `propertyRenderConfiguration` before `profilePicture.publicResourceUri` to avoid 500 errors (API requires parent objects before nested properties)
- Fixed response parsing to correctly extract data from the `{ person: ... }` wrapper object returned by the API

## Test Plan

- [ ] Navigate to Settings page while logged in (not in demo mode)
- [ ] Verify the profile section loads without 500 error
- [ ] Verify user's first name and last name display correctly
- [ ] Verify Swiss Volley number displays correctly
- [ ] Verify profile picture displays if user has one
- [ ] Test in Debug Panel: "Fetch My Profile (Live API)" should return data successfully
