### PR TITLE
feat(api): implement calendar API for iCal-based assignments

### DIFF
--- a/web-app/src/api/calendar-api.test.ts
+++ b/web-app/src/api/calendar-api.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  fetchCalendarAssignments,
+  validateCalendarCode,
+  InvalidCalendarCodeError,
+  CalendarNotFoundError,
+} from './calendar-api';
+
+// Mock fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Sample iCal content for testing
+const SAMPLE_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Volleyball.ch//Volleymanager//EN
+BEGIN:VEVENT
+UID:referee-convocation-for-game-100002
+SUMMARY:ARB 2 | Team C - Team D (NLA Herren)
+DTSTART:20250221T190000
+DTEND:20250221T220000
+LOCATION:Halle 2, Address 2
+GEO:47.5;7.6
+END:VEVENT
+BEGIN:VEVENT
+UID:referee-convocation-for-game-100001
+SUMMARY:ARB 1 | Team A - Team B (NLA Damen)
+DTSTART:20250220T180000
+DTEND:20250220T210000
+LOCATION:Halle 1, Address 1
+GEO:47.1234;8.5678
+END:VEVENT
+END:VCALENDAR`;
+
+// Sample empty calendar
+const EMPTY_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Volleyball.ch//Volleymanager//EN
+END:VCALENDAR`;
+
+// Low-confidence event (missing game ID pattern)
+const LOW_CONFIDENCE_ICAL = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:some-random-event-id
+SUMMARY:Random Event
+DTSTART:20250220T180000
+DTEND:20250220T210000
+END:VEVENT
+END:VCALENDAR`;
+
+function createMockResponse(
+  content: string,
+  options: { ok?: boolean; status?: number; statusText?: string } = {},
+) {
+  const { ok = true, status = 200, statusText = 'OK' } = options;
+  return {
+    ok,
+    status,
+    statusText,
+    text: () => Promise.resolve(content),
+  };
+}
+
+describe('fetchCalendarAssignments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('successful fetch', () => {
+    it('fetches and parses iCal content successfully', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(SAMPLE_ICAL));
+
+      const assignments = await fetchCalendarAssignments('ABC123');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/iCal/referee/ABC123'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(assignments).toHaveLength(2);
+    });
+
+    it('returns assignments sorted by start time (upcoming first)', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(SAMPLE_ICAL));
+
+      const assignments = await fetchCalendarAssignments('ABC123');
+
+      // First event should be 2025-02-20 (earlier)
+      expect(assignments[0]!.gameId).toBe('100001');
+      expect(assignments[0]!.startTime).toBe('2025-02-20T18:00:00');
+
+      // Second event should be 2025-02-21 (later)
+      expect(assignments[1]!.gameId).toBe('100002');
+      expect(assignments[1]!.startTime).toBe('2025-02-21T19:00:00');
+    });
+
+    it('extracts assignment details correctly', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(SAMPLE_ICAL));
+
+      const assignments = await fetchCalendarAssignments('XYZ789');
+
+      const assignment = assignments.find((a) => a.gameId === '100001');
+      expect(assignment).toBeDefined();
+      expect(assignment!.homeTeam).toBe('Team A');
+      expect(assignment!.awayTeam).toBe('Team B');
+      expect(assignment!.league).toBe('NLA Damen');
+      expect(assignment!.role).toBe('referee1');
+      expect(assignment!.gender).toBe('women');
+    });
+
+    it('returns empty array for empty calendar', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(EMPTY_ICAL));
+
+      const assignments = await fetchCalendarAssignments('EMPTY1');
+
+      expect(assignments).toEqual([]);
+    });
+
+    it('filters out low-confidence results', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(LOW_CONFIDENCE_ICAL));
+
+      const assignments = await fetchCalendarAssignments('LOW123');
+
+      // Low-confidence events should be filtered out
+      expect(assignments).toEqual([]);
+    });
+  });
+
+  describe('request configuration', () => {
+    it('does not include credentials (public endpoint)', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(SAMPLE_ICAL));
+
+      await fetchCalendarAssignments('ABC123');
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(options.credentials).toBeUndefined();
+    });
+
+    it('passes abort signal to fetch', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(SAMPLE_ICAL));
+      const controller = new AbortController();
+
+      await fetchCalendarAssignments('ABC123', controller.signal);
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(options.signal).toBe(controller.signal);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws InvalidCalendarCodeError for invalid code format', async () => {
+      await expect(fetchCalendarAssignments('ABC')).rejects.toThrow(
+        InvalidCalendarCodeError,
+      );
+      await expect(fetchCalendarAssignments('ABC12')).rejects.toThrow(
+        InvalidCalendarCodeError,
+      );
+      await expect(fetchCalendarAssignments('ABC1234')).rejects.toThrow(
+        InvalidCalendarCodeError,
+      );
+      await expect(fetchCalendarAssignments('ABC-12')).rejects.toThrow(
+        InvalidCalendarCodeError,
+      );
+      await expect(fetchCalendarAssignments('')).rejects.toThrow(
+        InvalidCalendarCodeError,
+      );
+
+      // Fetch should not be called for invalid codes
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws CalendarNotFoundError on 404 response', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse('', { ok: false, status: 404, statusText: 'Not Found' }),
+      );
+
+      await expect(fetchCalendarAssignments('ABC123')).rejects.toThrow(
+        CalendarNotFoundError,
+      );
+    });
+
+    it('throws Error on other HTTP errors', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse('', { ok: false, status: 500, statusText: 'Internal Server Error' }),
+      );
+
+      await expect(fetchCalendarAssignments('ABC123')).rejects.toThrow(
+        'Failed to fetch calendar: 500 Internal Server Error',
+      );
+    });
+
+    it('throws Error on network failure', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(fetchCalendarAssignments('ABC123')).rejects.toThrow(
+        'Network error',
+      );
+    });
+  });
+
+  describe('code format validation', () => {
+    it('accepts valid 6-character alphanumeric codes', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(EMPTY_ICAL));
+
+      // All letters
+      await expect(fetchCalendarAssignments('ABCDEF')).resolves.toEqual([]);
+
+      // All numbers
+      await expect(fetchCalendarAssignments('123456')).resolves.toEqual([]);
+
+      // Mixed case
+      await expect(fetchCalendarAssignments('AbC123')).resolves.toEqual([]);
+
+      // Lowercase
+      await expect(fetchCalendarAssignments('abcdef')).resolves.toEqual([]);
+    });
+  });
+});
+
+describe('validateCalendarCode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('valid codes', () => {
+    it('returns true when calendar exists', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(SAMPLE_ICAL));
+
+      const isValid = await validateCalendarCode('ABC123');
+
+      expect(isValid).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/iCal/referee/ABC123'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
+    it('returns true for empty calendar (valid code with no events)', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(EMPTY_ICAL));
+
+      const isValid = await validateCalendarCode('EMPTY1');
+
+      expect(isValid).toBe(true);
+    });
+
+    it('returns true even for malformed calendar content', async () => {
+      // If the server returns 200 with garbage, it means the code exists
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse('not valid ical content'),
+      );
+
+      const isValid = await validateCalendarCode('VALID1');
+
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe('invalid codes', () => {
+    it('returns false on 404 response', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse('', { ok: false, status: 404, statusText: 'Not Found' }),
+      );
+
+      const isValid = await validateCalendarCode('NOTFND');
+
+      expect(isValid).toBe(false);
+    });
+
+    it('returns false on other error responses', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse('', { ok: false, status: 500, statusText: 'Server Error' }),
+      );
+
+      const isValid = await validateCalendarCode('ERROR1');
+
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws InvalidCalendarCodeError for invalid code format', async () => {
+      await expect(validateCalendarCode('ABC')).rejects.toThrow(
+        InvalidCalendarCodeError,
+      );
+      await expect(validateCalendarCode('TOOLONG7')).rejects.toThrow(
+        InvalidCalendarCodeError,
+      );
+      await expect(validateCalendarCode('ABC-12')).rejects.toThrow(
+        InvalidCalendarCodeError,
+      );
+
+      // Fetch should not be called
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('re-throws network errors', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      await expect(validateCalendarCode('ABC123')).rejects.toThrow(
+        'Network error',
+      );
+    });
+
+    it('re-throws AbortError for cancelled requests', async () => {
+      const abortError = new DOMException('Aborted', 'AbortError');
+      mockFetch.mockRejectedValueOnce(abortError);
+
+      await expect(validateCalendarCode('ABC123')).rejects.toThrow(
+        'Aborted',
+      );
+    });
+
+    it('passes abort signal to fetch', async () => {
+      mockFetch.mockResolvedValueOnce(createMockResponse(SAMPLE_ICAL));
+      const controller = new AbortController();
+
+      await validateCalendarCode('ABC123', controller.signal);
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(options.signal).toBe(controller.signal);
+    });
+  });
+});
+
+describe('error classes', () => {
+  describe('InvalidCalendarCodeError', () => {
+    it('has correct name', () => {
+      const error = new InvalidCalendarCodeError('BAD');
+      expect(error.name).toBe('InvalidCalendarCodeError');
+    });
+
+    it('has descriptive message', () => {
+      const error = new InvalidCalendarCodeError('BAD');
+      expect(error.message).toContain('BAD');
+      expect(error.message).toContain('6 alphanumeric');
+    });
+
+    it('is an instance of Error', () => {
+      const error = new InvalidCalendarCodeError('BAD');
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('CalendarNotFoundError', () => {
+    it('has correct name', () => {
+      const error = new CalendarNotFoundError('ABC123');
+      expect(error.name).toBe('CalendarNotFoundError');
+    });
+
+    it('has descriptive message', () => {
+      const error = new CalendarNotFoundError('ABC123');
+      expect(error.message).toContain('ABC123');
+      expect(error.message).toContain('not found');
+    });
+
+    it('is an instance of Error', () => {
+      const error = new CalendarNotFoundError('ABC123');
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/web-app/src/api/calendar-api.ts
+++ b/web-app/src/api/calendar-api.ts
@@ -1,0 +1,192 @@
+/**
+ * Calendar API for fetching assignments from public iCal feeds.
+ *
+ * This module provides functions to fetch and parse calendar data from
+ * the volleymanager public iCal endpoint. It's used in Calendar Mode
+ * as an alternative to the authenticated API.
+ *
+ * ## iCal Endpoint
+ * The endpoint pattern is: `/iCal/referee/{code}`
+ * where `code` is a 6-character alphanumeric calendar code.
+ *
+ * ## Error Handling
+ * - 404: Calendar code not found (returns empty array or false)
+ * - Network errors: Throws an error that should be handled by the caller
+ */
+
+import { parseCalendarFeed, type CalendarAssignment, type ParseResult } from './ical';
+
+// Re-export types for consumers
+export type { CalendarAssignment, ParseResult } from './ical';
+
+/** Base URL for API requests - uses proxy URL if set */
+const API_BASE_URL = import.meta.env.VITE_API_PROXY_URL || '';
+
+/** Calendar codes are exactly 6 alphanumeric characters */
+const CALENDAR_CODE_PATTERN = /^[a-zA-Z0-9]{6}$/;
+
+/**
+ * Error thrown when the calendar code format is invalid.
+ */
+export class InvalidCalendarCodeError extends Error {
+  constructor(code: string) {
+    super(`Invalid calendar code format: "${code}". Must be 6 alphanumeric characters.`);
+    this.name = 'InvalidCalendarCodeError';
+  }
+}
+
+/**
+ * Error thrown when the calendar code is not found (404).
+ */
+export class CalendarNotFoundError extends Error {
+  constructor(code: string) {
+    super(`Calendar not found for code: "${code}"`);
+    this.name = 'CalendarNotFoundError';
+  }
+}
+
+/**
+ * Validates the format of a calendar code.
+ *
+ * @param code - The calendar code to validate
+ * @throws InvalidCalendarCodeError if the format is invalid
+ */
+function validateCodeFormat(code: string): void {
+  if (!CALENDAR_CODE_PATTERN.test(code)) {
+    throw new InvalidCalendarCodeError(code);
+  }
+}
+
+/**
+ * Fetches calendar assignments for a given referee calendar code.
+ *
+ * This function:
+ * 1. Fetches the iCal feed from the worker proxy
+ * 2. Parses the iCal content using the parser module
+ * 3. Converts to CalendarAssignment[] sorted by date (upcoming first)
+ *
+ * @param code - The 6-character calendar code
+ * @param signal - Optional AbortSignal for request cancellation
+ * @returns Array of calendar assignments sorted by start time (upcoming first)
+ * @throws InvalidCalendarCodeError if code format is invalid
+ * @throws CalendarNotFoundError if the calendar code is not found (404)
+ * @throws Error on network or other errors
+ *
+ * @example
+ * ```typescript
+ * const assignments = await fetchCalendarAssignments('ABC123');
+ * console.log(assignments[0].homeTeam); // "VBC Zürich"
+ * ```
+ */
+export async function fetchCalendarAssignments(
+  code: string,
+  signal?: AbortSignal,
+): Promise<CalendarAssignment[]> {
+  validateCodeFormat(code);
+
+  const url = `${API_BASE_URL}/iCal/referee/${code}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    signal,
+    // No credentials needed - public endpoint
+  });
+
+  if (response.status === 404) {
+    throw new CalendarNotFoundError(code);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch calendar: ${response.status} ${response.statusText}`);
+  }
+
+  const icsContent = await response.text();
+
+  // Parse the iCal content
+  const parseResults: ParseResult[] = parseCalendarFeed(icsContent);
+
+  // Extract assignments, excluding low-confidence results
+  const assignments: CalendarAssignment[] = parseResults
+    .filter((result) => result.confidence !== 'low')
+    .map((result) => result.assignment);
+
+  // Sort by start time (upcoming first)
+  return sortByStartTime(assignments);
+}
+
+/**
+ * Sorts calendar assignments by start time (ascending - upcoming first).
+ */
+function sortByStartTime(assignments: CalendarAssignment[]): CalendarAssignment[] {
+  return [...assignments].sort((a, b) => {
+    const timeA = new Date(a.startTime).getTime();
+    const timeB = new Date(b.startTime).getTime();
+    return timeA - timeB;
+  });
+}
+
+/**
+ * Validates a calendar code by attempting to fetch the calendar.
+ *
+ * This function is used during login to verify that a calendar code
+ * is valid before storing it.
+ *
+ * @param code - The 6-character calendar code to validate
+ * @param signal - Optional AbortSignal for request cancellation
+ * @returns true if the calendar exists (even if empty), false if not found (404)
+ * @throws InvalidCalendarCodeError if code format is invalid
+ * @throws Error on network errors (connection issues, timeouts, etc.)
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   const isValid = await validateCalendarCode('ABC123');
+ *   if (isValid) {
+ *     // Proceed with login
+ *   } else {
+ *     // Show "calendar not found" error
+ *   }
+ * } catch (error) {
+ *   // Network error - show connectivity message
+ * }
+ * ```
+ */
+export async function validateCalendarCode(
+  code: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  validateCodeFormat(code);
+
+  const url = `${API_BASE_URL}/iCal/referee/${code}`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      signal,
+    });
+
+    // 404 means the calendar code doesn't exist
+    if (response.status === 404) {
+      return false;
+    }
+
+    // Any successful response means the calendar exists
+    // (even if the content is empty or malformed)
+    if (response.ok) {
+      return true;
+    }
+
+    // Other error statuses - could be server errors, etc.
+    // Treat as invalid to be safe
+    return false;
+  } catch (error) {
+    // Re-throw AbortErrors (cancellation)
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error;
+    }
+
+    // Re-throw network errors - caller should handle these differently
+    // from "not found" cases (e.g., show "check your connection" message)
+    throw error;
+  }
+}

