### PR TITLE
feat(calendar-mode): hide unavailable features in read-only view

### DIFF
--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -133,6 +133,7 @@ const de: Translations = {
     position: "Position",
     requiredLevel: "Erforderliches Niveau",
     demoModeBanner: "Demo-Modus - Beispieldaten werden angezeigt",
+    calendarModeBanner: "Kalender-Modus - Nur-Lesen-Ansicht",
     optional: "Optional",
     tbd: "TBD",
     locationTbd: "Ort unbekannt",
@@ -249,6 +250,9 @@ const de: Translations = {
       "Entschädigungseintrag nicht gefunden. Das Spiel liegt möglicherweise zu weit in der Zukunft.",
     compensationMissingId:
       "Entschädigungseintrag hat keine Kennung. Bitte versuchen Sie es später erneut.",
+    unavailableInCalendarModeTitle: "Im Kalender-Modus nicht verfügbar",
+    unavailableInCalendarModeDescription:
+      "Entschädigungsdaten sind im Kalender-Modus nicht verfügbar. Verwenden Sie die vollständige Anmeldung, um auf Entschädigungsdetails zuzugreifen.",
   },
   exchange: {
     title: "Tauschbörse",
@@ -292,6 +296,9 @@ const de: Translations = {
     submittedBy: "Von:",
     levelRequired: "Niveau {level}+",
     errorLoading: "Fehler beim Laden der Tauschangebote",
+    unavailableInCalendarModeTitle: "Im Kalender-Modus nicht verfügbar",
+    unavailableInCalendarModeDescription:
+      "Tauschbörsen-Funktionen sind im Kalender-Modus nicht verfügbar. Verwenden Sie die vollständige Anmeldung, um Tauschangebote zu durchsuchen und zu bewerben.",
     settings: {
       title: "Filtereinstellungen",
       maxDistance: "Maximale Entfernung",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -133,6 +133,7 @@ const en: Translations = {
     position: "Position",
     requiredLevel: "Required Level",
     demoModeBanner: "Demo Mode - Viewing sample data",
+    calendarModeBanner: "Calendar Mode - Read-only view",
     optional: "Optional",
     tbd: "TBD",
     locationTbd: "Location TBD",
@@ -249,6 +250,9 @@ const en: Translations = {
       "Compensation record not found. The game may be too far in the future.",
     compensationMissingId:
       "Compensation record is missing an identifier. Please try again later.",
+    unavailableInCalendarModeTitle: "Not available in Calendar Mode",
+    unavailableInCalendarModeDescription:
+      "Compensation data is not available in calendar mode. Use full login to access compensation details.",
   },
   exchange: {
     title: "Exchange",
@@ -290,6 +294,9 @@ const en: Translations = {
     submittedBy: "By:",
     levelRequired: "Level {level}+",
     errorLoading: "Failed to load exchanges",
+    unavailableInCalendarModeTitle: "Not available in Calendar Mode",
+    unavailableInCalendarModeDescription:
+      "Exchange features are not available in calendar mode. Use full login to browse and apply for exchanges.",
     settings: {
       title: "Filter Settings",
       maxDistance: "Maximum distance",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -133,6 +133,7 @@ const fr: Translations = {
     position: "Position",
     requiredLevel: "Niveau requis",
     demoModeBanner: "Mode Démo - Données d'exemple",
+    calendarModeBanner: "Mode Calendrier - Vue en lecture seule",
     optional: "Optionnel",
     tbd: "À déterminer",
     locationTbd: "Lieu à déterminer",
@@ -249,6 +250,9 @@ const fr: Translations = {
       "Enregistrement d'indemnité introuvable. Le match est peut-être trop éloigné dans le futur.",
     compensationMissingId:
       "L'enregistrement d'indemnité n'a pas d'identifiant. Veuillez réessayer plus tard.",
+    unavailableInCalendarModeTitle: "Non disponible en mode calendrier",
+    unavailableInCalendarModeDescription:
+      "Les données d'indemnités ne sont pas disponibles en mode calendrier. Utilisez la connexion complète pour accéder aux détails des indemnités.",
   },
   exchange: {
     title: "Bourse aux échanges",
@@ -291,6 +295,9 @@ const fr: Translations = {
     submittedBy: "Par :",
     levelRequired: "Niveau {level}+",
     errorLoading: "Échec du chargement des échanges",
+    unavailableInCalendarModeTitle: "Non disponible en mode calendrier",
+    unavailableInCalendarModeDescription:
+      "Les fonctionnalités d'échange ne sont pas disponibles en mode calendrier. Utilisez la connexion complète pour parcourir et postuler aux échanges.",
     settings: {
       title: "Paramètres des filtres",
       maxDistance: "Distance maximale",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -133,6 +133,7 @@ const it: Translations = {
     position: "Posizione",
     requiredLevel: "Livello richiesto",
     demoModeBanner: "Modalità Demo - Dati di esempio",
+    calendarModeBanner: "Modalità Calendario - Vista di sola lettura",
     optional: "Opzionale",
     tbd: "Da definire",
     locationTbd: "Luogo da definire",
@@ -247,6 +248,9 @@ const it: Translations = {
       "Record di compenso non trovato. La partita potrebbe essere troppo lontana nel futuro.",
     compensationMissingId:
       "Il record di compenso non ha un identificatore. Riprova più tardi.",
+    unavailableInCalendarModeTitle: "Non disponibile in modalità calendario",
+    unavailableInCalendarModeDescription:
+      "I dati dei compensi non sono disponibili in modalità calendario. Usa l'accesso completo per accedere ai dettagli dei compensi.",
   },
   exchange: {
     title: "Borsa scambi",
@@ -289,6 +293,9 @@ const it: Translations = {
     submittedBy: "Da:",
     levelRequired: "Livello {level}+",
     errorLoading: "Impossibile caricare gli scambi",
+    unavailableInCalendarModeTitle: "Non disponibile in modalità calendario",
+    unavailableInCalendarModeDescription:
+      "Le funzionalità di scambio non sono disponibili in modalità calendario. Usa l'accesso completo per sfogliare e candidarti agli scambi.",
     settings: {
       title: "Impostazioni filtri",
       maxDistance: "Distanza massima",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -25,6 +25,7 @@ export interface Translations {
     position: string;
     requiredLevel: string;
     demoModeBanner: string;
+    calendarModeBanner: string;
     optional: string;
     tbd: string;
     locationTbd: string;
@@ -133,6 +134,8 @@ export interface Translations {
     assignmentNotFoundInCache: string;
     compensationNotFound: string;
     compensationMissingId: string;
+    unavailableInCalendarModeTitle: string;
+    unavailableInCalendarModeDescription: string;
   };
   exchange: {
     title: string;
@@ -172,6 +175,8 @@ export interface Translations {
     submittedBy: string;
     levelRequired: string;
     errorLoading: string;
+    unavailableInCalendarModeTitle: string;
+    unavailableInCalendarModeDescription: string;
     settings: {
       title: string;
       maxDistance: string;

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { useTour } from "@/hooks/useTour";
 import { TOUR_DUMMY_ASSIGNMENT } from "@/components/tour/definitions/assignments";
 import { useAuthStore } from "@/stores/auth";
+import { useShallow } from "zustand/react/shallow";
 
 const PdfLanguageModal = lazy(
   () =>
@@ -51,8 +52,11 @@ type TabType = "upcoming" | "validationClosed";
 export function AssignmentsPage() {
   const [activeTab, setActiveTab] = useState<TabType>("upcoming");
   const { t } = useTranslation();
-  const isAssociationSwitching = useAuthStore(
-    (state) => state.isAssociationSwitching,
+  const { isAssociationSwitching, isCalendarMode } = useAuthStore(
+    useShallow((state) => ({
+      isAssociationSwitching: state.isAssociationSwitching,
+      isCalendarMode: state.isCalendarMode(),
+    })),
   );
 
   // Initialize tour for this page (triggers auto-start on first visit)
@@ -111,6 +115,11 @@ export function AssignmentsPage() {
 
   const getSwipeConfig = useCallback(
     (assignment: Assignment) => {
+      // In calendar mode, disable all swipe actions (read-only view)
+      if (isCalendarMode) {
+        return { left: [], right: [] };
+      }
+
       const actions = createAssignmentActions(assignment, {
         onEditCompensation: editCompensationModal.open,
         onValidateGame: validateGameModal.open,
@@ -147,6 +156,7 @@ export function AssignmentsPage() {
       };
     },
     [
+      isCalendarMode,
       editCompensationModal,
       validateGameModal,
       handleGenerateReport,

--- a/web-app/src/pages/CompensationsPage.tsx
+++ b/web-app/src/pages/CompensationsPage.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { useTour } from "@/hooks/useTour";
 import { TOUR_DUMMY_COMPENSATION } from "@/components/tour/definitions/compensations";
 import { useAuthStore } from "@/stores/auth";
+import { useShallow } from "zustand/react/shallow";
 
 const EditCompensationModal = lazy(
   () =>
@@ -60,8 +61,11 @@ export function CompensationsPage() {
   const [filter, setFilter] = useState<FilterType>("pendingPast");
   const { t } = useTranslation();
   const { editCompensationModal, handleGeneratePDF } = useCompensationActions();
-  const isAssociationSwitching = useAuthStore(
-    (state) => state.isAssociationSwitching,
+  const { isAssociationSwitching, isCalendarMode } = useAuthStore(
+    useShallow((state) => ({
+      isAssociationSwitching: state.isAssociationSwitching,
+      isCalendarMode: state.isCalendarMode(),
+    })),
   );
 
   // Initialize tour for this page (triggers auto-start on first visit)
@@ -248,6 +252,19 @@ export function CompensationsPage() {
       </div>
     );
   };
+
+  // In calendar mode, show empty state since compensation data is not available
+  if (isCalendarMode) {
+    return (
+      <div className="space-y-3">
+        <EmptyState
+          icon="wallet"
+          title={t("compensations.unavailableInCalendarModeTitle")}
+          description={t("compensations.unavailableInCalendarModeDescription")}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3">

--- a/web-app/src/pages/ExchangePage.test.tsx
+++ b/web-app/src/pages/ExchangePage.test.tsx
@@ -106,11 +106,13 @@ describe("ExchangePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Default: not in demo mode
+    // Default: not in demo mode, not in calendar mode
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
-        typeof authStore.useAuthStore.getState
-      >),
+      selector({
+        isDemoMode: false,
+        isAssociationSwitching: false,
+        isCalendarMode: () => false,
+      } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
     );
 
     vi.mocked(demoStore.useDemoStore).mockReturnValue({
@@ -151,9 +153,11 @@ describe("ExchangePage", () => {
   describe("Level Filter Toggle", () => {
     it("should not show level filter when not in demo mode", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
-          typeof authStore.useAuthStore.getState
-        >),
+        selector({
+          isDemoMode: false,
+          isAssociationSwitching: false,
+          isCalendarMode: () => false,
+        } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
       );
 
       render(<ExchangePage />);
@@ -166,9 +170,11 @@ describe("ExchangePage", () => {
 
     it("should show level filter when in demo mode with user level", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
-          typeof authStore.useAuthStore.getState
-        >),
+        selector({
+          isDemoMode: true,
+          isAssociationSwitching: false,
+          isCalendarMode: () => false,
+        } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
       );
 
       vi.mocked(demoStore.useDemoStore).mockReturnValue({
@@ -186,9 +192,11 @@ describe("ExchangePage", () => {
 
     it("should not show level filter on Added by Me tab", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
-          typeof authStore.useAuthStore.getState
-        >),
+        selector({
+          isDemoMode: true,
+          isAssociationSwitching: false,
+          isCalendarMode: () => false,
+        } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
       );
 
       vi.mocked(demoStore.useDemoStore).mockReturnValue({
@@ -229,9 +237,11 @@ describe("ExchangePage", () => {
 
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
-          typeof authStore.useAuthStore.getState
-        >),
+        selector({
+          isDemoMode: true,
+          isAssociationSwitching: false,
+          isCalendarMode: () => false,
+        } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
       );
 
       // User is N2 level (gradation value 2)

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -51,10 +51,11 @@ export function ExchangePage() {
   // Use showDummyData to show dummy data immediately, avoiding race condition with empty states
   const { showDummyData } = useTour("exchange");
 
-  const { isDemoMode, isAssociationSwitching } = useAuthStore(
+  const { isDemoMode, isAssociationSwitching, isCalendarMode } = useAuthStore(
     useShallow((state) => ({
       isDemoMode: state.isDemoMode,
       isAssociationSwitching: state.isAssociationSwitching,
+      isCalendarMode: state.isCalendarMode(),
     })),
   );
   const { userRefereeLevel, userRefereeLevelGradationValue } = useDemoStore(
@@ -401,6 +402,19 @@ export function ExchangePage() {
       </div>
     );
   };
+
+  // In calendar mode, show empty state since exchange features are not available
+  if (isCalendarMode) {
+    return (
+      <div className="space-y-3">
+        <EmptyState
+          icon="exchange"
+          title={t("exchange.unavailableInCalendarModeTitle")}
+          description={t("exchange.unavailableInCalendarModeDescription")}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
## Summary
- Hide features unavailable in Calendar Mode (read-only iCal view)
- Users see only assignments without mutation actions
- Clean UX with subtle banner indicating calendar mode

## Changes
- Hide swipe actions (validate, edit compensation, exchange) on assignments page when in calendar mode
- Hide Exchange and Compensations navigation items in calendar mode
- Show empty state with explanation on Exchange/Compensations pages if user navigates directly
- Add Calendar Mode banner in AppShell to indicate read-only state
- Add translations for all 4 languages (de, en, fr, it)
- Update test mocks to include isCalendarMode function

## Test Plan
- [ ] Verify swipe actions are hidden on assignments when in calendar mode
- [ ] Verify Exchange and Compensations nav items are hidden in calendar mode
- [ ] Verify calendar mode banner displays correctly
- [ ] Verify empty state shows on Exchange/Compensations pages if accessed directly
- [x] Run npm run lint (passes)
- [x] Run npm test (all 2649 tests pass)
- [x] Run npm run build (builds successfully)