### PR TITLE
refactor(auth): add DataSource type to support multiple auth modes

### DIFF
--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -103,6 +103,8 @@ function createMockAuthStore(
     status: "authenticated" as const,
     error: null,
     csrfToken: null,
+    dataSource: "api" as const,
+    calendarCode: null,
     isDemoMode: false,
     isAssociationSwitching: false,
     _checkSessionPromise: null,
@@ -117,6 +119,10 @@ function createMockAuthStore(
     setActiveOccupation: vi.fn(),
     setAssociationSwitching: vi.fn(),
     hasMultipleAssociations: vi.fn().mockReturnValue(false),
+    isCalendarMode: vi.fn().mockReturnValue(false),
+    loginWithCalendar: vi.fn(),
+    logoutCalendar: vi.fn(),
+    getAuthMode: vi.fn().mockReturnValue("full" as const),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Refactored the auth store to support multiple data sources in preparation for the Calendar Mode feature
- Replaced the simple `isDemoMode: boolean` with a flexible `DataSource` type that supports 'api', 'demo', and 'calendar' modes
- Maintained full backwards compatibility - existing code using `isDemoMode` continues to work

## Changes

- Added `DataSource` type: `'api' | 'demo' | 'calendar'`
- Added `dataSource: DataSource` state field (default: 'api')
- Added `calendarCode: string | null` for storing the 6-char calendar code
- Kept `isDemoMode` as a derived/synced value for backwards compatibility
- Added `isCalendarMode()` getter that returns `dataSource === 'calendar'`
- Added `loginWithCalendar(code: string)` placeholder action
- Added `logoutCalendar()` action (alias for logout)
- Added `getAuthMode()` helper returning `'full' | 'calendar' | 'demo' | 'none'`
- Updated `setDemoAuthenticated()` to set `dataSource: 'demo'`
- Updated `logout()` to reset `dataSource: 'api'` and clear `calendarCode`
- Updated `checkSession()` to skip session verification for demo/calendar modes
- Updated localStorage persistence with backwards-compatible migration
- Added comprehensive tests for all new functionality

## Test Plan

- [x] All 2544 existing tests pass
- [x] Build completes without type errors
- [x] Lint passes with no warnings
- [ ] Verify demo mode still works as expected in the app
- [ ] Verify login/logout flow still works correctly
- [ ] Verify session restoration from localStorage works with old persisted state (backwards compatibility)
