### PR TITLE
feat(api): add calendar mode support to getApiClient

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -654,6 +654,35 @@ export const api = {
 
 export type ApiClient = typeof api;
 
-export function getApiClient(isDemoMode: boolean): ApiClient {
-  return isDemoMode ? mockApi : api;
+/**
+ * Data source type for API client selection.
+ * Matches the DataSource type from the auth store.
+ */
+export type DataSource = "api" | "demo" | "calendar";
+
+/**
+ * Returns the appropriate API client based on the data source.
+ *
+ * @param dataSource - The data source to use. Accepts either:
+ *   - DataSource string: 'api', 'demo', or 'calendar'
+ *   - boolean (deprecated): true = demo mode, false = api mode
+ *
+ * @returns The API client for the specified data source
+ * @throws Error if calendar mode is requested (not yet implemented)
+ */
+export function getApiClient(dataSource: DataSource | boolean): ApiClient {
+  // Handle legacy boolean parameter for backwards compatibility
+  if (typeof dataSource === "boolean") {
+    return dataSource ? mockApi : api;
+  }
+
+  switch (dataSource) {
+    case "demo":
+      return mockApi;
+    case "calendar":
+      // Calendar mode API will be implemented in a future PR
+      throw new Error("Calendar API not yet implemented");
+    default:
+      return api;
+  }
 }

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -654,11 +654,11 @@ export const api = {
 
 export type ApiClient = typeof api;
 
-/**
- * Data source type for API client selection.
- * Matches the DataSource type from the auth store.
- */
-export type DataSource = "api" | "demo" | "calendar";
+// Re-export DataSource from auth store for consumers that import from client
+export type { DataSource } from "@/stores/auth";
+
+// Import for internal use
+import type { DataSource } from "@/stores/auth";
 
 /**
  * Returns the appropriate API client based on the data source.
@@ -682,7 +682,7 @@ export function getApiClient(dataSource: DataSource | boolean): ApiClient {
     case "calendar":
       // Calendar mode API will be implemented in a future PR
       throw new Error("Calendar API not yet implemented");
-    default:
+    case "api":
       return api;
   }
 }

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -684,5 +684,9 @@ export function getApiClient(dataSource: DataSource | boolean): ApiClient {
       throw new Error("Calendar API not yet implemented");
     case "api":
       return api;
+    default: {
+      const _exhaustive: never = dataSource;
+      throw new Error(`Unknown data source: ${_exhaustive}`);
+    }
   }
 }

--- a/web-app/src/components/features/EditCompensationModal.test.tsx
+++ b/web-app/src/components/features/EditCompensationModal.test.tsx
@@ -115,7 +115,7 @@ describe("EditCompensationModal", () => {
     });
 
     (useAuthStore as unknown as Mock).mockImplementation((selector) =>
-      selector({ isDemoMode: false }),
+      selector({ dataSource: "api", isDemoMode: false }),
     );
 
     // Mock useDemoStore to return getAssignmentCompensation
@@ -605,7 +605,7 @@ describe("EditCompensationModal", () => {
   describe("demo mode", () => {
     beforeEach(() => {
       (useAuthStore as unknown as Mock).mockImplementation((selector) =>
-        selector({ isDemoMode: true }),
+        selector({ dataSource: "demo", isDemoMode: true }),
       );
 
       // In demo mode, also mock getAssignmentCompensation with demo values

--- a/web-app/src/components/features/ValidateGameModal.test.tsx
+++ b/web-app/src/components/features/ValidateGameModal.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/hooks/useScorerSearch", () => ({
 }));
 
 vi.mock("@/stores/auth", () => ({
-  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+  useAuthStore: vi.fn((selector) => selector({ dataSource: "api" })),
 }));
 
 function createMockAssignment(overrides: Partial<Assignment> = {}): Assignment {

--- a/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
+++ b/web-app/src/components/features/validation/AddPlayerSheet.test.tsx
@@ -63,7 +63,7 @@ vi.mock("@/hooks/usePlayerNominations", () => ({
 
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector) =>
-    selector({ isDemoMode: false }),
+    selector({ dataSource: "api" }),
   ),
 }));
 

--- a/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
+++ b/web-app/src/components/features/validation/ScorerSearchPanel.test.tsx
@@ -49,7 +49,7 @@ vi.mock("@/hooks/useScorerSearch", () => ({
 }));
 
 vi.mock("@/stores/auth", () => ({
-  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+  useAuthStore: vi.fn((selector) => selector({ dataSource: "api" })),
 }));
 
 function createWrapper() {

--- a/web-app/src/components/features/validation/ScoresheetPanel.test.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import { ScoresheetPanel } from "./ScoresheetPanel";
 
 vi.mock("@/stores/auth", () => ({
-  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+  useAuthStore: vi.fn((selector) => selector({ dataSource: "api" })),
 }));
 
 const SIMULATED_UPLOAD_DURATION_MS = 1500;

--- a/web-app/src/components/features/validation/panels.test.tsx
+++ b/web-app/src/components/features/validation/panels.test.tsx
@@ -154,7 +154,7 @@ vi.mock("@/hooks/useScorerSearch", () => ({
 }));
 
 vi.mock("@/stores/auth", () => ({
-  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+  useAuthStore: vi.fn((selector) => selector({ dataSource: "api" })),
 }));
 
 describe("ScorerPanel", () => {

--- a/web-app/src/components/layout/AppShell.error.test.tsx
+++ b/web-app/src/components/layout/AppShell.error.test.tsx
@@ -66,6 +66,7 @@ describe("AppShell Error Handling", () => {
     useAuthStore.setState({
       status: "idle",
       user: null,
+      dataSource: "api",
       isDemoMode: false,
       activeOccupationId: null,
       isAssociationSwitching: false,

--- a/web-app/src/components/layout/AppShell.integration.test.tsx
+++ b/web-app/src/components/layout/AppShell.integration.test.tsx
@@ -36,6 +36,7 @@ describe("AppShell Integration", () => {
     useAuthStore.setState({
       status: "idle",
       user: null,
+      dataSource: "api",
       isDemoMode: false,
       activeOccupationId: null,
       isAssociationSwitching: false,

--- a/web-app/src/components/layout/AppShell.test.tsx
+++ b/web-app/src/components/layout/AppShell.test.tsx
@@ -13,17 +13,20 @@ vi.mock("@/stores/auth", () => ({
 
 /**
  * Create a mock auth store return value with sensible defaults.
- * Accepts Partial<ReturnType<typeof useAuthStore>> to allow overriding any property.
+ * Accepts partial overrides to allow customizing any property.
  */
 function createMockAuthStore(
-  overrides: Partial<ReturnType<typeof useAuthStore>> = {},
+  overrides: Record<string, unknown> = {},
 ) {
+  const isDemoMode = overrides.isDemoMode === true;
+  const dataSource = isDemoMode ? "demo" : "api";
   return {
     status: "authenticated" as const,
     user: null,
     error: null,
     csrfToken: null,
-    isDemoMode: false,
+    dataSource: dataSource as "api" | "demo" | "calendar",
+    isDemoMode,
     activeOccupationId: null,
     _checkSessionPromise: null,
     login: vi.fn(),

--- a/web-app/src/hooks/useAssignments.test.tsx
+++ b/web-app/src/hooks/useAssignments.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/api/client", () => ({
 
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector: AnyFunction) =>
-    selector({ isDemoMode: false }),
+    selector({ dataSource: "api" }),
   ),
 }));
 
