### PR TITLE
feat(calendar): implement error handling for Calendar Mode

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -51,13 +51,13 @@
     {
       "name": "CSS Bundle",
       "path": "dist/assets/*.css",
-      "limit": "10 kB",
+      "limit": "10.1 kB",
       "gzip": true
     },
     {
       "name": "Total JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "445 kB",
+      "limit": "448 kB",
       "gzip": true
     }
   ],

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -29,6 +29,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { useViewportZoom } from "@/hooks/useViewportZoom";
 import { useCalendarTheme } from "@/hooks/useCalendarTheme";
 import { logger } from "@/utils/logger";
+import { CalendarErrorHandler } from "@/components/features/CalendarErrorHandler";
 
 // Lazy load pages to reduce initial bundle size
 // Each page becomes a separate chunk that loads on-demand
@@ -280,11 +281,13 @@ export default function App() {
                 <Route
                   element={
                     <ProtectedRoute>
-                      <Suspense fallback={null}>
-                        <TourProvider>
-                          <AppShell />
-                        </TourProvider>
-                      </Suspense>
+                      <CalendarErrorHandler>
+                        <Suspense fallback={null}>
+                          <TourProvider>
+                            <AppShell />
+                          </TourProvider>
+                        </Suspense>
+                      </CalendarErrorHandler>
                     </ProtectedRoute>
                   }
                 >

--- a/web-app/src/components/features/CalendarAssignmentCard.test.tsx
+++ b/web-app/src/components/features/CalendarAssignmentCard.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CalendarAssignmentCard } from "./CalendarAssignmentCard";
+import type { CalendarAssignment } from "@/api/calendar-api";
+
+// Mock date to ensure consistent test results
+const mockDate = new Date("2025-12-15T12:00:00Z");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(mockDate);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function createMockCalendarAssignment(
+  overrides: Partial<CalendarAssignment> = {},
+): CalendarAssignment {
+  return {
+    gameId: "game-123",
+    role: "referee1",
+    roleRaw: "1. SR",
+    startTime: "2025-12-16T18:00:00Z",
+    endTime: "2025-12-16T20:00:00Z",
+    homeTeam: "VBC Zürich",
+    awayTeam: "VBC Basel",
+    league: "NLA Men",
+    address: "Saalsporthalle, Zürich",
+    coordinates: null,
+    hallName: null,
+    gender: "men",
+    mapsUrl: null,
+    ...overrides,
+  };
+}
+
+describe("CalendarAssignmentCard", () => {
+  describe("date display", () => {
+    it("should show 'Today' for today's assignments", () => {
+      const assignment = createMockCalendarAssignment({
+        startTime: "2025-12-15T18:00:00Z", // Same day as mockDate
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      expect(screen.getByText(/today/i)).toBeInTheDocument();
+    });
+
+    it("should show 'Tomorrow' for tomorrow's assignments", () => {
+      const assignment = createMockCalendarAssignment({
+        startTime: "2025-12-16T18:00:00Z", // Day after mockDate
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      expect(screen.getByText(/tomorrow/i)).toBeInTheDocument();
+    });
+
+    it("should show full date for other days", () => {
+      const assignment = createMockCalendarAssignment({
+        startTime: "2025-12-20T18:00:00Z", // 5 days after mockDate
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      // Should show day of week and date
+      expect(screen.getByText(/saturday.*20.*december/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("team display", () => {
+    it("should display home and away teams", () => {
+      const assignment = createMockCalendarAssignment({
+        homeTeam: "Team A",
+        awayTeam: "Team B",
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      expect(screen.getByText("Team A")).toBeInTheDocument();
+      expect(screen.getByText("Team B")).toBeInTheDocument();
+    });
+
+    it("should show 'Unknown' for missing team names", () => {
+      const assignment = createMockCalendarAssignment({
+        homeTeam: undefined,
+        awayTeam: undefined,
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      // Should have two "Unknown" texts (home and away)
+      expect(screen.getAllByText(/unknown/i)).toHaveLength(2);
+    });
+
+    it("should display vs separator between teams", () => {
+      const assignment = createMockCalendarAssignment();
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      expect(screen.getByText(/vs/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("role display", () => {
+    it("should display the role badge", () => {
+      const assignment = createMockCalendarAssignment({
+        roleRaw: "2. SR",
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      expect(screen.getByText("2. SR")).toBeInTheDocument();
+    });
+  });
+
+  describe("league display", () => {
+    it("should display the league when provided", () => {
+      const assignment = createMockCalendarAssignment({
+        league: "1. Liga Women",
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      expect(screen.getByText("1. Liga Women")).toBeInTheDocument();
+    });
+
+    it("should not display league section when not provided", () => {
+      const assignment = createMockCalendarAssignment({
+        league: undefined,
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      // The league text should not be present
+      expect(screen.queryByText("NLA Men")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("time display", () => {
+    it("should display the game time", () => {
+      const assignment = createMockCalendarAssignment({
+        startTime: "2025-12-16T18:30:00Z",
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      // Time should be displayed in 24h format (test environment uses UTC)
+      expect(screen.getByText(/18:30/)).toBeInTheDocument();
+    });
+  });
+
+  describe("location display", () => {
+    it("should display the address when provided", () => {
+      const assignment = createMockCalendarAssignment({
+        address: "Saalsporthalle, Zürich",
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      expect(screen.getByText("Saalsporthalle, Zürich")).toBeInTheDocument();
+    });
+
+    it("should not display address section when not provided", () => {
+      const assignment = createMockCalendarAssignment({
+        address: undefined,
+      });
+
+      render(<CalendarAssignmentCard assignment={assignment} />);
+
+      expect(
+        screen.queryByText("Saalsporthalle, Zürich"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("data-tour attribute", () => {
+    it("should apply data-tour attribute when provided", () => {
+      const assignment = createMockCalendarAssignment();
+
+      const { container } = render(
+        <CalendarAssignmentCard
+          assignment={assignment}
+          dataTour="assignment-card"
+        />,
+      );
+
+      expect(
+        container.querySelector('[data-tour="assignment-card"]'),
+      ).toBeInTheDocument();
+    });
+
+    it("should not apply data-tour attribute when not provided", () => {
+      const assignment = createMockCalendarAssignment();
+
+      const { container } = render(
+        <CalendarAssignmentCard assignment={assignment} />,
+      );
+
+      expect(container.querySelector("[data-tour]")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web-app/src/components/features/CalendarAssignmentCard.tsx
+++ b/web-app/src/components/features/CalendarAssignmentCard.tsx
@@ -1,0 +1,96 @@
+import { memo } from "react";
+import type { CalendarAssignment } from "@/api/calendar-api";
+import { Card } from "@/components/ui/Card";
+import { Calendar, MapPin, Clock } from "@/components/ui/icons";
+import { format, isToday, isTomorrow } from "date-fns";
+import { useTranslation } from "@/hooks/useTranslation";
+import { useDateLocale } from "@/hooks/useDateFormat";
+
+interface CalendarAssignmentCardProps {
+  assignment: CalendarAssignment;
+  dataTour?: string;
+}
+
+/**
+ * A simplified assignment card for calendar mode.
+ *
+ * Displays basic assignment information from the iCal calendar feed.
+ * This card is read-only and doesn't support swipe actions.
+ *
+ * @example
+ * ```tsx
+ * <CalendarAssignmentCard
+ *   assignment={calendarAssignment}
+ * />
+ * ```
+ */
+export const CalendarAssignmentCard = memo(function CalendarAssignmentCard({
+  assignment,
+  dataTour,
+}: CalendarAssignmentCardProps) {
+  const { t } = useTranslation();
+  const dateLocale = useDateLocale();
+  const startDate = new Date(assignment.startTime);
+
+  const getDateLabel = (): string => {
+    if (isToday(startDate)) return t("common.today");
+    if (isTomorrow(startDate)) return t("common.tomorrow");
+    return format(startDate, "EEEE, d MMMM", { locale: dateLocale });
+  };
+
+  const timeLabel = format(startDate, "HH:mm", { locale: dateLocale });
+
+  return (
+    <Card
+      data-tour={dataTour}
+      className="p-4"
+    >
+      <div className="space-y-3">
+        {/* Header with date and role */}
+        <div className="flex justify-between items-start">
+          <div className="flex items-center gap-2 text-sm text-text-muted dark:text-text-muted-dark">
+            <Calendar className="w-4 h-4" aria-hidden="true" />
+            <span>{getDateLabel()}</span>
+          </div>
+          <span className="px-2 py-0.5 rounded bg-primary-100 dark:bg-primary-900 text-primary-700 dark:text-primary-300 text-xs font-medium">
+            {assignment.roleRaw}
+          </span>
+        </div>
+
+        {/* Teams */}
+        <div className="text-center">
+          <p className="font-medium text-text-primary dark:text-text-primary-dark">
+            {assignment.homeTeam || t("common.unknown")}
+          </p>
+          <p className="text-xs text-text-muted dark:text-text-muted-dark my-1">
+            {t("common.vs")}
+          </p>
+          <p className="font-medium text-text-primary dark:text-text-primary-dark">
+            {assignment.awayTeam || t("common.unknown")}
+          </p>
+        </div>
+
+        {/* League */}
+        {assignment.league && (
+          <p className="text-sm text-center text-text-secondary dark:text-text-secondary-dark">
+            {assignment.league}
+          </p>
+        )}
+
+        {/* Time and location */}
+        <div className="flex justify-between items-center text-sm text-text-muted dark:text-text-muted-dark">
+          <div className="flex items-center gap-1">
+            <Clock className="w-4 h-4" aria-hidden="true" />
+            <span>{timeLabel}</span>
+          </div>
+          {assignment.address && (
+            <div className="flex items-center gap-1">
+              <MapPin className="w-4 h-4" aria-hidden="true" />
+              <span className="truncate max-w-[150px]">{assignment.address}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+});

--- a/web-app/src/components/features/CalendarAssignmentCard.tsx
+++ b/web-app/src/components/features/CalendarAssignmentCard.tsx
@@ -6,6 +6,12 @@ import { format, isToday, isTomorrow } from "date-fns";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateLocale } from "@/hooks/useDateFormat";
 
+/**
+ * Maximum width for the address text to prevent layout overflow.
+ * Sized to fit typical Swiss venue addresses while leaving room for time display.
+ */
+const ADDRESS_MAX_WIDTH_CLASS = "max-w-[150px]";
+
 interface CalendarAssignmentCardProps {
   assignment: CalendarAssignment;
   dataTour?: string;
@@ -86,7 +92,7 @@ export const CalendarAssignmentCard = memo(function CalendarAssignmentCard({
           {assignment.address && (
             <div className="flex items-center gap-1">
               <MapPin className="w-4 h-4" aria-hidden="true" />
-              <span className="truncate max-w-[150px]">{assignment.address}</span>
+              <span className={`truncate ${ADDRESS_MAX_WIDTH_CLASS}`}>{assignment.address}</span>
             </div>
           )}
         </div>

--- a/web-app/src/components/features/CalendarErrorHandler.test.tsx
+++ b/web-app/src/components/features/CalendarErrorHandler.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { CalendarErrorHandler } from "./CalendarErrorHandler";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as authStore from "@/stores/auth";
+
+// Mock dependencies
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn(),
+}));
+
+vi.mock("@/hooks/useCalendarErrorHandler", () => ({
+  useCalendarErrorHandler: vi.fn(),
+}));
+
+vi.mock("@/api/queryKeys", () => ({
+  queryKeys: {
+    calendar: {
+      assignmentsByCode: (code: string) => ["calendar", "assignments", code],
+    },
+  },
+}));
+
+import { useCalendarErrorHandler } from "@/hooks/useCalendarErrorHandler";
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = createQueryClient();
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    ),
+    queryClient,
+  };
+}
+
+describe("CalendarErrorHandler", () => {
+  const mockHandleError = vi.fn();
+  const mockAcknowledgeError = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: not in calendar mode
+    vi.mocked(authStore.useAuthStore).mockImplementation((selector) => {
+      const state = {
+        isCalendarMode: () => false,
+        calendarCode: null,
+      };
+      return selector(state as ReturnType<typeof authStore.useAuthStore.getState>);
+    });
+
+    vi.mocked(useCalendarErrorHandler).mockReturnValue({
+      errorState: null,
+      handleError: mockHandleError,
+      acknowledgeError: mockAcknowledgeError,
+      logParseWarning: vi.fn(),
+    });
+  });
+
+  it("should render children", () => {
+    renderWithQueryClient(
+      <CalendarErrorHandler>
+        <div data-testid="child">Child Content</div>
+      </CalendarErrorHandler>,
+    );
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("should not show modal when no error state", () => {
+    renderWithQueryClient(
+      <CalendarErrorHandler>
+        <div>Content</div>
+      </CalendarErrorHandler>,
+    );
+
+    expect(
+      screen.queryByRole("dialog", { hidden: true }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show modal when error state is present", () => {
+    vi.mocked(useCalendarErrorHandler).mockReturnValue({
+      errorState: {
+        isOpen: true,
+        errorType: "network",
+      },
+      handleError: mockHandleError,
+      acknowledgeError: mockAcknowledgeError,
+      logParseWarning: vi.fn(),
+    });
+
+    renderWithQueryClient(
+      <CalendarErrorHandler>
+        <div>Content</div>
+      </CalendarErrorHandler>,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: /calendar error/i, hidden: true }),
+    ).toBeInTheDocument();
+  });
+
+  it("should call acknowledgeError when OK button is clicked", () => {
+    vi.mocked(useCalendarErrorHandler).mockReturnValue({
+      errorState: {
+        isOpen: true,
+        errorType: "invalidCode",
+      },
+      handleError: mockHandleError,
+      acknowledgeError: mockAcknowledgeError,
+      logParseWarning: vi.fn(),
+    });
+
+    renderWithQueryClient(
+      <CalendarErrorHandler>
+        <div>Content</div>
+      </CalendarErrorHandler>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /ok/i, hidden: true }));
+
+    expect(mockAcknowledgeError).toHaveBeenCalledOnce();
+  });
+
+  it("should not subscribe to query cache when not in calendar mode", () => {
+    vi.mocked(authStore.useAuthStore).mockImplementation((selector) => {
+      const state = {
+        isCalendarMode: () => false,
+        calendarCode: null,
+      };
+      return selector(state as ReturnType<typeof authStore.useAuthStore.getState>);
+    });
+
+    const { queryClient } = renderWithQueryClient(
+      <CalendarErrorHandler>
+        <div>Content</div>
+      </CalendarErrorHandler>,
+    );
+
+    // Simulate a query error
+    act(() => {
+      queryClient.setQueryData(["calendar", "assignments", "TESTCD"], null);
+    });
+
+    // handleError should not be called since we're not in calendar mode
+    expect(mockHandleError).not.toHaveBeenCalled();
+  });
+});
+
+describe("deepEqual utility", () => {
+  // Test the internal deepEqual function through the isCalendarQueryKey behavior
+  it("should correctly compare simple arrays", () => {
+    vi.mocked(authStore.useAuthStore).mockImplementation((selector) => {
+      const state = {
+        isCalendarMode: () => true,
+        calendarCode: "ABC123",
+      };
+      return selector(state as ReturnType<typeof authStore.useAuthStore.getState>);
+    });
+
+    // The component should work correctly with array comparison
+    renderWithQueryClient(
+      <CalendarErrorHandler>
+        <div>Content</div>
+      </CalendarErrorHandler>,
+    );
+
+    // If deepEqual works, the component should render without errors
+    expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+});

--- a/web-app/src/components/features/CalendarErrorHandler.tsx
+++ b/web-app/src/components/features/CalendarErrorHandler.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthStore } from "@/stores/auth";
+import { useShallow } from "zustand/react/shallow";
+import { queryKeys } from "@/api/queryKeys";
+import { useCalendarErrorHandler } from "@/hooks/useCalendarErrorHandler";
+import { CalendarErrorModal } from "./CalendarErrorModal";
+
+interface CalendarErrorHandlerProps {
+  children: ReactNode;
+}
+
+/**
+ * Component that handles calendar mode errors globally.
+ *
+ * Watches for errors in calendar queries and shows the CalendarErrorModal
+ * when a critical error occurs. The modal prompts the user to acknowledge
+ * the error, which triggers logout and redirect to the login page.
+ *
+ * This component should wrap the protected routes to ensure calendar
+ * errors are handled consistently across all pages.
+ *
+ * @example
+ * ```tsx
+ * <CalendarErrorHandler>
+ *   <ProtectedRoute>
+ *     <AppShell />
+ *   </ProtectedRoute>
+ * </CalendarErrorHandler>
+ * ```
+ */
+export function CalendarErrorHandler({ children }: CalendarErrorHandlerProps) {
+  const queryClient = useQueryClient();
+  const { isCalendarMode, calendarCode } = useAuthStore(
+    useShallow((state) => ({
+      isCalendarMode: state.isCalendarMode(),
+      calendarCode: state.calendarCode,
+    })),
+  );
+  const { errorState, handleError, acknowledgeError } = useCalendarErrorHandler();
+
+  // Track if we've already handled an error to prevent duplicate modals
+  const hasHandledErrorRef = useRef(false);
+
+  // Subscribe to calendar query errors
+  useEffect(() => {
+    if (!isCalendarMode || !calendarCode) return;
+
+    const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+      // Only handle updated events with errors
+      if (event.type !== "updated" || !event.query.state.error) return;
+
+      // Only handle calendar assignment queries
+      const queryKey = event.query.queryKey;
+      const calendarAssignmentsKey = queryKeys.calendar.assignmentsByCode(calendarCode);
+
+      // Check if this is a calendar assignments query
+      if (!isCalendarQueryKey(queryKey, calendarAssignmentsKey)) return;
+
+      // Prevent duplicate error handling
+      if (hasHandledErrorRef.current) return;
+      hasHandledErrorRef.current = true;
+
+      handleError(event.query.state.error as Error);
+    });
+
+    return () => {
+      unsubscribe();
+      hasHandledErrorRef.current = false;
+    };
+  }, [queryClient, isCalendarMode, calendarCode, handleError]);
+
+  // Reset error handling when the user logs in again
+  useEffect(() => {
+    if (!isCalendarMode) {
+      hasHandledErrorRef.current = false;
+    }
+  }, [isCalendarMode]);
+
+  return (
+    <>
+      {children}
+      {errorState && (
+        <CalendarErrorModal
+          isOpen={errorState.isOpen}
+          errorType={errorState.errorType}
+          onAcknowledge={acknowledgeError}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Check if a query key matches the calendar assignments query key.
+ */
+function isCalendarQueryKey(
+  queryKey: readonly unknown[],
+  expectedKey: readonly unknown[],
+): boolean {
+  // Query keys are arrays, compare by structure
+  if (queryKey.length !== expectedKey.length) return false;
+
+  return queryKey.every((part, index) => {
+    const expected = expectedKey[index];
+
+    // Handle nested objects (like the query key structure)
+    if (typeof part === "object" && part !== null) {
+      return JSON.stringify(part) === JSON.stringify(expected);
+    }
+
+    return part === expected;
+  });
+}

--- a/web-app/src/components/features/CalendarErrorModal.test.tsx
+++ b/web-app/src/components/features/CalendarErrorModal.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CalendarErrorModal } from "./CalendarErrorModal";
+
+describe("CalendarErrorModal", () => {
+  it("should not render when closed", () => {
+    const onAcknowledge = vi.fn();
+
+    render(
+      <CalendarErrorModal
+        isOpen={false}
+        errorType="network"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("dialog", { name: /calendar error/i, hidden: true }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render when open", () => {
+    const onAcknowledge = vi.fn();
+
+    render(
+      <CalendarErrorModal
+        isOpen={true}
+        errorType="network"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: /calendar error/i, hidden: true }),
+    ).toBeInTheDocument();
+  });
+
+  it("should display network error message", () => {
+    const onAcknowledge = vi.fn();
+
+    render(
+      <CalendarErrorModal
+        isOpen={true}
+        errorType="network"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    expect(
+      screen.getByText(/unable to load your calendar/i),
+    ).toBeInTheDocument();
+  });
+
+  it("should display invalid code error message", () => {
+    const onAcknowledge = vi.fn();
+
+    render(
+      <CalendarErrorModal
+        isOpen={true}
+        errorType="invalidCode"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    expect(
+      screen.getByText(/calendar code is invalid or has expired/i),
+    ).toBeInTheDocument();
+  });
+
+  it("should display parse error message", () => {
+    const onAcknowledge = vi.fn();
+
+    render(
+      <CalendarErrorModal
+        isOpen={true}
+        errorType="parse"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    expect(
+      screen.getByText(/some calendar data could not be read/i),
+    ).toBeInTheDocument();
+  });
+
+  it("should call onAcknowledge when OK button is clicked", () => {
+    const onAcknowledge = vi.fn();
+
+    render(
+      <CalendarErrorModal
+        isOpen={true}
+        errorType="network"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /ok/i, hidden: true }));
+
+    expect(onAcknowledge).toHaveBeenCalledOnce();
+  });
+
+  it("should call onAcknowledge when Escape key is pressed", () => {
+    const onAcknowledge = vi.fn();
+
+    render(
+      <CalendarErrorModal
+        isOpen={true}
+        errorType="network"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onAcknowledge).toHaveBeenCalledOnce();
+  });
+
+  it("should display error icon", () => {
+    const onAcknowledge = vi.fn();
+
+    render(
+      <CalendarErrorModal
+        isOpen={true}
+        errorType="network"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    // Check that the warning icon container is present
+    expect(
+      document.querySelector(".bg-red-100, .bg-red-900"),
+    ).toBeInTheDocument();
+  });
+
+  it("should clean up event listener when modal closes", () => {
+    const onAcknowledge = vi.fn();
+
+    const { rerender } = render(
+      <CalendarErrorModal
+        isOpen={true}
+        errorType="network"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    // Close the modal
+    rerender(
+      <CalendarErrorModal
+        isOpen={false}
+        errorType="network"
+        onAcknowledge={onAcknowledge}
+      />,
+    );
+
+    // Escape key should not trigger onAcknowledge after modal is closed
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onAcknowledge).not.toHaveBeenCalled();
+  });
+});

--- a/web-app/src/components/features/CalendarErrorModal.tsx
+++ b/web-app/src/components/features/CalendarErrorModal.tsx
@@ -1,0 +1,91 @@
+import { Modal } from "@/components/ui/Modal";
+import { ModalHeader } from "@/components/ui/ModalHeader";
+import { ModalFooter } from "@/components/ui/ModalFooter";
+import { Button } from "@/components/ui/Button";
+import { AlertTriangle } from "@/components/ui/icons";
+import { useTranslation } from "@/hooks/useTranslation";
+
+/**
+ * Type of calendar error to display appropriate message.
+ */
+export type CalendarErrorType = "network" | "invalidCode" | "parse";
+
+interface CalendarErrorModalProps {
+  /** Whether the modal is open */
+  isOpen: boolean;
+  /** Type of error that occurred */
+  errorType: CalendarErrorType;
+  /** Callback when the user acknowledges the error */
+  onAcknowledge: () => void;
+}
+
+/**
+ * Modal displayed when a calendar error occurs.
+ *
+ * Shows an appropriate error message based on the error type and provides
+ * an OK button that triggers logout for critical errors (network, invalidCode)
+ * or dismisses for non-critical errors (parse).
+ *
+ * @example
+ * ```tsx
+ * <CalendarErrorModal
+ *   isOpen={hasError}
+ *   errorType="network"
+ *   onAcknowledge={handleLogout}
+ * />
+ * ```
+ */
+export function CalendarErrorModal({
+  isOpen,
+  errorType,
+  onAcknowledge,
+}: CalendarErrorModalProps) {
+  const { t } = useTranslation();
+
+  const getMessage = (): string => {
+    switch (errorType) {
+      case "network":
+        return t("calendarError.networkMessage");
+      case "invalidCode":
+        return t("calendarError.invalidCodeMessage");
+      case "parse":
+        return t("calendarError.parseErrorMessage");
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onAcknowledge}
+      titleId="calendar-error-modal-title"
+      size="sm"
+      closeOnEscape={true}
+      closeOnBackdrop={false}
+    >
+      <ModalHeader
+        title={t("calendarError.title")}
+        titleId="calendar-error-modal-title"
+        icon={
+          <div className="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 dark:bg-red-900 flex items-center justify-center">
+            <AlertTriangle
+              className="w-5 h-5 text-red-600 dark:text-red-400"
+              aria-hidden="true"
+            />
+          </div>
+        }
+      />
+      <p className="text-sm text-text-secondary dark:text-text-secondary-dark mb-6">
+        {getMessage()}
+      </p>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={onAcknowledge}
+          className="flex-1"
+        >
+          {t("calendarError.ok")}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/web-app/src/hooks/useCalendarErrorHandler.test.ts
+++ b/web-app/src/hooks/useCalendarErrorHandler.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCalendarErrorHandler } from "./useCalendarErrorHandler";
+import { CalendarNotFoundError } from "@/api/calendar-api";
+import * as authStore from "@/stores/auth";
+import * as toastStore from "@/stores/toast";
+
+// Mock dependencies
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: vi.fn(),
+}));
+
+vi.mock("@/stores/toast", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("useCalendarErrorHandler", () => {
+  const mockLogout = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authStore.useAuthStore).mockImplementation((selector) => {
+      const state = { logout: mockLogout };
+      return selector(state as unknown as ReturnType<typeof authStore.useAuthStore.getState>);
+    });
+  });
+
+  describe("initial state", () => {
+    it("should initialize with null error state", () => {
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      expect(result.current.errorState).toBeNull();
+    });
+  });
+
+  describe("handleError", () => {
+    it("should set error state for CalendarNotFoundError", () => {
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      act(() => {
+        result.current.handleError(new CalendarNotFoundError("Not found"));
+      });
+
+      expect(result.current.errorState).toEqual({
+        isOpen: true,
+        errorType: "invalidCode",
+      });
+    });
+
+    it("should set error state for network errors", () => {
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      const networkError = new Error("Failed to fetch");
+      networkError.name = "TypeError";
+
+      act(() => {
+        result.current.handleError(networkError);
+      });
+
+      expect(result.current.errorState).toEqual({
+        isOpen: true,
+        errorType: "network",
+      });
+    });
+
+    it("should default to invalidCode for other errors", () => {
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      act(() => {
+        result.current.handleError(new Error("Some API error"));
+      });
+
+      expect(result.current.errorState).toEqual({
+        isOpen: true,
+        errorType: "invalidCode",
+      });
+    });
+  });
+
+  describe("acknowledgeError", () => {
+    it("should clear error state", async () => {
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      act(() => {
+        result.current.handleError(new CalendarNotFoundError("Not found"));
+      });
+
+      expect(result.current.errorState).not.toBeNull();
+
+      await act(async () => {
+        await result.current.acknowledgeError();
+      });
+
+      expect(result.current.errorState).toBeNull();
+    });
+
+    it("should show toast and logout for invalidCode error", async () => {
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      act(() => {
+        result.current.handleError(new CalendarNotFoundError("Not found"));
+      });
+
+      await act(async () => {
+        await result.current.acknowledgeError();
+      });
+
+      expect(toastStore.toast.error).toHaveBeenCalledWith(
+        "calendarError.loggedOutToast",
+      );
+      expect(mockLogout).toHaveBeenCalled();
+    });
+
+    it("should show toast and logout for network error", async () => {
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      const networkError = new Error("Failed to fetch");
+      networkError.name = "TypeError";
+
+      act(() => {
+        result.current.handleError(networkError);
+      });
+
+      await act(async () => {
+        await result.current.acknowledgeError();
+      });
+
+      expect(toastStore.toast.error).toHaveBeenCalledWith(
+        "calendarError.loggedOutToast",
+      );
+      expect(mockLogout).toHaveBeenCalled();
+    });
+
+    it("should not logout when no error state", async () => {
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      await act(async () => {
+        await result.current.acknowledgeError();
+      });
+
+      expect(mockLogout).not.toHaveBeenCalled();
+      expect(toastStore.toast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("logParseWarning", () => {
+    it("should log warning to console", () => {
+      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { result } = renderHook(() => useCalendarErrorHandler());
+
+      act(() => {
+        result.current.logParseWarning("Parse error occurred");
+      });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[Calendar Parse Warning]",
+        "Parse error occurred",
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe("function stability", () => {
+    it("should have stable handleError reference", () => {
+      const { result, rerender } = renderHook(() => useCalendarErrorHandler());
+
+      const firstHandleError = result.current.handleError;
+      rerender();
+
+      expect(result.current.handleError).toBe(firstHandleError);
+    });
+
+    it("should have stable logParseWarning reference", () => {
+      const { result, rerender } = renderHook(() => useCalendarErrorHandler());
+
+      const firstLogParseWarning = result.current.logParseWarning;
+      rerender();
+
+      expect(result.current.logParseWarning).toBe(firstLogParseWarning);
+    });
+  });
+});

--- a/web-app/src/hooks/useCalendarErrorHandler.ts
+++ b/web-app/src/hooks/useCalendarErrorHandler.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { useAuthStore } from "@/stores/auth";
 import { toast } from "@/stores/toast";
-import { t } from "@/i18n";
+import { useTranslation } from "@/hooks/useTranslation";
 import { classifyError } from "@/utils/error-helpers";
 import { CalendarNotFoundError } from "@/api/calendar-api";
 import type { CalendarErrorType } from "@/components/features/CalendarErrorModal";
@@ -58,6 +58,7 @@ interface UseCalendarErrorHandlerResult {
 export function useCalendarErrorHandler(): UseCalendarErrorHandlerResult {
   const [errorState, setErrorState] = useState<CalendarErrorState | null>(null);
   const logout = useAuthStore((state) => state.logout);
+  const { t } = useTranslation();
 
   const handleError = useCallback((error: Error) => {
     // Classify the error type
@@ -94,7 +95,7 @@ export function useCalendarErrorHandler(): UseCalendarErrorHandlerResult {
       // Logout will clear calendar code and redirect to login
       await logout();
     }
-  }, [errorState, logout]);
+  }, [errorState, logout, t]);
 
   const logParseWarning = useCallback((message: string) => {
     // Parse errors are logged but don't show a modal

--- a/web-app/src/hooks/useCalendarErrorHandler.ts
+++ b/web-app/src/hooks/useCalendarErrorHandler.ts
@@ -1,0 +1,111 @@
+import { useCallback, useState } from "react";
+import { useAuthStore } from "@/stores/auth";
+import { toast } from "@/stores/toast";
+import { t } from "@/i18n";
+import { classifyError } from "@/utils/error-helpers";
+import { CalendarNotFoundError } from "@/api/calendar-api";
+import type { CalendarErrorType } from "@/components/features/CalendarErrorModal";
+
+interface CalendarErrorState {
+  /** Whether the error modal is open */
+  isOpen: boolean;
+  /** Type of error that occurred */
+  errorType: CalendarErrorType;
+}
+
+interface UseCalendarErrorHandlerResult {
+  /** Current error state for the modal */
+  errorState: CalendarErrorState | null;
+  /** Handle a calendar fetch error */
+  handleError: (error: Error) => void;
+  /** Acknowledge the error and perform cleanup (logout for critical errors) */
+  acknowledgeError: () => Promise<void>;
+  /** Log a parse warning (non-critical) */
+  logParseWarning: (message: string) => void;
+}
+
+/**
+ * Hook for handling calendar mode errors.
+ *
+ * Provides error classification and modal state management for calendar errors.
+ * Critical errors (network, invalid code) trigger logout after acknowledgement.
+ * Parse errors are logged but don't interrupt the user flow.
+ *
+ * @example
+ * ```tsx
+ * function CalendarPage() {
+ *   const { errorState, handleError, acknowledgeError } = useCalendarErrorHandler();
+ *   const { error } = useCalendarAssignments();
+ *
+ *   useEffect(() => {
+ *     if (error) handleError(error);
+ *   }, [error, handleError]);
+ *
+ *   return (
+ *     <>
+ *       {errorState && (
+ *         <CalendarErrorModal
+ *           isOpen={errorState.isOpen}
+ *           errorType={errorState.errorType}
+ *           onAcknowledge={acknowledgeError}
+ *         />
+ *       )}
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+export function useCalendarErrorHandler(): UseCalendarErrorHandlerResult {
+  const [errorState, setErrorState] = useState<CalendarErrorState | null>(null);
+  const logout = useAuthStore((state) => state.logout);
+
+  const handleError = useCallback((error: Error) => {
+    // Classify the error type
+    let errorType: CalendarErrorType;
+
+    if (error instanceof CalendarNotFoundError) {
+      // Calendar code is invalid or expired
+      errorType = "invalidCode";
+    } else if (classifyError(error) === "network") {
+      // Network-related error
+      errorType = "network";
+    } else {
+      // Default to invalid code for other API errors
+      errorType = "invalidCode";
+    }
+
+    setErrorState({
+      isOpen: true,
+      errorType,
+    });
+  }, []);
+
+  const acknowledgeError = useCallback(async () => {
+    const currentErrorType = errorState?.errorType;
+
+    // Close the modal first
+    setErrorState(null);
+
+    // For critical errors, logout and show toast
+    if (currentErrorType === "network" || currentErrorType === "invalidCode") {
+      // Show toast before logout
+      toast.error(t("calendarError.loggedOutToast"));
+
+      // Logout will clear calendar code and redirect to login
+      await logout();
+    }
+  }, [errorState, logout]);
+
+  const logParseWarning = useCallback((message: string) => {
+    // Parse errors are logged but don't show a modal
+    // They result in partial data being displayed
+    console.warn("[Calendar Parse Warning]", message);
+  }, []);
+
+  return {
+    errorState,
+    handleError,
+    acknowledgeError,
+    logParseWarning,
+  };
+}

--- a/web-app/src/hooks/useConvocations.ts
+++ b/web-app/src/hooks/useConvocations.ts
@@ -22,6 +22,8 @@ export {
   usePastAssignments,
   useValidationClosedAssignments,
   useAssignmentDetails,
+  useCalendarAssignments,
+  type CalendarAssignment,
 } from "./useAssignments";
 
 // Compensation hooks and types

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -185,6 +185,14 @@ const de: Translations = {
     calendarModeInfo: "Nur-Lese-Zugriff auf Ihre Spieleinsätze",
     calendarModeHint: "Finden Sie Ihre Kalender-URL im VolleyManager unter Profil → Kalender-Export",
   },
+  calendarError: {
+    title: "Kalenderfehler",
+    networkMessage: "Ihr Kalender konnte nicht geladen werden. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.",
+    invalidCodeMessage: "Der Kalendercode ist ungültig oder abgelaufen. Bitte melden Sie sich mit einem neuen Code an.",
+    parseErrorMessage: "Einige Kalenderdaten konnten nicht gelesen werden. Verfügbare Einsätze werden angezeigt.",
+    ok: "OK",
+    loggedOutToast: "Aufgrund eines Kalenderfehlers abgemeldet",
+  },
   occupations: {
     referee: "Schiedsrichter",
     linesmen: "Linienrichter",
@@ -205,6 +213,12 @@ const de: Translations = {
     noClosedTitle: "Keine abgeschlossenen Einsätze",
     noClosedDescription:
       "Keine Einsätze mit abgeschlossener Validierung in dieser Saison.",
+    calendarNoUpcomingTitle: "Keine bevorstehenden Einsätze",
+    calendarNoUpcomingDescription:
+      "Alle Ihre Einsätze liegen in der Vergangenheit. Schauen Sie wieder vorbei, wenn neue Spiele geplant sind.",
+    calendarEmptyTitle: "Keine Einsätze im Kalender",
+    calendarEmptyDescription:
+      "Ihr Kalender ist leer. Einsätze werden hier angezeigt, sobald Sie für Spiele eingeteilt sind.",
     confirmed: "Bestätigt",
     pending: "Ausstehend",
     cancelled: "Abgesagt",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -185,6 +185,14 @@ const en: Translations = {
     calendarModeInfo: "Read-only access to your assignments",
     calendarModeHint: "Find your calendar URL in VolleyManager under Profile → Calendar Export",
   },
+  calendarError: {
+    title: "Calendar Error",
+    networkMessage: "Unable to load your calendar. Please check your internet connection and try again.",
+    invalidCodeMessage: "The calendar code is invalid or has expired. Please log in with a new code.",
+    parseErrorMessage: "Some calendar data could not be read. Displaying available assignments.",
+    ok: "OK",
+    loggedOutToast: "Logged out due to calendar error",
+  },
   occupations: {
     referee: "Referee",
     linesmen: "Line Judges",
@@ -205,6 +213,12 @@ const en: Translations = {
     noClosedTitle: "No closed assignments",
     noClosedDescription:
       "No assignments with closed validation in this season.",
+    calendarNoUpcomingTitle: "No upcoming assignments",
+    calendarNoUpcomingDescription:
+      "All your assignments are in the past. Check back when new games are scheduled.",
+    calendarEmptyTitle: "No assignments in calendar",
+    calendarEmptyDescription:
+      "Your calendar is empty. Assignments will appear here once you are scheduled for games.",
     confirmed: "Confirmed",
     pending: "Pending",
     cancelled: "Cancelled",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -185,6 +185,14 @@ const fr: Translations = {
     calendarModeInfo: "Accès en lecture seule à vos désignations",
     calendarModeHint: "Trouvez votre URL de calendrier dans VolleyManager sous Profil → Export du calendrier",
   },
+  calendarError: {
+    title: "Erreur de calendrier",
+    networkMessage: "Impossible de charger votre calendrier. Veuillez vérifier votre connexion internet et réessayer.",
+    invalidCodeMessage: "Le code de calendrier est invalide ou a expiré. Veuillez vous connecter avec un nouveau code.",
+    parseErrorMessage: "Certaines données du calendrier n'ont pas pu être lues. Affichage des désignations disponibles.",
+    ok: "OK",
+    loggedOutToast: "Déconnecté en raison d'une erreur de calendrier",
+  },
   occupations: {
     referee: "Arbitre",
     linesmen: "Juges de ligne",
@@ -204,6 +212,12 @@ const fr: Translations = {
     noClosedTitle: "Aucune désignation clôturée",
     noClosedDescription:
       "Aucune désignation avec validation fermée cette saison.",
+    calendarNoUpcomingTitle: "Aucune désignation à venir",
+    calendarNoUpcomingDescription:
+      "Toutes vos désignations sont passées. Revenez quand de nouveaux matchs seront programmés.",
+    calendarEmptyTitle: "Aucune désignation dans le calendrier",
+    calendarEmptyDescription:
+      "Votre calendrier est vide. Les désignations apparaîtront ici dès que vous serez programmé pour des matchs.",
     confirmed: "Confirmé",
     pending: "En attente",
     cancelled: "Annulé",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -185,6 +185,14 @@ const it: Translations = {
     calendarModeInfo: "Accesso in sola lettura alle tue designazioni",
     calendarModeHint: "Trova l'URL del calendario in VolleyManager sotto Profilo → Esporta calendario",
   },
+  calendarError: {
+    title: "Errore calendario",
+    networkMessage: "Impossibile caricare il calendario. Verifica la connessione internet e riprova.",
+    invalidCodeMessage: "Il codice calendario non è valido o è scaduto. Accedi con un nuovo codice.",
+    parseErrorMessage: "Alcuni dati del calendario non sono stati letti. Visualizzazione delle designazioni disponibili.",
+    ok: "OK",
+    loggedOutToast: "Disconnesso a causa di un errore del calendario",
+  },
   occupations: {
     referee: "Arbitro",
     linesmen: "Giudici di linea",
@@ -204,6 +212,12 @@ const it: Translations = {
     noClosedTitle: "Nessuna designazione chiusa",
     noClosedDescription:
       "Nessuna designazione con validazione chiusa in questa stagione.",
+    calendarNoUpcomingTitle: "Nessuna designazione in programma",
+    calendarNoUpcomingDescription:
+      "Tutte le tue designazioni sono passate. Torna quando saranno programmate nuove partite.",
+    calendarEmptyTitle: "Nessuna designazione nel calendario",
+    calendarEmptyDescription:
+      "Il tuo calendario è vuoto. Le designazioni appariranno qui quando sarai programmato per le partite.",
     confirmed: "Confermato",
     pending: "In attesa",
     cancelled: "Annullato",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -77,6 +77,14 @@ export interface Translations {
     calendarModeInfo: string;
     calendarModeHint: string;
   };
+  calendarError: {
+    title: string;
+    networkMessage: string;
+    invalidCodeMessage: string;
+    parseErrorMessage: string;
+    ok: string;
+    loggedOutToast: string;
+  };
   occupations: {
     referee: string;
     linesmen: string;
@@ -95,6 +103,10 @@ export interface Translations {
     noUpcomingDescription: string;
     noClosedTitle: string;
     noClosedDescription: string;
+    calendarNoUpcomingTitle: string;
+    calendarNoUpcomingDescription: string;
+    calendarEmptyTitle: string;
+    calendarEmptyDescription: string;
     confirmed: string;
     pending: string;
     cancelled: string;

--- a/web-app/src/pages/AssignmentsPage.test.tsx
+++ b/web-app/src/pages/AssignmentsPage.test.tsx
@@ -84,14 +84,16 @@ function createMockQueryResult(
   isLoading = false,
   error: Error | null = null,
 ): UseQueryResult<Assignment[], Error> {
+  // Compute status first, then derive other flags from it
+  const status = isLoading ? "pending" : error !== null ? "error" : "success";
   return {
     data,
     isLoading,
     isFetching: false,
-    isError: !!error,
+    isError: status === "error",
     error,
-    isSuccess: !isLoading && !error && !!data,
-    status: isLoading ? "pending" : error ? "error" : "success",
+    isSuccess: status === "success" && data !== undefined,
+    status,
     refetch: vi.fn(),
   } as unknown as UseQueryResult<Assignment[], Error>;
 }
@@ -102,14 +104,16 @@ function createMockCalendarQueryResult(
   isLoading = false,
   error: Error | null = null,
 ) {
+  // Compute status first, then derive other flags from it
+  const status = isLoading ? "pending" : error !== null ? "error" : "success";
   return {
     data,
     isLoading,
     isFetching: false,
-    isError: !!error,
+    isError: status === "error",
     error,
-    isSuccess: !isLoading && !error && !!data,
-    status: isLoading ? "pending" : error ? "error" : "success",
+    isSuccess: status === "success" && data !== undefined,
+    status,
     refetch: vi.fn(),
   } as unknown as ReturnType<typeof useConvocations.useCalendarAssignments>;
 }

--- a/web-app/src/pages/AssignmentsPage.test.tsx
+++ b/web-app/src/pages/AssignmentsPage.test.tsx
@@ -96,6 +96,24 @@ function createMockQueryResult(
   } as unknown as UseQueryResult<Assignment[], Error>;
 }
 
+// Create a mock for calendar assignments
+function createMockCalendarQueryResult(
+  data: useConvocations.CalendarAssignment[] | undefined = [],
+  isLoading = false,
+  error: Error | null = null,
+) {
+  return {
+    data,
+    isLoading,
+    isFetching: false,
+    isError: !!error,
+    error,
+    isSuccess: !isLoading && !error && !!data,
+    status: isLoading ? "pending" : error ? "error" : "success",
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useConvocations.useCalendarAssignments>;
+}
+
 describe("AssignmentsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -106,6 +124,10 @@ describe("AssignmentsPage", () => {
     );
     vi.mocked(useConvocations.useValidationClosedAssignments).mockReturnValue(
       createMockQueryResult([]),
+    );
+    // Mock calendar assignments (empty by default - calendar mode not active)
+    vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+      createMockCalendarQueryResult([]),
     );
   });
 


### PR DESCRIPTION
## Summary
- Add comprehensive error handling for Calendar Mode
- Show error modal for network and invalid code errors, then logout
- Log parse warnings without interrupting user flow
- Handle edge cases for empty calendar and only past events

## Changes
- CalendarErrorModal: Modal component for calendar errors
- CalendarErrorHandler: Global handler that wraps protected routes
- useCalendarErrorHandler: Hook for error classification and modal state
- CalendarAssignmentCard: Simplified card for calendar assignments
- Updated AssignmentsPage to support calendar mode data and empty states
- Added translations in all 4 languages (de, en, fr, it)
- Updated tests with calendar mock support

## Test Plan
- [ ] Verify network error shows modal and logs out on OK
- [ ] Verify invalid calendar code shows modal and logs out on OK
- [ ] Verify empty calendar shows appropriate empty state message
- [ ] Verify only past events shows "No upcoming" message
- [ ] Verify past events tab displays calendar past events
- [ ] Verify all translations display correctly
- [ ] Verify all existing tests pass