### PR TITLE
refactor(api): migrate remaining call sites to use dataSource

### DIFF
--- a/web-app/src/components/features/EditCompensationModal.tsx
+++ b/web-app/src/components/features/EditCompensationModal.tsx
@@ -68,7 +68,7 @@ function EditCompensationModalComponent({
 }: EditCompensationModalProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
   const getAssignmentCompensation = useDemoStore(
     (state) => state.getAssignmentCompensation,
   );
@@ -93,7 +93,7 @@ function EditCompensationModalComponent({
     if (!isOpen) return;
 
     // For assignment edits in demo mode, load from stored assignment compensations
-    if (isAssignmentEdit && isDemoMode && assignment) {
+    if (isAssignmentEdit && dataSource === "demo" && assignment) {
       const storedData = getAssignmentCompensation(assignment.__identity);
       if (storedData) {
         if (storedData.distanceInMetres !== undefined && storedData.distanceInMetres > 0) {
@@ -110,8 +110,8 @@ function EditCompensationModalComponent({
       return;
     }
 
-    // For assignment edits in production mode, find compensation by game number
-    if (isAssignmentEdit && !isDemoMode && assignment) {
+    // For assignment edits in production/calendar mode, find compensation by game number
+    if (isAssignmentEdit && dataSource !== "demo" && assignment) {
       const gameNumber = assignment.refereeGame?.game?.number;
       if (!gameNumber) {
         logger.debug(
@@ -125,7 +125,7 @@ function EditCompensationModalComponent({
       const fetchDetailsForAssignment = async () => {
         setIsLoading(true);
         setFetchError(null);
-        const apiClient = getApiClient(isDemoMode);
+        const apiClient = getApiClient(dataSource);
 
         try {
           // Try to find compensation in cache first
@@ -211,7 +211,7 @@ function EditCompensationModalComponent({
     const fetchDetails = async () => {
       setIsLoading(true);
       setFetchError(null);
-      const apiClient = getApiClient(isDemoMode);
+      const apiClient = getApiClient(dataSource);
 
       try {
         const details = await apiClient.getCompensationDetails(compensationId);
@@ -261,7 +261,7 @@ function EditCompensationModalComponent({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, compensationId, isDemoMode, isAssignmentEdit, assignment, getAssignmentCompensation, queryClient, t]);
+  }, [isOpen, compensationId, dataSource, isAssignmentEdit, assignment, getAssignmentCompensation, queryClient, t]);
 
   // Reset form when modal closes
   useEffect(() => {

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -56,7 +56,7 @@ export function AppShell() {
     logout,
     activeOccupationId,
     setActiveOccupation,
-    isDemoMode,
+    dataSource,
     isAssociationSwitching,
     setAssociationSwitching,
   } = useAuthStore(
@@ -66,7 +66,7 @@ export function AppShell() {
       logout: state.logout,
       activeOccupationId: state.activeOccupationId,
       setActiveOccupation: state.setActiveOccupation,
-      isDemoMode: state.isDemoMode,
+      dataSource: state.dataSource,
       isAssociationSwitching: state.isAssociationSwitching,
       setAssociationSwitching: state.setAssociationSwitching,
     })),
@@ -131,7 +131,7 @@ export function AppShell() {
       // Call API to switch association (works for both demo and production mode)
       // In demo mode, the mock API handles regenerating demo data
       // In production mode, this switches the server-side active party
-      const apiClient = getApiClient(isDemoMode);
+      const apiClient = getApiClient(dataSource);
       await apiClient.switchRoleAndAttribute(id);
 
       // Check if this is still the latest switch request (race condition protection)
@@ -156,7 +156,7 @@ export function AppShell() {
       // Prefetch data for all tabs in production mode.
       // This improves UX by loading data for tabs the user hasn't visited yet.
       // In demo mode, data comes directly from the store, so no prefetch needed.
-      if (!isDemoMode) {
+      if (dataSource === "api") {
         // Don't await - let prefetch happen in background while user interacts
         prefetchAllTabData(queryClient, id).catch(() => {
           // Errors are already logged in prefetchAllTabData, no action needed
@@ -266,7 +266,7 @@ export function AppShell() {
       <div className="header-spacer" aria-hidden="true" />
 
       {/* Demo mode banner */}
-      {isDemoMode && (
+      {dataSource === "demo" && (
         <div
           className="bg-amber-100 dark:bg-amber-900/50 border-b border-amber-200 dark:border-amber-800"
           role="alert"


### PR DESCRIPTION
Update AppShell and EditCompensationModal components to use the new
dataSource property from auth store instead of the deprecated isDemoMode
boolean when calling getApiClient().

This prepares the codebase for calendar mode by ensuring all API client
selection uses the DataSource type ('api' | 'demo' | 'calendar').