### PR TITLE
fix(auth): add support for indoor/iCal/referee calendar URL format

### DIFF
--- a/web-app/e2e/calendar-mode.spec.ts
+++ b/web-app/e2e/calendar-mode.spec.ts
@@ -89,7 +89,7 @@ test.describe("Calendar Mode", () => {
   test.describe("Calendar Mode Login Flow", () => {
     test.beforeEach(async ({ page }) => {
       // Mock the calendar API endpoint to return valid iCal data
-      await page.route("**/sportmanager.volleyball/calendar/ical/*", (route) =>
+      await page.route("**/iCal/referee/*", (route) =>
         route.fulfill({
           status: 200,
           contentType: "text/calendar",
@@ -133,7 +133,7 @@ test.describe("Calendar Mode", () => {
   test.describe("Calendar Mode Navigation Restrictions", () => {
     test.beforeEach(async ({ page }) => {
       // Mock the calendar API
-      await page.route("**/sportmanager.volleyball/calendar/ical/*", (route) =>
+      await page.route("**/iCal/referee/*", (route) =>
         route.fulfill({
           status: 200,
           contentType: "text/calendar",
@@ -200,7 +200,7 @@ test.describe("Calendar Mode", () => {
   test.describe("Calendar Mode Logout", () => {
     test.beforeEach(async ({ page }) => {
       // Mock the calendar API
-      await page.route("**/sportmanager.volleyball/calendar/ical/*", (route) =>
+      await page.route("**/iCal/referee/*", (route) =>
         route.fulfill({
           status: 200,
           contentType: "text/calendar",
@@ -249,7 +249,7 @@ test.describe("Calendar Mode", () => {
 
     test("shows error when calendar is not found", async ({ page }) => {
       // Mock 404 response for calendar API
-      await page.route("**/sportmanager.volleyball/calendar/ical/*", (route) =>
+      await page.route("**/iCal/referee/*", (route) =>
         route.fulfill({
           status: 404,
           body: "Not Found",

--- a/web-app/src/utils/calendar-helpers.test.ts
+++ b/web-app/src/utils/calendar-helpers.test.ts
@@ -106,6 +106,40 @@ describe("extractCalendarCode", () => {
     });
   });
 
+  describe("URL extraction - indoor/iCal/referee/", () => {
+    it("extracts code from indoor iCal referee path", () => {
+      expect(
+        extractCalendarCode(
+          "https://volleymanager.volleyball.ch/indoor/iCal/referee/ABC123",
+        ),
+      ).toBe("ABC123");
+    });
+
+    it("extracts code from indoor iCal referee path with trailing slash", () => {
+      expect(
+        extractCalendarCode(
+          "https://volleymanager.volleyball.ch/indoor/iCal/referee/ABC123/",
+        ),
+      ).toBe("ABC123");
+    });
+
+    it("extracts code from webcal indoor iCal referee path", () => {
+      expect(
+        extractCalendarCode(
+          "webcal://volleymanager.volleyball.ch/indoor/iCal/referee/ABC123",
+        ),
+      ).toBe("ABC123");
+    });
+
+    it("extracts code regardless of case in path", () => {
+      expect(
+        extractCalendarCode(
+          "https://volleymanager.volleyball.ch/indoor/iCal/referee/BLYMVF",
+        ),
+      ).toBe("BLYMVF");
+    });
+  });
+
   describe("invalid URLs", () => {
     it("returns null for URLs from other domains", () => {
       expect(
@@ -173,7 +207,7 @@ describe("validateCalendarCode", () => {
 
       expect(result).toEqual({ valid: true });
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.example.com/sportmanager.volleyball/calendar/ical/ABC123",
+        "https://api.example.com/iCal/referee/ABC123",
         { method: "HEAD", signal: undefined },
       );
     });

--- a/web-app/src/utils/calendar-helpers.ts
+++ b/web-app/src/utils/calendar-helpers.ts
@@ -1,9 +1,10 @@
 /**
  * Calendar URL/code extraction and validation utilities.
  *
- * Calendar URLs from VolleyManager follow this pattern:
- * https://volleymanager.volleyball.ch/calendar/{6-char-code}
- * webcal://volleymanager.volleyball.ch/calendar/{6-char-code}
+ * Calendar URLs from VolleyManager follow these patterns:
+ * - https://volleymanager.volleyball.ch/calendar/{6-char-code}
+ * - https://volleymanager.volleyball.ch/indoor/iCal/referee/{6-char-code}
+ * - webcal://volleymanager.volleyball.ch/calendar/{6-char-code}
  *
  * Users can provide:
  * - Full HTTPS URL
@@ -24,6 +25,10 @@ const CALENDAR_URL_PATTERNS = [
   /^https?:\/\/(?:www\.)?volleymanager\.volleyball\.ch\/sportmanager\.volleyball\/calendar\/ical\/([a-z0-9]{6})\/?$/i,
   // webcal://volleymanager.volleyball.ch/sportmanager.volleyball/calendar/ical/XXXXXX
   /^webcal:\/\/(?:www\.)?volleymanager\.volleyball\.ch\/sportmanager\.volleyball\/calendar\/ical\/([a-z0-9]{6})\/?$/i,
+  // https://volleymanager.volleyball.ch/indoor/iCal/referee/XXXXXX
+  /^https?:\/\/(?:www\.)?volleymanager\.volleyball\.ch\/indoor\/iCal\/referee\/([a-z0-9]{6})\/?$/i,
+  // webcal://volleymanager.volleyball.ch/indoor/iCal/referee/XXXXXX
+  /^webcal:\/\/(?:www\.)?volleymanager\.volleyball\.ch\/indoor\/iCal\/referee\/([a-z0-9]{6})\/?$/i,
 ];
 
 /**
@@ -87,7 +92,7 @@ export async function validateCalendarCode(
   }
 
   const API_BASE = import.meta.env.VITE_API_PROXY_URL || "";
-  const calendarUrl = `${API_BASE}/sportmanager.volleyball/calendar/ical/${code}`;
+  const calendarUrl = `${API_BASE}/iCal/referee/${code}`;
 
   try {
     const response = await fetch(calendarUrl, {


### PR DESCRIPTION
## Summary
- Fixed calendar login validation failing for indoor/iCal/referee URL format
- Fixed validation endpoint to use correct path matching the calendar API

## Changes
- Added URL patterns for https://volleymanager.volleyball.ch/indoor/iCal/referee/XXXXXX
- Added URL patterns for webcal://volleymanager.volleyball.ch/indoor/iCal/referee/XXXXXX
- Fixed validation endpoint from /sportmanager.volleyball/calendar/ical/ to /iCal/referee/
- Added tests for the new URL patterns

## Test Plan
- [ ] Verify pasting full indoor/iCal/referee URL works
- [ ] Verify pasting webcal URL works
- [ ] Verify entering just the 6-character code still works
- [ ] Verify existing URL formats still work