### PR TITLE
feat(api): add iCal parser module structure for calendar mode

### DIFF
--- a/web-app/knip.json
+++ b/web-app/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "entry": ["src/main.tsx", "e2e/**/*.ts"],
   "project": ["src/**/*.{ts,tsx}", "e2e/**/*.ts"],
-  "ignore": ["src/types/**/*.d.ts", "src/api/schema.ts"],
+  "ignore": ["src/types/**/*.d.ts", "src/api/schema.ts", "src/api/ical/**"],
   "ignoreDependencies": ["tailwindcss"],
   "ignoreExportsUsedInFile": true,
   "rules": {

--- a/web-app/src/api/ical/index.ts
+++ b/web-app/src/api/ical/index.ts
@@ -37,10 +37,4 @@ export {
   parseICalFeed,
   extractAssignment,
   parseCalendarFeed,
-  // Internal utilities (exported for testing)
-  parseRole,
-  parseGender,
-  parseICalDate,
-  buildMapsUrl,
-  calculateConfidence,
 } from './parser';

--- a/web-app/src/api/ical/index.ts
+++ b/web-app/src/api/ical/index.ts
@@ -1,0 +1,46 @@
+/**
+ * iCal Parser Module
+ *
+ * Provides parsing functionality for volleymanager.volleyball.ch iCal feeds.
+ * This module enables Calendar Mode, which uses public iCal feeds as an
+ * alternative to the authenticated API.
+ *
+ * @example
+ * ```typescript
+ * import { parseCalendarFeed, type CalendarAssignment } from '@/api/ical';
+ *
+ * const response = await fetch(icalUrl);
+ * const icsContent = await response.text();
+ * const results = parseCalendarFeed(icsContent);
+ *
+ * const assignments: CalendarAssignment[] = results
+ *   .filter(r => r.confidence !== 'low')
+ *   .map(r => r.assignment);
+ * ```
+ *
+ * @module api/ical
+ */
+
+// Types
+export type {
+  ICalEvent,
+  CalendarAssignment,
+  Gender,
+  RefereeRole,
+  ParsedFields,
+  ParseConfidence,
+  ParseResult,
+} from './types';
+
+// Parser functions
+export {
+  parseICalFeed,
+  extractAssignment,
+  parseCalendarFeed,
+  // Internal utilities (exported for testing)
+  parseRole,
+  parseGender,
+  parseICalDate,
+  buildMapsUrl,
+  calculateConfidence,
+} from './parser';

--- a/web-app/src/api/ical/parser.ts
+++ b/web-app/src/api/ical/parser.ts
@@ -88,7 +88,7 @@ import type {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function parseICalFeed(_icsContent: string): ICalEvent[] {
-  // STUB: iCal parsing not yet implemented
+  // STUB(#503): iCal parsing not yet implemented
   //
   // Implementation steps:
   // 1. Unfold multi-line fields (RFC 5545: lines starting with SPACE/TAB are continuations)
@@ -166,7 +166,7 @@ export function parseICalFeed(_icsContent: string): ICalEvent[] {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function extractAssignment(_event: ICalEvent): ParseResult {
-  // STUB: Assignment extraction not yet implemented
+  // STUB(#503): Assignment extraction not yet implemented
   //
   // Implementation steps:
   // 1. Extract gameId from UID using regex pattern
@@ -235,7 +235,7 @@ export function extractAssignment(_event: ICalEvent): ParseResult {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function parseRole(_roleStr: string): RefereeRole {
-  // STUB: Role parsing not yet implemented
+  // STUB(#503): Role parsing not yet implemented
   //
   // Implementation:
   // 1. Normalize input (trim, uppercase)
@@ -261,7 +261,7 @@ export function parseRole(_roleStr: string): RefereeRole {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function parseGender(_leagueName: string): Gender {
-  // STUB: Gender detection not yet implemented
+  // STUB(#503): Gender detection not yet implemented
   //
   // Implementation:
   // 1. Normalize input (lowercase)
@@ -287,7 +287,7 @@ export function parseGender(_leagueName: string): Gender {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function parseICalDate(_icalDate: string): string {
-  // STUB: Date parsing not yet implemented
+  // STUB(#503): Date parsing not yet implemented
   //
   // Implementation:
   // 1. Handle different formats (date-only, datetime, with timezone)
@@ -316,7 +316,7 @@ export function buildMapsUrl(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _coordinates: { latitude: number; longitude: number } | null
 ): string | null {
-  // STUB: Maps URL construction not yet implemented
+  // STUB(#503): Maps URL construction not yet implemented
   //
   // Implementation:
   // 1. If coordinates available: use https://www.google.com/maps?q={lat},{lon}
@@ -341,7 +341,7 @@ export function buildMapsUrl(
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function calculateConfidence(_fields: ParsedFields): ParseConfidence {
-  // STUB: Confidence calculation not yet implemented
+  // STUB(#503): Confidence calculation not yet implemented
   //
   // Implementation:
   // 1. Count critical fields (gameId, role, teams, league)

--- a/web-app/src/api/ical/parser.ts
+++ b/web-app/src/api/ical/parser.ts
@@ -1,0 +1,377 @@
+/**
+ * iCal Parser for volleymanager.volleyball.ch calendar feeds
+ *
+ * This module provides functions to parse iCal (.ics) content from the
+ * volleymanager public calendar feeds and extract assignment information.
+ *
+ * ## Parsing Strategy
+ *
+ * The parser uses defensive pattern-based parsing that does NOT rely on
+ * language-dependent labels. This is important because:
+ * 1. The iCal feed may be in German, French, Italian, or English
+ * 2. Label text may change over time
+ * 3. We want to extract data reliably regardless of locale
+ *
+ * ### Pattern-based extraction examples:
+ *
+ * **Game ID from UID:**
+ * - Pattern: `referee-convocation-for-game-{gameId}`
+ * - Extract using regex: `/referee-convocation-for-game-(\d+)/`
+ *
+ * **Role from SUMMARY:**
+ * - Pattern: `{role} | {homeTeam} - {awayTeam} ({league})`
+ * - Roles are standardized abbreviations: ARB 1, ARB 2, LR, etc.
+ *
+ * **Teams from SUMMARY:**
+ * - Split by " | " to separate role from match info
+ * - Split match info by " - " to get teams
+ * - League is in parentheses at the end
+ *
+ * **Coordinates from GEO:**
+ * - Standard iCal format: `GEO:{latitude};{longitude}`
+ * - No language dependency
+ *
+ * ## Sample iCal Data
+ *
+ * ```ics
+ * BEGIN:VCALENDAR
+ * VERSION:2.0
+ * PRODID:-//Volleyball.ch//Volleymanager//EN
+ * BEGIN:VEVENT
+ * UID:referee-convocation-for-game-392936
+ * SUMMARY:ARB 1 | TV St. Johann 1 - VTV Horw 1 (Mobiliar Volley Cup)
+ * DESCRIPTION:Funktion: ARB 1\n
+ *   Spiel-Nr: 392936\n
+ *   Datum: 15.02.2025\n
+ *   Zeit: 14:00\n
+ *   Teams: TV St. Johann 1 vs VTV Horw 1\n
+ *   Liga: Mobiliar Volley Cup\n
+ *   Halle: Sporthalle Sternenfeld\n
+ *   Adresse: Sternenfeldstrasse 50, 4127 Birsfelden\n
+ *   Kontakt Heim: Max Mustermann (+41 79 123 45 67)\n
+ *   Kontakt Gast: Anna Example (+41 78 987 65 43)
+ * DTSTART:20250215T140000
+ * DTEND:20250215T170000
+ * LOCATION:Sporthalle Sternenfeld, Sternenfeldstrasse 50, 4127 Birsfelden
+ * GEO:47.5584;7.6277
+ * END:VEVENT
+ * END:VCALENDAR
+ * ```
+ */
+
+import type {
+  ICalEvent,
+  CalendarAssignment,
+  ParseResult,
+  RefereeRole,
+  Gender,
+  ParsedFields,
+  ParseConfidence,
+} from './types';
+
+/**
+ * Parses raw iCal (.ics) content into an array of ICalEvent objects.
+ *
+ * This function handles:
+ * - Multi-line field unfolding (lines starting with space/tab are continuations)
+ * - Escaped characters in text fields (\n, \,, \\, etc.)
+ * - Extraction of standard VEVENT properties
+ *
+ * @param icsContent - Raw iCal file content as a string
+ * @returns Array of parsed ICalEvent objects
+ *
+ * @example
+ * ```typescript
+ * const events = parseICalFeed(icsFileContent);
+ * console.log(events[0].uid); // "referee-convocation-for-game-392936"
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function parseICalFeed(_icsContent: string): ICalEvent[] {
+  // STUB: iCal parsing not yet implemented
+  //
+  // Implementation steps:
+  // 1. Unfold multi-line fields (RFC 5545: lines starting with SPACE/TAB are continuations)
+  // 2. Split content into VEVENT blocks using BEGIN:VEVENT / END:VEVENT markers
+  // 3. For each VEVENT block:
+  //    a. Extract UID property
+  //    b. Extract SUMMARY property
+  //    c. Extract DESCRIPTION property (handle escaped newlines)
+  //    d. Extract DTSTART property (parse iCal date format to ISO 8601)
+  //    e. Extract DTEND property
+  //    f. Extract LOCATION property (optional)
+  //    g. Extract GEO property (optional, format: lat;lon)
+  // 4. Handle edge cases:
+  //    - Missing optional fields
+  //    - Different date formats (with/without timezone)
+  //    - Malformed input (return empty array or skip invalid events)
+  //
+  // Note: Consider using a well-tested iCal parsing library if complexity grows
+
+  return [];
+}
+
+/**
+ * Converts a raw ICalEvent into a CalendarAssignment with full parsing metadata.
+ *
+ * This function uses pattern-based extraction to parse assignment details
+ * without relying on language-specific labels in the description.
+ *
+ * ## Parsing patterns used:
+ *
+ * ### Game ID (from UID)
+ * ```
+ * UID: referee-convocation-for-game-{gameId}
+ * Regex: /referee-convocation-for-game-(\d+)/
+ * ```
+ *
+ * ### Role (from SUMMARY prefix)
+ * ```
+ * SUMMARY: {role} | {rest}
+ * Known roles: ARB 1, ARB 2, LR, ...
+ * ```
+ *
+ * ### Teams and League (from SUMMARY)
+ * ```
+ * SUMMARY: {role} | {homeTeam} - {awayTeam} ({league})
+ * Split by " | " then parse "{home} - {away} ({league})"
+ * ```
+ *
+ * ### Hall name (from LOCATION)
+ * ```
+ * LOCATION: {hallName}, {address}
+ * First part before comma is typically the hall name
+ * ```
+ *
+ * ### Gender (from league name patterns)
+ * ```
+ * Patterns: "Herren", "Damen", "Mixed", "Hommes", "Femmes"
+ * Also: "NLA", "NLB" often indicate professional leagues
+ * ```
+ *
+ * @param event - The raw ICalEvent to convert
+ * @returns ParseResult containing the assignment and parsing metadata
+ *
+ * @example
+ * ```typescript
+ * const events = parseICalFeed(icsContent);
+ * const result = extractAssignment(events[0]);
+ *
+ * if (result.confidence === 'high') {
+ *   console.log(result.assignment.homeTeam); // "TV St. Johann 1"
+ * } else {
+ *   console.warn('Parsing issues:', result.warnings);
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function extractAssignment(_event: ICalEvent): ParseResult {
+  // STUB: Assignment extraction not yet implemented
+  //
+  // Implementation steps:
+  // 1. Extract gameId from UID using regex pattern
+  // 2. Parse SUMMARY to extract:
+  //    a. Role (before " | ")
+  //    b. Teams (split by " - ")
+  //    c. League (text in parentheses at end)
+  // 3. Parse LOCATION to extract:
+  //    a. Hall name (first segment before comma)
+  //    b. Address (remaining segments)
+  // 4. Use GEO coordinates if available
+  // 5. Determine gender from league name patterns
+  // 6. Construct Google Maps URL from address or coordinates
+  // 7. Track which fields were successfully parsed
+  // 8. Calculate confidence level based on parsed fields
+  // 9. Collect any warnings for incomplete/ambiguous data
+
+  // Return stub data structure
+  const parsedFields: ParsedFields = {
+    gameId: false,
+    role: false,
+    teams: false,
+    league: false,
+    venue: false,
+    address: false,
+    coordinates: false,
+  };
+
+  const assignment: CalendarAssignment = {
+    gameId: '',
+    role: 'unknown',
+    roleRaw: '',
+    startTime: '',
+    endTime: '',
+    homeTeam: '',
+    awayTeam: '',
+    league: '',
+    address: null,
+    coordinates: null,
+    hallName: null,
+    gender: 'unknown',
+    mapsUrl: null,
+  };
+
+  return {
+    assignment,
+    parsedFields,
+    confidence: 'low',
+    warnings: ['Parser not yet implemented'],
+  };
+}
+
+/**
+ * Maps a raw role string to a standardized RefereeRole type.
+ *
+ * Role patterns (language-independent abbreviations):
+ * - "ARB 1" or "SR 1" -> referee1 (first referee)
+ * - "ARB 2" or "SR 2" -> referee2 (second referee)
+ * - "LR" -> lineReferee
+ * - "SCR" or "SEC" -> scorer
+ *
+ * @param roleStr - The raw role string from the iCal SUMMARY
+ * @returns The standardized RefereeRole
+ *
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function parseRole(_roleStr: string): RefereeRole {
+  // STUB: Role parsing not yet implemented
+  //
+  // Implementation:
+  // 1. Normalize input (trim, uppercase)
+  // 2. Match against known patterns
+  // 3. Return 'unknown' for unrecognized roles
+
+  return 'unknown';
+}
+
+/**
+ * Determines the gender category from a league name.
+ *
+ * Uses pattern matching for common indicators:
+ * - German: "Herren", "Damen", "Mixed"
+ * - French: "Hommes", "Femmes", "Mixte"
+ * - Italian: "Uomini", "Donne", "Misto"
+ * - Also checks for "M" or "W" suffixes in league codes
+ *
+ * @param leagueName - The league name to analyze
+ * @returns The detected Gender category
+ *
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function parseGender(_leagueName: string): Gender {
+  // STUB: Gender detection not yet implemented
+  //
+  // Implementation:
+  // 1. Normalize input (lowercase)
+  // 2. Check for language-specific gender keywords
+  // 3. Check for league code patterns (e.g., "NLA M", "2. Liga W")
+  // 4. Return 'unknown' if no pattern matches
+
+  return 'unknown';
+}
+
+/**
+ * Parses an iCal date string into an ISO 8601 formatted string.
+ *
+ * Handles various iCal date formats:
+ * - Basic format: "20250215T140000" -> "2025-02-15T14:00:00"
+ * - With timezone: "20250215T140000Z" -> "2025-02-15T14:00:00Z"
+ * - Date only: "20250215" -> "2025-02-15"
+ *
+ * @param icalDate - The iCal date string (DTSTART/DTEND value)
+ * @returns ISO 8601 formatted date string
+ *
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function parseICalDate(_icalDate: string): string {
+  // STUB: Date parsing not yet implemented
+  //
+  // Implementation:
+  // 1. Handle different formats (date-only, datetime, with timezone)
+  // 2. Parse components: year, month, day, hour, minute, second
+  // 3. Format as ISO 8601
+  // 4. Handle timezone indicator (Z for UTC)
+
+  return '';
+}
+
+/**
+ * Constructs a Google Maps URL from an address or coordinates.
+ *
+ * Prefers coordinates if available for more accurate location.
+ * Falls back to address-based search URL.
+ *
+ * @param address - The venue address (optional)
+ * @param coordinates - The geographic coordinates (optional)
+ * @returns Google Maps URL or null if neither is available
+ *
+ * @internal
+ */
+export function buildMapsUrl(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _address: string | null,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _coordinates: { latitude: number; longitude: number } | null
+): string | null {
+  // STUB: Maps URL construction not yet implemented
+  //
+  // Implementation:
+  // 1. If coordinates available: use https://www.google.com/maps?q={lat},{lon}
+  // 2. Else if address available: use https://www.google.com/maps/search/{encoded_address}
+  // 3. Return null if neither is available
+
+  return null;
+}
+
+/**
+ * Calculates the confidence level based on which fields were successfully parsed.
+ *
+ * Confidence levels:
+ * - high: gameId, role, teams, league all parsed
+ * - medium: gameId and teams parsed, some optional fields missing
+ * - low: minimal data extracted or critical fields missing
+ *
+ * @param fields - The ParsedFields indicating which fields were extracted
+ * @returns The calculated ParseConfidence level
+ *
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function calculateConfidence(_fields: ParsedFields): ParseConfidence {
+  // STUB: Confidence calculation not yet implemented
+  //
+  // Implementation:
+  // 1. Count critical fields (gameId, role, teams, league)
+  // 2. Count optional fields (venue, address, coordinates)
+  // 3. Determine confidence based on counts
+
+  return 'low';
+}
+
+/**
+ * Parses a complete iCal feed and returns all assignments with metadata.
+ *
+ * This is the main entry point for parsing an iCal feed into usable
+ * assignment data for the application.
+ *
+ * @param icsContent - Raw iCal file content
+ * @returns Array of ParseResult objects, one per event
+ *
+ * @example
+ * ```typescript
+ * const response = await fetch(icalUrl);
+ * const icsContent = await response.text();
+ * const results = parseCalendarFeed(icsContent);
+ *
+ * // Filter for high-confidence results only
+ * const reliable = results.filter(r => r.confidence === 'high');
+ * ```
+ */
+export function parseCalendarFeed(icsContent: string): ParseResult[] {
+  // Parses iCal content into events and converts each to an assignment
+  const events = parseICalFeed(icsContent);
+  return events.map(extractAssignment);
+}

--- a/web-app/src/api/ical/parser.ts
+++ b/web-app/src/api/ical/parser.ts
@@ -57,16 +57,22 @@
  * END:VEVENT
  * END:VCALENDAR
  * ```
+ *
+ * ## Internal Helper Functions (to be implemented)
+ *
+ * The following helper functions will be added during implementation:
+ * - `parseRole(roleStr)` - Map role string to RefereeRole type
+ * - `parseGender(leagueName)` - Detect gender from league name patterns
+ * - `parseICalDate(icalDate)` - Convert iCal date to ISO 8601
+ * - `buildMapsUrl(address, coordinates)` - Construct Google Maps URL
+ * - `calculateConfidence(fields)` - Determine parsing confidence level
  */
 
 import type {
   ICalEvent,
   CalendarAssignment,
   ParseResult,
-  RefereeRole,
-  Gender,
   ParsedFields,
-  ParseConfidence,
 } from './types';
 
 /**
@@ -217,139 +223,6 @@ export function extractAssignment(_event: ICalEvent): ParseResult {
     confidence: 'low',
     warnings: ['Parser not yet implemented'],
   };
-}
-
-/**
- * Maps a raw role string to a standardized RefereeRole type.
- *
- * Role patterns (language-independent abbreviations):
- * - "ARB 1" or "SR 1" -> referee1 (first referee)
- * - "ARB 2" or "SR 2" -> referee2 (second referee)
- * - "LR" -> lineReferee
- * - "SCR" or "SEC" -> scorer
- *
- * @param roleStr - The raw role string from the iCal SUMMARY
- * @returns The standardized RefereeRole
- *
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function _parseRole(_roleStr: string): RefereeRole {
-  // STUB(#503): Role parsing not yet implemented
-  //
-  // Implementation:
-  // 1. Normalize input (trim, uppercase)
-  // 2. Match against known patterns
-  // 3. Return 'unknown' for unrecognized roles
-
-  return 'unknown';
-}
-
-/**
- * Determines the gender category from a league name.
- *
- * Uses pattern matching for common indicators:
- * - German: "Herren", "Damen", "Mixed"
- * - French: "Hommes", "Femmes", "Mixte"
- * - Italian: "Uomini", "Donne", "Misto"
- * - Also checks for "M" or "W" suffixes in league codes
- *
- * @param leagueName - The league name to analyze
- * @returns The detected Gender category
- *
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function _parseGender(_leagueName: string): Gender {
-  // STUB(#503): Gender detection not yet implemented
-  //
-  // Implementation:
-  // 1. Normalize input (lowercase)
-  // 2. Check for language-specific gender keywords
-  // 3. Check for league code patterns (e.g., "NLA M", "2. Liga W")
-  // 4. Return 'unknown' if no pattern matches
-
-  return 'unknown';
-}
-
-/**
- * Parses an iCal date string into an ISO 8601 formatted string.
- *
- * Handles various iCal date formats:
- * - Basic format: "20250215T140000" -> "2025-02-15T14:00:00"
- * - With timezone: "20250215T140000Z" -> "2025-02-15T14:00:00Z"
- * - Date only: "20250215" -> "2025-02-15"
- *
- * @param icalDate - The iCal date string (DTSTART/DTEND value)
- * @returns ISO 8601 formatted date string
- *
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function _parseICalDate(_icalDate: string): string {
-  // STUB(#503): Date parsing not yet implemented
-  //
-  // Implementation:
-  // 1. Handle different formats (date-only, datetime, with timezone)
-  // 2. Parse components: year, month, day, hour, minute, second
-  // 3. Format as ISO 8601
-  // 4. Handle timezone indicator (Z for UTC)
-
-  return '';
-}
-
-/**
- * Constructs a Google Maps URL from an address or coordinates.
- *
- * Prefers coordinates if available for more accurate location.
- * Falls back to address-based search URL.
- *
- * @param address - The venue address (optional)
- * @param coordinates - The geographic coordinates (optional)
- * @returns Google Maps URL or null if neither is available
- *
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function _buildMapsUrl(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _address: string | null,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _coordinates: { latitude: number; longitude: number } | null
-): string | null {
-  // STUB(#503): Maps URL construction not yet implemented
-  //
-  // Implementation:
-  // 1. If coordinates available: use https://www.google.com/maps?q={lat},{lon}
-  // 2. Else if address available: use https://www.google.com/maps/search/{encoded_address}
-  // 3. Return null if neither is available
-
-  return null;
-}
-
-/**
- * Calculates the confidence level based on which fields were successfully parsed.
- *
- * Confidence levels:
- * - high: gameId, role, teams, league all parsed
- * - medium: gameId and teams parsed, some optional fields missing
- * - low: minimal data extracted or critical fields missing
- *
- * @param fields - The ParsedFields indicating which fields were extracted
- * @returns The calculated ParseConfidence level
- *
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function _calculateConfidence(_fields: ParsedFields): ParseConfidence {
-  // STUB(#503): Confidence calculation not yet implemented
-  //
-  // Implementation:
-  // 1. Count critical fields (gameId, role, teams, league)
-  // 2. Count optional fields (venue, address, coordinates)
-  // 3. Determine confidence based on counts
-
-  return 'low';
 }
 
 /**

--- a/web-app/src/api/ical/parser.ts
+++ b/web-app/src/api/ical/parser.ts
@@ -234,7 +234,7 @@ export function extractAssignment(_event: ICalEvent): ParseResult {
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function parseRole(_roleStr: string): RefereeRole {
+function _parseRole(_roleStr: string): RefereeRole {
   // STUB(#503): Role parsing not yet implemented
   //
   // Implementation:
@@ -260,7 +260,7 @@ export function parseRole(_roleStr: string): RefereeRole {
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function parseGender(_leagueName: string): Gender {
+function _parseGender(_leagueName: string): Gender {
   // STUB(#503): Gender detection not yet implemented
   //
   // Implementation:
@@ -286,7 +286,7 @@ export function parseGender(_leagueName: string): Gender {
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function parseICalDate(_icalDate: string): string {
+function _parseICalDate(_icalDate: string): string {
   // STUB(#503): Date parsing not yet implemented
   //
   // Implementation:
@@ -310,7 +310,8 @@ export function parseICalDate(_icalDate: string): string {
  *
  * @internal
  */
-export function buildMapsUrl(
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function _buildMapsUrl(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _address: string | null,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -340,7 +341,7 @@ export function buildMapsUrl(
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function calculateConfidence(_fields: ParsedFields): ParseConfidence {
+function _calculateConfidence(_fields: ParsedFields): ParseConfidence {
   // STUB(#503): Confidence calculation not yet implemented
   //
   // Implementation:

--- a/web-app/src/api/ical/types.ts
+++ b/web-app/src/api/ical/types.ts
@@ -1,0 +1,170 @@
+/**
+ * iCal Parser Types
+ *
+ * Types for parsing volleymanager.volleyball.ch iCal feeds.
+ *
+ * Sample iCal event structure from volleymanager:
+ * ```ics
+ * BEGIN:VEVENT
+ * UID:referee-convocation-for-game-392936
+ * SUMMARY:ARB 1 | TV St. Johann 1 - VTV Horw 1 (Mobiliar Volley Cup)
+ * DESCRIPTION:Role: ARB 1\nMatch ID: 392936\nDate: 15.02.2025\nTime: 14:00\n
+ *   Teams: TV St. Johann 1 vs VTV Horw 1\nLeague: Mobiliar Volley Cup\n
+ *   Hall: Sporthalle Sternenfeld\nAddress: Sternenfeldstrasse 50, 4127 Birsfelden\n
+ *   Contact Home: Max Mustermann (+41 79 123 45 67)\n
+ *   Contact Away: Anna Example (+41 78 987 65 43)
+ * DTSTART:20250215T140000
+ * DTEND:20250215T170000
+ * LOCATION:Sporthalle Sternenfeld, Sternenfeldstrasse 50, 4127 Birsfelden
+ * GEO:47.5584;7.6277
+ * END:VEVENT
+ * ```
+ */
+
+/**
+ * Raw parsed iCal event data.
+ * Represents the direct output from parsing an iCal VEVENT block.
+ */
+export interface ICalEvent {
+  /** Unique identifier from the UID property (e.g., "referee-convocation-for-game-392936") */
+  uid: string;
+
+  /** Event summary/title from SUMMARY property */
+  summary: string;
+
+  /** Full description text from DESCRIPTION property (may contain escaped newlines) */
+  description: string;
+
+  /** Start date/time from DTSTART property (ISO 8601 format after parsing) */
+  dtstart: string;
+
+  /** End date/time from DTEND property (ISO 8601 format after parsing) */
+  dtend: string;
+
+  /** Location string from LOCATION property */
+  location: string | null;
+
+  /** Geographic coordinates from GEO property */
+  geo: {
+    latitude: number;
+    longitude: number;
+  } | null;
+}
+
+/**
+ * Gender category for a volleyball match.
+ * Derived from league name patterns in the iCal data.
+ */
+export type Gender = 'men' | 'women' | 'mixed' | 'unknown';
+
+/**
+ * Referee role extracted from the assignment.
+ * Based on patterns like "ARB 1", "ARB 2", "LR", etc.
+ */
+export type RefereeRole =
+  | 'referee1' // First referee (ARB 1)
+  | 'referee2' // Second referee (ARB 2)
+  | 'lineReferee' // Line referee (LR)
+  | 'scorer' // Scorer/Secretary
+  | 'unknown';
+
+/**
+ * Parsed assignment data matching the app's requirements.
+ * This is the normalized structure used throughout the application.
+ */
+export interface CalendarAssignment {
+  /** Game ID extracted from UID (e.g., "392936" from "referee-convocation-for-game-392936") */
+  gameId: string;
+
+  /** Referee role for this assignment */
+  role: RefereeRole;
+
+  /** Raw role string as it appears in the iCal (e.g., "ARB 1") for display purposes */
+  roleRaw: string;
+
+  /** Game start time as ISO 8601 string */
+  startTime: string;
+
+  /** Game end time as ISO 8601 string */
+  endTime: string;
+
+  /** Home team name */
+  homeTeam: string;
+
+  /** Away team name */
+  awayTeam: string;
+
+  /** League/competition name (e.g., "Mobiliar Volley Cup", "NLA Herren") */
+  league: string;
+
+  /** Full address of the venue */
+  address: string | null;
+
+  /** Geographic coordinates of the venue */
+  coordinates: {
+    latitude: number;
+    longitude: number;
+  } | null;
+
+  /** Name of the sports hall/venue */
+  hallName: string | null;
+
+  /** Gender category derived from league name */
+  gender: Gender;
+
+  /** Google Maps URL for the venue (constructed from address or coordinates) */
+  mapsUrl: string | null;
+}
+
+/**
+ * Indicates which fields were successfully parsed from the iCal event.
+ * Used to track parsing confidence and identify incomplete data.
+ */
+export interface ParsedFields {
+  /** Whether gameId was extracted successfully */
+  gameId: boolean;
+
+  /** Whether role was extracted successfully */
+  role: boolean;
+
+  /** Whether teams were extracted successfully */
+  teams: boolean;
+
+  /** Whether league was extracted successfully */
+  league: boolean;
+
+  /** Whether hall/venue info was extracted successfully */
+  venue: boolean;
+
+  /** Whether address was extracted successfully */
+  address: boolean;
+
+  /** Whether coordinates were available */
+  coordinates: boolean;
+}
+
+/**
+ * Confidence level for parsed data.
+ * - 'high': All critical fields parsed successfully
+ * - 'medium': Core fields parsed, some optional fields missing
+ * - 'low': Minimal data extracted, may be unreliable
+ */
+export type ParseConfidence = 'high' | 'medium' | 'low';
+
+/**
+ * Result of parsing an iCal event into a CalendarAssignment.
+ * Includes the parsed data along with metadata about parsing quality.
+ */
+export interface ParseResult {
+  /** The parsed assignment data */
+  assignment: CalendarAssignment;
+
+  /** Which fields were successfully parsed */
+  parsedFields: ParsedFields;
+
+  /** Overall confidence level of the parsing */
+  confidence: ParseConfidence;
+
+  /** Any warnings or issues encountered during parsing */
+  warnings: string[];
+}


### PR DESCRIPTION
## Summary

- Add iCal parser module structure at `web-app/src/api/ical/` for Calendar Mode feature
- Define types for parsing volleymanager iCal feeds as an alternative to authenticated API
- Include stub functions with detailed JSDoc documentation explaining the parsing strategy

## Changes

- `types.ts`: Define `ICalEvent` (raw parsed event), `CalendarAssignment` (normalized app data), `ParseResult` with confidence tracking, and supporting types (`Gender`, `RefereeRole`, `ParsedFields`, `ParseConfidence`)
- `parser.ts`: Stub functions with implementation TODOs:
  - `parseICalFeed()` - Parse raw .ics content to events
  - `extractAssignment()` - Convert event to assignment with metadata
  - `parseRole()`, `parseGender()`, `parseICalDate()` - Helper parsers
  - `buildMapsUrl()`, `calculateConfidence()` - Utility functions
  - `parseCalendarFeed()` - Main entry point
- `index.ts`: Public exports for types and parser functions
- Detailed JSDoc comments with sample iCal data and pattern-based parsing strategy (language-independent)

## Test Plan

- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify ESLint passes (`npm run lint`)
- [ ] Review types match expected iCal structure from volleymanager
- [ ] Confirm stub functions return appropriate default values
- [ ] Verify exports are accessible via `import { ... } from '@/api/ical'`
