### PR TITLE
feat(helpers): add calendar mode detection for assignments

### DIFF
--- a/web-app/src/utils/assignment-helpers.ts
+++ b/web-app/src/utils/assignment-helpers.ts
@@ -7,6 +7,21 @@ import type { Assignment, CompensationRecord } from "@/api/client";
 export const MODAL_CLEANUP_DELAY = 300;
 
 /**
+ * Calendar assignments are missing nested league/group data.
+ * Use this to conditionally show/hide features that require that data.
+ *
+ * Calendar mode provides a read-only view of assignments sourced from
+ * iCal feeds. These assignments lack the full nested structure that
+ * the API provides (league category, referee names, compensation data, etc.).
+ *
+ * @param assignment - The assignment to check
+ * @returns true if the assignment was sourced from calendar mode (missing league data)
+ */
+export function isFromCalendarMode(assignment: Assignment): boolean {
+  return assignment.refereeGame?.game?.group?.phase?.league === undefined;
+}
+
+/**
  * Extracts team names from a game object structure.
  * Works with both Assignment and CompensationRecord types.
  */
@@ -64,8 +79,9 @@ const GAME_REPORT_ELIGIBLE_LEAGUES = ["NLA", "NLB"];
  * Checks if an assignment is eligible for game report generation.
  *
  * Game reports are only available when:
- * 1. The game is NLA (Nationalliga A) or NLB (Nationalliga B), the top two tiers
- * 2. The referee is assigned as the first head referee (head-one position)
+ * 1. The assignment is from the full API (not calendar mode)
+ * 2. The game is NLA (Nationalliga A) or NLB (Nationalliga B), the top two tiers
+ * 3. The referee is assigned as the first head referee (head-one position)
  *
  * Only the first head referee fills out the official game report.
  * Games in other leagues (1L and below) do not require official
@@ -76,6 +92,11 @@ const GAME_REPORT_ELIGIBLE_LEAGUES = ["NLA", "NLB"];
  *          is in head-one position, false otherwise
  */
 export function isGameReportEligible(assignment: Assignment): boolean {
+  // Calendar mode assignments lack league data needed for game reports
+  if (isFromCalendarMode(assignment)) {
+    return false;
+  }
+
   const leagueName =
     assignment.refereeGame?.game?.group?.phase?.league?.leagueCategory?.name;
   const isEligibleLeague =
@@ -169,4 +190,50 @@ export function isGamePast(gameStartTime: string | undefined | null): boolean {
  */
 export function isGameAlreadyValidated(assignment: Assignment): boolean {
   return !!assignment.refereeGame?.game?.scoresheet?.closedAt;
+}
+
+/**
+ * Action types that can be performed on an assignment.
+ * - confirm: Confirm attendance for the assignment
+ * - report: Generate a game report (NLA/NLB games only)
+ * - exchange: Request an exchange/substitution
+ */
+export type AssignmentAction = "confirm" | "report" | "exchange";
+
+/**
+ * Checks if a specific action is available for an assignment.
+ *
+ * Calendar mode assignments are read-only, so no actions are available.
+ * For API-sourced assignments, availability depends on the action type
+ * and any additional eligibility requirements.
+ *
+ * @param assignment - The referee assignment to check
+ * @param action - The action to check availability for
+ * @returns true if the action is available, false otherwise
+ */
+export function isActionAvailable(
+  assignment: Assignment,
+  action: AssignmentAction,
+): boolean {
+  // Calendar mode is read-only - no actions available
+  if (isFromCalendarMode(assignment)) {
+    return false;
+  }
+
+  switch (action) {
+    case "confirm":
+      // Confirmation is available for all API-sourced assignments
+      return true;
+    case "report":
+      // Game reports have additional eligibility requirements
+      return isGameReportEligible(assignment);
+    case "exchange":
+      // Exchange requests are available for all API-sourced assignments
+      return true;
+    default: {
+      // Exhaustive check - TypeScript will error if a new action is added
+      const _exhaustiveCheck: never = action;
+      return _exhaustiveCheck;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Add type guards and helpers to detect calendar-sourced assignments
- Calendar mode assignments lack nested league/group data and are read-only
- Prepare codebase for Calendar Mode feature by enabling conditional feature display

## Changes

- Add `isFromCalendarMode(assignment)` type guard to detect calendar-sourced assignments by checking if `refereeGame.game.group.phase.league` is undefined
- Update `isGameReportEligible()` to return `false` for calendar mode assignments (game reports require league data)
- Add `isActionAvailable(assignment, action)` helper to check if actions (confirm, report, exchange) are available - all return `false` for calendar mode
- Export `AssignmentAction` type for the available action types
- Add comprehensive tests for all new guard functions (24 new test cases)

## Test Plan

- [x] All 2550 tests pass
- [x] ESLint passes with 0 warnings
- [ ] Verify `isFromCalendarMode()` returns `true` for assignments without nested league structure
- [ ] Verify `isFromCalendarMode()` returns `false` for full API assignments
- [ ] Verify `isGameReportEligible()` returns `false` for calendar assignments even with head-one position
- [ ] Verify `isActionAvailable()` returns `false` for all actions on calendar assignments
- [ ] Verify existing functionality for API assignments is unchanged