--- a/web-app/src/api/queryKeys.ts
+++ b/web-app/src/api/queryKeys.ts
@@ -200,4 +200,21 @@ export const queryKeys = {
         dayType,
       ] as const,
   },
+
+  /**
+   * Calendar mode query keys for iCal-based assignment fetching.
+   * Used when in calendar mode instead of authenticated API mode.
+   */
+  calendar: {
+    /** Base key - invalidates ALL calendar queries */
+    all: ["calendar"] as const,
+    /** Parent key for calendar assignment queries */
+    assignments: () => [...queryKeys.calendar.all, "assignments"] as const,
+    /**
+     * Calendar assignments for a specific calendar code.
+     * @param code - The 6-character calendar code
+     */
+    assignmentsByCode: (code: string) =>
+      [...queryKeys.calendar.assignments(), code] as const,
+  },
 } as const;

--- a/web-app/src/hooks/useAssignments.test.tsx
+++ b/web-app/src/hooks/useAssignments.test.tsx
@@ -8,6 +8,7 @@ import {
   usePastAssignments,
   useValidationClosedAssignments,
   useAssignmentDetails,
+  useCalendarAssignments,
   getDateRangeForPeriod,
 } from "./useAssignments";
 import type { Assignment } from "@/api/client";
@@ -490,5 +491,50 @@ describe("useAssignmentDetails", () => {
     });
 
     expect(result.current.isPending).toBe(true);
