### PR TITLE
feat(theme): add darker green theme variant for calendar mode

### DIFF
--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -27,6 +27,7 @@ import {
 import { usePreloadLocales } from "@/hooks/usePreloadLocales";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useViewportZoom } from "@/hooks/useViewportZoom";
+import { useCalendarTheme } from "@/hooks/useCalendarTheme";
 import { logger } from "@/utils/logger";
 
 // Lazy load pages to reduce initial bundle size
@@ -254,6 +255,7 @@ function QueryErrorHandler({ children }: { children: React.ReactNode }) {
 export default function App() {
   usePreloadLocales();
   useViewportZoom();
+  useCalendarTheme();
 
   return (
     <ErrorBoundary>

--- a/web-app/src/hooks/useCalendarTheme.test.ts
+++ b/web-app/src/hooks/useCalendarTheme.test.ts
@@ -1,0 +1,55 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useCalendarTheme } from "./useCalendarTheme";
+
+const mockIsCalendarMode = vi.fn().mockReturnValue(false);
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: (selector: (state: { isCalendarMode: () => boolean }) => boolean) =>
+    selector({ isCalendarMode: mockIsCalendarMode }),
+}));
+
+describe("useCalendarTheme", () => {
+  beforeEach(() => {
+    // Reset class list before each test
+    document.documentElement.classList.remove("calendar-mode");
+    vi.clearAllMocks();
+  });
+
+  it("does not add calendar-mode class when not in calendar mode", () => {
+    mockIsCalendarMode.mockReturnValue(false);
+
+    renderHook(() => useCalendarTheme());
+
+    expect(document.documentElement.classList.contains("calendar-mode")).toBe(false);
+  });
+
+  it("adds calendar-mode class when in calendar mode", () => {
+    mockIsCalendarMode.mockReturnValue(true);
+
+    renderHook(() => useCalendarTheme());
+
+    expect(document.documentElement.classList.contains("calendar-mode")).toBe(true);
+  });
+
+  it("removes calendar-mode class on unmount", () => {
+    mockIsCalendarMode.mockReturnValue(true);
+
+    const { unmount } = renderHook(() => useCalendarTheme());
+    expect(document.documentElement.classList.contains("calendar-mode")).toBe(true);
+
+    unmount();
+    expect(document.documentElement.classList.contains("calendar-mode")).toBe(false);
+  });
+
+  it("removes calendar-mode class when transitioning out of calendar mode", () => {
+    mockIsCalendarMode.mockReturnValue(true);
+
+    const { rerender } = renderHook(() => useCalendarTheme());
+    expect(document.documentElement.classList.contains("calendar-mode")).toBe(true);
+
+    mockIsCalendarMode.mockReturnValue(false);
+    rerender();
+    expect(document.documentElement.classList.contains("calendar-mode")).toBe(false);
+  });
+});

--- a/web-app/src/hooks/useCalendarTheme.test.ts
+++ b/web-app/src/hooks/useCalendarTheme.test.ts
@@ -1,31 +1,40 @@
 import { renderHook } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useCalendarTheme } from "./useCalendarTheme";
+import type { DataSource } from "@/stores/auth";
 
