### PR TITLE
feat(api): implement iCal parser for calendar mode

### DIFF
--- a/web-app/src/api/ical/parser.test.ts
+++ b/web-app/src/api/ical/parser.test.ts
@@ -1,0 +1,1008 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseICalFeed,
+  extractAssignment,
+  parseCalendarFeed,
+} from './parser';
+import type { ICalEvent } from './types';
+
+// Sample iCal content for testing
+const SAMPLE_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Volleyball.ch//Volleymanager//EN
+BEGIN:VEVENT
+UID:referee-convocation-for-game-392936
+SUMMARY:ARB 1 | TV St. Johann 1 - VTV Horw 1 (Mobiliar Volley Cup)
+DESCRIPTION:Funktion: ARB 1\\nSpiel-Nr: 392936\\nDatum: 15.02.2025\\nZeit: 14:00
+DTSTART:20250215T140000
+DTEND:20250215T170000
+LOCATION:Sporthalle Sternenfeld, Sternenfeldstrasse 50, 4127 Birsfelden
+GEO:47.5584;7.6277
+END:VEVENT
+END:VCALENDAR`;
+
+// Sample with multiple events
+const MULTI_EVENT_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:referee-convocation-for-game-100001
+SUMMARY:ARB 1 | Team A - Team B (NLA Herren)
+DTSTART:20250220T180000
+DTEND:20250220T210000
+LOCATION:Halle 1, Address 1
+GEO:47.1234;8.5678
+END:VEVENT
+BEGIN:VEVENT
+UID:referee-convocation-for-game-100002
+SUMMARY:ARB 2 | Team C - Team D (NLA Damen)
+DTSTART:20250221T190000
+DTEND:20250221T220000
+LOCATION:Halle 2, Address 2
+END:VEVENT
+END:VCALENDAR`;
+
+describe('parseICalFeed', () => {
+  describe('basic parsing', () => {
+    it('parses a single VEVENT from iCal content', () => {
+      const events = parseICalFeed(SAMPLE_ICAL);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.uid).toBe('referee-convocation-for-game-392936');
+      expect(events[0]!.summary).toBe(
+        'ARB 1 | TV St. Johann 1 - VTV Horw 1 (Mobiliar Volley Cup)'
+      );
+    });
+
+    it('parses multiple VEVENTs from iCal content', () => {
+      const events = parseICalFeed(MULTI_EVENT_ICAL);
+
+      expect(events).toHaveLength(2);
+      expect(events[0]!.uid).toBe('referee-convocation-for-game-100001');
+      expect(events[1]!.uid).toBe('referee-convocation-for-game-100002');
+    });
+
+    it('parses DTSTART and DTEND to ISO format', () => {
+      const events = parseICalFeed(SAMPLE_ICAL);
+
+      expect(events[0]!.dtstart).toBe('2025-02-15T14:00:00');
+      expect(events[0]!.dtend).toBe('2025-02-15T17:00:00');
+    });
+
+    it('parses LOCATION field', () => {
+      const events = parseICalFeed(SAMPLE_ICAL);
+
+      expect(events[0]!.location).toBe(
+        'Sporthalle Sternenfeld, Sternenfeldstrasse 50, 4127 Birsfelden'
+      );
+    });
+
+    it('parses GEO coordinates', () => {
+      const events = parseICalFeed(SAMPLE_ICAL);
+
+      expect(events[0]!.geo).toEqual({
+        latitude: 47.5584,
+        longitude: 7.6277,
+      });
+    });
+
+    it('handles events without GEO field', () => {
+      const events = parseICalFeed(MULTI_EVENT_ICAL);
+
+      expect(events[1]!.geo).toBeNull();
+    });
+  });
+
+  describe('multi-line field handling (RFC 5545 unfolding)', () => {
+    it('unfolds continuation lines starting with space', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:This is a very long summary that continues
+ on the next line
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.summary).toBe(
+        'This is a very long summary that continueson the next line'
+      );
+    });
+
+    it('unfolds continuation lines starting with tab', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Summary with tab
+\tcontinuation
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.summary).toBe('Summary with tabcontinuation');
+    });
+  });
+
+  describe('escaped character handling', () => {
+    it('unescapes newline characters in DESCRIPTION', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DESCRIPTION:Line 1\\nLine 2\\nLine 3
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.description).toBe('Line 1\nLine 2\nLine 3');
+    });
+
+    it('unescapes comma characters', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Team A\\, Division 1 | Match
+DESCRIPTION:Test
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.summary).toBe('Team A, Division 1 | Match');
+    });
+
+    it('unescapes backslash characters', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test\\\\Path
+DESCRIPTION:Test
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.summary).toBe('Test\\Path');
+    });
+
+    it('unescapes semicolon characters', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DESCRIPTION:Key\\;Value
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.description).toBe('Key;Value');
+    });
+  });
+
+  describe('date format handling', () => {
+    it('handles UTC dates with Z suffix', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DTSTART:20250215T140000Z
+DTEND:20250215T170000Z
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.dtstart).toBe('2025-02-15T14:00:00Z');
+      expect(events[0]!.dtend).toBe('2025-02-15T17:00:00Z');
+    });
+
+    it('handles date-only format (all-day events)', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:All Day Event
+DTSTART:20250215
+DTEND:20250216
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.dtstart).toBe('2025-02-15');
+      expect(events[0]!.dtend).toBe('2025-02-16');
+    });
+
+    it('handles dates with TZID parameter', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DTSTART;TZID=Europe/Zurich:20250215T140000
+DTEND;TZID=Europe/Zurich:20250215T170000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.dtstart).toBe('2025-02-15T14:00:00');
+      expect(events[0]!.dtend).toBe('2025-02-15T17:00:00');
+    });
+
+    it('uses DTSTART as DTEND when DTEND is missing', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.dtend).toBe('2025-02-15T14:00:00');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array for empty input', () => {
+      expect(parseICalFeed('')).toEqual([]);
+    });
+
+    it('returns empty array for null/undefined input', () => {
+      expect(parseICalFeed(null as unknown as string)).toEqual([]);
+      expect(parseICalFeed(undefined as unknown as string)).toEqual([]);
+    });
+
+    it('returns empty array for non-string input', () => {
+      expect(parseICalFeed(123 as unknown as string)).toEqual([]);
+    });
+
+    it('skips events without required UID field', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+SUMMARY:No UID
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('skips events without required SUMMARY field', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('skips events without required DTSTART field', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('handles malformed iCal without END:VEVENT', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DTSTART:20250215T140000
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events).toHaveLength(0);
+    });
+
+    it('handles invalid GEO format gracefully', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DTSTART:20250215T140000
+GEO:invalid
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.geo).toBeNull();
+    });
+
+    it('handles GEO with non-numeric values', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DTSTART:20250215T140000
+GEO:abc;def
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.geo).toBeNull();
+    });
+
+    it('handles events without DESCRIPTION', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.description).toBe('');
+    });
+
+    it('handles events without LOCATION', () => {
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events[0]!.location).toBeNull();
+    });
+
+    it('handles case-insensitive property names', () => {
+      const ical = `BEGIN:VCALENDAR
+begin:vevent
+uid:test-123
+SUMMARY:Test
+dtstart:20250215T140000
+end:vevent
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.uid).toBe('test-123');
+    });
+  });
+});
+
+describe('extractAssignment', () => {
+  // Helper to create a minimal valid ICalEvent
+  function createEvent(overrides: Partial<ICalEvent> = {}): ICalEvent {
+    return {
+      uid: 'referee-convocation-for-game-392936',
+      summary: 'ARB 1 | TV St. Johann 1 - VTV Horw 1 (Mobiliar Volley Cup)',
+      description: '',
+      dtstart: '2025-02-15T14:00:00',
+      dtend: '2025-02-15T17:00:00',
+      location: 'Sporthalle Sternenfeld, Sternenfeldstrasse 50, 4127 Birsfelden',
+      geo: { latitude: 47.5584, longitude: 7.6277 },
+      ...overrides,
+    };
+  }
+
+  describe('game ID extraction', () => {
+    it('extracts game ID from standard UID format', () => {
+      const event = createEvent({
+        uid: 'referee-convocation-for-game-392936',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.gameId).toBe('392936');
+      expect(result.parsedFields.gameId).toBe(true);
+    });
+
+    it('extracts game ID with many digits', () => {
+      const event = createEvent({
+        uid: 'referee-convocation-for-game-1234567890',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.gameId).toBe('1234567890');
+    });
+
+    it('adds warning when game ID cannot be extracted', () => {
+      const event = createEvent({
+        uid: 'some-other-format-abc',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.gameId).toBe('');
+      expect(result.parsedFields.gameId).toBe(false);
+      expect(result.warnings).toContain('Could not extract game ID from UID');
+    });
+
+    it('uses fallback pattern for IDs with hash prefix', () => {
+      const event = createEvent({
+        uid: 'event-#123456',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.gameId).toBe('123456');
+      expect(result.parsedFields.gameId).toBe(true);
+      expect(result.warnings).toContain(
+        'Game ID extracted using fallback pattern'
+      );
+    });
+  });
+
+  describe('role extraction', () => {
+    const roleTestCases = [
+      { input: 'ARB 1', expected: 'referee1', raw: 'ARB 1' },
+      { input: 'ARB 2', expected: 'referee2', raw: 'ARB 2' },
+      { input: 'ARB1', expected: 'referee1', raw: 'ARB1' },
+      { input: 'ARB2', expected: 'referee2', raw: 'ARB2' },
+      { input: 'SR 1', expected: 'referee1', raw: 'SR 1' },
+      { input: 'SR 2', expected: 'referee2', raw: 'SR 2' },
+      { input: 'JL', expected: 'scorer', raw: 'JL' },
+      { input: 'JL 1', expected: 'scorer', raw: 'JL 1' },
+      { input: 'JL 2', expected: 'scorer', raw: 'JL 2' },
+      { input: 'LR', expected: 'lineReferee', raw: 'LR' },
+      { input: 'LR 1', expected: 'lineReferee', raw: 'LR 1' },
+      { input: 'LR 2', expected: 'lineReferee', raw: 'LR 2' },
+    ];
+
+    roleTestCases.forEach(({ input, expected, raw }) => {
+      it(`maps "${input}" to "${expected}"`, () => {
+        const event = createEvent({
+          summary: `${input} | Team A - Team B (League)`,
+        });
+        const result = extractAssignment(event);
+
+        expect(result.assignment.role).toBe(expected);
+        expect(result.assignment.roleRaw).toBe(raw);
+        expect(result.parsedFields.role).toBe(true);
+      });
+    });
+
+    it('handles case-insensitive role matching', () => {
+      const event = createEvent({
+        summary: 'arb 1 | Team A - Team B (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.role).toBe('referee1');
+    });
+
+    it('handles roles with extra whitespace', () => {
+      const event = createEvent({
+        summary: '  ARB  1  | Team A - Team B (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.role).toBe('referee1');
+    });
+
+    it('returns unknown for unrecognized roles', () => {
+      const event = createEvent({
+        summary: 'UNKNOWN | Team A - Team B (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.role).toBe('unknown');
+      expect(result.assignment.roleRaw).toBe('UNKNOWN');
+      expect(result.parsedFields.role).toBe(false);
+      expect(result.warnings).toContain('Unknown role format: "UNKNOWN"');
+    });
+  });
+
+  describe('teams extraction', () => {
+    it('extracts home and away teams from standard format', () => {
+      const event = createEvent({
+        summary: 'ARB 1 | TV St. Johann 1 - VTV Horw 1 (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.homeTeam).toBe('TV St. Johann 1');
+      expect(result.assignment.awayTeam).toBe('VTV Horw 1');
+      expect(result.parsedFields.teams).toBe(true);
+    });
+
+    it('handles teams with special characters', () => {
+      const event = createEvent({
+        summary: 'ARB 1 | VBC Zürich (W) - BC Bern/Köniz 2 (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.homeTeam).toBe('VBC Zürich (W)');
+      expect(result.assignment.awayTeam).toBe('BC Bern/Köniz 2');
+    });
+
+    it('handles teams with numbers in names', () => {
+      const event = createEvent({
+        summary: 'ARB 1 | Team 1 Basel 3 - FC 2000 Luzern 1 (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.homeTeam).toBe('Team 1 Basel 3');
+      expect(result.assignment.awayTeam).toBe('FC 2000 Luzern 1');
+    });
+
+    it('adds warning when teams cannot be extracted', () => {
+      const event = createEvent({
+        summary: 'ARB 1 | No separator here (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.parsedFields.teams).toBe(false);
+      expect(result.warnings).toContain('Could not extract teams from summary');
+    });
+
+    it('handles summary without pipe separator', () => {
+      const event = createEvent({
+        summary: 'Some random event title',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.homeTeam).toBe('');
+      expect(result.assignment.awayTeam).toBe('');
+      expect(result.parsedFields.teams).toBe(false);
+    });
+
+    it('handles pipe without spaces', () => {
+      const event = createEvent({
+        summary: 'ARB 1|Team A - Team B (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.roleRaw).toBe('ARB 1');
+    });
+  });
+
+  describe('league extraction', () => {
+    it('extracts league from parentheses at end of summary', () => {
+      const event = createEvent({
+        summary: 'ARB 1 | Team A - Team B (Mobiliar Volley Cup)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.league).toBe('Mobiliar Volley Cup');
+      expect(result.parsedFields.league).toBe(true);
+    });
+
+    it('handles leagues with special characters', () => {
+      const event = createEvent({
+        summary: 'ARB 1 | Team A - Team B (NLA Herren 2024/25)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.league).toBe('NLA Herren 2024/25');
+    });
+
+    it('adds warning when league cannot be extracted', () => {
+      const event = createEvent({
+        summary: 'ARB 1 | Team A - Team B',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.league).toBe('');
+      expect(result.parsedFields.league).toBe(false);
+      expect(result.warnings).toContain(
+        'Could not extract league from summary'
+      );
+    });
+  });
+
+  describe('location parsing', () => {
+    it('extracts hall name and address from location', () => {
+      const event = createEvent({
+        location: 'Sporthalle Sternenfeld, Sternenfeldstrasse 50, 4127 Birsfelden',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.hallName).toBe('Sporthalle Sternenfeld');
+      expect(result.assignment.address).toBe(
+        'Sternenfeldstrasse 50, 4127 Birsfelden'
+      );
+      expect(result.parsedFields.venue).toBe(true);
+      expect(result.parsedFields.address).toBe(true);
+    });
+
+    it('handles location without comma', () => {
+      const event = createEvent({
+        location: 'Sporthalle Sternenfeld',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.hallName).toBe('Sporthalle Sternenfeld');
+      expect(result.assignment.address).toBe('Sporthalle Sternenfeld');
+    });
+
+    it('handles null location', () => {
+      const event = createEvent({
+        location: null,
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.hallName).toBeNull();
+      expect(result.assignment.address).toBeNull();
+      expect(result.parsedFields.venue).toBe(false);
+      expect(result.parsedFields.address).toBe(false);
+    });
+  });
+
+  describe('coordinates handling', () => {
+    it('includes coordinates from event geo field', () => {
+      const event = createEvent({
+        geo: { latitude: 47.5584, longitude: 7.6277 },
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.coordinates).toEqual({
+        latitude: 47.5584,
+        longitude: 7.6277,
+      });
+      expect(result.parsedFields.coordinates).toBe(true);
+    });
+
+    it('handles null coordinates', () => {
+      const event = createEvent({
+        geo: null,
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.coordinates).toBeNull();
+      expect(result.parsedFields.coordinates).toBe(false);
+    });
+  });
+
+  describe('gender detection', () => {
+    const genderTestCases = [
+      // German patterns
+      { league: 'NLA Herren', description: '', expected: 'men' },
+      { league: 'NLB Damen', description: '', expected: 'women' },
+      { league: 'Mixed League', description: '', expected: 'mixed' },
+      // French patterns
+      { league: 'Ligue Hommes', description: '', expected: 'men' },
+      { league: 'Ligue Femmes', description: '', expected: 'women' },
+      // Gender symbols in description
+      { league: 'Some League', description: 'Match ♂', expected: 'men' },
+      { league: 'Some League', description: 'Match ♀', expected: 'women' },
+      // Unknown when no pattern matches
+      { league: 'Mobiliar Volley Cup', description: '', expected: 'unknown' },
+    ];
+
+    genderTestCases.forEach(({ league, description, expected }) => {
+      it(`detects "${expected}" from league "${league}" and description "${description}"`, () => {
+        const event = createEvent({
+          summary: `ARB 1 | Team A - Team B (${league})`,
+          description,
+        });
+        const result = extractAssignment(event);
+
+        expect(result.assignment.gender).toBe(expected);
+      });
+    });
+  });
+
+  describe('maps URL handling', () => {
+    it('extracts maps URL from description if present', () => {
+      const event = createEvent({
+        description:
+          'Location: https://maps.google.com/maps?q=47.5,7.6 Details here',
+        geo: null,
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.mapsUrl).toBe(
+        'https://maps.google.com/maps?q=47.5,7.6'
+      );
+    });
+
+    it('extracts google.com/maps URL from description', () => {
+      const event = createEvent({
+        description:
+          'Location: https://www.google.com/maps/place/Test Details',
+        geo: null,
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.mapsUrl).toBe(
+        'https://www.google.com/maps/place/Test'
+      );
+    });
+
+    it('builds maps URL from coordinates when not in description', () => {
+      const event = createEvent({
+        description: 'No maps link here',
+        geo: { latitude: 47.5584, longitude: 7.6277 },
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.mapsUrl).toBe(
+        'https://www.google.com/maps?q=47.5584,7.6277'
+      );
+    });
+
+    it('builds maps URL from address when no coordinates', () => {
+      const event = createEvent({
+        description: 'No maps link here',
+        geo: null,
+        location: 'Hall, Some Address 123',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.mapsUrl).toBe(
+        'https://www.google.com/maps/search/?api=1&query=Some%20Address%20123'
+      );
+    });
+
+    it('returns null when no maps info available', () => {
+      const event = createEvent({
+        description: '',
+        geo: null,
+        location: null,
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.mapsUrl).toBeNull();
+    });
+  });
+
+  describe('confidence calculation', () => {
+    it('returns high confidence when all critical and most optional fields are parsed', () => {
+      const event = createEvent(); // Default event has all fields
+      const result = extractAssignment(event);
+
+      expect(result.confidence).toBe('high');
+    });
+
+    it('returns medium confidence when critical fields parsed but some optional missing', () => {
+      const event = createEvent({
+        geo: null,
+        location: null,
+      });
+      const result = extractAssignment(event);
+
+      expect(result.confidence).toBe('medium');
+    });
+
+    it('returns low confidence when critical fields are missing', () => {
+      const event = createEvent({
+        uid: 'invalid-uid',
+        summary: 'Invalid summary format',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.confidence).toBe('low');
+    });
+
+    it('returns low confidence when game ID cannot be extracted', () => {
+      const event = createEvent({
+        uid: 'no-game-id-here',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.confidence).toBe('low');
+    });
+
+    it('returns low confidence when role is unknown', () => {
+      const event = createEvent({
+        summary: 'UNKNOWN | Team A - Team B (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.confidence).toBe('low');
+    });
+
+    it('returns low confidence when teams cannot be extracted', () => {
+      const event = createEvent({
+        summary: 'ARB 1 | No team separator (League)',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.confidence).toBe('low');
+    });
+  });
+
+  describe('time handling', () => {
+    it('includes start and end times from event', () => {
+      const event = createEvent({
+        dtstart: '2025-02-15T14:00:00',
+        dtend: '2025-02-15T17:00:00',
+      });
+      const result = extractAssignment(event);
+
+      expect(result.assignment.startTime).toBe('2025-02-15T14:00:00');
+      expect(result.assignment.endTime).toBe('2025-02-15T17:00:00');
+    });
+  });
+});
+
+describe('parseCalendarFeed', () => {
+  it('parses complete iCal feed and returns assignments', () => {
+    const results = parseCalendarFeed(SAMPLE_ICAL);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.assignment.gameId).toBe('392936');
+    expect(results[0]!.assignment.homeTeam).toBe('TV St. Johann 1');
+    expect(results[0]!.assignment.awayTeam).toBe('VTV Horw 1');
+  });
+
+  it('parses multiple events and returns all assignments', () => {
+    const results = parseCalendarFeed(MULTI_EVENT_ICAL);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]!.assignment.gameId).toBe('100001');
+    expect(results[1]!.assignment.gameId).toBe('100002');
+  });
+
+  it('returns empty array for empty input', () => {
+    const results = parseCalendarFeed('');
+
+    expect(results).toEqual([]);
+  });
+
+  it('handles mixed valid and invalid events', () => {
+    const mixedIcal = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:referee-convocation-for-game-100001
+SUMMARY:ARB 1 | Team A - Team B (League)
+DTSTART:20250215T140000
+END:VEVENT
+BEGIN:VEVENT
+UID:missing-summary
+DTSTART:20250215T140000
+END:VEVENT
+BEGIN:VEVENT
+UID:referee-convocation-for-game-100002
+SUMMARY:ARB 2 | Team C - Team D (League)
+DTSTART:20250215T180000
+END:VEVENT
+END:VCALENDAR`;
+
+    const results = parseCalendarFeed(mixedIcal);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]!.assignment.gameId).toBe('100001');
+    expect(results[1]!.assignment.gameId).toBe('100002');
+  });
+
+  it('allows filtering by confidence level', () => {
+    const mixedIcal = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:referee-convocation-for-game-100001
+SUMMARY:ARB 1 | Team A - Team B (League)
+DTSTART:20250215T140000
+LOCATION:Hall, Address
+GEO:47.5;7.6
+END:VEVENT
+BEGIN:VEVENT
+UID:bad-uid-format
+SUMMARY:UNKNOWN | Something (League)
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+    const results = parseCalendarFeed(mixedIcal);
+    const highConfidence = results.filter((r) => r.confidence === 'high');
+    const lowConfidence = results.filter((r) => r.confidence === 'low');
+
+    expect(highConfidence).toHaveLength(1);
+    expect(lowConfidence).toHaveLength(1);
+  });
+});
+
+describe('integration scenarios', () => {
+  it('handles a realistic German iCal feed', () => {
+    const germanIcal = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Volleyball.ch//Volleymanager//DE
+BEGIN:VEVENT
+UID:referee-convocation-for-game-456789
+SUMMARY:ARB 1 | VBC Zürich - Volley Luzern 1 (NLA Herren)
+DESCRIPTION:Funktion: ARB 1\\nSpiel-Nr: 456789\\nDatum: 20.02.2025\\nZeit: 19:30\\nTeams: VBC Zürich vs Volley Luzern 1\\nLiga: NLA Herren\\nHalle: Saalsporthalle\\nAdresse: Sihlhölzlistrasse 5\\, 8045 Zürich\\nKontakt: Max Muster (+41 79 123 45 67)
+DTSTART:20250220T193000
+DTEND:20250220T220000
+LOCATION:Saalsporthalle, Sihlhölzlistrasse 5, 8045 Zürich
+GEO:47.3769;8.5417
+END:VEVENT
+END:VCALENDAR`;
+
+    const results = parseCalendarFeed(germanIcal);
+
+    expect(results).toHaveLength(1);
+    const assignment = results[0]!.assignment;
+
+    expect(assignment.gameId).toBe('456789');
+    expect(assignment.role).toBe('referee1');
+    expect(assignment.roleRaw).toBe('ARB 1');
+    expect(assignment.homeTeam).toBe('VBC Zürich');
+    expect(assignment.awayTeam).toBe('Volley Luzern 1');
+    expect(assignment.league).toBe('NLA Herren');
+    expect(assignment.gender).toBe('men');
+    expect(assignment.hallName).toBe('Saalsporthalle');
+    expect(assignment.startTime).toBe('2025-02-20T19:30:00');
+    expect(results[0]!.confidence).toBe('high');
+  });
+
+  it('handles a French iCal feed', () => {
+    const frenchIcal = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:referee-convocation-for-game-789012
+SUMMARY:ARB 2 | Genève Volley - Lausanne UC (Ligue Femmes A)
+DESCRIPTION:Fonction: ARB 2\\nMatch: 789012\\nDate: 22.02.2025\\nLigue: Ligue Femmes A
+DTSTART:20250222T150000
+DTEND:20250222T180000
+LOCATION:Centre Sportif du Bois-des-Frères, Route de Valavran 10, 1293 Bellevue
+GEO:46.2539;6.1589
+END:VEVENT
+END:VCALENDAR`;
+
+    const results = parseCalendarFeed(frenchIcal);
+
+    expect(results).toHaveLength(1);
+    const assignment = results[0]!.assignment;
+
+    expect(assignment.gameId).toBe('789012');
+    expect(assignment.role).toBe('referee2');
+    expect(assignment.homeTeam).toBe('Genève Volley');
+    expect(assignment.awayTeam).toBe('Lausanne UC');
+    expect(assignment.league).toBe('Ligue Femmes A');
+    expect(assignment.gender).toBe('women');
+  });
+
+  it('handles events with gender symbols', () => {
+    const icalWithSymbols = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:referee-convocation-for-game-111222
+SUMMARY:JL 1 | Team Alpha - Team Beta (Cup ♀)
+DESCRIPTION:Match für Frauen ♀
+DTSTART:20250225T140000
+DTEND:20250225T170000
+LOCATION:Sportcenter, Main Street 1
+END:VEVENT
+END:VCALENDAR`;
+
+    const results = parseCalendarFeed(icalWithSymbols);
+    const assignment = results[0]!.assignment;
+
+    expect(assignment.role).toBe('scorer');
+    expect(assignment.gender).toBe('women');
+  });
+
+  it('handles line referee role', () => {
+    const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:referee-convocation-for-game-333444
+SUMMARY:LR 2 | Home Team - Away Team (League)
+DTSTART:20250228T160000
+DTEND:20250228T190000
+END:VEVENT
+END:VCALENDAR`;
+
+    const results = parseCalendarFeed(ical);
+    const assignment = results[0]!.assignment;
+
+    expect(assignment.role).toBe('lineReferee');
+    expect(assignment.roleRaw).toBe('LR 2');
+  });
+});