+  });
+});
+
+describe("useCalendarAssignments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is disabled when not in calendar mode", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({
+        dataSource: "api",
+        calendarCode: null,
+      }),
+    );
+
+    const { result } = renderHook(() => useCalendarAssignments(), {
+      wrapper: createWrapper(),
+    });
+
+    // Query should be disabled when not in calendar mode
+    // fetchStatus is 'idle' when query is disabled
+    expect(result.current.fetchStatus).toBe("idle");
+    // Returns empty placeholder data when disabled
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("is disabled when calendar code is missing", async () => {
+    const { useAuthStore } = await import("@/stores/auth");
+    vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
+      selector({
+        dataSource: "calendar",
+        calendarCode: null,
+      }),
+    );
+
+    const { result } = renderHook(() => useCalendarAssignments(), {
+      wrapper: createWrapper(),
+    });
+
+    // Query should be disabled when no calendar code
+    expect(result.current.fetchStatus).toBe("idle");
+    // Returns empty placeholder data when disabled
+    expect(result.current.data).toEqual([]);
   });
 });

--- a/web-app/src/hooks/useAssignments.ts
+++ b/web-app/src/hooks/useAssignments.ts
@@ -31,6 +31,10 @@ import {
   getGameTimestamp,
 } from "./usePaginatedQuery";
 
