### PR TITLE
fix(hooks): clarify post-git-push hook instructions for PR generation

### DIFF
--- a/.claude/hooks/post-git-push.sh
+++ b/.claude/hooks/post-git-push.sh
@@ -66,11 +66,11 @@ if [[ "$command" == *"git push"* ]]; then
 
     if [ "$pr_exists" = "true" ]; then
       if [ -n "$github_token" ]; then
-        # PR exists and we have a token - instruct Claude to update PR via API
+        # PR exists and we have a token - update via API and output description
         cat <<EOF
 {
   "decision": "block",
-  "reason": "Code pushed successfully. PR #${pr_number} exists.\\n\\nYou MUST now update the PR description via the GitHub API.\\n\\nSteps:\\n1. Generate a PR title (concise, following conventional commit style)\\n2. Generate the PR description with: Summary (bullet points), Changes (list), Test Plan (checklist)\\n3. Update the PR using curl:\\n\\ncurl -X PATCH \\\"https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}\\\" \\\\\\n  -H \\\"Authorization: token \\\$GITHUB_TOKEN\\\" \\\\\\n  -H \\\"Accept: application/vnd.github.v3+json\\\" \\\\\\n  -d '{\\\"title\\\": \\\"<title>\\\", \\\"body\\\": \\\"<description>\\\"}'\\n\\n4. Confirm the update was successful\\n\\nIMPORTANT:\\n- Properly escape JSON in the request body\\n- Use \\\$GITHUB_TOKEN (it is set in the environment)\\n- Report success or failure to the user"
+  "reason": "Push successful. PR #${pr_number} exists: ${pr_html_url}\\n\\nYou MUST do the following:\\n\\n1. Generate a PR title (conventional commit style, e.g., feat(scope): description)\\n\\n2. Generate a PR description in markdown with these sections:\\n   - ## Summary (bullet points)\\n   - ## Changes (list of changes)\\n   - ## Test Plan (checklist with [ ] items)\\n\\n3. Update the PR via GitHub API:\\n   curl -X PATCH \"https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}\" \\\\\\n     -H \"Authorization: token \\\$GITHUB_TOKEN\" \\\\\\n     -H \"Accept: application/vnd.github.v3+json\" \\\\\\n     -d '{\"title\": \"<title>\", \"body\": \"<description>\"}'\\n\\n4. Output the PR description in a code block so the user can see it:\\n   \\n   **Title:** <title>\\n   \\n   \\\`\\\`\\\`markdown\\n   <description>\\n   \\\`\\\`\\\`\\n\\nIMPORTANT:\\n- Escape JSON properly in the curl request (use jq if needed)\\n- Any code snippets INSIDE the description must use 4-space indentation, NOT backticks\\n- Report whether the API update succeeded or failed"
 }
 EOF
         exit 0
@@ -79,13 +79,13 @@ EOF
         cat <<EOF
 {
   "decision": "block",
-  "reason": "Code pushed successfully. PR already exists: ${pr_html_url}\\n\\nYou MUST now output the PR title and description.\\n\\nOutput format (use EXACTLY this structure):\\n\\n**Title:** [concise PR title following conventional commit style, e.g., feat(scope): description]\\n\\n\`\`\`\\n## Summary\\n\\n- [bullet points summarizing what was done]\\n\\n## Changes\\n\\n- [list of specific changes made]\\n\\n## Test Plan\\n\\n- [ ] [checklist items for testing]\\n\`\`\`\\n\\nIMPORTANT:\\n- The code block is REQUIRED so the user can easily copy the PR description.\\n- Any code snippets INSIDE the PR description must use 4-space indentation, NOT triple backticks (to avoid breaking the outer code block)."
+  "reason": "Push successful. PR already exists: ${pr_html_url}\\n\\nYou MUST output the PR title and description for manual copy.\\n\\nOutput EXACTLY this format:\\n\\n**Title:** <conventional commit style title>\\n\\n\\\`\\\`\\\`markdown\\n## Summary\\n\\n- <bullet points summarizing what was done>\\n\\n## Changes\\n\\n- <list of specific changes>\\n\\n## Test Plan\\n\\n- [ ] <checklist items for testing>\\n\\\`\\\`\\\`\\n\\nIMPORTANT:\\n- The code block is REQUIRED so the user can copy the description\\n- Any code snippets INSIDE the description must use 4-space indentation, NOT backticks"
 }
 EOF
         exit 0
       fi
     else
-      # No PR exists - instruct Claude to generate a clickable markdown link only
+      # No PR exists - generate a clickable markdown link
       default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
       if [ -z "$default_branch" ]; then
         default_branch="main"