--- a/web-app/src/api/ical/parser.test.ts
+++ b/web-app/src/api/ical/parser.test.ts
@@ -172,6 +172,25 @@ END:VCALENDAR`;
       expect(events[0]!.summary).toBe('Test\\Path');
     });
 
+    it('handles escaped backslash followed by n without double-unescaping', () => {
+      // \\\\n in the template literal = \\n in the actual string = escaped backslash + n
+      // This should become \n (backslash + n), NOT a newline character
+      const ical = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-123
+SUMMARY:Test
+DESCRIPTION:Path\\\\nName
+DTSTART:20250215T140000
+END:VEVENT
+END:VCALENDAR`;
+
+      const events = parseICalFeed(ical);
+
+      // Should be backslash + 'n' + 'N' + 'a' + 'm' + 'e' (6 chars), not newline + 'Name' (5 chars)
+      expect(events[0]!.description).toBe('Path\\nName');
+      expect(events[0]!.description.length).toBe(10);
+    });
+
     it('unescapes semicolon characters', () => {
       const ical = `BEGIN:VCALENDAR
 BEGIN:VEVENT

--- a/web-app/src/api/ical/parser.ts
+++ b/web-app/src/api/ical/parser.ts
@@ -57,15 +57,6 @@
  * END:VEVENT
  * END:VCALENDAR
  * ```
- *
- * ## Internal Helper Functions (to be implemented)
- *
- * The following helper functions will be added during implementation:
- * - `parseRole(roleStr)` - Map role string to RefereeRole type
- * - `parseGender(leagueName)` - Detect gender from league name patterns
- * - `parseICalDate(icalDate)` - Convert iCal date to ISO 8601
- * - `buildMapsUrl(address, coordinates)` - Construct Google Maps URL
- * - `calculateConfidence(fields)` - Determine parsing confidence level
  */
 
 import type {
@@ -73,7 +64,206 @@ import type {
   CalendarAssignment,
   ParseResult,
   ParsedFields,
+  ParseConfidence,
+  RefereeRole,
+  Gender,
 } from './types';
+
+/** Pattern to extract game ID from UID */
+const GAME_ID_PATTERN = /referee-convocation-for-game-(\d+)/;
+
+/** Pattern to match numeric IDs (for fallback extraction) */
+const NUMERIC_ID_PATTERN = /#(\d+)/;
+
+/** Pattern to extract Google Maps URL from description */
+const MAPS_URL_PATTERN = /https?:\/\/(?:www\.)?(?:maps\.google\.com|google\.com\/maps)[^\s\\]*/i;
+
+/** Role mapping from raw strings to RefereeRole type */
+const ROLE_MAPPINGS: Record<string, RefereeRole> = {
+  'ARB 1': 'referee1',
+  'ARB 2': 'referee2',
+  'ARB1': 'referee1',
+  'ARB2': 'referee2',
+  'SR 1': 'referee1',
+  'SR 2': 'referee2',
+  'SR1': 'referee1',
+  'SR2': 'referee2',
+  JL: 'scorer',
+  'JL 1': 'scorer',
+  'JL 2': 'scorer',
+  JL1: 'scorer',
+  JL2: 'scorer',
+  LR: 'lineReferee',
+  'LR 1': 'lineReferee',
+  'LR 2': 'lineReferee',
+  LR1: 'lineReferee',
+  LR2: 'lineReferee',
+};
+
+/**
+ * Maps a raw role string to a RefereeRole type.
+ * Uses case-insensitive matching and normalizes whitespace.
+ */
+function parseRole(roleStr: string): RefereeRole {
+  const normalized = roleStr.trim().toUpperCase().replace(/\s+/g, ' ');
+  return ROLE_MAPPINGS[normalized] ?? 'unknown';
+}
+
+/**
+ * Detects gender from league name patterns.
+ * Handles German, French, Italian, and English patterns,
+ * as well as gender symbols (♀/♂).
+ */
+function parseGender(leagueName: string, description: string): Gender {
+  const combined = `${leagueName} ${description}`.toLowerCase();
+
+  // Check for gender symbols first (most reliable)
+  if (combined.includes('♀')) return 'women';
+  if (combined.includes('♂')) return 'men';
+
+  // Check for mixed patterns
+  if (/\bmixed\b/i.test(combined) || /\bgemischt\b/i.test(combined)) {
+    return 'mixed';
+  }
+
+  // Check for women's patterns in multiple languages
+  const womenPatterns =
+    /\b(damen|frauen|femmes|donne|women|ladies|fem\.|f\.|nla\s*f|nlb\s*f)\b/i;
+  if (womenPatterns.test(combined)) return 'women';
+
+  // Check for men's patterns in multiple languages
+  const menPatterns =
+    /\b(herren|männer|hommes|uomini|men|masc\.|m\.|nla\s*m|nlb\s*m)\b/i;
+  if (menPatterns.test(combined)) return 'men';
+
+  return 'unknown';
+}
+
+/**
+ * Converts an iCal date string to ISO 8601 format.
+ * Handles formats:
+ * - YYYYMMDDTHHMMSS (local time)
+ * - YYYYMMDDTHHMMSSZ (UTC)
+ * - YYYYMMDD (date only)
+ */
+function parseICalDate(icalDate: string): string {
+  // Remove any parameters (e.g., TZID)
+  const dateStr = icalDate.includes(':')
+    ? icalDate.split(':').pop()!
+    : icalDate;
+
+  // Handle date-only format (YYYYMMDD)
+  if (dateStr.length === 8) {
+    const year = dateStr.slice(0, 4);
+    const month = dateStr.slice(4, 6);
+    const day = dateStr.slice(6, 8);
+    return `${year}-${month}-${day}`;
+  }
+
+  // Handle datetime format (YYYYMMDDTHHMMSS or YYYYMMDDTHHMMSSZ)
+  const match = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(Z)?$/.exec(
+    dateStr
+  );
+  if (match) {
+    const [, year, month, day, hour, minute, second, utc] = match;
+    const iso = `${year}-${month}-${day}T${hour}:${minute}:${second}`;
+    return utc ? `${iso}Z` : iso;
+  }
+
+  // Return as-is if format is unrecognized
+  return icalDate;
+}
+
+/**
+ * Constructs a Google Maps URL from address or coordinates.
+ */
+function buildMapsUrl(
+  address: string | null,
+  coordinates: { latitude: number; longitude: number } | null
+): string | null {
+  if (coordinates) {
+    return `https://www.google.com/maps?q=${coordinates.latitude},${coordinates.longitude}`;
+  }
+  if (address) {
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`;
+  }
+  return null;
+}
+
+/**
+ * Calculates confidence level based on which fields were successfully parsed.
+ */
+function calculateConfidence(fields: ParsedFields): ParseConfidence {
+  const criticalFields = [fields.gameId, fields.role, fields.teams];
+  const allCriticalParsed = criticalFields.every(Boolean);
+
+  if (!allCriticalParsed) return 'low';
+
+  const optionalFields = [
+    fields.league,
+    fields.venue,
+    fields.address,
+    fields.coordinates,
+  ];
+  const optionalParsedCount = optionalFields.filter(Boolean).length;
+
+  if (optionalParsedCount >= 3) return 'high';
+  return 'medium';
+}
+
+/**
+ * Unfolds multi-line iCal content according to RFC 5545.
+ * Lines starting with a space or tab are continuations of the previous line.
+ */
+function unfoldLines(content: string): string {
+  // Normalize line endings to \r\n (iCal standard)
+  const normalized = content.replace(/\r?\n/g, '\r\n');
+  // Unfold continuation lines (lines starting with space or tab)
+  return normalized.replace(/\r\n[ \t]/g, '');
+}
+
+/**
+ * Unescapes iCal text values.
+ * Handles: \n -> newline, \, -> comma, \\ -> backslash, \; -> semicolon
+ */
+function unescapeText(text: string): string {
+  return text
+    .replace(/\\n/g, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\;/g, ';');
+}
+
+/**
+ * Extracts a property value from an iCal event block.
+ * Handles property parameters (e.g., DTSTART;TZID=...:value)
+ */
+function extractProperty(
+  eventBlock: string,
+  propertyName: string
+): string | null {
+  // Split into lines and find the property line
+  const lines = eventBlock.split(/\r?\n/);
+  const upperPropName = propertyName.toUpperCase();
+
+  for (const line of lines) {
+    const upperLine = line.toUpperCase();
+    // Check if line starts with property name followed by : or ;
+    if (
+      upperLine.startsWith(`${upperPropName}:`) ||
+      upperLine.startsWith(`${upperPropName};`)
+    ) {
+      // Find the colon that separates parameters from value
+      const colonIndex = line.indexOf(':');
+      if (colonIndex === -1) continue;
+
+      const value = line.slice(colonIndex + 1);
+      return unescapeText(value.trim());
+    }
+  }
+
+  return null;
+}
 
 /**
  * Parses raw iCal (.ics) content into an array of ICalEvent objects.
@@ -92,29 +282,172 @@ import type {
  * console.log(events[0].uid); // "referee-convocation-for-game-392936"
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function parseICalFeed(_icsContent: string): ICalEvent[] {
-  // STUB(#503): iCal parsing not yet implemented
-  //
-  // Implementation steps:
-  // 1. Unfold multi-line fields (RFC 5545: lines starting with SPACE/TAB are continuations)
-  // 2. Split content into VEVENT blocks using BEGIN:VEVENT / END:VEVENT markers
-  // 3. For each VEVENT block:
-  //    a. Extract UID property
-  //    b. Extract SUMMARY property
-  //    c. Extract DESCRIPTION property (handle escaped newlines)
-  //    d. Extract DTSTART property (parse iCal date format to ISO 8601)
-  //    e. Extract DTEND property
-  //    f. Extract LOCATION property (optional)
-  //    g. Extract GEO property (optional, format: lat;lon)
-  // 4. Handle edge cases:
-  //    - Missing optional fields
-  //    - Different date formats (with/without timezone)
-  //    - Malformed input (return empty array or skip invalid events)
-  //
-  // Note: Consider using a well-tested iCal parsing library if complexity grows
+export function parseICalFeed(icsContent: string): ICalEvent[] {
+  if (!icsContent || typeof icsContent !== 'string') {
+    return [];
+  }
 
-  return [];
+  const unfolded = unfoldLines(icsContent);
+  const events: ICalEvent[] = [];
+
+  // Split into VEVENT blocks
+  const eventBlocks = unfolded.split(/BEGIN:VEVENT/i).slice(1);
+
+  for (const block of eventBlocks) {
+    // Find the end of the event
+    const endIndex = block.search(/END:VEVENT/i);
+    if (endIndex === -1) continue;
+
+    const eventContent = block.slice(0, endIndex);
+
+    // Extract required properties
+    const uid = extractProperty(eventContent, 'UID');
+    const summary = extractProperty(eventContent, 'SUMMARY');
+    const dtstart = extractProperty(eventContent, 'DTSTART');
+    const dtend = extractProperty(eventContent, 'DTEND');
+
+    // Skip events without required fields
+    if (!uid || !summary || !dtstart) continue;
+
+    // Extract optional properties
+    const description = extractProperty(eventContent, 'DESCRIPTION') ?? '';
+    const location = extractProperty(eventContent, 'LOCATION');
+    const geoStr = extractProperty(eventContent, 'GEO');
+
+    // Parse GEO coordinates
+    let geo: ICalEvent['geo'] = null;
+    if (geoStr) {
+      const geoParts = geoStr.split(';');
+      const latStr = geoParts[0];
+      const lonStr = geoParts[1];
+      if (latStr !== undefined && lonStr !== undefined) {
+        const latitude = parseFloat(latStr);
+        const longitude = parseFloat(lonStr);
+        if (!isNaN(latitude) && !isNaN(longitude)) {
+          geo = { latitude, longitude };
+        }
+      }
+    }
+
+    events.push({
+      uid,
+      summary,
+      description,
+      dtstart: parseICalDate(dtstart),
+      dtend: dtend ? parseICalDate(dtend) : parseICalDate(dtstart),
+      location,
+      geo,
+    });
+  }
+
+  return events;
+}
+
+/**
+ * Parses the SUMMARY field to extract role, teams, and league.
+ * Expected format: "ARB 1 | Team1 - Team2 (League Name)"
+ */
+function parseSummary(summary: string): {
+  roleRaw: string;
+  role: RefereeRole;
+  homeTeam: string;
+  awayTeam: string;
+  league: string;
+  parsed: { role: boolean; teams: boolean; league: boolean };
+} {
+  const result = {
+    roleRaw: '',
+    role: 'unknown' as RefereeRole,
+    homeTeam: '',
+    awayTeam: '',
+    league: '',
+    parsed: { role: false, teams: false, league: false },
+  };
+
+  // Split by " | " to separate role from match info
+  const pipeIndex = summary.indexOf(' | ');
+  if (pipeIndex === -1) {
+    // Try without spaces around pipe
+    const altPipeIndex = summary.indexOf('|');
+    if (altPipeIndex !== -1) {
+      result.roleRaw = summary.slice(0, altPipeIndex).trim();
+      result.role = parseRole(result.roleRaw);
+      result.parsed.role = result.role !== 'unknown';
+    }
+    return result;
+  }
+
+  result.roleRaw = summary.slice(0, pipeIndex).trim();
+  result.role = parseRole(result.roleRaw);
+  result.parsed.role = result.role !== 'unknown';
+
+  const matchInfo = summary.slice(pipeIndex + 3).trim();
+
+  // Extract league from parentheses at the end using string operations
+  // to avoid ReDoS vulnerability from regex backtracking
+  let leagueStartIndex = -1;
+
+  const lastCloseParen = matchInfo.lastIndexOf(')');
+  if (lastCloseParen !== -1) {
+    // Find matching open paren by scanning backwards
+    const lastOpenParen = matchInfo.lastIndexOf('(', lastCloseParen);
+    if (lastOpenParen !== -1 && lastOpenParen < lastCloseParen) {
+      leagueStartIndex = lastOpenParen;
+      result.league = matchInfo.slice(lastOpenParen + 1, lastCloseParen).trim();
+      result.parsed.league = result.league.length > 0;
+    }
+  }
+
+  // Extract teams (everything before the league parentheses)
+  const teamsStr =
+    leagueStartIndex !== -1
+      ? matchInfo.slice(0, leagueStartIndex).trim()
+      : matchInfo;
+
+  // Split teams by " - "
+  const teamSeparator = teamsStr.indexOf(' - ');
+  if (teamSeparator !== -1) {
+    result.homeTeam = teamsStr.slice(0, teamSeparator).trim();
+    result.awayTeam = teamsStr.slice(teamSeparator + 3).trim();
+    result.parsed.teams = result.homeTeam.length > 0 && result.awayTeam.length > 0;
+  }
+
+  return result;
+}
+
+/**
+ * Parses the LOCATION field to extract hall name and address.
+ * Expected format: "Hall Name, Address Parts"
+ */
+function parseLocation(location: string | null): {
+  hallName: string | null;
+  address: string | null;
+  parsed: { venue: boolean; address: boolean };
+} {
+  const result = {
+    hallName: null as string | null,
+    address: null as string | null,
+    parsed: { venue: false, address: false },
+  };
+
+  if (!location) return result;
+
+  // First part before comma is typically the hall name
+  const commaIndex = location.indexOf(',');
+  if (commaIndex !== -1) {
+    result.hallName = location.slice(0, commaIndex).trim();
+    result.address = location.slice(commaIndex + 1).trim();
+    result.parsed.venue = result.hallName.length > 0;
+    result.parsed.address = result.address.length > 0;
+  } else {
+    // If no comma, the whole thing could be either hall name or address
+    result.hallName = location.trim();
+    result.address = location.trim();
+    result.parsed.venue = location.trim().length > 0;
+    result.parsed.address = location.trim().length > 0;
+  }
+
+  return result;
 }
 
 /**
@@ -170,27 +503,8 @@ export function parseICalFeed(_icsContent: string): ICalEvent[] {
  * }
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function extractAssignment(_event: ICalEvent): ParseResult {
-  // STUB(#503): Assignment extraction not yet implemented
-  //
-  // Implementation steps:
-  // 1. Extract gameId from UID using regex pattern
-  // 2. Parse SUMMARY to extract:
-  //    a. Role (before " | ")
-  //    b. Teams (split by " - ")
-  //    c. League (text in parentheses at end)
-  // 3. Parse LOCATION to extract:
-  //    a. Hall name (first segment before comma)
-  //    b. Address (remaining segments)
-  // 4. Use GEO coordinates if available
-  // 5. Determine gender from league name patterns
-  // 6. Construct Google Maps URL from address or coordinates
-  // 7. Track which fields were successfully parsed
-  // 8. Calculate confidence level based on parsed fields
-  // 9. Collect any warnings for incomplete/ambiguous data
-
-  // Return stub data structure
+export function extractAssignment(event: ICalEvent): ParseResult {
+  const warnings: string[] = [];
   const parsedFields: ParsedFields = {
     gameId: false,
     role: false,
@@ -201,27 +515,83 @@ export function extractAssignment(_event: ICalEvent): ParseResult {
     coordinates: false,
   };
 
+  // Extract game ID from UID
+  let gameId = '';
+  const gameIdMatch = GAME_ID_PATTERN.exec(event.uid);
+  if (gameIdMatch?.[1]) {
+    gameId = gameIdMatch[1];
+    parsedFields.gameId = true;
+  } else {
+    // Fallback: try to extract any numeric ID
+    const numericMatch = NUMERIC_ID_PATTERN.exec(event.uid);
+    if (numericMatch?.[1]) {
+      gameId = numericMatch[1];
+      parsedFields.gameId = true;
+      warnings.push('Game ID extracted using fallback pattern');
+    } else {
+      warnings.push('Could not extract game ID from UID');
+    }
+  }
+
+  // Parse SUMMARY for role, teams, and league
+  const summaryData = parseSummary(event.summary);
+  parsedFields.role = summaryData.parsed.role;
+  parsedFields.teams = summaryData.parsed.teams;
+  parsedFields.league = summaryData.parsed.league;
+
+  if (!summaryData.parsed.role) {
+    warnings.push(`Unknown role format: "${summaryData.roleRaw}"`);
+  }
+  if (!summaryData.parsed.teams) {
+    warnings.push('Could not extract teams from summary');
+  }
+  if (!summaryData.parsed.league) {
+    warnings.push('Could not extract league from summary');
+  }
+
+  // Parse LOCATION for hall name and address
+  const locationData = parseLocation(event.location);
+  parsedFields.venue = locationData.parsed.venue;
+  parsedFields.address = locationData.parsed.address;
+
+  // Check for coordinates
+  parsedFields.coordinates = event.geo !== null;
+
+  // Determine gender from league and description
+  const gender = parseGender(summaryData.league, event.description);
+
+  // Extract or build maps URL
+  let mapsUrl: string | null = null;
+  const mapsMatch = MAPS_URL_PATTERN.exec(event.description);
+  if (mapsMatch) {
+    mapsUrl = mapsMatch[0];
+  } else {
+    mapsUrl = buildMapsUrl(locationData.address, event.geo);
+  }
+
   const assignment: CalendarAssignment = {
-    gameId: '',
-    role: 'unknown',
-    roleRaw: '',
-    startTime: '',
-    endTime: '',
-    homeTeam: '',
-    awayTeam: '',
-    league: '',
-    address: null,
-    coordinates: null,
-    hallName: null,
-    gender: 'unknown',
-    mapsUrl: null,
+    gameId,
+    role: summaryData.role,
+    roleRaw: summaryData.roleRaw,
+    startTime: event.dtstart,
+    endTime: event.dtend,
+    homeTeam: summaryData.homeTeam,
+    awayTeam: summaryData.awayTeam,
+    league: summaryData.league,
+    address: locationData.address,
+    coordinates: event.geo,
+    hallName: locationData.hallName,
+    gender,
+    mapsUrl,
   };
+
+  const confidence = calculateConfidence(parsedFields);
 
   return {
     assignment,
     parsedFields,
-    confidence: 'low',
-    warnings: ['Parser not yet implemented'],
+    confidence,
+    warnings,
   };
 }
 
@@ -245,7 +615,6 @@ export function extractAssignment(_event: ICalEvent): ParseResult {
  * ```
  */
 export function parseCalendarFeed(icsContent: string): ParseResult[] {
-  // Parses iCal content into events and converts each to an assignment
   const events = parseICalFeed(icsContent);
   return events.map(extractAssignment);
 }

--- a/web-app/src/api/ical/parser.ts
+++ b/web-app/src/api/ical/parser.ts
@@ -225,13 +225,26 @@ function unfoldLines(content: string): string {
 /**
  * Unescapes iCal text values.
  * Handles: \n -> newline, \, -> comma, \\ -> backslash, \; -> semicolon
+ *
+ * Uses a placeholder approach to prevent double-unescaping vulnerabilities.
+ * For example, "\\n" (escaped backslash + n) should become "\n" (backslash + n),
+ * not a newline character.
  */
 function unescapeText(text: string): string {
-  return text
-    .replace(/\\n/g, '\n')
-    .replace(/\\,/g, ',')
-    .replace(/\\\\/g, '\\')
-    .replace(/\\;/g, ';');
+  // Use null character as placeholder for escaped backslashes
+  const BACKSLASH_PLACEHOLDER = '\x00';
+
+  return (
+    text
+      // First, replace escaped backslashes with placeholder to prevent double-unescaping
+      .replace(/\\\\/g, BACKSLASH_PLACEHOLDER)
+      // Then unescape other sequences
+      .replace(/\\n/g, '\n')
+      .replace(/\\,/g, ',')
+      .replace(/\\;/g, ';')
+      // Finally, convert placeholder back to single backslash
+      .replaceAll(BACKSLASH_PLACEHOLDER, '\\')
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements a defensive, language-independent iCal parser for volleymanager calendar feeds. The parser extracts assignment data from VEVENT blocks using reliable patterns rather than language-specific labels, supporting German, French, Italian, and English feeds.

- Parse game ID from UID pattern: `referee-convocation-for-game-{id}`
- Extract role, teams, and league from SUMMARY field
- Handle RFC 5545 multi-line unfolding and escaped characters
- Parse DTSTART/DTEND with timezone support (local, UTC, date-only, TZID)
- Extract coordinates from GEO field
- Detect gender from league name patterns (DE/FR/IT/EN) and symbols (♀/♂)
- Build Google Maps URLs from coordinates or address
- Calculate confidence levels (high/medium/low) based on parsed fields

## Test plan

- [x] All 90 unit tests pass covering:
  - Basic parsing and multi-event feeds
  - RFC 5545 unfolding and character escaping
  - All date formats (UTC, local, date-only, TZID parameter)
  - Edge cases (missing fields, malformed input, invalid GEO)
  - All role types (ARB 1/2, SR 1/2, JL 1/2, LR 1/2)
  - Teams with special characters and numbers
  - Gender detection in multiple languages
  - Integration tests with realistic German and French feeds
- [x] ESLint passes with zero warnings
- [x] TypeScript build succeeds