### PR TITLE
feat(auth): make Calendar Mode the default login method

### DIFF
--- a/web-app/e2e/app.spec.ts
+++ b/web-app/e2e/app.spec.ts
@@ -48,8 +48,10 @@ test.describe("VolleyKit App", () => {
       await page.setViewportSize({ width: 375, height: 667 });
       await page.goto("/login");
 
-      // Form should still be visible using stable test ID (locale-independent)
-      await expect(page.getByTestId("login-button")).toBeVisible();
+      // Calendar mode is the default - check calendar login button is visible
+      await expect(page.getByTestId("calendar-login-button")).toBeVisible();
+      // Demo button should also be visible
+      await expect(page.getByTestId("demo-button")).toBeVisible();
     });
   });
 });

--- a/web-app/e2e/pages/login.page.ts
+++ b/web-app/e2e/pages/login.page.ts
@@ -3,30 +3,55 @@ import { type Page, type Locator, expect } from "@playwright/test";
 /**
  * Page Object Model for the Login page.
  * Encapsulates login page interactions for maintainable E2E tests.
+ *
+ * Note: Calendar Mode is the default login method. Full login mode
+ * requires switching tabs first.
  */
 export class LoginPage {
   readonly page: Page;
+  // Full login mode elements
   readonly usernameInput: Locator;
   readonly passwordInput: Locator;
   readonly loginButton: Locator;
+  // Calendar mode elements (default)
+  readonly calendarInput: Locator;
+  readonly calendarLoginButton: Locator;
+  // Common elements
   readonly demoButton: Locator;
+  readonly fullLoginTab: Locator;
+  readonly calendarTab: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    // Use stable test IDs for locale independence
+    // Full login mode elements
     this.usernameInput = page.getByTestId("username-input");
     this.passwordInput = page.getByTestId("password-input");
     this.loginButton = page.getByTestId("login-button");
+    // Calendar mode elements (default)
+    this.calendarInput = page.getByTestId("calendar-input");
+    this.calendarLoginButton = page.getByTestId("calendar-login-button");
+    // Common elements
     this.demoButton = page.getByTestId("demo-button");
+    this.fullLoginTab = page.getByRole("tab", { name: /full/i });
+    this.calendarTab = page.getByRole("tab", { name: /calendar/i });
   }
 
   async goto() {
     await this.page.goto("/login");
-    // Wait for login form to be ready
+    // Wait for login form to be ready - calendar mode is the default
+    await expect(this.demoButton).toBeVisible();
+  }
+
+  /**
+   * Switch to full login mode (username/password)
+   */
+  async switchToFullLogin() {
+    await this.fullLoginTab.click();
     await expect(this.loginButton).toBeVisible();
   }
 
   async login(username: string, password: string) {
+    await this.switchToFullLogin();
     await this.usernameInput.fill(username);
     await this.passwordInput.fill(password);
     await this.loginButton.click();
@@ -45,7 +70,20 @@ export class LoginPage {
     await expect(this.page.getByRole("main")).toBeVisible();
   }
 
-  async expectToBeVisible() {
+  /**
+   * Check that calendar mode (default) elements are visible
+   */
+  async expectCalendarModeToBeVisible() {
+    await expect(this.calendarInput).toBeVisible();
+    await expect(this.calendarLoginButton).toBeVisible();
+    await expect(this.demoButton).toBeVisible();
+  }
+
+  /**
+   * Check that full login mode elements are visible
+   * (must switch to full login mode first)
+   */
+  async expectFullLoginToBeVisible() {
     await expect(this.usernameInput).toBeVisible();
     await expect(this.passwordInput).toBeVisible();
     await expect(this.loginButton).toBeVisible();

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -183,7 +183,7 @@ const de: Translations = {
     enterCalendarMode: "Kalender-Modus starten",
     enteringCalendarMode: "Wird gestartet...",
     calendarModeInfo: "Nur-Lese-Zugriff auf Ihre Spieleinsätze",
-    calendarModeHint: "Finden Sie Ihre Kalender-URL im VolleyManager unter Profil → Kalender-Export",
+    calendarModeHint: "Finden Sie Ihre Kalender-URL im VolleyManager auf der Seite Meine Einsätze",
   },
   calendarError: {
     title: "Kalenderfehler",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -183,7 +183,7 @@ const en: Translations = {
     enterCalendarMode: "Enter Calendar Mode",
     enteringCalendarMode: "Entering...",
     calendarModeInfo: "Read-only access to your assignments",
-    calendarModeHint: "Find your calendar URL in VolleyManager under Profile → Calendar Export",
+    calendarModeHint: "Find your calendar URL in VolleyManager on the My Assignments page",
   },
   calendarError: {
     title: "Calendar Error",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -183,7 +183,7 @@ const fr: Translations = {
     enterCalendarMode: "Entrer en mode calendrier",
     enteringCalendarMode: "Chargement...",
     calendarModeInfo: "Accès en lecture seule à vos désignations",
-    calendarModeHint: "Trouvez votre URL de calendrier dans VolleyManager sous Profil → Export du calendrier",
+    calendarModeHint: "Trouvez votre URL de calendrier dans VolleyManager sur la page Mes désignations",
   },
   calendarError: {
     title: "Erreur de calendrier",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -183,7 +183,7 @@ const it: Translations = {
     enterCalendarMode: "Entra in modalità calendario",
     enteringCalendarMode: "Caricamento...",
     calendarModeInfo: "Accesso in sola lettura alle tue designazioni",
-    calendarModeHint: "Trova l'URL del calendario in VolleyManager sotto Profilo → Esporta calendario",
+    calendarModeHint: "Trova l'URL del calendario in VolleyManager sulla pagina Le mie designazioni",
   },
   calendarError: {
     title: "Errore calendario",

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -33,7 +33,7 @@ export function LoginPage() {
   const initializeDemoData = useDemoStore((state) => state.initializeDemoData);
   const { t } = useTranslation();
 
-  const [loginMode, setLoginMode] = useState<LoginMode>("full");
+  const [loginMode, setLoginMode] = useState<LoginMode>("calendar");
   const [username, setUsername] = useState("");
   const [calendarInput, setCalendarInput] = useState("");
   const [calendarError, setCalendarError] = useState<string | null>(null);
@@ -272,21 +272,6 @@ export function LoginPage() {
             <button
               type="button"
               role="tab"
-              aria-selected={loginMode === "full"}
-              aria-controls="full-login-panel"
-              id="full-login-tab"
-              onClick={() => setLoginMode("full")}
-              className={`flex-1 py-2 px-4 text-sm font-medium rounded-md transition-colors ${
-                loginMode === "full"
-                  ? "bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark shadow-sm"
-                  : "text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
-              }`}
-            >
-              {t("auth.fullLogin")}
-            </button>
-            <button
-              type="button"
-              role="tab"
               aria-selected={loginMode === "calendar"}
               aria-controls="calendar-login-panel"
               id="calendar-login-tab"
@@ -298,6 +283,21 @@ export function LoginPage() {
               }`}
             >
               {t("auth.calendarMode")}
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={loginMode === "full"}
+              aria-controls="full-login-panel"
+              id="full-login-tab"
+              onClick={() => setLoginMode("full")}
+              className={`flex-1 py-2 px-4 text-sm font-medium rounded-md transition-colors ${
+                loginMode === "full"
+                  ? "bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark shadow-sm"
+                  : "text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
+              }`}
+            >
+              {t("auth.fullLogin")}
             </button>
           </div>
 


### PR DESCRIPTION
## Summary
- Calendar Mode is now the default login option on the LoginPage
- Users can immediately use their calendar URL from VolleyManager's "My Assignments" page
- Full login option remains available via tab switch

## Changes
- Changed default login mode from 'full' to 'calendar'
- Swapped tab order so Calendar Mode tab appears first
- Updated translation hints in all 4 languages (de, en, fr, it) to reference "My Assignments" page
- Updated LoginPage tests to reflect new default behavior

## Test Plan
- [ ] Verify Calendar Mode tab is selected by default on login page
- [ ] Verify Calendar Mode tab appears first (left side)
- [ ] Verify hint text correctly references "My Assignments" page in all languages
- [ ] Verify switching to Full Login mode still works
- [ ] Verify demo mode button works from both login modes