### PR TITLE
fix(settings): include hasProfilePicture before profilePicture in API request

### DIFF
--- a/web-app/src/components/features/settings/ProfileSection.tsx
+++ b/web-app/src/components/features/settings/ProfileSection.tsx
@@ -58,12 +58,15 @@ function ProfileSectionComponent({ user }: ProfileSectionProps) {
       try {
         const params = new URLSearchParams();
         params.set("person[__identity]", user.id);
-        // Parent objects must be requested before nested properties to avoid 500 errors
-        params.set("propertyRenderConfiguration[0]", "profilePicture");
-        params.set("propertyRenderConfiguration[1]", "profilePicture.publicResourceUri");
-        params.set("propertyRenderConfiguration[2]", "svNumber");
-        params.set("propertyRenderConfiguration[3]", "firstName");
-        params.set("propertyRenderConfiguration[4]", "lastName");
+        // Parent objects must be requested before nested properties to avoid 500 errors.
+        // hasProfilePicture must be requested before profilePicture to allow the API
+        // to check existence before accessing the nested object.
+        params.set("propertyRenderConfiguration[0]", "hasProfilePicture");
+        params.set("propertyRenderConfiguration[1]", "profilePicture");
+        params.set("propertyRenderConfiguration[2]", "profilePicture.publicResourceUri");
+        params.set("propertyRenderConfiguration[3]", "svNumber");
+        params.set("propertyRenderConfiguration[4]", "firstName");
+        params.set("propertyRenderConfiguration[5]", "lastName");
 
         const response = await fetch(
           `${API_BASE}/sportmanager.volleyball/api%5cperson/showWithNestedObjects?${params}`,

--- a/web-app/src/components/features/settings/ProfileSection.tsx
+++ b/web-app/src/components/features/settings/ProfileSection.tsx
@@ -58,15 +58,15 @@ function ProfileSectionComponent({ user }: ProfileSectionProps) {
       try {
         const params = new URLSearchParams();
         params.set("person[__identity]", user.id);
-        // Parent objects must be requested before nested properties to avoid 500 errors.
-        // hasProfilePicture must be requested before profilePicture to allow the API
-        // to check existence before accessing the nested object.
-        params.set("propertyRenderConfiguration[0]", "hasProfilePicture");
-        params.set("propertyRenderConfiguration[1]", "profilePicture");
-        params.set("propertyRenderConfiguration[2]", "profilePicture.publicResourceUri");
-        params.set("propertyRenderConfiguration[3]", "svNumber");
-        params.set("propertyRenderConfiguration[4]", "firstName");
-        params.set("propertyRenderConfiguration[5]", "lastName");
+        // Request basic properties first, then nested properties.
+        // Parent objects (hasProfilePicture, profilePicture) must be requested before
+        // nested properties (profilePicture.publicResourceUri) to avoid 500 errors.
+        params.set("propertyRenderConfiguration[0]", "firstName");
+        params.set("propertyRenderConfiguration[1]", "lastName");
+        params.set("propertyRenderConfiguration[2]", "svNumber");
+        params.set("propertyRenderConfiguration[3]", "hasProfilePicture");
+        params.set("propertyRenderConfiguration[4]", "profilePicture");
+        params.set("propertyRenderConfiguration[5]", "profilePicture.publicResourceUri");
 
         const response = await fetch(
           `${API_BASE}/sportmanager.volleyball/api%5cperson/showWithNestedObjects?${params}`,


### PR DESCRIPTION
## Summary

- Fixed 500 error when fetching profile data on the Settings page
- Fixed missing first/last name display by reordering API property requests

## Changes

- Added `hasProfilePicture` before `profilePicture` in propertyRenderConfiguration (required by API)
- Reordered properties to request basic fields (firstName, lastName, svNumber) before nested object properties (profilePicture)
- Updated comments to document the API ordering requirements

## Test Plan

- [ ] Navigate to Settings page while logged in
- [ ] Verify first name and last name display correctly
- [ ] Verify SV number displays correctly
- [ ] Verify profile picture loads (if user has one)
- [ ] Check Network tab - person/showWithNestedObjects should return 200
- [ ] Check console for no API errors
- [ ] Verify DebugPanel "My Profile (API)" fetch still works for comparison
