### PR TITLE
fix(worker): add /api prefix for sportmanager.volleyball API endpoints

### DIFF
--- a/web-app/src/components/features/settings/ProfileSection.tsx
+++ b/web-app/src/components/features/settings/ProfileSection.tsx
@@ -69,7 +69,7 @@ function ProfileSectionComponent({ user }: ProfileSectionProps) {
         params.set("propertyRenderConfiguration[5]", "profilePicture.publicResourceUri");
 
         const response = await fetch(
-          `${API_BASE}/sportmanager.volleyball/api%5cperson/showWithNestedObjects?${params}`,
+          `${API_BASE}/sportmanager.volleyball/api%5Cperson/showWithNestedObjects?${params}`,
           {
             credentials: "include",
             signal: controller.signal,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -76,9 +76,10 @@ const ALLOWED_PREFIX_PATHS_NO_API = [
 ];
 
 // Specific paths within NO_API prefixes that DO need the /api/ prefix
-// The party switching endpoint is under /sportmanager.security/ but needs /api/
+// These are API endpoints under packages that normally serve dashboard/auth pages.
 const EXCEPTIONS_NEED_API = [
   "/sportmanager.security/api", // e.g., /sportmanager.security/api\party/switchRoleAndAttribute
+  "/sportmanager.volleyball/api", // e.g., /sportmanager.volleyball/api\person/showWithNestedObjects
 ];
 
 // Prefix match paths that ARE prefixed with /api/ (API endpoints)


### PR DESCRIPTION
## Summary

- Fixed 500 error when fetching user profile on the settings page
- Root cause: The Cloudflare Worker proxy was not adding the `/api/` prefix for `/sportmanager.volleyball/api\person/showWithNestedObjects` requests

## Changes

- **worker/src/index.ts**: Added `/sportmanager.volleyball/api` to `EXCEPTIONS_NEED_API` list so API endpoints under this package get the required `/api/` prefix when proxied to volleymanager.volleyball.ch
- **ProfileSection.tsx**: Normalized URL encoding case (`%5c` -> `%5C`) for consistency with other endpoints

## Root Cause Analysis

The person profile API was returning 500 because the proxy was sending requests to the wrong path:

| Expected by API | What proxy was sending |
|-----------------|------------------------|
| `/api/sportmanager.volleyball/api\person/...` | `/sportmanager.volleyball/api\person/...` |

The `/sportmanager.volleyball/` prefix was in `ALLOWED_PREFIX_PATHS_NO_API` (for dashboard pages), but API endpoints under this package (like `api\person`) need the `/api/` prefix just like other API endpoints.

## Test Plan

- [ ] Deploy the updated worker to Cloudflare
- [ ] Navigate to Settings page and verify profile section loads without 500 error
- [ ] Verify firstName, lastName, svNumber, and profilePicture are displayed correctly
- [ ] Verify existing functionality (assignments, compensations, exchanges) still works
- [ ] Run worker tests: `cd worker && npm test`
- [ ] Run web-app tests: `cd web-app && npm test`