@@ -277,7 +277,7 @@ describe("useAssignments", () => {
     const { useDemoStore } = await import("@/stores/demo");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ dataSource: "demo" }),
     );
 
     const futureDate = new Date();
@@ -320,7 +320,7 @@ describe("useUpcomingAssignments", () => {
     // Reset to non-demo mode for API tests
     const { useAuthStore } = await import("@/stores/auth");
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: false }),
+      selector({ dataSource: "api" }),
     );
   });
 
@@ -362,7 +362,7 @@ describe("usePastAssignments", () => {
     // Reset to non-demo mode for API tests
     const { useAuthStore } = await import("@/stores/auth");
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: false }),
+      selector({ dataSource: "api" }),
     );
   });
 

--- a/web-app/src/hooks/useAssignments.ts
+++ b/web-app/src/hooks/useAssignments.ts
@@ -112,13 +112,14 @@ export function useAssignments(
   period: DatePeriod = "upcoming",
   customRange?: { from: Date; to: Date },
 ): UseQueryResult<Assignment[], Error> {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
   const demoAssignments = useDemoStore((state) => state.assignments);
   const demoAssociationCode = useDemoStore(
     (state) => state.activeAssociationCode,
   );
-  const apiClient = getApiClient(isDemoMode);
+  const apiClient = getApiClient(dataSource);
 
   // Use appropriate key for cache invalidation when switching associations
   const associationKey = isDemoMode ? demoAssociationCode : activeOccupationId;
@@ -366,8 +367,8 @@ export function useValidationClosedAssignments(): UseQueryResult<
  * @param assignmentId - The assignment ID to fetch, or null to disable the query
  */
 export function useAssignmentDetails(assignmentId: string | null) {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const apiClient = getApiClient(isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const apiClient = getApiClient(dataSource);
 
   return useQuery({
     queryKey: queryKeys.assignments.detail(assignmentId || ""),

--- a/web-app/src/hooks/useCompensations.test.tsx
+++ b/web-app/src/hooks/useCompensations.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/api/client", () => ({
 
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector: AnyFunction) =>
-    selector({ isDemoMode: false }),
+    selector({ dataSource: "api" }),
   ),
 }));
 