-const mockIsCalendarMode = vi.fn().mockReturnValue(false);
+let mockDataSource: DataSource = "api";
 
 vi.mock("@/stores/auth", () => ({
-  useAuthStore: (selector: (state: { isCalendarMode: () => boolean }) => boolean) =>
-    selector({ isCalendarMode: mockIsCalendarMode }),
+  useAuthStore: (selector: (state: { dataSource: DataSource }) => boolean) =>
+    selector({ dataSource: mockDataSource }),
 }));
 
 describe("useCalendarTheme", () => {
   beforeEach(() => {
     // Reset class list before each test
     document.documentElement.classList.remove("calendar-mode");
-    vi.clearAllMocks();
+    mockDataSource = "api";
   });
 
-  it("does not add calendar-mode class when not in calendar mode", () => {
-    mockIsCalendarMode.mockReturnValue(false);
+  it("does not add calendar-mode class when dataSource is api", () => {
+    mockDataSource = "api";
 
     renderHook(() => useCalendarTheme());
 
     expect(document.documentElement.classList.contains("calendar-mode")).toBe(false);
   });
 
-  it("adds calendar-mode class when in calendar mode", () => {
-    mockIsCalendarMode.mockReturnValue(true);
+  it("does not add calendar-mode class when dataSource is demo", () => {
+    mockDataSource = "demo";
+
+    renderHook(() => useCalendarTheme());
+
+    expect(document.documentElement.classList.contains("calendar-mode")).toBe(false);
+  });
+
+  it("adds calendar-mode class when dataSource is calendar", () => {
+    mockDataSource = "calendar";
 
     renderHook(() => useCalendarTheme());
 
@@ -33,7 +42,7 @@ describe("useCalendarTheme", () => {
   });
 
   it("removes calendar-mode class on unmount", () => {
-    mockIsCalendarMode.mockReturnValue(true);
+    mockDataSource = "calendar";
 
     const { unmount } = renderHook(() => useCalendarTheme());
     expect(document.documentElement.classList.contains("calendar-mode")).toBe(true);
@@ -43,12 +52,12 @@ describe("useCalendarTheme", () => {
   });
 
   it("removes calendar-mode class when transitioning out of calendar mode", () => {
-    mockIsCalendarMode.mockReturnValue(true);
+    mockDataSource = "calendar";
 
     const { rerender } = renderHook(() => useCalendarTheme());
     expect(document.documentElement.classList.contains("calendar-mode")).toBe(true);
 
-    mockIsCalendarMode.mockReturnValue(false);
+    mockDataSource = "api";
     rerender();
     expect(document.documentElement.classList.contains("calendar-mode")).toBe(false);
   });

--- a/web-app/src/hooks/useCalendarTheme.ts
+++ b/web-app/src/hooks/useCalendarTheme.ts
@@ -11,7 +11,9 @@ const CALENDAR_MODE_CLASS = "calendar-mode";
  * The CSS variables are overridden in index.css when .calendar-mode is present.
  */
 export function useCalendarTheme(): void {
-  const isCalendarMode = useAuthStore((state) => state.isCalendarMode());
+  // Subscribe to dataSource directly for proper Zustand reactivity
+  // (calling methods inside selectors can miss updates)
+  const isCalendarMode = useAuthStore((state) => state.dataSource === "calendar");
 
   useEffect(() => {
     const root = document.documentElement;

--- a/web-app/src/hooks/useCalendarTheme.ts
+++ b/web-app/src/hooks/useCalendarTheme.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useAuthStore } from "@/stores/auth";
+
+const CALENDAR_MODE_CLASS = "calendar-mode";
+
+/**
+ * Applies calendar mode theme by toggling a class on the document root.
+ * When in calendar mode, the primary green color becomes slightly darker
+ * (~10-15%) to visually distinguish from the regular app mode.
+ *
+ * The CSS variables are overridden in index.css when .calendar-mode is present.
+ */
+export function useCalendarTheme(): void {
+  const isCalendarMode = useAuthStore((state) => state.isCalendarMode());
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    if (isCalendarMode) {
+      root.classList.add(CALENDAR_MODE_CLASS);
+    } else {
+      root.classList.remove(CALENDAR_MODE_CLASS);
+    }
+
+    // Cleanup on unmount
+    return () => {
+      root.classList.remove(CALENDAR_MODE_CLASS);
+    };
+  }, [isCalendarMode]);
+}

--- a/web-app/src/index.css
+++ b/web-app/src/index.css
@@ -118,21 +118,26 @@
 
 /* ==============================================
  * CALENDAR MODE THEME VARIANT
- * Slightly darker green (~10-15%) for calendar mode
+ * Slightly darker green (~15%) for calendar mode
  * Applied via .calendar-mode class on :root
+ *
+ * Colors derived by reducing HSL lightness of each
+ * primary shade by ~15% from the base palette:
+ *   Base primary-500: #b2e600 (hsl 73, 100%, 45%)
+ *   Calendar primary-500: #98c400 (hsl 73, 100%, 38%)
  * ============================================== */
 .calendar-mode {
-  --color-primary-50: #f5fad6;
-  --color-primary-100: #ebf5aa;
-  --color-primary-200: #dceb70;
-  --color-primary-300: #c8dc38;
-  --color-primary-400: #b8d020;
-  --color-primary-500: #98c400;  /* Main brand - ~15% darker */
-  --color-primary-600: #759c00;  /* Hover state - ~15% darker */
-  --color-primary-700: #587500;
-  --color-primary-800: #465d06;
-  --color-primary-900: #3b4e09;
-  --color-primary-950: #1e2c00;
+  --color-primary-50: #f5fad6;   /* Base #fdffe4 lightness 95% → 91% */
+  --color-primary-100: #ebf5aa;  /* Base #f9ffc4 lightness 88% → 81% */
+  --color-primary-200: #dceb70;  /* Base #f1ff90 lightness 78% → 68% */
+  --color-primary-300: #c8dc38;  /* Base #e2ff50 lightness 66% → 54% */
+  --color-primary-400: #b8d020;  /* Base #d7ff37 lightness 61% → 47% */
+  --color-primary-500: #98c400;  /* Base #b2e600 lightness 45% → 38% */
+  --color-primary-600: #759c00;  /* Base #8ab800 lightness 36% → 31% */
+  --color-primary-700: #587500;  /* Base #688b00 lightness 27% → 23% */
+  --color-primary-800: #465d06;  /* Base #526d07 lightness 23% → 19% */
+  --color-primary-900: #3b4e09;  /* Base #455c0b lightness 20% → 17% */
+  --color-primary-950: #1e2c00;  /* Base #233400 lightness 10% → 9% */
 }
 
 /* Base styles */

--- a/web-app/src/index.css
+++ b/web-app/src/index.css
@@ -116,6 +116,25 @@
   --color-border-strong-dark: var(--color-gray-600);
 }
 
+/* ==============================================
+ * CALENDAR MODE THEME VARIANT
+ * Slightly darker green (~10-15%) for calendar mode
+ * Applied via .calendar-mode class on :root
+ * ============================================== */
+.calendar-mode {
+  --color-primary-50: #f5fad6;
+  --color-primary-100: #ebf5aa;
+  --color-primary-200: #dceb70;
+  --color-primary-300: #c8dc38;
+  --color-primary-400: #b8d020;
+  --color-primary-500: #98c400;  /* Main brand - ~15% darker */
+  --color-primary-600: #759c00;  /* Hover state - ~15% darker */
+  --color-primary-700: #587500;
+  --color-primary-800: #465d06;
+  --color-primary-900: #3b4e09;
+  --color-primary-950: #1e2c00;
+}
+
 /* Base styles */
 @layer base {
   html {


### PR DESCRIPTION
## Summary
- Add calendar mode CSS class with ~15% darker primary green color palette
- Create `useCalendarTheme` hook to toggle class on document root based on auth state
- Apply theme automatically when `isCalendarMode()` returns true

## Test plan
- [ ] Verify calendar mode shows darker green in navigation bar
- [ ] Verify buttons use darker green in calendar mode
- [ ] Verify theme reverts when exiting calendar mode
- [ ] Verify no visual change in regular/demo modes
