### PR TITLE
feat(demo): add single-ball hall assignment to showcase feature

### DIFF
--- a/web-app/src/components/features/AssignmentCard.tsx
+++ b/web-app/src/components/features/AssignmentCard.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import { ExpandableCard } from "@/components/ui/ExpandableCard";
 import { Badge } from "@/components/ui/Badge";
-import { MapPin, MaleIcon, FemaleIcon, TrainFront, Loader2, Navigation, CircleAlert } from "@/components/ui/icons";
+import { MapPin, MaleIcon, FemaleIcon, TrainFront, Loader2, Navigation, CircleAlert, ExternalLink } from "@/components/ui/icons";
 import type { Assignment } from "@/api/client";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useDateFormat } from "@/hooks/useDateFormat";
@@ -278,15 +278,16 @@ function AssignmentCardComponent({
               href={singleBallPdfPath}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 px-2 py-1.5 rounded-md hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors"
+              className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 px-2 py-1.5 rounded-md hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors group"
               onClick={(e) => e.stopPropagation()}
             >
               <CircleAlert className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-              <span>
+              <span className="underline decoration-amber-400/50 group-hover:decoration-amber-500 underline-offset-2">
                 {singleBallMatch.isConditional
                   ? t("assignments.singleBallHallConditional")
                   : t("assignments.singleBallHall")}
               </span>
+              <ExternalLink className="w-3 h-3 flex-shrink-0 opacity-60 group-hover:opacity-100" aria-hidden="true" />
             </a>
           )}
 

--- a/web-app/src/components/ui/icons.tsx
+++ b/web-app/src/components/ui/icons.tsx
@@ -53,6 +53,7 @@ export { Volleyball } from "lucide-react";
 
 // Indicator icons
 export { CircleAlert } from "lucide-react";
+export { ExternalLink } from "lucide-react";
 
 // Gender icons - custom SVGs since Lucide doesn't have Mars/Venus symbols
 import type { SVGProps } from "react";

--- a/web-app/src/stores/demo-generators.ts
+++ b/web-app/src/stores/demo-generators.ts
@@ -27,7 +27,7 @@ export type DemoAssociationCode = "SV" | "SVRBA" | "SVRZ";
 
 // Demo game numbers for assignments, compensations, and exchanges
 const DEMO_GAME_NUMBERS = {
-  ASSIGNMENTS: [382417, 382418, 382419, 382420, 382421] as const,
+  ASSIGNMENTS: [382417, 382418, 382419, 382420, 382421, 382422] as const,
   COMPENSATIONS: [382500, 382501, 382502, 382503, 382504] as const,
   EXCHANGES: [382600, 382601, 382602, 382603, 382604] as const,
 } as const;
@@ -258,6 +258,21 @@ const SV_VENUES: VenueConfig[] = [
       latitude: 47.396438,
       longitude: 8.057063,
       plusCode: "8FVC93W4+HR",
+    },
+  },
+  // Single-ball hall venue for demo (matches SINGLE_BALL_HALLS entry for Däniken)
+  {
+    teamHome: { name: "Volley Schönenwerd NLB", identifier: BASE_TEAM_IDENTIFIER + 8 },
+    teamAway: { name: "VBC Einsiedeln", identifier: BASE_TEAM_IDENTIFIER + 9 },
+    hall: {
+      name: "Mehrzweckhalle Erlimatt",
+      street: "Erlimattstrasse",
+      houseNumber: "17",
+      postalCode: "4658",
+      city: "Däniken",
+      latitude: 47.353312,
+      longitude: 7.988187,
+      plusCode: "9X3J+4C",
     },
   },
 ];