+// Re-export calendar assignments hook for calendar mode
+export { useCalendarAssignments } from "./useCalendarAssignments";
+export type { CalendarAssignment } from "./useCalendarAssignments";
+
 // Stable empty array for React Query selectors to prevent unnecessary re-renders.
 // Using `|| []` creates a new array reference on each render, while this constant
 // provides referential stability when data.items is nullish.

--- a/web-app/src/hooks/useCalendarAssignments.ts
+++ b/web-app/src/hooks/useCalendarAssignments.ts
@@ -1,0 +1,66 @@
+/**
+ * Hook for fetching calendar assignments in Calendar Mode.
+ *
+ * This hook provides a TanStack Query-based interface for fetching
+ * assignments from the iCal calendar feed when in calendar mode.
+ */
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useAuthStore } from "@/stores/auth";
+import { queryKeys } from "@/api/queryKeys";
+import { fetchCalendarAssignments, type CalendarAssignment } from "@/api/calendar-api";
+
+// Stable empty array to prevent unnecessary re-renders
+const EMPTY_ASSIGNMENTS: CalendarAssignment[] = [];
+
+/**
+ * Fetches assignments from the calendar iCal feed.
+ *
+ * This hook is only enabled when in calendar mode and a valid
+ * calendar code is stored. The assignments are automatically
+ * sorted by start time (upcoming first).
+ *
+ * @returns Query result with calendar assignments
+ *
+ * @example
+ * ```tsx
+ * function CalendarAssignmentsPage() {
+ *   const { data: assignments, isLoading, error } = useCalendarAssignments();
+ *
+ *   if (isLoading) return <Loading />;
+ *   if (error) return <Error message={error.message} />;
+ *
+ *   return (
+ *     <ul>
+ *       {assignments.map(a => (
+ *         <li key={a.gameId}>{a.homeTeam} vs {a.awayTeam}</li>
+ *       ))}
+ *     </ul>
+ *   );
+ * }
+ * ```
+ */
+export function useCalendarAssignments(): UseQueryResult<CalendarAssignment[], Error> {
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const calendarCode = useAuthStore((state) => state.calendarCode);
+  const isCalendarMode = dataSource === "calendar";
+
+  return useQuery({
+    queryKey: queryKeys.calendar.assignmentsByCode(calendarCode ?? ""),
+    queryFn: ({ signal }) => {
+      if (!calendarCode) {
+        return Promise.resolve(EMPTY_ASSIGNMENTS);
+      }
+      return fetchCalendarAssignments(calendarCode, signal);
+    },
+    // Only fetch when in calendar mode with a valid code
+    enabled: isCalendarMode && !!calendarCode,
+    // Cache for 5 minutes - calendar data updates infrequently
+    staleTime: 5 * 60 * 1000,
+    // Use empty array as placeholder to avoid undefined data
+    placeholderData: EMPTY_ASSIGNMENTS,
+  });
+}
+
+// Re-export types for convenience
+export type { CalendarAssignment } from "@/api/calendar-api";