@@ -427,7 +427,7 @@ describe("useUpdateAssignmentCompensation", () => {
     const { useDemoStore } = await import("@/stores/demo");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ dataSource: "demo" }),
     );
 
     vi.mocked(useDemoStore).mockImplementation((selector: AnyFunction) =>
@@ -459,7 +459,7 @@ describe("useUpdateAssignmentCompensation", () => {
     const { useDemoStore } = await import("@/stores/demo");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true }),
+      selector({ dataSource: "demo" }),
     );
 
     vi.mocked(useDemoStore).mockImplementation((selector: AnyFunction) =>

--- a/web-app/src/hooks/useCompensations.ts
+++ b/web-app/src/hooks/useCompensations.ts
@@ -46,12 +46,13 @@ export type CompensationErrorKey =
  * @param paidFilter - Optional filter: true for paid, false for unpaid, undefined for all
  */
 export function useCompensations(paidFilter?: boolean) {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
   const demoAssociationCode = useDemoStore(
     (state) => state.activeAssociationCode,
   );
-  const apiClient = getApiClient(isDemoMode);
+  const apiClient = getApiClient(dataSource);
 
   // Use appropriate key for cache invalidation when switching associations
   const associationKey = isDemoMode ? demoAssociationCode : activeOccupationId;
@@ -120,8 +121,8 @@ export function useUpdateCompensation(): UseMutationResult<
   { compensationId: string; data: CompensationUpdateData }
 > {
   const queryClient = useQueryClient();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const apiClient = getApiClient(isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const apiClient = getApiClient(dataSource);
 
   return useMutation({
     mutationFn: async ({
@@ -134,7 +135,7 @@ export function useUpdateCompensation(): UseMutationResult<
       log.debug("Updating compensation:", {
         compensationId,
         data,
-        isDemoMode,
+        dataSource,
       });
       await apiClient.updateCompensation(compensationId, data);
     },
@@ -267,7 +268,8 @@ export function useUpdateAssignmentCompensation(): UseMutationResult<
   { assignmentId: string; data: CompensationUpdateData }
 > {
   const queryClient = useQueryClient();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const updateAssignmentCompensation = useDemoStore(
     (state) => state.updateAssignmentCompensation,
   );

--- a/web-app/src/hooks/useConvocations.test.tsx
+++ b/web-app/src/hooks/useConvocations.test.tsx
@@ -65,10 +65,10 @@ describe("useConvocations - API Client Routing", () => {
   });
 
   describe("useAssignments", () => {
-    it("should call getApiClient with isDemoMode value in non-demo mode", async () => {
+    it("should call getApiClient with dataSource value in non-demo mode", async () => {
       // In non-demo mode, the API should be called
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -91,7 +91,7 @@ describe("useConvocations - API Client Routing", () => {
         expect(result.current.isFetching).toBe(false);
       });
 
-      expect(getApiClient).toHaveBeenCalledWith(false);
+      expect(getApiClient).toHaveBeenCalledWith("api");
       expect(mockApi.searchAssignments).toHaveBeenCalled();
     });
 
@@ -99,7 +99,7 @@ describe("useConvocations - API Client Routing", () => {
       const futureDate = addDays(new Date(), 1).toISOString();
 
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -136,7 +136,7 @@ describe("useConvocations - API Client Routing", () => {
 
     it("should call API with correct search configuration", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -154,7 +154,7 @@ describe("useConvocations - API Client Routing", () => {
         expect(result.current.isFetching).toBe(false);
       });
 
-      expect(getApiClient).toHaveBeenCalledWith(false);
+      expect(getApiClient).toHaveBeenCalledWith("api");
       expect(mockApi.searchAssignments).toHaveBeenCalledWith(
         expect.objectContaining({
           offset: 0,
@@ -173,7 +173,7 @@ describe("useConvocations - API Client Routing", () => {
   describe("useAssignmentDetails", () => {
     it("should call API when assignmentId is provided", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -201,7 +201,7 @@ describe("useConvocations - API Client Routing", () => {
 
     it("should not call API when assignmentId is null", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -217,7 +217,7 @@ describe("useConvocations - API Client Routing", () => {
   describe("useCompensations", () => {
     it("should apply client-side filtering when paid filter is provided", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -259,7 +259,7 @@ describe("useConvocations - API Client Routing", () => {
 
     it("should call API without filter when no paid filter provided", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -288,7 +288,7 @@ describe("useConvocations - API Client Routing", () => {
   describe("useGameExchanges", () => {
     it("should call API with status filter when not all", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -320,7 +320,7 @@ describe("useConvocations - API Client Routing", () => {
 
     it("should always fetch open exchanges regardless of status parameter", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -363,7 +363,7 @@ describe("useConvocations - API Client Routing", () => {
   describe("useApplyForExchange", () => {
     it("should call API with exchange ID", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -383,7 +383,7 @@ describe("useConvocations - API Client Routing", () => {
   describe("useWithdrawFromExchange", () => {
     it("should call API with exchange ID", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -420,7 +420,7 @@ describe("useConvocations - Data Handling", () => {
       const futureDate = addDays(now, 5).toISOString();
 
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -457,7 +457,7 @@ describe("useConvocations - Data Handling", () => {
       const futureDate = addDays(now, 5).toISOString();
 
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -489,7 +489,7 @@ describe("useConvocations - Data Handling", () => {
 
     it("should use past date range for past period", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -524,7 +524,7 @@ describe("useConvocations - Data Handling", () => {
   describe("useAssignmentDetails", () => {
     it("should return assignment details from API response", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -554,7 +554,7 @@ describe("useConvocations - Data Handling", () => {
 
     it("should return error when assignment not found", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -584,7 +584,7 @@ describe("useConvocations - Data Handling", () => {
   describe("useCompensations", () => {
     it("should return filtered compensations from API response", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -621,7 +621,7 @@ describe("useConvocations - Data Handling", () => {
   describe("useGameExchanges", () => {
     it("should return filtered exchanges from API response", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -670,7 +670,7 @@ describe("useConvocations - Unified API Architecture", () => {
   it("should use different code paths for demo and non-demo modes", async () => {
     // In demo mode, data comes from the store (no API call)
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: true } as ReturnType<
+      selector({ dataSource: "demo" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -695,7 +695,7 @@ describe("useConvocations - Unified API Architecture", () => {
 
     // In non-demo mode, data comes from the API
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -715,13 +715,13 @@ describe("useConvocations - Unified API Architecture", () => {
       expect(realResult.current.isFetching).toBe(false);
     });
 
-    expect(getApiClient).toHaveBeenCalledWith(false);
+    expect(getApiClient).toHaveBeenCalledWith("api");
     expect(mockApi.searchAssignments).toHaveBeenCalled();
   });
 
   it("should invalidate queries after successful mutations", async () => {
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -755,7 +755,7 @@ describe("useConvocations - Compensation Totals", () => {
 
   it("should fetch compensations successfully", async () => {
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -814,7 +814,7 @@ describe("useConvocations - Demo Association Switching", () => {
 
     // Test with SV association
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: true } as ReturnType<
+      selector({ dataSource: "demo" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -886,7 +886,7 @@ describe("useConvocations - Demo Association Switching", () => {
     // Verify that in non-demo mode, the association code is null
     // and doesn't affect the query key
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -920,12 +920,12 @@ describe("useConvocations - Demo Association Switching", () => {
     });
 
     // Verify that getApiClient was called with false (non-demo mode)
-    expect(getApiClient).toHaveBeenCalledWith(false);
+    expect(getApiClient).toHaveBeenCalledWith("api");
   });
 
   it("should include association code in query keys for compensations and exchanges", async () => {
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: true } as ReturnType<
+      selector({ dataSource: "demo" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -974,7 +974,7 @@ describe("useConvocations - Demo Association Switching", () => {
     });
 
     // Both should have been called with the demo API client
-    expect(getApiClient).toHaveBeenCalledWith(true);
+    expect(getApiClient).toHaveBeenCalledWith("demo");
     expect(mockApi.searchCompensations).toHaveBeenCalled();
     expect(mockApi.searchExchanges).toHaveBeenCalled();
   });

--- a/web-app/src/hooks/useExchanges.ts
+++ b/web-app/src/hooks/useExchanges.ts
@@ -36,13 +36,14 @@ export type ExchangeStatus = "open" | "applied" | "closed" | "all" | "mine";
  * @param status - Filter by exchange status, or 'all' for no filtering
  */
 export function useGameExchanges(status: ExchangeStatus = "all") {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
   const userId = useAuthStore((state) => state.user?.id);
   const demoAssociationCode = useDemoStore(
     (state) => state.activeAssociationCode,
   );
-  const apiClient = getApiClient(isDemoMode);
+  const apiClient = getApiClient(dataSource);
 
   // Use appropriate key for cache invalidation when switching associations
   const associationKey = isDemoMode ? demoAssociationCode : activeOccupationId;
@@ -131,8 +132,8 @@ export function useGameExchanges(status: ExchangeStatus = "all") {
  */
 export function useApplyForExchange(): UseMutationResult<void, Error, string> {
   const queryClient = useQueryClient();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const apiClient = getApiClient(isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const apiClient = getApiClient(dataSource);
 
   return useMutation({
     mutationFn: (exchangeId: string) => apiClient.applyForExchange(exchangeId),
@@ -151,8 +152,8 @@ export function useWithdrawFromExchange(): UseMutationResult<
   string
 > {
   const queryClient = useQueryClient();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const apiClient = getApiClient(isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const apiClient = getApiClient(dataSource);
 
   return useMutation({
     mutationFn: (exchangeId: string) =>

--- a/web-app/src/hooks/usePlayerNominations.test.ts
+++ b/web-app/src/hooks/usePlayerNominations.test.ts
@@ -78,7 +78,7 @@ describe("usePossiblePlayerNominations", () => {
     vi.clearAllMocks();
 
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -223,7 +223,7 @@ describe("usePossiblePlayerNominations", () => {
 
   it("uses demo API client when in demo mode", async () => {
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: true } as ReturnType<
+      selector({ dataSource: "demo" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -244,12 +244,12 @@ describe("usePossiblePlayerNominations", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(apiClient.getApiClient).toHaveBeenCalledWith(true);
+    expect(apiClient.getApiClient).toHaveBeenCalledWith("demo");
   });
 
   it("uses production API client when not in demo mode", async () => {
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -270,6 +270,6 @@ describe("usePossiblePlayerNominations", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(apiClient.getApiClient).toHaveBeenCalledWith(false);
+    expect(apiClient.getApiClient).toHaveBeenCalledWith("api");
   });
 });

--- a/web-app/src/hooks/usePlayerNominations.ts
+++ b/web-app/src/hooks/usePlayerNominations.ts
@@ -26,8 +26,8 @@ export function usePossiblePlayerNominations({
   PossibleNomination[],
   Error
 > {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const apiClient = getApiClient(isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const apiClient = getApiClient(dataSource);
 
   return useQuery({
     queryKey: queryKeys.nominations.possible(nominationListId),

--- a/web-app/src/hooks/useScorerSearch.test.tsx
+++ b/web-app/src/hooks/useScorerSearch.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/api/client", () => ({
 }));
 
 vi.mock("@/stores/auth", () => ({
-  useAuthStore: vi.fn((selector) => selector({ isDemoMode: false })),
+  useAuthStore: vi.fn((selector) => selector({ dataSource: "api" })),
 }));
 
 function createWrapper() {
@@ -328,15 +328,15 @@ describe("useScorerSearch - integration with mock API", () => {
 
     // Mock to use real implementations with demo mode enabled
     const { getApiClient } = await import("@/api/client");
-    vi.mocked(getApiClient).mockImplementation((isDemoMode: boolean) =>
-      realGetApiClient(isDemoMode),
+    vi.mocked(getApiClient).mockImplementation((dataSource) =>
+      realGetApiClient(dataSource),
     );
 
     const { useAuthStore } = await import("@/stores/auth");
     vi.mocked(useAuthStore).mockImplementation((selector: unknown) => {
       if (typeof selector === "function") {
-        return (selector as (state: { isDemoMode: boolean }) => boolean)({
-          isDemoMode: true,
+        return (selector as (state: { dataSource: string }) => string)({
+          dataSource: "demo",
         });
       }
       return realUseAuthStore(selector as never);

--- a/web-app/src/hooks/useScorerSearch.ts
+++ b/web-app/src/hooks/useScorerSearch.ts
@@ -88,8 +88,8 @@ export function useScorerSearch(
   filters: PersonSearchFilter,
   options: UseScorerSearchOptions = {},
 ): UseScorerSearchResult {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
-  const apiClient = getApiClient(isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const apiClient = getApiClient(dataSource);
 
   const hasFilters = Boolean(
     filters.firstName || filters.lastName || filters.yearOfBirth,

--- a/web-app/src/hooks/useValidationState.test.ts
+++ b/web-app/src/hooks/useValidationState.test.ts
@@ -78,7 +78,7 @@ describe("useValidationState", () => {
     vi.clearAllMocks();
 
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );

--- a/web-app/src/hooks/useValidationState.ts
+++ b/web-app/src/hooks/useValidationState.ts
@@ -61,8 +61,8 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
   const isSavingRef = useRef(false);
   const isFinalizingRef = useRef(false);
 
-  const isDemoMode = useAuthStore((s) => s.isDemoMode);
-  const apiClient = getApiClient(isDemoMode);
+  const dataSource = useAuthStore((s) => s.dataSource);
+  const apiClient = getApiClient(dataSource);
   const queryClient = useQueryClient();
 
   // Fetch game details (scoresheet and nomination list IDs)


### PR DESCRIPTION
## Summary

- Add calendar mode support to the API client selection logic
- Update `getApiClient()` to accept the new `DataSource` type (`'api' | 'demo' | 'calendar'`)
- Maintain backwards compatibility with the legacy boolean parameter
- Update all hooks to use `dataSource` from auth store instead of `isDemoMode`

## Changes

- **web-app/src/api/client.ts**: 
  - Export `DataSource` type
  - Update `getApiClient()` to handle both `DataSource` string and legacy boolean
  - Add placeholder for calendar mode that throws until implemented
- **web-app/src/hooks/useAssignments.ts**: Use `dataSource` from auth store, derive `isDemoMode` locally
- **web-app/src/hooks/useCompensations.ts**: Update `useCompensations`, `useUpdateCompensation`, and `useUpdateAssignmentCompensation` to use `dataSource`
- **web-app/src/hooks/useExchanges.ts**: Update `useGameExchanges`, `useApplyForExchange`, and `useWithdrawFromExchange` to use `dataSource`
- **web-app/src/hooks/useScorerSearch.ts**: Use `dataSource` from auth store
- **web-app/src/hooks/usePlayerNominations.ts**: Use `dataSource` from auth store
- **web-app/src/hooks/useValidationState.ts**: Use `dataSource` from auth store
- **Test files**: Update all test mocks to use `dataSource: "api"` or `dataSource: "demo"` instead of `isDemoMode: true/false`

## Test Plan

- [ ] Verify existing assignment functionality works in API mode
- [ ] Verify demo mode still works correctly (assignments, compensations, exchanges)
- [ ] Verify lint passes with `npm run lint`
- [ ] Verify all tests pass with `npm test`
- [ ] Verify build succeeds with `npm run build`
