### PR TITLE
fix(compensations): remove totals summary from compensation page

### DIFF
--- a/web-app/e2e/compensations.spec.ts
+++ b/web-app/e2e/compensations.spec.ts
@@ -7,7 +7,6 @@ import { LoginPage, CompensationsPage, NavigationPage } from "./pages";
  * These tests verify:
  * - Page loading with real data fetching
  * - Cross-page navigation flows
- * - Data display that requires API integration (CHF totals)
  *
  * Tab navigation, ARIA attributes, card rendering, and accessibility
  * are covered by unit tests in src/pages/CompensationsPage.test.tsx
@@ -33,13 +32,6 @@ test.describe("Compensations Journey", () => {
       await expect(compensationsPage.pendingTab).toBeVisible();
       await expect(compensationsPage.paidTab).toBeVisible();
       await expect(compensationsPage.allTab).toBeVisible();
-    });
-
-    test("loads and displays compensation totals in CHF", async ({ page }) => {
-      // Verify CHF amounts are displayed (requires real data loading)
-      const chfAmounts = page.locator("text=/CHF/");
-      const count = await chfAmounts.count();
-      expect(count).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/web-app/src/pages/CompensationsPage.test.tsx
+++ b/web-app/src/pages/CompensationsPage.test.tsx
@@ -85,10 +85,6 @@ describe("CompensationsPage", () => {
     vi.mocked(useConvocations.useCompensations).mockReturnValue(
       createMockQueryResult([]),
     );
-    vi.mocked(useConvocations.useCompensationTotals).mockReturnValue({
-      paid: 0,
-      unpaid: 0,
-    });
   });
 
   describe("Tab Navigation", () => {
@@ -197,20 +193,6 @@ describe("CompensationsPage", () => {
       render(<CompensationsPage />);
 
       expect(screen.getByText(/Team A vs Team B/i)).toBeInTheDocument();
-    });
-  });
-
-  describe("Totals Summary", () => {
-    it("should display pending and received totals", () => {
-      vi.mocked(useConvocations.useCompensationTotals).mockReturnValue({
-        paid: 250.5,
-        unpaid: 150.0,
-      });
-
-      render(<CompensationsPage />);
-
-      expect(screen.getByText("CHF 150.00")).toBeInTheDocument();
-      expect(screen.getByText("CHF 250.50")).toBeInTheDocument();
     });
   });
 

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, lazy, Suspense, Fragment } from "react";
 import { parseISO } from "date-fns";
-import { useCompensations, useCompensationTotals } from "@/hooks/useConvocations";
+import { useCompensations } from "@/hooks/useConvocations";
 import { CompensationCard } from "@/components/features/CompensationCard";
 import { SwipeableCard } from "@/components/ui/SwipeableCard";
 import { WeekSeparator } from "@/components/ui/WeekSeparator";
@@ -111,8 +111,6 @@ export function CompensationsPage() {
     if (!data || data.length === 0) return [];
     return groupByWeek(data, (c) => c.refereeGame?.game?.startingDateTime);
   }, [data]);
-
-  const totals = useCompensationTotals();
 
   const tabs = [
     { id: "unpaid" as const, label: t("compensations.pending") },
@@ -227,28 +225,6 @@ export function CompensationsPage() {
 
   return (
     <div className="space-y-3">
-      {/* Totals summary */}
-      <div className="flex justify-end">
-        <div className="flex gap-4">
-          <div className="text-center">
-            <div className="text-sm text-text-muted dark:text-text-muted-dark">
-              {t("compensations.pending")}
-            </div>
-            <div className="text-lg font-bold text-warning-500 dark:text-warning-400">
-              CHF {totals.unpaid.toFixed(2)}
-            </div>
-          </div>
-          <div className="text-center">
-            <div className="text-sm text-text-muted dark:text-text-muted-dark">
-              {t("compensations.received")}
-            </div>
-            <div className="text-lg font-bold text-success-500 dark:text-success-400">
-              CHF {totals.paid.toFixed(2)}
-            </div>
-          </div>
-        </div>
-      </div>
-
       {/* Filter tabs with keyboard navigation */}
       <Tabs
         tabs={tabs}


### PR DESCRIPTION
## Summary

- Removed the compensation totals summary display from the CompensationsPage to reclaim screen real estate

## Changes

- Removed the totals summary section showing pending and received CHF amounts
- Removed unused `useCompensationTotals` hook import from `useConvocations`
- Net reduction of 25 lines of code

## Test Plan

- [ ] Navigate to the Compensations page
- [ ] Verify the page loads correctly without the totals display
- [ ] Verify filter tabs (Pending, Paid, All) still work correctly
- [ ] Verify compensation cards still display and are interactive
- [ ] Check that swipe actions (edit, PDF) still function