--- a/web-app/src/hooks/useCalendarAssignments.ts
+++ b/web-app/src/hooks/useCalendarAssignments.ts
@@ -13,6 +13,9 @@ import { fetchCalendarAssignments, type CalendarAssignment } from "@/api/calenda
 // Stable empty array to prevent unnecessary re-renders
 const EMPTY_ASSIGNMENTS: CalendarAssignment[] = [];
 
+/** Cache duration for calendar assignments (5 minutes). Calendar data updates infrequently. */
+const CALENDAR_STALE_TIME_MS = 5 * 60 * 1000;
+
 /**
  * Fetches assignments from the calendar iCal feed.
  *
@@ -55,8 +58,7 @@ export function useCalendarAssignments(): UseQueryResult<CalendarAssignment[], E
     },
     // Only fetch when in calendar mode with a valid code
     enabled: isCalendarMode && !!calendarCode,
-    // Cache for 5 minutes - calendar data updates infrequently
-    staleTime: 5 * 60 * 1000,
+    staleTime: CALENDAR_STALE_TIME_MS,
     // Use empty array as placeholder to avoid undefined data
     placeholderData: EMPTY_ASSIGNMENTS,
   });

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -4,7 +4,6 @@ import { setCsrfToken, clearSession } from "@/api/client";
 import {
   validateCalendarCode,
   InvalidCalendarCodeError,
-  CalendarNotFoundError,
 } from "@/api/calendar-api";
 import {
   filterRefereeOccupations,
@@ -602,11 +601,6 @@ export const useAuthStore = create<AuthState>()(
           // Handle specific error types
           if (error instanceof InvalidCalendarCodeError) {
             set({ status: "error", error: "auth.invalidCalendarCode" });
-            return;
-          }
-
-          if (error instanceof CalendarNotFoundError) {
-            set({ status: "error", error: "auth.calendarNotFound" });
             return;
           }
 


### PR DESCRIPTION
## Summary

- Implement `fetchCalendarAssignments()` to fetch and parse iCal content from `/iCal/referee/{code}`
- Implement `validateCalendarCode()` to verify calendar codes exist before login
- Update `loginWithCalendar()` in auth store to validate codes with loading state
- Add `useCalendarAssignments` hook for React Query integration in calendar mode
- Add calendar query keys for cache management

## Implementation Details

### Calendar API (`src/api/calendar-api.ts`)
- `fetchCalendarAssignments(code, signal?)`: Fetches iCal feed, parses with existing parser, filters low-confidence results, returns sorted assignments (upcoming first)
- `validateCalendarCode(code, signal?)`: Returns `true` if calendar exists, `false` on 404, throws on network errors
- Custom error classes: `InvalidCalendarCodeError`, `CalendarNotFoundError`

### Auth Store Changes
- `loginWithCalendar()` now shows loading state while validating
- Validates calendar code exists before setting authenticated state
- Shows `auth.calendarNotFound` error for invalid codes

### Hook (`src/hooks/useCalendarAssignments.ts`)
- TanStack Query hook enabled only in calendar mode
- 5-minute stale time for cache management

## Test plan

- [x] All 27 new calendar API tests pass
- [x] All existing auth store tests updated and passing
- [x] Full test suite passes (2678 tests)
- [x] Lint passes with 0 warnings
- [x] Build succeeds
