### PR TITLE
fix(assignments): handle missing fields gracefully for calendar mode

### DIFF
--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -161,6 +161,7 @@ function AssignmentCardComponent({
               {t("common.vs")} {awayTeam}
             </div>
             {/* Position and gender shown in compact view */}
+            {/* Note: Gender icon hidden in calendar mode (gender data unavailable) */}
             <div className="text-xs text-text-subtle dark:text-text-subtle-dark flex items-center gap-1">
               <span>{position}</span>
               {gender === "m" && (
@@ -184,6 +185,7 @@ function AssignmentCardComponent({
               <span className="text-xs text-text-muted dark:text-text-muted-dark truncate w-full text-right">
                 {city || ""}
               </span>
+              {/* Note: League category hidden in calendar mode (league data unavailable) */}
               {game?.group?.phase?.league?.leagueCategory?.name && (
                 <span className="text-xs text-text-subtle dark:text-text-subtle-dark truncate w-full text-right">
                   {game.group.phase.league.leagueCategory.name}
@@ -273,7 +275,7 @@ function AssignmentCardComponent({
             </div>
           )}
 
-          {/* Category/League */}
+          {/* Category/League - hidden in calendar mode (league data unavailable) */}
           {game?.group?.phase?.league?.leagueCategory?.name && (
             <div className="text-xs text-text-subtle dark:text-text-subtle-dark">
               {game.group.phase.league.leagueCategory.name}
@@ -282,7 +284,7 @@ function AssignmentCardComponent({
             </div>
           )}
 
-          {/* Referee names */}
+          {/* Referee names - hidden in calendar mode (referee convocation data unavailable) */}
           {(headReferee1 || headReferee2 || linesmen.length > 0) && (
             <div className="text-xs text-text-subtle dark:text-text-subtle-dark pt-1 space-y-0.5">
               {headReferee1 && (

--- a/web-app/src/utils/compensation-actions.ts
+++ b/web-app/src/utils/compensation-actions.ts
@@ -2,6 +2,7 @@ import { createElement } from "react";
 import type { Assignment, CompensationRecord } from "@/api/client";
 import { type SwipeAction, SWIPE_ACTION_ICON_SIZE } from "@/types/swipe";
 import { Wallet, FileText } from "@/components/ui/icons";
+import { isFromCalendarMode } from "@/utils/assignment-helpers";
 
 /**
  * Disbursement method for compensation payments.
@@ -77,17 +78,23 @@ export function isCompensationEditable(compensation: CompensationRecord): boolea
  * Checks if an assignment's compensation can be edited.
  *
  * Editability rules (same as isCompensationEditable):
+ * - Non-editable: Calendar mode assignments (missing compensation data entirely)
  * - Non-editable: paymentDone=true (already paid)
  * - Non-editable: relevant lock is true based on methodOfDisbursementArbitration
- * - Editable: convocationCompensation not present (defaults to editable for backwards compatibility)
+ * - Editable: convocationCompensation not present but NOT calendar mode (defaults to editable for backwards compatibility)
  * - Editable: not paid AND relevant lock is false
  */
 export function isAssignmentCompensationEditable(assignment: Assignment): boolean {
+  // Calendar mode assignments are read-only - compensation editing not available
+  if (isFromCalendarMode(assignment)) {
+    return false;
+  }
+
   const cc = assignment.convocationCompensation as
     | ConvocationCompensationWithLockFlags
     | undefined;
-  // If no compensation data, default to editable (for backwards compatibility
-  // and when the API doesn't return compensation properties)
+  // If no compensation data but NOT calendar mode, default to editable
+  // (for backwards compatibility and when the API doesn't return compensation properties)
   if (!cc) return true;
 
   // Already paid - not editable


### PR DESCRIPTION
## Summary

- Prepare assignment display components for Calendar Mode by ensuring they handle missing fields gracefully
- Calendar mode assignments lack league/gender, referee convocation data, compensation data, and permissions
- Components now degrade gracefully without crashing when these fields are undefined

## Changes

- **compensation-actions.ts**: Updated `isAssignmentCompensationEditable` to return `false` for calendar mode assignments (compensation editing requires full API data)
- **AssignmentCard.tsx**: Added comments documenting which sections are hidden in calendar mode:
  - Gender icon (gender data unavailable)
  - League category (league data unavailable)  
  - Referee names (referee convocation data unavailable)
- **compensation-actions.test.ts**: Restructured tests with dedicated calendar mode test cases and updated existing tests to include league data for non-calendar-mode scenarios

## Test Plan

- [ ] Run `npm test` - all 2562 tests pass
- [ ] Run `npm run lint` - no warnings
- [ ] Run `npm run build` - production build succeeds
- [ ] Verify in demo mode that assignment cards render without errors
- [ ] Verify that swipe actions (edit compensation, validate, report) are properly hidden/shown based on data availability
