### PR TITLE
test(calendar): add comprehensive integration tests for Calendar Mode

### DIFF
--- a/web-app/e2e/calendar-mode.spec.ts
+++ b/web-app/e2e/calendar-mode.spec.ts
@@ -1,0 +1,275 @@
+import { test, expect } from "@playwright/test";
+import { LoginPage, NavigationPage, AssignmentsPage } from "./pages";
+
+/**
+ * Calendar Mode E2E tests - focused on browser-specific behavior.
+ *
+ * These tests verify:
+ * - Calendar mode login tab rendering and switching
+ * - Calendar mode login flow with mocked API
+ * - Navigation restrictions in calendar mode (hidden nav items)
+ * - Calendar mode banner display
+ *
+ * Component rendering details and accessibility attributes are covered
+ * by unit tests in src/pages/LoginPage.test.tsx and
+ * src/components/layout/AppShell.test.tsx
+ */
+
+/**
+ * Sample iCal content for mocking the calendar API response.
+ * Contains a single upcoming assignment for testing.
+ */
+const MOCK_ICAL_CONTENT = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//SwissVolley//VolleyManager//EN
+X-WR-CALNAME:Referee Calendar
+BEGIN:VEVENT
+UID:referee-convocation-for-game-12345@volleymanager.volleyball.ch
+DTSTART:20251220T180000Z
+DTEND:20251220T200000Z
+SUMMARY:ARB 1 | VBC Zürich - VBC Basel (NLA Men)
+LOCATION:Saalsporthalle, Hardturmstrasse 150, 8005 Zürich
+GEO:47.3928;8.5035
+END:VEVENT
+END:VCALENDAR`;
+
+test.describe("Calendar Mode", () => {
+  let loginPage: LoginPage;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    await loginPage.goto();
+    // Wait for full hydration
+    await page.waitForLoadState("networkidle");
+  });
+
+  test.describe("Login Page Tab Rendering", () => {
+    test("displays both login mode tabs", async () => {
+      await loginPage.expectCalendarModeTabVisible();
+    });
+
+    test("defaults to full login tab", async () => {
+      // Username input should be visible by default (full login mode)
+      await expect(loginPage.usernameInput).toBeVisible();
+      await expect(loginPage.calendarInput).not.toBeVisible();
+    });
+
+    test("can switch to calendar mode tab", async () => {
+      await loginPage.switchToCalendarMode();
+
+      // Calendar input should now be visible
+      await expect(loginPage.calendarInput).toBeVisible();
+      await expect(loginPage.calendarLoginButton).toBeVisible();
+
+      // Username/password should be hidden
+      await expect(loginPage.usernameInput).not.toBeVisible();
+      await expect(loginPage.passwordInput).not.toBeVisible();
+    });
+
+    test("can switch back to full login tab", async () => {
+      await loginPage.switchToCalendarMode();
+      await loginPage.switchToFullLogin();
+
+      // Username/password should be visible again
+      await expect(loginPage.usernameInput).toBeVisible();
+      await expect(loginPage.passwordInput).toBeVisible();
+
+      // Calendar input should be hidden
+      await expect(loginPage.calendarInput).not.toBeVisible();
+    });
+
+    test("demo button is visible in calendar mode tab", async () => {
+      await loginPage.switchToCalendarMode();
+
+      // Demo button should still be accessible
+      await expect(loginPage.demoButton).toBeVisible();
+    });
+  });
+
+  test.describe("Calendar Mode Login Flow", () => {
+    test.beforeEach(async ({ page }) => {
+      // Mock the calendar API endpoint to return valid iCal data
+      await page.route("**/sportmanager.volleyball/calendar/ical/*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/calendar",
+          body: MOCK_ICAL_CONTENT,
+        }),
+      );
+    });
+
+    test("can enter calendar mode with valid code", async ({ page }) => {
+      await loginPage.enterCalendarMode("ABC123");
+
+      // Should be on assignments page
+      await expect(page).toHaveURL("/");
+
+      // Should see calendar mode banner
+      await expect(page.getByRole("alert")).toBeVisible();
+      await expect(page.getByText(/calendar mode/i)).toBeVisible();
+    });
+
+    test("shows assignment from calendar data", async ({ page }) => {
+      const assignmentsPage = new AssignmentsPage(page);
+      await loginPage.enterCalendarMode("ABC123");
+
+      // Wait for assignments to load
+      await assignmentsPage.waitForAssignmentsLoaded();
+
+      // Should show team names from the mocked iCal
+      await expect(page.getByText(/VBC Zürich/)).toBeVisible();
+      await expect(page.getByText(/VBC Basel/)).toBeVisible();
+    });
+
+    test("displays calendar mode indicator banner", async ({ page }) => {
+      await loginPage.enterCalendarMode("ABC123");
+
+      // Banner should indicate read-only calendar mode
+      const banner = page.getByRole("alert");
+      await expect(banner).toBeVisible();
+      await expect(banner).toContainText(/calendar/i);
+    });
+  });
+
+  test.describe("Calendar Mode Navigation Restrictions", () => {
+    test.beforeEach(async ({ page }) => {
+      // Mock the calendar API
+      await page.route("**/sportmanager.volleyball/calendar/ical/*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/calendar",
+          body: MOCK_ICAL_CONTENT,
+        }),
+      );
+
+      await loginPage.enterCalendarMode("ABC123");
+    });
+
+    test("hides Compensations nav item in calendar mode", async ({ page }) => {
+      // Compensations link should not be visible
+      await expect(
+        page.getByRole("link", { name: /compensation/i }),
+      ).not.toBeVisible();
+    });
+
+    test("hides Exchange nav item in calendar mode", async ({ page }) => {
+      // Exchange link should not be visible
+      await expect(
+        page.getByRole("link", { name: /exchange/i }),
+      ).not.toBeVisible();
+    });
+
+    test("shows Assignments nav item in calendar mode", async ({ page }) => {
+      const navigation = new NavigationPage(page);
+      // Assignments link should be visible
+      await expect(navigation.assignmentsLink).toBeVisible();
+    });
+
+    test("shows Settings nav item in calendar mode", async ({ page }) => {
+      const navigation = new NavigationPage(page);
+      // Settings link should be visible
+      await expect(navigation.settingsLink).toBeVisible();
+    });
+
+    test("cannot access compensations page via direct URL", async ({
+      page,
+    }) => {
+      // Try to navigate directly to compensations
+      await page.goto("/compensations");
+
+      // Should redirect back (exact behavior depends on implementation)
+      // Either stays on assignments or shows not found
+      await expect(page).not.toHaveURL("/compensations");
+    });
+
+    test("cannot access exchange page via direct URL", async ({ page }) => {
+      // Try to navigate directly to exchange
+      await page.goto("/exchange");
+
+      // Should redirect back
+      await expect(page).not.toHaveURL("/exchange");
+    });
+  });
+
+  test.describe("Calendar Mode Logout", () => {
+    test.beforeEach(async ({ page }) => {
+      // Mock the calendar API
+      await page.route("**/sportmanager.volleyball/calendar/ical/*", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/calendar",
+          body: MOCK_ICAL_CONTENT,
+        }),
+      );
+
+      await loginPage.enterCalendarMode("ABC123");
+    });
+
+    test("can logout from calendar mode", async ({ page }) => {
+      const navigation = new NavigationPage(page);
+
+      // Click logout
+      await navigation.logout();
+
+      // Should be redirected to login page
+      await expect(page).toHaveURL(/login/);
+      await loginPage.expectToBeVisible();
+    });
+
+    test("calendar mode banner disappears after logout", async ({ page }) => {
+      const navigation = new NavigationPage(page);
+
+      // Verify banner is visible first
+      await expect(page.getByRole("alert")).toBeVisible();
+
+      // Logout
+      await navigation.logout();
+
+      // On login page, no calendar banner
+      await expect(page.getByRole("alert")).not.toBeVisible();
+    });
+  });
+
+  test.describe("Calendar Mode Error Handling", () => {
+    test("shows error for invalid calendar code format", async ({ page }) => {
+      await loginPage.switchToCalendarMode();
+      await loginPage.calendarInput.fill("bad");
+      await loginPage.calendarLoginButton.click();
+
+      // Should show error message (stays on login page)
+      await expect(page).toHaveURL(/login/);
+      // Error should be displayed
+      await expect(page.getByText(/invalid/i)).toBeVisible();
+    });
+
+    test("shows error when calendar is not found", async ({ page }) => {
+      // Mock 404 response for calendar API
+      await page.route("**/sportmanager.volleyball/calendar/ical/*", (route) =>
+        route.fulfill({
+          status: 404,
+          body: "Not Found",
+        }),
+      );
+
+      await loginPage.switchToCalendarMode();
+      await loginPage.calendarInput.fill("NOTFND");
+      await loginPage.calendarLoginButton.click();
+
+      // Should show not found error
+      await expect(page).toHaveURL(/login/);
+      await expect(
+        page.getByText(/not found|calendar.*not.*found/i),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("Calendar Mode Responsive", () => {
+    test("calendar mode tab works on mobile viewport", async ({ page }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      await loginPage.switchToCalendarMode();
+      await expect(loginPage.calendarInput).toBeVisible();
+      await expect(loginPage.calendarLoginButton).toBeVisible();
+    });
+  });
+});

--- a/web-app/e2e/calendar-mode.spec.ts
+++ b/web-app/e2e/calendar-mode.spec.ts
@@ -51,29 +51,16 @@ test.describe("Calendar Mode", () => {
       await loginPage.expectCalendarModeTabVisible();
     });
 
-    test("defaults to full login tab", async () => {
-      // Username input should be visible by default (full login mode)
-      await expect(loginPage.usernameInput).toBeVisible();
-      await expect(loginPage.calendarInput).not.toBeVisible();
-    });
-
-    test("can switch to calendar mode tab", async () => {
-      await loginPage.switchToCalendarMode();
-
-      // Calendar input should now be visible
+    test("defaults to calendar mode tab", async () => {
+      // Calendar input should be visible by default (calendar mode is the default)
       await expect(loginPage.calendarInput).toBeVisible();
-      await expect(loginPage.calendarLoginButton).toBeVisible();
-
-      // Username/password should be hidden
       await expect(loginPage.usernameInput).not.toBeVisible();
-      await expect(loginPage.passwordInput).not.toBeVisible();
     });
 
-    test("can switch back to full login tab", async () => {
-      await loginPage.switchToCalendarMode();
+    test("can switch to full login tab", async () => {
       await loginPage.switchToFullLogin();
 
-      // Username/password should be visible again
+      // Username/password should now be visible
       await expect(loginPage.usernameInput).toBeVisible();
       await expect(loginPage.passwordInput).toBeVisible();
 
@@ -81,10 +68,20 @@ test.describe("Calendar Mode", () => {
       await expect(loginPage.calendarInput).not.toBeVisible();
     });
 
-    test("demo button is visible in calendar mode tab", async () => {
+    test("can switch back to calendar mode tab", async () => {
+      await loginPage.switchToFullLogin();
       await loginPage.switchToCalendarMode();
 
-      // Demo button should still be accessible
+      // Calendar input should be visible again
+      await expect(loginPage.calendarInput).toBeVisible();
+      await expect(loginPage.calendarLoginButton).toBeVisible();
+
+      // Username/password should be hidden
+      await expect(loginPage.usernameInput).not.toBeVisible();
+    });
+
+    test("demo button is visible in calendar mode tab", async () => {
+      // Demo button should be accessible (calendar mode is already the default)
       await expect(loginPage.demoButton).toBeVisible();
     });
   });
@@ -272,12 +269,13 @@ test.describe("Calendar Mode", () => {
   });
 
   test.describe("Calendar Mode Responsive", () => {
-    test("calendar mode tab works on mobile viewport", async ({ page }) => {
+    test("calendar mode displays correctly on mobile viewport", async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 667 });
 
-      await loginPage.switchToCalendarMode();
+      // Calendar mode is the default, verify it displays correctly on mobile
       await expect(loginPage.calendarInput).toBeVisible();
       await expect(loginPage.calendarLoginButton).toBeVisible();
+      await expect(loginPage.demoButton).toBeVisible();
     });
   });
 });

--- a/web-app/e2e/calendar-mode.spec.ts
+++ b/web-app/e2e/calendar-mode.spec.ts
@@ -1,31 +1,20 @@
 import { test, expect } from "@playwright/test";
 import { LoginPage, NavigationPage } from "./pages";
 
-/**
- * Calendar Mode E2E tests - focused on browser-specific behavior.
- *
- * These tests verify:
- * - Calendar mode login tab rendering and switching
- * - Calendar mode login flow with mocked API
- * - Navigation restrictions in calendar mode (hidden nav items)
- * - Calendar mode banner display
- *
- * Component rendering details and accessibility attributes are covered
- * by unit tests in src/pages/LoginPage.test.tsx and
- * src/components/layout/AppShell.test.tsx
- */
+// Calendar Mode E2E tests: login flow, navigation restrictions, and banner display.
+// Component details and accessibility are covered in unit tests.
 
-/**
- * Generate mock iCal content with a future date.
- * Uses dynamic dates to prevent test brittleness.
- */
+// Uses dynamic dates to prevent test brittleness
+const DAYS_IN_FUTURE = 7;
+const GAME_START_HOUR = 18;
+const GAME_END_HOUR = 20;
+
 function generateMockIcalContent(): string {
-  // Create a date 7 days in the future to ensure the assignment appears in upcoming tab
   const futureDate = new Date();
-  futureDate.setDate(futureDate.getDate() + 7);
-  futureDate.setHours(18, 0, 0, 0);
+  futureDate.setDate(futureDate.getDate() + DAYS_IN_FUTURE);
+  futureDate.setHours(GAME_START_HOUR, 0, 0, 0);
   const endDate = new Date(futureDate);
-  endDate.setHours(20, 0, 0, 0);
+  endDate.setHours(GAME_END_HOUR, 0, 0, 0);
 
   // Format as iCal timestamp (YYYYMMDDTHHMMSSZ)
   const formatIcalDate = (date: Date) => {

--- a/web-app/e2e/pages/login.page.ts
+++ b/web-app/e2e/pages/login.page.ts
@@ -19,7 +19,7 @@ export class LoginPage {
   // Common elements
   readonly demoButton: Locator;
   readonly fullLoginTab: Locator;
-  readonly calendarTab: Locator;
+  readonly calendarModeTab: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -32,22 +32,14 @@ export class LoginPage {
     this.calendarLoginButton = page.getByTestId("calendar-login-button");
     // Common elements
     this.demoButton = page.getByTestId("demo-button");
-    this.fullLoginTab = page.getByRole("tab", { name: /full/i });
-    this.calendarTab = page.getByRole("tab", { name: /calendar/i });
+    this.fullLoginTab = page.getByTestId("full-login-tab");
+    this.calendarModeTab = page.getByTestId("calendar-login-tab");
   }
 
   async goto() {
     await this.page.goto("/login");
     // Wait for login form to be ready - calendar mode is the default
     await expect(this.demoButton).toBeVisible();
-  }
-
-  /**
-   * Switch to full login mode (username/password)
-   */
-  async switchToFullLogin() {
-    await this.fullLoginTab.click();
-    await expect(this.loginButton).toBeVisible();
   }
 
   async login(username: string, password: string) {
@@ -70,22 +62,46 @@ export class LoginPage {
     await expect(this.page.getByRole("main")).toBeVisible();
   }
 
-  /**
-   * Check that calendar mode (default) elements are visible
-   */
-  async expectCalendarModeToBeVisible() {
+  async expectToBeVisible() {
     await expect(this.calendarInput).toBeVisible();
-    await expect(this.calendarLoginButton).toBeVisible();
     await expect(this.demoButton).toBeVisible();
   }
 
   /**
-   * Check that full login mode elements are visible
-   * (must switch to full login mode first)
+   * Switch to calendar mode tab on the login page.
    */
-  async expectFullLoginToBeVisible() {
+  async switchToCalendarMode() {
+    await this.calendarModeTab.click();
+    await expect(this.calendarInput).toBeVisible();
+  }
+
+  /**
+   * Switch to full login tab on the login page.
+   */
+  async switchToFullLogin() {
+    await this.fullLoginTab.click();
     await expect(this.usernameInput).toBeVisible();
-    await expect(this.passwordInput).toBeVisible();
-    await expect(this.loginButton).toBeVisible();
+  }
+
+  /**
+   * Enter calendar mode using a calendar code.
+   * Note: Requires the calendar API to be mocked for E2E tests.
+   */
+  async enterCalendarMode(calendarCode: string) {
+    await this.switchToCalendarMode();
+    await this.calendarInput.fill(calendarCode);
+    await this.calendarLoginButton.click();
+
+    // Wait for navigation away from login page and main content to appear
+    await expect(this.page).not.toHaveURL(/login/);
+    await expect(this.page.getByRole("main")).toBeVisible();
+  }
+
+  /**
+   * Expect calendar mode tab to be visible.
+   */
+  async expectCalendarModeTabVisible() {
+    await expect(this.calendarModeTab).toBeVisible();
+    await expect(this.fullLoginTab).toBeVisible();
   }
 }

--- a/web-app/knip.json
+++ b/web-app/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "entry": ["src/main.tsx", "e2e/**/*.ts"],
   "project": ["src/**/*.{ts,tsx}", "e2e/**/*.ts"],
-  "ignore": ["src/types/**/*.d.ts", "src/api/schema.ts", "src/api/ical/**"],
+  "ignore": ["src/types/**/*.d.ts", "src/api/schema.ts"],
   "ignoreDependencies": ["tailwindcss"],
   "ignoreExportsUsedInFile": true,
   "rules": {

--- a/web-app/src/components/layout/AppShell.test.tsx
+++ b/web-app/src/components/layout/AppShell.test.tsx
@@ -11,10 +11,7 @@ vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn(),
 }));
 
-/**
- * Create a mock auth store return value with sensible defaults.
- * Accepts partial overrides to allow customizing any property.
- */
+// Creates mock auth store with sensible defaults; accepts partial overrides
 function createMockAuthStore(
   overrides: Record<string, unknown> = {},
 ) {

--- a/web-app/src/pages/AssignmentsPage.test.tsx
+++ b/web-app/src/pages/AssignmentsPage.test.tsx
@@ -409,8 +409,12 @@ describe("AssignmentsPage", () => {
   });
 
   describe("Calendar Mode", () => {
-    // Helper to create a future date string for mock assignments
-    function getFutureDateString(hoursFromNow = 24): string {
+    // Named constants for time offsets in hours
+    const DEFAULT_HOURS_FROM_NOW = 24;
+    const GAME_START_HOURS_FROM_NOW = 48;
+    const GAME_END_HOURS_FROM_NOW = 50;
+
+    function getFutureDateString(hoursFromNow = DEFAULT_HOURS_FROM_NOW): string {
       const date = new Date();
       date.setHours(date.getHours() + hoursFromNow);
       return date.toISOString();
@@ -419,9 +423,8 @@ describe("AssignmentsPage", () => {
     function createMockCalendarAssignment(
       overrides: Partial<useConvocations.CalendarAssignment> = {},
     ): useConvocations.CalendarAssignment {
-      // Use a dynamically computed future date to ensure assignments are "upcoming"
-      const startTime = getFutureDateString(48); // 48 hours from now
-      const endTime = getFutureDateString(50); // 50 hours from now
+      const startTime = getFutureDateString(GAME_START_HOURS_FROM_NOW);
+      const endTime = getFutureDateString(GAME_END_HOURS_FROM_NOW);
       return {
         gameId: `game-${Math.random()}`,
         role: "referee1",

--- a/web-app/src/pages/AssignmentsPage.test.tsx
+++ b/web-app/src/pages/AssignmentsPage.test.tsx
@@ -4,6 +4,7 @@ import { AssignmentsPage } from "./AssignmentsPage";
 import type { Assignment } from "@/api/client";
 import type { UseQueryResult } from "@tanstack/react-query";
 import * as useConvocations from "@/hooks/useConvocations";
+import * as authStore from "@/stores/auth";
 
 // Mock useTour to disable tour mode during tests (see src/test/mocks.ts for shared pattern)
 const mockUseTour = vi.hoisted(() => ({
@@ -21,6 +22,52 @@ const mockUseTour = vi.hoisted(() => ({
 
 vi.mock("@/hooks/useConvocations");
 vi.mock("@/hooks/useTour", () => mockUseTour);
+vi.mock("@/stores/auth");
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      // Return readable strings for key assertions
+      const translations: Record<string, string> = {
+        "assignments.title": "Assignments",
+        "assignments.upcoming": "Upcoming",
+        "assignments.validationClosed": "Validation Closed",
+        "assignments.past": "Past",
+        "assignments.loading": "Loading...",
+        "assignments.failedToLoadData": "Failed to load data",
+        "assignments.noUpcomingTitle": "No upcoming assignments",
+        "assignments.noUpcomingDescription": "You have no upcoming assignments",
+        "assignments.noClosedTitle": "No closed assignments",
+        "assignments.noClosedDescription": "No closed assignments yet",
+        "assignments.calendarEmptyTitle": "No calendar data",
+        "assignments.calendarEmptyDescription": "Your calendar is empty",
+        "assignments.calendarNoUpcomingTitle": "No upcoming calendar events",
+        "assignments.calendarNoUpcomingDescription": "No upcoming events in calendar",
+        "common.today": "Today",
+        "common.tomorrow": "Tomorrow",
+        "common.vs": "vs",
+        "common.unknown": "Unknown",
+        "common.retry": "Retry",
+      };
+      return translations[key] ?? key;
+    },
+    locale: "en",
+  }),
+}));
+
+// Helper to mock auth store
+function mockAuthStoreState(overrides: Record<string, unknown> = {}) {
+  const state = {
+    isAssociationSwitching: false,
+    isCalendarMode: () => false,
+    ...overrides,
+  };
+  vi.mocked(authStore.useAuthStore).mockImplementation((selector?: unknown) => {
+    if (typeof selector === "function") {
+      return selector(state);
+    }
+    return state as ReturnType<typeof authStore.useAuthStore>;
+  });
+}
 vi.mock("@/hooks/useAssignmentActions", () => ({
   useAssignmentActions: () => ({
     editCompensationModal: {
@@ -121,6 +168,9 @@ function createMockCalendarQueryResult(
 describe("AssignmentsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Default mocks - not in calendar mode
+    mockAuthStoreState();
 
     // Default mocks - empty data
     vi.mocked(useConvocations.useUpcomingAssignments).mockReturnValue(
@@ -355,6 +405,312 @@ describe("AssignmentsPage", () => {
       fireEvent.click(screen.getByRole("button", { name: /retry/i }));
 
       expect(mockRefetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("Calendar Mode", () => {
+    // Helper to create a future date string for mock assignments
+    function getFutureDateString(hoursFromNow = 24): string {
+      const date = new Date();
+      date.setHours(date.getHours() + hoursFromNow);
+      return date.toISOString();
+    }
+
+    function createMockCalendarAssignment(
+      overrides: Partial<useConvocations.CalendarAssignment> = {},
+    ): useConvocations.CalendarAssignment {
+      // Use a dynamically computed future date to ensure assignments are "upcoming"
+      const startTime = getFutureDateString(48); // 48 hours from now
+      const endTime = getFutureDateString(50); // 50 hours from now
+      return {
+        gameId: `game-${Math.random()}`,
+        role: "referee1",
+        roleRaw: "1. SR",
+        startTime,
+        endTime,
+        homeTeam: "VBC Zürich",
+        awayTeam: "VBC Basel",
+        league: "NLA Men",
+        address: "Saalsporthalle, Zürich",
+        coordinates: null,
+        hallName: null,
+        gender: "men",
+        mapsUrl: null,
+        ...overrides,
+      };
+    }
+
+    beforeEach(() => {
+      // Set calendar mode
+      mockAuthStoreState({ isCalendarMode: () => true });
+    });
+
+    describe("Tab Labels", () => {
+      it("should show 'Past' instead of 'Validation Closed' in calendar mode", () => {
+        render(<AssignmentsPage />);
+
+        // Should have "Past" tab, not "Validation Closed"
+        expect(screen.getByRole("tab", { name: /past/i })).toBeInTheDocument();
+        expect(
+          screen.queryByRole("tab", { name: /validation closed/i }),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should still show 'Upcoming' tab in calendar mode", () => {
+        render(<AssignmentsPage />);
+
+        expect(
+          screen.getByRole("tab", { name: /upcoming/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe("Data Display", () => {
+      it("should show loading state for calendar data", () => {
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult(undefined, true),
+        );
+
+        render(<AssignmentsPage />);
+
+        expect(screen.getByText(/loading/i)).toBeInTheDocument();
+      });
+
+      it("should show calendar assignments when data is available", () => {
+        const calendarAssignment = createMockCalendarAssignment({
+          homeTeam: "Calendar Team A",
+          awayTeam: "Calendar Team B",
+        });
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([calendarAssignment]),
+        );
+
+        render(<AssignmentsPage />);
+
+        expect(screen.getByText("Calendar Team A")).toBeInTheDocument();
+        expect(screen.getByText("Calendar Team B")).toBeInTheDocument();
+      });
+
+      it("should display role badge from calendar data", () => {
+        const calendarAssignment = createMockCalendarAssignment({
+          roleRaw: "2. SR",
+        });
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([calendarAssignment]),
+        );
+
+        render(<AssignmentsPage />);
+
+        expect(screen.getByText("2. SR")).toBeInTheDocument();
+      });
+
+      it("should display league from calendar data", () => {
+        const calendarAssignment = createMockCalendarAssignment({
+          league: "1. Liga Women",
+        });
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([calendarAssignment]),
+        );
+
+        render(<AssignmentsPage />);
+
+        expect(screen.getByText("1. Liga Women")).toBeInTheDocument();
+      });
+    });
+
+    describe("Empty States", () => {
+      it("should show calendar-specific empty state when no calendar data", () => {
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([]),
+        );
+
+        render(<AssignmentsPage />);
+
+        // Should show calendar-specific empty message
+        expect(
+          screen.getByRole("heading", { name: /no.*calendar|calendar.*empty/i }),
+        ).toBeInTheDocument();
+      });
+
+      it("should show calendar-specific no upcoming message", () => {
+        // Return an empty array but with isSuccess true
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([]),
+        );
+
+        render(<AssignmentsPage />);
+
+        // Should find empty state heading
+        const heading = screen.getByRole("heading");
+        expect(heading).toBeInTheDocument();
+      });
+    });
+
+    describe("Error Handling", () => {
+      it("should show error state with retry button for calendar data", () => {
+        const mockRefetch = vi.fn();
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue({
+          ...createMockCalendarQueryResult(
+            undefined,
+            false,
+            new Error("Calendar fetch failed"),
+          ),
+          refetch: mockRefetch,
+        } as unknown as ReturnType<
+          typeof useConvocations.useCalendarAssignments
+        >);
+
+        render(<AssignmentsPage />);
+
+        expect(screen.getByText(/calendar fetch failed/i)).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: /retry/i }),
+        ).toBeInTheDocument();
+      });
+
+      it("should call refetch when retry button is clicked for calendar error", () => {
+        const mockRefetch = vi.fn();
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue({
+          ...createMockCalendarQueryResult(
+            undefined,
+            false,
+            new Error("Failed"),
+          ),
+          refetch: mockRefetch,
+        } as unknown as ReturnType<
+          typeof useConvocations.useCalendarAssignments
+        >);
+
+        render(<AssignmentsPage />);
+        fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+        expect(mockRefetch).toHaveBeenCalled();
+      });
+    });
+
+    describe("Read-Only Mode", () => {
+      it("should not show swipe action buttons in calendar mode", () => {
+        const calendarAssignment = createMockCalendarAssignment();
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([calendarAssignment]),
+        );
+
+        render(<AssignmentsPage />);
+
+        // Swipe actions (confirm, exchange, etc.) should not be visible
+        expect(
+          screen.queryByRole("button", { name: /confirm/i }),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole("button", { name: /exchange/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("Multiple Assignments", () => {
+      it("should display multiple calendar assignments", () => {
+        const assignments = [
+          createMockCalendarAssignment({
+            gameId: "game-1",
+            homeTeam: "Team Alpha",
+            awayTeam: "Team Beta",
+          }),
+          createMockCalendarAssignment({
+            gameId: "game-2",
+            homeTeam: "Team Gamma",
+            awayTeam: "Team Delta",
+          }),
+        ];
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult(assignments),
+        );
+
+        render(<AssignmentsPage />);
+
+        expect(screen.getByText("Team Alpha")).toBeInTheDocument();
+        expect(screen.getByText("Team Beta")).toBeInTheDocument();
+        expect(screen.getByText("Team Gamma")).toBeInTheDocument();
+        expect(screen.getByText("Team Delta")).toBeInTheDocument();
+      });
+
+      it("should show count badge for calendar assignments", () => {
+        const assignments = [
+          createMockCalendarAssignment({ gameId: "game-1" }),
+          createMockCalendarAssignment({ gameId: "game-2" }),
+          createMockCalendarAssignment({ gameId: "game-3" }),
+        ];
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult(assignments),
+        );
+
+        render(<AssignmentsPage />);
+
+        const upcomingTab = screen.getByRole("tab", { name: /upcoming/i });
+        expect(upcomingTab).toHaveTextContent("3");
+      });
+    });
+
+    describe("Date and Time Display", () => {
+      it("should display time from calendar assignment", () => {
+        // Create a specific future time for testing
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 7); // 1 week from now
+        futureDate.setHours(19, 30, 0, 0);
+        const calendarAssignment = createMockCalendarAssignment({
+          startTime: futureDate.toISOString(),
+        });
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([calendarAssignment]),
+        );
+
+        render(<AssignmentsPage />);
+
+        // Time should be displayed (format may vary based on locale)
+        expect(screen.getByText(/19:30/)).toBeInTheDocument();
+      });
+
+      it("should display address from calendar assignment", () => {
+        const calendarAssignment = createMockCalendarAssignment({
+          address: "Test Arena, Bern",
+        });
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([calendarAssignment]),
+        );
+
+        render(<AssignmentsPage />);
+
+        expect(screen.getByText("Test Arena, Bern")).toBeInTheDocument();
+      });
+    });
+
+    describe("API mode vs Calendar mode", () => {
+      it("should use useCalendarAssignments when in calendar mode", () => {
+        mockAuthStoreState({ isCalendarMode: () => true });
+        const calendarAssignment = createMockCalendarAssignment();
+        vi.mocked(useConvocations.useCalendarAssignments).mockReturnValue(
+          createMockCalendarQueryResult([calendarAssignment]),
+        );
+
+        render(<AssignmentsPage />);
+
+        // Should use calendar data
+        expect(useConvocations.useCalendarAssignments).toHaveBeenCalled();
+        expect(screen.getByText("VBC Zürich")).toBeInTheDocument();
+      });
+
+      it("should use useUpcomingAssignments when NOT in calendar mode", () => {
+        mockAuthStoreState({ isCalendarMode: () => false });
+        const apiAssignment = createMockAssignment();
+        vi.mocked(useConvocations.useUpcomingAssignments).mockReturnValue(
+          createMockQueryResult([apiAssignment]),
+        );
+
+        render(<AssignmentsPage />);
+
+        // Should use API data
+        expect(useConvocations.useUpcomingAssignments).toHaveBeenCalled();
+        expect(screen.getByText("VBC Zürich")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/web-app/src/pages/LoginPage.test.tsx
+++ b/web-app/src/pages/LoginPage.test.tsx
@@ -331,23 +331,24 @@ describe("LoginPage", () => {
         ).toBeInTheDocument();
       });
 
-      it("defaults to full login tab", () => {
+      it("defaults to calendar mode tab", () => {
         render(<LoginPage />);
 
-        const fullTab = screen.getByRole("tab", { name: "auth.fullLogin" });
-        expect(fullTab).toHaveAttribute("aria-selected", "true");
-      });
-
-      it("switches to calendar mode tab when clicked", () => {
-        render(<LoginPage />);
-
-        const calendarTab = screen.getByRole("tab", {
-          name: "auth.calendarMode",
-        });
-        fireEvent.click(calendarTab);
-
+        const calendarTab = screen.getByRole("tab", { name: "auth.calendarMode" });
         expect(calendarTab).toHaveAttribute("aria-selected", "true");
         expect(screen.getByTestId("calendar-input")).toBeInTheDocument();
+      });
+
+      it("switches to full login tab when clicked", () => {
+        render(<LoginPage />);
+
+        const fullTab = screen.getByRole("tab", {
+          name: "auth.fullLogin",
+        });
+        fireEvent.click(fullTab);
+
+        expect(fullTab).toHaveAttribute("aria-selected", "true");
+        expect(screen.getByTestId("username-input")).toBeInTheDocument();
       });
 
       it("shows calendar input field in calendar mode", () => {
@@ -489,8 +490,8 @@ describe("LoginPage", () => {
         vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(
           "ABC123",
         );
-        // Create a promise that doesn't resolve immediately
-        let resolveValidation: (value: { valid: boolean }) => void = () => {};
+        // Use definite assignment assertion - resolve is assigned in Promise constructor
+        let resolveValidation!: (value: { valid: boolean }) => void;
         vi.mocked(calendarHelpers.validateCalendarCode).mockReturnValue(
           new Promise((resolve) => {
             resolveValidation = resolve;
@@ -517,7 +518,7 @@ describe("LoginPage", () => {
         vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(
           "ABC123",
         );
-        let resolveValidation: (value: { valid: boolean }) => void = () => {};
+        let resolveValidation!: (value: { valid: boolean }) => void;
         vi.mocked(calendarHelpers.validateCalendarCode).mockReturnValue(
           new Promise((resolve) => {
             resolveValidation = resolve;

--- a/web-app/src/pages/LoginPage.test.tsx
+++ b/web-app/src/pages/LoginPage.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { LoginPage } from "./LoginPage";
 import * as authStore from "@/stores/auth";
 import * as demoStore from "@/stores/demo";
+import * as calendarHelpers from "@/utils/calendar-helpers";
 
 // Mock react-router-dom
 const mockNavigate = vi.fn();
@@ -12,6 +13,7 @@ vi.mock("react-router-dom", () => ({
 
 vi.mock("@/stores/auth");
 vi.mock("@/stores/demo");
+vi.mock("@/utils/calendar-helpers");
 vi.mock("@/hooks/useTranslation", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -20,12 +22,14 @@ vi.mock("@/hooks/useTranslation", () => ({
 }));
 
 const mockLogin = vi.fn();
+const mockLoginWithCalendar = vi.fn();
 const mockSetDemoAuthenticated = vi.fn();
 const mockInitializeDemoData = vi.fn();
 
 function mockAuthStoreState(overrides = {}) {
   const state = {
     login: mockLogin,
+    loginWithCalendar: mockLoginWithCalendar,
     status: "idle" as const,
     error: null,
     setDemoAuthenticated: mockSetDemoAuthenticated,
@@ -296,6 +300,353 @@ describe("LoginPage", () => {
 
       expect(screen.getByRole("tablist")).toBeInTheDocument();
       expect(screen.getAllByRole("tab")).toHaveLength(2);
+    });
+  });
+
+  describe("Calendar Mode", () => {
+    beforeEach(() => {
+      // Default mocks for calendar helpers
+      vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(null);
+      vi.mocked(calendarHelpers.validateCalendarCode).mockResolvedValue({
+        valid: false,
+        error: "auth.calendarNotFound",
+      });
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    describe("Tab Switching", () => {
+      it("renders login mode tabs", () => {
+        render(<LoginPage />);
+
+        expect(screen.getByRole("tablist")).toBeInTheDocument();
+        // Tab names are translation keys since useTranslation is mocked
+        expect(
+          screen.getByRole("tab", { name: "auth.fullLogin" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("tab", { name: "auth.calendarMode" }),
+        ).toBeInTheDocument();
+      });
+
+      it("defaults to full login tab", () => {
+        render(<LoginPage />);
+
+        const fullTab = screen.getByRole("tab", { name: "auth.fullLogin" });
+        expect(fullTab).toHaveAttribute("aria-selected", "true");
+      });
+
+      it("switches to calendar mode tab when clicked", () => {
+        render(<LoginPage />);
+
+        const calendarTab = screen.getByRole("tab", {
+          name: "auth.calendarMode",
+        });
+        fireEvent.click(calendarTab);
+
+        expect(calendarTab).toHaveAttribute("aria-selected", "true");
+        expect(screen.getByTestId("calendar-input")).toBeInTheDocument();
+      });
+
+      it("shows calendar input field in calendar mode", () => {
+        render(<LoginPage />);
+
+        fireEvent.click(
+          screen.getByRole("tab", { name: "auth.calendarMode" }),
+        );
+
+        expect(screen.getByTestId("calendar-input")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("calendar-login-button"),
+        ).toBeInTheDocument();
+      });
+
+      it("hides username/password fields in calendar mode", () => {
+        render(<LoginPage />);
+
+        fireEvent.click(
+          screen.getByRole("tab", { name: "auth.calendarMode" }),
+        );
+
+        expect(screen.queryByLabelText(/username/i)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument();
+      });
+
+      it("shows info box in calendar mode", () => {
+        render(<LoginPage />);
+
+        fireEvent.click(
+          screen.getByRole("tab", { name: "auth.calendarMode" }),
+        );
+
+        // Info box appears in the form area (also appears at bottom of page)
+        const infoTexts = screen.getAllByText("auth.calendarModeInfo");
+        expect(infoTexts.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    describe("Calendar Code Validation", () => {
+      it("shows error for invalid calendar code format", async () => {
+        vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(null);
+
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: { value: "invalid" },
+        });
+        fireEvent.click(screen.getByTestId("calendar-login-button"));
+
+        await waitFor(() => {
+          expect(
+            screen.getByText(/invalidCalendarCode/i),
+          ).toBeInTheDocument();
+        });
+      });
+
+      it("validates calendar code and shows not found error", async () => {
+        vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(
+          "ABC123",
+        );
+        vi.mocked(calendarHelpers.validateCalendarCode).mockResolvedValue({
+          valid: false,
+          error: "auth.calendarNotFound",
+        });
+
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: { value: "ABC123" },
+        });
+        fireEvent.click(screen.getByTestId("calendar-login-button"));
+
+        await waitFor(() => {
+          expect(calendarHelpers.validateCalendarCode).toHaveBeenCalledWith(
+            "ABC123",
+            expect.any(AbortSignal),
+          );
+        });
+      });
+
+      it("calls loginWithCalendar on valid code", async () => {
+        vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(
+          "ABC123",
+        );
+        vi.mocked(calendarHelpers.validateCalendarCode).mockResolvedValue({
+          valid: true,
+        });
+        mockLoginWithCalendar.mockResolvedValue(undefined);
+
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: { value: "ABC123" },
+        });
+        fireEvent.click(screen.getByTestId("calendar-login-button"));
+
+        await waitFor(() => {
+          expect(mockLoginWithCalendar).toHaveBeenCalledWith("ABC123");
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith("/");
+      });
+
+      it("extracts code from URL input", async () => {
+        vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(
+          "XYZ789",
+        );
+        vi.mocked(calendarHelpers.validateCalendarCode).mockResolvedValue({
+          valid: true,
+        });
+        mockLoginWithCalendar.mockResolvedValue(undefined);
+
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: {
+            value:
+              "https://volleymanager.volleyball.ch/calendar/XYZ789",
+          },
+        });
+        fireEvent.click(screen.getByTestId("calendar-login-button"));
+
+        await waitFor(() => {
+          expect(calendarHelpers.extractCalendarCode).toHaveBeenCalledWith(
+            "https://volleymanager.volleyball.ch/calendar/XYZ789",
+          );
+          expect(mockLoginWithCalendar).toHaveBeenCalledWith("XYZ789");
+        });
+      });
+    });
+
+    describe("Calendar Mode Loading State", () => {
+      it("disables calendar input while validating", async () => {
+        vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(
+          "ABC123",
+        );
+        // Create a promise that doesn't resolve immediately
+        let resolveValidation: (value: { valid: boolean }) => void = () => {};
+        vi.mocked(calendarHelpers.validateCalendarCode).mockReturnValue(
+          new Promise((resolve) => {
+            resolveValidation = resolve;
+          }),
+        );
+
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: { value: "ABC123" },
+        });
+        fireEvent.click(screen.getByTestId("calendar-login-button"));
+
+        await waitFor(() => {
+          expect(screen.getByTestId("calendar-input")).toBeDisabled();
+        });
+
+        // Cleanup: resolve the validation
+        resolveValidation({ valid: false });
+      });
+
+      it("shows loading text while validating", async () => {
+        vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(
+          "ABC123",
+        );
+        let resolveValidation: (value: { valid: boolean }) => void = () => {};
+        vi.mocked(calendarHelpers.validateCalendarCode).mockReturnValue(
+          new Promise((resolve) => {
+            resolveValidation = resolve;
+          }),
+        );
+
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: { value: "ABC123" },
+        });
+        fireEvent.click(screen.getByTestId("calendar-login-button"));
+
+        await waitFor(() => {
+          expect(
+            screen.getByText(/enteringCalendarMode/i),
+          ).toBeInTheDocument();
+        });
+
+        // Cleanup
+        resolveValidation({ valid: false });
+      });
+    });
+
+    describe("Calendar Mode Error Handling", () => {
+      it("shows validation failed error on network error", async () => {
+        vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(
+          "ABC123",
+        );
+        vi.mocked(calendarHelpers.validateCalendarCode).mockRejectedValue(
+          new Error("Network error"),
+        );
+
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: { value: "ABC123" },
+        });
+        fireEvent.click(screen.getByTestId("calendar-login-button"));
+
+        await waitFor(() => {
+          expect(
+            screen.getByText(/calendarValidationFailed/i),
+          ).toBeInTheDocument();
+        });
+      });
+
+      it("clears error when user starts typing", async () => {
+        vi.mocked(calendarHelpers.extractCalendarCode).mockReturnValue(null);
+
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: { value: "bad" },
+        });
+        fireEvent.click(screen.getByTestId("calendar-login-button"));
+
+        await waitFor(() => {
+          expect(
+            screen.getByText(/invalidCalendarCode/i),
+          ).toBeInTheDocument();
+        });
+
+        // Start typing again
+        fireEvent.change(screen.getByTestId("calendar-input"), {
+          target: { value: "ABC123" },
+        });
+
+        expect(
+          screen.queryByText(/invalidCalendarCode/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("Calendar Mode Accessibility", () => {
+      it("has proper tab accessibility attributes", () => {
+        render(<LoginPage />);
+
+        const tablist = screen.getByRole("tablist");
+        expect(tablist).toHaveAttribute("aria-label", "Login mode");
+
+        const fullTab = screen.getByRole("tab", { name: "auth.fullLogin" });
+        expect(fullTab).toHaveAttribute("aria-controls", "full-login-panel");
+
+        const calendarTab = screen.getByRole("tab", { name: "auth.calendarMode" });
+        expect(calendarTab).toHaveAttribute(
+          "aria-controls",
+          "calendar-login-panel",
+        );
+      });
+
+      it("has proper tabpanel accessibility attributes", () => {
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+
+        const panel = screen.getByRole("tabpanel");
+        expect(panel).toHaveAttribute("id", "calendar-login-panel");
+        expect(panel).toHaveAttribute(
+          "aria-labelledby",
+          "calendar-login-tab",
+        );
+      });
+
+      it("calendar input has required attribute", () => {
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+
+        expect(screen.getByTestId("calendar-input")).toHaveAttribute(
+          "required",
+        );
+      });
+    });
+
+    describe("Demo Mode in Calendar Tab", () => {
+      it("demo button works in calendar mode tab", () => {
+        render(<LoginPage />);
+
+        fireEvent.click(screen.getByRole("tab", { name: "auth.calendarMode" }));
+        fireEvent.click(screen.getByRole("button", { name: /demo/i }));
+
+        expect(mockInitializeDemoData).toHaveBeenCalledWith("SV");
+        expect(mockSetDemoAuthenticated).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith("/");
+      });
     });
   });
 });

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -275,6 +275,7 @@ export function LoginPage() {
               aria-selected={loginMode === "calendar"}
               aria-controls="calendar-login-panel"
               id="calendar-login-tab"
+              data-testid="calendar-login-tab"
               onClick={() => setLoginMode("calendar")}
               className={`flex-1 py-2 px-4 text-sm font-medium rounded-md transition-colors ${
                 loginMode === "calendar"
@@ -290,6 +291,7 @@ export function LoginPage() {
               aria-selected={loginMode === "full"}
               aria-controls="full-login-panel"
               id="full-login-tab"
+              data-testid="full-login-tab"
               onClick={() => setLoginMode("full")}
               className={`flex-1 py-2 px-4 text-sm font-medium rounded-md transition-colors ${
                 loginMode === "full"

--- a/web-app/src/stores/auth.test.ts
+++ b/web-app/src/stores/auth.test.ts
@@ -940,7 +940,7 @@ describe("useAuthStore", () => {
     });
 
     it("shows loading state while validating", async () => {
-      let resolveValidation: (value: boolean) => void = () => {};
+      let resolveValidation!: (value: boolean) => void;
       mockValidateCalendarCode.mockReturnValueOnce(
         new Promise((resolve) => {
           resolveValidation = resolve;


### PR DESCRIPTION
## Summary
- Add unit tests for Calendar Mode login, assignments display, and feature gating
- Add E2E tests for calendar mode login flow with mocked API
- Update login page POM with calendar mode elements
- Remove obsolete iCal exception from knip config

## Changes
- LoginPage.test.tsx: Calendar mode tab switching, validation, loading states, error handling, accessibility
- AssignmentsPage.test.tsx: Calendar data display, tab labels, empty states, read-only mode
- AppShell.test.tsx: Calendar mode banner, navigation filtering, demo vs calendar distinction
- calendar-mode.spec.ts: E2E tests for login flow, navigation restrictions, logout
- login.page.ts: Calendar mode elements in page object model
- knip.json: Remove src/api/ical/** from ignore list

## Test Plan
- [ ] Unit tests pass (npm test)
- [ ] E2E tests pass (npm run test:e2e)
- [ ] Lint passes (npm run lint)
- [ ] Build passes (npm run build)