@@ -94,7 +94,7 @@ EOF
       cat <<EOF
 {
   "decision": "block",
-  "reason": "Code pushed successfully.\\n\\nNo PR exists yet. You MUST now output a clickable markdown link to create the PR.\\n\\nSteps:\\n1. Generate a PR title (concise, following conventional commit style, e.g., feat(scope): description)\\n2. Generate the PR description with these sections: Summary (bullet points), Changes (list), Test Plan (checklist)\\n3. Build the GitHub URL:\\n   Base: ${base_url}\\n   Append \\\"&title=\\\" + URL-encoded title\\n   Append \\\"&body=\\\" + URL-encoded description\\n4. Output ONLY a markdown link in this format:\\n   [Create PR: <title>](<full-url>)\\n\\nIMPORTANT:\\n- Output ONLY the markdown link, nothing else (no code blocks, no raw URLs)\\n- URL-encode all special characters (spaces as %20, newlines as %0A, # as %23, etc.)\\n- The link text should be \\\"Create PR: \\\" followed by the title"
+  "reason": "Push successful. No PR exists yet.\\n\\nYou MUST output a clickable markdown link to create the PR.\\n\\nSteps:\\n1. Generate a PR title (conventional commit style, e.g., feat(scope): description)\\n\\n2. Generate a PR description with these sections:\\n   - ## Summary (bullet points)\\n   - ## Changes (list of changes)  \\n   - ## Test Plan (checklist with [ ] items)\\n\\n3. URL-encode the title and description:\\n   - Spaces → %20\\n   - Newlines → %0A\\n   - # → %23\\n   - Other special chars as needed\\n\\n4. Build the URL: ${base_url}&title=<encoded-title>&body=<encoded-description>\\n\\n5. Output a SINGLE markdown link (nothing else):\\n   [Create PR: <title>](<url>)\\n\\nIMPORTANT:\\n- Output ONLY the markdown link - no code blocks, no raw URLs, no extra text\\n- Any code snippets in the description must use 4-space indentation, NOT backticks\\n- The link text format is: Create PR: <title>"
 }
 EOF
       exit 0
@@ -105,7 +105,7 @@ EOF
   cat <<EOF
 {
   "decision": "block",
-  "reason": "Code pushed successfully.\\n\\nYou MUST now output the PR title and description.\\n\\nOutput format (use EXACTLY this structure):\\n\\n**Title:** [concise PR title following conventional commit style, e.g., feat(scope): description]\\n\\n\`\`\`\\n## Summary\\n\\n- [bullet points summarizing what was done]\\n\\n## Changes\\n\\n- [list of specific changes made]\\n\\n## Test Plan\\n\\n- [ ] [checklist items for testing]\\n\`\`\`\\n\\nIMPORTANT:\\n- The code block is REQUIRED so the user can easily copy the PR description.\\n- Any code snippets INSIDE the PR description must use 4-space indentation, NOT triple backticks (to avoid breaking the outer code block)."
+  "reason": "Push successful.\\n\\nYou MUST output the PR title and description for manual copy.\\n\\nOutput EXACTLY this format:\\n\\n**Title:** <conventional commit style title>\\n\\n\\\`\\\`\\\`markdown\\n## Summary\\n\\n- <bullet points summarizing what was done>\\n\\n## Changes\\n\\n- <list of specific changes>\\n\\n## Test Plan\\n\\n- [ ] <checklist items for testing>\\n\\\`\\\`\\\`\\n\\nIMPORTANT:\\n- The code block is REQUIRED so the user can copy the description\\n- Any code snippets INSIDE the description must use 4-space indentation, NOT backticks"
 }
 EOF
   exit 0


### PR DESCRIPTION
## Summary

- Improved clarity of post-git-push hook instructions to ensure Claude generates PR links and descriptions correctly
- Fixed issue where PR descriptions were output as formatted markdown instead of clickable links

## Changes

- Restructured hook instructions with numbered steps for better clarity
- Added requirement to output PR description in code block when updating existing PRs via API
- Clarified that internal code snippets must use 4-space indentation instead of backticks
- Simplified the no-PR case to emphasize outputting a single markdown link
- Included PR URL in the "PR exists with token" message for reference

## Test Plan

- [ ] Push to a branch with no existing PR and verify a clickable link is generated
- [ ] Push to a branch with an existing PR (with GITHUB_TOKEN) and verify API update plus code block output
- [ ] Push to a branch with an existing PR (without GITHUB_TOKEN) and verify code block output