### PR TITLE
feat(claude): add SessionStart hook for web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code Remote environment (web sessions)
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Run in background for faster session startup
+echo '{"async": true, "asyncTimeout": 300000}'
+
+echo "Setting up VolleyKit development environment..."
+
+# Install web-app dependencies and generate API types
+(
+  cd "$CLAUDE_PROJECT_DIR/web-app"
+  echo "Installing web-app dependencies..."
+  npm install
+  echo "Generating API types..."
+  npm run generate:api
+)
+
+echo "Development environment ready!"
+
+# Inform Claude about available GitHub token if present
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  echo ""
+  echo "=== GitHub API Access ==="
+  echo "A GitHub token (GITHUB_TOKEN) is available in this environment."
+  echo "You can use the GitHub API via curl or the WebFetch tool."
+  echo "========================="
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,16 @@
     "deny": []
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary
- Add SessionStart hook that runs when Claude Code starts a new web session
- Automatically installs dependencies and generates API types
- Informs Claude about GitHub API access availability

## Changes
- Created .claude/hooks/session-start.sh script
- Updated .claude/settings.json to register the SessionStart hook

## Test Plan
- [ ] Verify hook runs on new Claude Code web session
- [ ] Confirm npm dependencies are installed for web-app and worker
- [ ] Confirm API types are generated from OpenAPI spec
- [ ] Verify GitHub token message is displayed