@@ -629,7 +644,9 @@ export function generateAssignments(
     // NLB for SV, 3L for regional - women (3L women have only 1st ref)
     { index: 4, status: "cancelled", position: "head-one", confirmationStatus: "confirmed", confirmationDaysAgo: 10, gameDate: addDays(now, 7), venueIndex: 3, leagueIndex: associationCode === "SV" ? 1 : 2, gender: "f", isGameInFuture: true, isOpenInExchange: true },
     // NLA for SV (linesman assignment), 3L for regional
-    { index: 5, status: "archived", position: "linesman-two", confirmationStatus: "confirmed", confirmationDaysAgo: 14, gameDate: subDays(now, 3), venueIndex: 4, leagueIndex: associationCode === "SV" ? 0 : 2, gender: "m", isGameInFuture: false },
+    { index: 5, status: "archived", position: "linesman-two", confirmationStatus: "confirmed", confirmationDaysAgo: 14, gameDate: subDays(now, 3), venueIndex: 5, leagueIndex: associationCode === "SV" ? 0 : 2, gender: "m", isGameInFuture: false },
+    // NLB in single-ball hall (Ruswil Dorfhalle) - only for SV to showcase single-ball indicator
+    ...(associationCode === "SV" ? [{ index: 6, status: "active" as const, position: "head-one" as const, confirmationStatus: "confirmed" as const, confirmationDaysAgo: 2, gameDate: addDays(now, 3), venueIndex: 4, leagueIndex: 1, gender: "m" as const, isGameInFuture: true }] : []),
   ];
 
   return configs.map((config) =>

--- a/web-app/src/stores/demo-generators.ts
+++ b/web-app/src/stores/demo-generators.ts
@@ -272,7 +272,7 @@ const SV_VENUES: VenueConfig[] = [
       city: "Däniken",
       latitude: 47.353312,
       longitude: 7.988187,
-      plusCode: "9X3J+4C",
+      plusCode: "8FVC82PJ+4C",
     },
   },
 ];
@@ -644,8 +644,8 @@ export function generateAssignments(
     // NLB for SV, 3L for regional - women (3L women have only 1st ref)
     { index: 4, status: "cancelled", position: "head-one", confirmationStatus: "confirmed", confirmationDaysAgo: 10, gameDate: addDays(now, 7), venueIndex: 3, leagueIndex: associationCode === "SV" ? 1 : 2, gender: "f", isGameInFuture: true, isOpenInExchange: true },
     // NLA for SV (linesman assignment), 3L for regional
-    { index: 5, status: "archived", position: "linesman-two", confirmationStatus: "confirmed", confirmationDaysAgo: 14, gameDate: subDays(now, 3), venueIndex: 5, leagueIndex: associationCode === "SV" ? 0 : 2, gender: "m", isGameInFuture: false },
-    // NLB in single-ball hall (Ruswil Dorfhalle) - only for SV to showcase single-ball indicator
+    { index: 5, status: "archived", position: "linesman-two", confirmationStatus: "confirmed", confirmationDaysAgo: 14, gameDate: subDays(now, 3), venueIndex: 0, leagueIndex: associationCode === "SV" ? 0 : 2, gender: "m", isGameInFuture: false },
+    // NLB in single-ball hall (Däniken Erlimatt) - only for SV to showcase single-ball indicator
     ...(associationCode === "SV" ? [{ index: 6, status: "active" as const, position: "head-one" as const, confirmationStatus: "confirmed" as const, confirmationDaysAgo: 2, gameDate: addDays(now, 3), venueIndex: 4, leagueIndex: 1, gender: "m" as const, isGameInFuture: true }] : []),
   ];
 

--- a/web-app/src/utils/single-ball-halls.ts
+++ b/web-app/src/utils/single-ball-halls.ts
@@ -103,7 +103,11 @@ export function detectSingleBallHall(
 
 /**
  * Gets the PDF path for single-ball halls documentation based on locale.
+ * Includes the base URL for correct resolution on GitHub Pages.
  */
 export function getSingleBallHallsPdfPath(locale: Locale): string {
-  return SINGLE_BALL_PDF_PATHS[locale];
+  const basePath = import.meta.env.BASE_URL;
+  const pdfPath = SINGLE_BALL_PDF_PATHS[locale];
+  // Remove leading slash from pdfPath since BASE_URL already ends with /
+  return `${basePath}${pdfPath.slice(1)}`;
 }


### PR DESCRIPTION
## Summary
- Add a demo mode assignment that showcases the single-ball hall indicator feature
- NLB game at Mehrzweckhalle Erlimatt in Däniken displays the "1" badge for single-ball halls

## Changes
- Add Däniken Erlimatt venue to SV_VENUES (matches SINGLE_BALL_HALLS entry)
- Add NLB assignment config using the single-ball hall venue (index 6)
- Add game number 382422 for the new assignment

## Test Plan
- [ ] Enter demo mode with SV (Swiss Volley) association
- [ ] Verify the new NLB assignment appears in the assignments list
- [ ] Check that the "1" badge appears next to Däniken in the assignment card
- [ ] Expand the card to verify the conditional single-ball hall notice appears