### PR TITLE
fix(tour): align compensation dummy data with CompensationCard structure

### DIFF
--- a/web-app/src/components/tour/definitions/compensations.ts
+++ b/web-app/src/components/tour/definitions/compensations.ts
@@ -42,19 +42,23 @@ export const TOUR_DUMMY_COMPENSATION: TourDummyCompensation = {
   __identity: "tour-dummy-compensation-record",
   amount: 85,
   status: "pending",
+  refereePosition: "head-one",
   refereeGame: {
     __identity: "tour-dummy-referee-game-comp",
     game: {
       __identity: "tour-dummy-game-comp",
-      gameNumber: "54321",
-      plannedStartDateTime: getPastDate(),
-      teamHome: {
-        __identity: "tour-dummy-team-home-comp",
-        name: "TV Demo",
-      },
-      teamAway: {
-        __identity: "tour-dummy-team-away-comp",
-        name: "BC Tutorial",
+      number: "54321",
+      startingDateTime: getPastDate(),
+      encounter: {
+        __identity: "tour-dummy-encounter-comp",
+        teamHome: {
+          __identity: "tour-dummy-team-home-comp",
+          name: "TV Demo",
+        },
+        teamAway: {
+          __identity: "tour-dummy-team-away-comp",
+          name: "BC Tutorial",
+        },
       },
     },
   },
@@ -62,7 +66,8 @@ export const TOUR_DUMMY_COMPENSATION: TourDummyCompensation = {
     __identity: "tour-dummy-conv-comp",
     distanceInMetres: 30000,
     distanceFormatted: "30 km",
-    gameFee: 55,
-    travelCompensation: 30,
+    gameCompensation: 55,
+    travelExpenses: 30,
+    paymentDone: false,
   },
 };

--- a/web-app/src/components/tour/definitions/types.ts
+++ b/web-app/src/components/tour/definitions/types.ts
@@ -95,19 +95,23 @@ export interface TourDummyCompensation {
   __identity: string;
   amount: number;
   status: string;
+  refereePosition?: string;
   refereeGame: {
     __identity: string;
     game: {
       __identity: string;
-      gameNumber: string;
-      plannedStartDateTime: string;
-      teamHome: {
+      number?: string;
+      startingDateTime: string;
+      encounter: {
         __identity: string;
-        name: string;
-      };
-      teamAway: {
-        __identity: string;
-        name: string;
+        teamHome: {
+          __identity: string;
+          name: string;
+        };
+        teamAway: {
+          __identity: string;
+          name: string;
+        };
       };
     };
   };
@@ -115,8 +119,9 @@ export interface TourDummyCompensation {
     __identity: string;
     distanceInMetres: number;
     distanceFormatted: string;
-    gameFee?: number;
-    travelCompensation?: number;
+    gameCompensation?: number;
+    travelExpenses?: number;
+    paymentDone?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary

- Fixed the compensation tour dummy item not displaying correctly by aligning the data structure with what `CompensationCard` expects

## Changes

- Updated `TourDummyCompensation` type in `types.ts`:
  - Changed `plannedStartDateTime` to `startingDateTime`
  - Changed flat `teamHome`/`teamAway` to nested `encounter.teamHome`/`encounter.teamAway`
  - Changed `gameFee`/`travelCompensation` to `gameCompensation`/`travelExpenses`
  - Added `paymentDone`, `refereePosition`, and `number` fields

- Updated `TOUR_DUMMY_COMPENSATION` in `compensations.ts` to match the new type structure

## Test Plan

- [ ] Enable tour mode on the Compensations page
- [ ] Verify the dummy compensation card displays correctly with date, time, teams, and amount
- [ ] Verify the tour works on all three tabs (Pending Past, Pending Future, Closed)
- [ ] Expand the dummy card and verify details section shows correctly
