### PR TITLE
feat(calendar): implement calendar API client for calendar mode

### DIFF
--- a/web-app/e2e/calendar-mode.spec.ts
+++ b/web-app/e2e/calendar-mode.spec.ts
@@ -115,10 +115,16 @@ test.describe("Calendar Mode", () => {
       // Wait for the page to be ready
       await expect(page.getByRole("main")).toBeVisible();
 
-      // Should see either assignments content or empty state message
-      // The specific content depends on how the parser handles the iCal data
-      const hasContent = await page.getByRole("tablist").or(page.getByText(/no assignments|assignment/i)).isVisible();
-      expect(hasContent).toBeTruthy();
+      // Should see assignments page content - either the tablist or empty state
+      // Use specific locator to avoid matching nav items
+      const tablist = page.getByRole("tablist", { name: "Assignments" });
+      const emptyState = page.getByText(/no assignments/i);
+
+      // Check if either is visible (calendar mode may have no assignments)
+      const tablistVisible = await tablist.isVisible().catch(() => false);
+      const emptyStateVisible = await emptyState.isVisible().catch(() => false);
+
+      expect(tablistVisible || emptyStateVisible).toBeTruthy();
     });
 
     test("displays calendar mode indicator banner", async ({ page }) => {

--- a/web-app/src/api/calendar-client.test.ts
+++ b/web-app/src/api/calendar-client.test.ts
@@ -1,0 +1,569 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  calendarApi,
+  CalendarModeNotSupportedError,
+  DEFAULT_REFEREE_EDIT_HOURS,
+} from "./calendar-client";
+import * as calendarApiModule from "./calendar-api";
+import { useAuthStore } from "@/stores/auth";
+import type { CalendarAssignment } from "./calendar-api";
+
+// Mock the calendar-api module
+vi.mock("./calendar-api", () => ({
+  fetchCalendarAssignments: vi.fn(),
+}));
+
+// Mock the auth store
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: {
+    getState: vi.fn(),
+  },
+}));
+
+describe("calendar-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("CalendarModeNotSupportedError", () => {
+    it("creates error with correct message", () => {
+      const error = new CalendarModeNotSupportedError("Test Operation");
+      expect(error.message).toBe(
+        "Test Operation is not available in Calendar Mode. Please log in with your VolleyManager credentials to access this feature.",
+      );
+      expect(error.name).toBe("CalendarModeNotSupportedError");
+    });
+
+    it("is instance of Error", () => {
+      const error = new CalendarModeNotSupportedError("Test");
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("mapRoleToPosition (via calendarAssignmentToAssignment)", () => {
+    const createMockCalendarAssignment = (
+      role: CalendarAssignment["role"],
+    ): CalendarAssignment => ({
+      gameId: "123456",
+      startTime: "2025-01-15T19:30:00+01:00",
+      endTime: "2025-01-15T22:30:00+01:00",
+      league: "NLA Men",
+      homeTeam: "Home Team",
+      awayTeam: "Away Team",
+      role,
+      roleRaw: role,
+      gender: "men",
+      address: null,
+      coordinates: null,
+      hallName: null,
+      mapsUrl: null,
+    });
+
+    beforeEach(() => {
+      vi.mocked(useAuthStore.getState).mockReturnValue({
+        calendarCode: "ABC123",
+      } as ReturnType<typeof useAuthStore.getState>);
+    });
+
+    it("maps referee1 to head-one", async () => {
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        createMockCalendarAssignment("referee1"),
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereePosition).toBe("head-one");
+    });
+
+    it("maps referee2 to head-two", async () => {
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        createMockCalendarAssignment("referee2"),
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereePosition).toBe("head-two");
+    });
+
+    it("maps lineReferee to linesman-one", async () => {
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        createMockCalendarAssignment("lineReferee"),
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereePosition).toBe("linesman-one");
+    });
+
+    it("maps scorer to head-one as fallback", async () => {
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        createMockCalendarAssignment("scorer"),
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereePosition).toBe("head-one");
+    });
+
+    it("maps unknown to head-one as fallback", async () => {
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        createMockCalendarAssignment("unknown"),
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereePosition).toBe("head-one");
+    });
+  });
+
+  describe("calendarAssignmentToAssignment", () => {
+    beforeEach(() => {
+      vi.mocked(useAuthStore.getState).mockReturnValue({
+        calendarCode: "ABC123",
+      } as ReturnType<typeof useAuthStore.getState>);
+    });
+
+    it("converts calendar assignment to API assignment format", async () => {
+      const calendarAssignment: CalendarAssignment = {
+        gameId: "123456",
+        startTime: "2025-01-15T19:30:00+01:00",
+        endTime: "2025-01-15T22:30:00+01:00",
+        league: "NLA Men",
+        homeTeam: "VBC Zürich",
+        awayTeam: "Volley Luzern",
+        role: "referee1",
+        roleRaw: "1SR",
+        gender: "men",
+        hallName: "Sporthalle Hardau",
+        address: "Hardaustrasse 10, 8005 Zürich",
+        coordinates: { latitude: 47.3769, longitude: 8.5417 },
+        mapsUrl: null,
+      };
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        calendarAssignment,
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      const assignment = result.items[0]!;
+
+      expect(assignment.__identity).toBe("calendar-123456");
+      expect(assignment.refereeConvocationStatus).toBe("active");
+      expect(assignment.refereePosition).toBe("head-one");
+      expect(assignment.refereeGame?.__identity).toBe("calendar-game-123456");
+      expect(assignment.refereeGame?.game?.__identity).toBe("123456");
+      expect(assignment.refereeGame?.game?.number).toBe(123456);
+      expect(assignment.refereeGame?.game?.startingDateTime).toBe(
+        "2025-01-15T19:30:00+01:00",
+      );
+      expect(assignment.refereeGame?.game?.encounter?.teamHome?.name).toBe(
+        "VBC Zürich",
+      );
+      expect(assignment.refereeGame?.game?.encounter?.teamAway?.name).toBe(
+        "Volley Luzern",
+      );
+      expect(assignment.refereeGame?.game?.group?.displayName).toBe("NLA Men");
+      expect(assignment.refereeGame?.game?.hall?.name).toBe("Sporthalle Hardau");
+      expect(
+        assignment.refereeGame?.game?.hall?.primaryPostalAddress?.combinedAddress,
+      ).toBe("Hardaustrasse 10, 8005 Zürich");
+      expect(
+        assignment.refereeGame?.game?.hall?.primaryPostalAddress
+          ?.geographicalLocation?.latitude,
+      ).toBe(47.3769);
+    });
+
+    it("maps men gender to m", async () => {
+      const calendarAssignment: CalendarAssignment = {
+        gameId: "123",
+        startTime: "2025-01-15T19:30:00+01:00",
+        endTime: "2025-01-15T22:30:00+01:00",
+        league: "NLA",
+        homeTeam: "Home",
+        awayTeam: "Away",
+        role: "referee1",
+        roleRaw: "1SR",
+        gender: "men",
+        address: null,
+        coordinates: null,
+        hallName: null,
+        mapsUrl: null,
+      };
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        calendarAssignment,
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereeGame?.game?.encounter?.teamHome?.gender).toBe(
+        "m",
+      );
+    });
+
+    it("maps women gender to f", async () => {
+      const calendarAssignment: CalendarAssignment = {
+        gameId: "123",
+        startTime: "2025-01-15T19:30:00+01:00",
+        endTime: "2025-01-15T22:30:00+01:00",
+        league: "NLA",
+        homeTeam: "Home",
+        awayTeam: "Away",
+        role: "referee1",
+        roleRaw: "1SR",
+        gender: "women",
+        address: null,
+        coordinates: null,
+        hallName: null,
+        mapsUrl: null,
+      };
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        calendarAssignment,
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereeGame?.game?.encounter?.teamHome?.gender).toBe(
+        "f",
+      );
+    });
+
+    it("maps mixed gender to undefined", async () => {
+      const calendarAssignment: CalendarAssignment = {
+        gameId: "123",
+        startTime: "2025-01-15T19:30:00+01:00",
+        endTime: "2025-01-15T22:30:00+01:00",
+        league: "NLA",
+        homeTeam: "Home",
+        awayTeam: "Away",
+        role: "referee1",
+        roleRaw: "1SR",
+        gender: "mixed",
+        address: null,
+        coordinates: null,
+        hallName: null,
+        mapsUrl: null,
+      };
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        calendarAssignment,
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(
+        result.items[0]?.refereeGame?.game?.encounter?.teamHome?.gender,
+      ).toBeUndefined();
+    });
+
+    it("handles assignment without hall", async () => {
+      const calendarAssignment: CalendarAssignment = {
+        gameId: "123",
+        startTime: "2025-01-15T19:30:00+01:00",
+        endTime: "2025-01-15T22:30:00+01:00",
+        league: "NLA",
+        homeTeam: "Home",
+        awayTeam: "Away",
+        role: "referee1",
+        roleRaw: "1SR",
+        gender: "men",
+        address: null,
+        coordinates: null,
+        hallName: null,
+        mapsUrl: null,
+      };
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        calendarAssignment,
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereeGame?.game?.hall).toBeUndefined();
+    });
+
+    it("handles hall without coordinates", async () => {
+      const calendarAssignment: CalendarAssignment = {
+        gameId: "123",
+        startTime: "2025-01-15T19:30:00+01:00",
+        endTime: "2025-01-15T22:30:00+01:00",
+        league: "NLA",
+        homeTeam: "Home",
+        awayTeam: "Away",
+        role: "referee1",
+        roleRaw: "1SR",
+        gender: "men",
+        hallName: "Test Hall",
+        address: "Test Address",
+        coordinates: null,
+        mapsUrl: null,
+      };
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        calendarAssignment,
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items[0]?.refereeGame?.game?.hall?.name).toBe("Test Hall");
+      expect(
+        result.items[0]?.refereeGame?.game?.hall?.primaryPostalAddress
+          ?.geographicalLocation,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("searchAssignments", () => {
+    it("returns empty array when no calendar code", async () => {
+      vi.mocked(useAuthStore.getState).mockReturnValue({
+        calendarCode: null,
+      } as unknown as ReturnType<typeof useAuthStore.getState>);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items).toEqual([]);
+      expect(result.totalItemsCount).toBe(0);
+    });
+
+    it("fetches and converts calendar assignments", async () => {
+      vi.mocked(useAuthStore.getState).mockReturnValue({
+        calendarCode: "ABC123",
+      } as ReturnType<typeof useAuthStore.getState>);
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        {
+          gameId: "1",
+          startTime: "2025-01-15T19:30:00+01:00",
+          endTime: "2025-01-15T22:30:00+01:00",
+          league: "NLA",
+          homeTeam: "Home",
+          awayTeam: "Away",
+          role: "referee1",
+          roleRaw: "1SR",
+          gender: "men",
+          address: null,
+          coordinates: null,
+          hallName: null,
+          mapsUrl: null,
+        },
+      ]);
+
+      const result = await calendarApi.searchAssignments();
+      expect(result.items).toHaveLength(1);
+      expect(result.totalItemsCount).toBe(1);
+      expect(calendarApiModule.fetchCalendarAssignments).toHaveBeenCalledWith(
+        "ABC123",
+      );
+    });
+  });
+
+  describe("getAssignmentDetails", () => {
+    it("throws error when no calendar code", async () => {
+      vi.mocked(useAuthStore.getState).mockReturnValue({
+        calendarCode: null,
+      } as unknown as ReturnType<typeof useAuthStore.getState>);
+
+      await expect(
+        calendarApi.getAssignmentDetails("calendar-123", []),
+      ).rejects.toThrow("Calendar code not available");
+    });
+
+    it("finds assignment by ID", async () => {
+      vi.mocked(useAuthStore.getState).mockReturnValue({
+        calendarCode: "ABC123",
+      } as ReturnType<typeof useAuthStore.getState>);
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
+        {
+          gameId: "12345",
+          startTime: "2025-01-15T19:30:00+01:00",
+          endTime: "2025-01-15T22:30:00+01:00",
+          league: "NLA",
+          homeTeam: "Home",
+          awayTeam: "Away",
+          role: "referee1",
+          roleRaw: "1SR",
+          gender: "men",
+          address: null,
+          coordinates: null,
+          hallName: null,
+          mapsUrl: null,
+        },
+      ]);
+
+      const result = await calendarApi.getAssignmentDetails("calendar-12345", []);
+      expect(result.__identity).toBe("calendar-12345");
+    });
+
+    it("throws error when assignment not found", async () => {
+      vi.mocked(useAuthStore.getState).mockReturnValue({
+        calendarCode: "ABC123",
+      } as ReturnType<typeof useAuthStore.getState>);
+
+      vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([]);
+
+      await expect(
+        calendarApi.getAssignmentDetails("calendar-99999", []),
+      ).rejects.toThrow("Assignment not found: calendar-99999");
+    });
+  });
+
+  describe("getAssociationSettings", () => {
+    it("returns default settings with referee edit hours", async () => {
+      const settings = await calendarApi.getAssociationSettings();
+      expect(settings.hoursAfterGameStartForRefereeToEditGameList).toBe(
+        DEFAULT_REFEREE_EDIT_HOURS,
+      );
+    });
+  });
+
+  describe("getActiveSeason", () => {
+    it("returns season spanning September to June", async () => {
+      const season = await calendarApi.getActiveSeason();
+      const startDate = new Date(season.seasonStartDate!);
+      const endDate = new Date(season.seasonEndDate!);
+
+      expect(startDate.getMonth()).toBe(8); // September (0-indexed)
+      expect(startDate.getDate()).toBe(1);
+      expect(endDate.getMonth()).toBe(5); // June (0-indexed)
+      expect(endDate.getDate()).toBe(30);
+    });
+
+    it("returns previous year season when before September", async () => {
+      // Mock a date in January 2025
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2025, 0, 15)); // January 15, 2025
+
+      const season = await calendarApi.getActiveSeason();
+      const startDate = new Date(season.seasonStartDate!);
+
+      // Should return 2024-2025 season (start in September 2024)
+      expect(startDate.getFullYear()).toBe(2024);
+
+      vi.useRealTimers();
+    });
+
+    it("returns current year season when in September or later", async () => {
+      // Mock a date in October 2025
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2025, 9, 15)); // October 15, 2025
+
+      const season = await calendarApi.getActiveSeason();
+      const startDate = new Date(season.seasonStartDate!);
+
+      // Should return 2025-2026 season (start in September 2025)
+      expect(startDate.getFullYear()).toBe(2025);
+
+      vi.useRealTimers();
+    });
+
+    it("handles edge case at August/September boundary", async () => {
+      // August 31 - should be previous season
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2025, 7, 31)); // August 31, 2025
+
+      let season = await calendarApi.getActiveSeason();
+      expect(new Date(season.seasonStartDate!).getFullYear()).toBe(2024);
+
+      // September 1 - should be current season
+      vi.setSystemTime(new Date(2025, 8, 1)); // September 1, 2025
+
+      season = await calendarApi.getActiveSeason();
+      expect(new Date(season.seasonStartDate!).getFullYear()).toBe(2025);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("unsupported operations", () => {
+    it("searchCompensations throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.searchCompensations()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("getCompensationDetails throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.getCompensationDetails()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("updateCompensation throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.updateCompensation()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("searchExchanges throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.searchExchanges()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("applyForExchange throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.applyForExchange()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("withdrawFromExchange throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.withdrawFromExchange()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("getPossiblePlayerNominations throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.getPossiblePlayerNominations()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("searchPersons throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.searchPersons()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("getGameWithScoresheet throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.getGameWithScoresheet()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("updateNominationList throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.updateNominationList()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("finalizeNominationList throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.finalizeNominationList()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("submitScorer throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.submitScorer()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("updateScoresheet throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.updateScoresheet()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("finalizeScoresheet throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.finalizeScoresheet()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("uploadResource throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.uploadResource()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+
+    it("switchRoleAndAttribute throws CalendarModeNotSupportedError", async () => {
+      await expect(calendarApi.switchRoleAndAttribute()).rejects.toThrow(
+        CalendarModeNotSupportedError,
+      );
+    });
+  });
+});

--- a/web-app/src/api/calendar-client.ts
+++ b/web-app/src/api/calendar-client.ts
@@ -1,0 +1,296 @@
+/**
+ * Calendar API client for Calendar Mode.
+ *
+ * This module implements the same API interface as the real API client,
+ * but uses the iCal calendar feed instead of authenticated API calls.
+ * Calendar mode provides read-only access to assignments.
+ *
+ * Features supported in calendar mode:
+ * - searchAssignments: Returns assignments from the iCal feed
+ * - getAssociationSettings: Returns mock settings (for UI compatibility)
+ * - getActiveSeason: Returns mock season (for UI compatibility)
+ *
+ * Features NOT supported in calendar mode (will throw errors):
+ * - Compensations (searchCompensations, getCompensationDetails, updateCompensation)
+ * - Exchanges (searchExchanges, applyForExchange, withdrawFromExchange)
+ * - Nominations (getPossiblePlayerNominations, updateNominationList, finalizeNominationList)
+ * - Scoresheet operations (getGameWithScoresheet, submitScorer, finalizeScoresheet, uploadResource)
+ * - Person search (searchPersons)
+ * - Role switching (switchRoleAndAttribute)
+ */
+
+import type {
+  SearchConfiguration,
+  Assignment,
+  AssignmentsResponse,
+  CompensationsResponse,
+  ConvocationCompensationDetailed,
+  ExchangesResponse,
+  AssociationSettings,
+  Season,
+  NominationList,
+  NominationListFinalizeResponse,
+  Scoresheet,
+  FileResource,
+  GameDetails,
+  PossibleNominationsResponse,
+  PersonSearchResponse,
+} from "./client";
+import {
+  fetchCalendarAssignments,
+  type CalendarAssignment,
+} from "./calendar-api";
+import { useAuthStore } from "@/stores/auth";
+
+/**
+ * Error thrown when an operation is not supported in calendar mode.
+ */
+export class CalendarModeNotSupportedError extends Error {
+  constructor(operation: string) {
+    super(
+      `${operation} is not available in Calendar Mode. Please log in with your VolleyManager credentials to access this feature.`,
+    );
+    this.name = "CalendarModeNotSupportedError";
+  }
+}
+
+import type { components } from "./schema";
+
+type RefereePosition = components["schemas"]["RefereePosition"];
+type RefereeRole = CalendarAssignment["role"];
+
+/**
+ * Maps iCal referee role to API RefereePosition enum value.
+ */
+function mapRoleToPosition(role: RefereeRole): RefereePosition {
+  const roleMap: Record<RefereeRole, RefereePosition> = {
+    referee1: "head-one",
+    referee2: "head-two",
+    lineReferee: "linesman-one",
+    scorer: "head-one", // Scorer doesn't have a dedicated position, use head-one as fallback
+    unknown: "head-one",
+  };
+  return roleMap[role];
+}
+
+/**
+ * Converts a CalendarAssignment to the Assignment format used by the app.
+ * This mapping preserves as much information as possible from the iCal data.
+ */
+function calendarAssignmentToAssignment(
+  calendarAssignment: CalendarAssignment,
+): Assignment {
+  // Map gender to team gender format
+  const genderMap: Record<string, "m" | "f" | undefined> = {
+    men: "m",
+    women: "f",
+    mixed: undefined,
+    unknown: undefined,
+  };
+
+  const teamGender = genderMap[calendarAssignment.gender];
+
+  return {
+    // Use gameId as the assignment identity (since we don't have a real convocation ID)
+    __identity: `calendar-${calendarAssignment.gameId}`,
+    refereeConvocationStatus: "active",
+    refereePosition: mapRoleToPosition(calendarAssignment.role),
+    refereeGame: {
+      __identity: `calendar-game-${calendarAssignment.gameId}`,
+      game: {
+        __identity: calendarAssignment.gameId,
+        number: parseInt(calendarAssignment.gameId, 10) || undefined,
+        startingDateTime: calendarAssignment.startTime,
+        encounter: {
+          teamHome: {
+            name: calendarAssignment.homeTeam,
+            displayName: calendarAssignment.homeTeam,
+            gender: teamGender,
+          },
+          teamAway: {
+            name: calendarAssignment.awayTeam,
+            displayName: calendarAssignment.awayTeam,
+            gender: teamGender,
+          },
+        },
+        group: {
+          displayName: calendarAssignment.league,
+        },
+        hall: calendarAssignment.hallName
+          ? {
+              name: calendarAssignment.hallName,
+              primaryPostalAddress: calendarAssignment.address
+                ? {
+                    combinedAddress: calendarAssignment.address,
+                    geographicalLocation: calendarAssignment.coordinates
+                      ? {
+                          latitude: calendarAssignment.coordinates.latitude,
+                          longitude: calendarAssignment.coordinates.longitude,
+                        }
+                      : undefined,
+                  }
+                : undefined,
+            }
+          : undefined,
+      },
+      // Determine if game is in future based on start time
+      isGameInFuture:
+        new Date(calendarAssignment.startTime) > new Date() ? "1" : "0",
+    },
+  };
+}
+
+/**
+ * Calendar API client implementation.
+ * Implements the same interface as the regular API client but uses iCal data.
+ */
+export const calendarApi = {
+  async searchAssignments(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
+    _config: SearchConfiguration = {},
+  ): Promise<AssignmentsResponse> {
+    // Get calendar code from auth store
+    const calendarCode = useAuthStore.getState().calendarCode;
+
+    if (!calendarCode) {
+      return { items: [], totalItemsCount: 0 };
+    }
+
+    // Fetch assignments from iCal feed
+    const calendarAssignments = await fetchCalendarAssignments(calendarCode);
+
+    // Convert to Assignment format
+    const assignments = calendarAssignments.map(calendarAssignmentToAssignment);
+
+    // Note: We ignore the search configuration filters since iCal doesn't support them
+    // The hook-level filtering will handle date range filtering client-side
+
+    return {
+      items: assignments,
+      totalItemsCount: assignments.length,
+    };
+  },
+
+  async getAssignmentDetails(
+    convocationId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
+    _properties: string[],
+  ): Promise<Assignment> {
+    // Get calendar code from auth store
+    const calendarCode = useAuthStore.getState().calendarCode;
+
+    if (!calendarCode) {
+      throw new Error("Calendar code not available");
+    }
+
+    // Fetch all assignments and find the one matching the ID
+    const calendarAssignments = await fetchCalendarAssignments(calendarCode);
+
+    // Extract the gameId from the convocation ID (format: "calendar-{gameId}")
+    const gameId = convocationId.replace(/^calendar-/, "");
+
+    const calendarAssignment = calendarAssignments.find(
+      (a) => a.gameId === gameId,
+    );
+
+    if (!calendarAssignment) {
+      throw new Error(`Assignment not found: ${convocationId}`);
+    }
+
+    return calendarAssignmentToAssignment(calendarAssignment);
+  },
+
+  // Compensations - not supported in calendar mode
+  async searchCompensations(): Promise<CompensationsResponse> {
+    throw new CalendarModeNotSupportedError("Compensations");
+  },
+
+  async getCompensationDetails(): Promise<ConvocationCompensationDetailed> {
+    throw new CalendarModeNotSupportedError("Compensation details");
+  },
+
+  async updateCompensation(): Promise<void> {
+    throw new CalendarModeNotSupportedError("Compensation updates");
+  },
+
+  // Exchanges - not supported in calendar mode
+  async searchExchanges(): Promise<ExchangesResponse> {
+    throw new CalendarModeNotSupportedError("Exchanges");
+  },
+
+  async applyForExchange(): Promise<void> {
+    throw new CalendarModeNotSupportedError("Exchange applications");
+  },
+
+  async withdrawFromExchange(): Promise<void> {
+    throw new CalendarModeNotSupportedError("Exchange withdrawals");
+  },
+
+  // Settings - return mock data for UI compatibility
+  async getAssociationSettings(): Promise<AssociationSettings> {
+    // Return sensible defaults for calendar mode
+    return {
+      hoursAfterGameStartForRefereeToEditGameList: 6,
+    } as AssociationSettings;
+  },
+
+  async getActiveSeason(): Promise<Season> {
+    // Return a season spanning the current volleyball year
+    // Season typically runs September to June
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth();
+
+    // If we're before September, we're in the previous season
+    const seasonStartYear = currentMonth < 8 ? currentYear - 1 : currentYear;
+
+    const seasonStart = new Date(seasonStartYear, 8, 1); // September 1st
+    const seasonEnd = new Date(seasonStartYear + 1, 5, 30); // June 30th next year
+
+    return {
+      seasonStartDate: seasonStart.toISOString(),
+      seasonEndDate: seasonEnd.toISOString(),
+    } as Season;
+  },
+
+  // Nominations - not supported in calendar mode
+  async getPossiblePlayerNominations(): Promise<PossibleNominationsResponse> {
+    throw new CalendarModeNotSupportedError("Player nominations");
+  },
+
+  async searchPersons(): Promise<PersonSearchResponse> {
+    throw new CalendarModeNotSupportedError("Person search");
+  },
+
+  async getGameWithScoresheet(): Promise<GameDetails> {
+    throw new CalendarModeNotSupportedError("Scoresheet access");
+  },
+
+  async updateNominationList(): Promise<NominationList> {
+    throw new CalendarModeNotSupportedError("Nomination list updates");
+  },
+
+  async finalizeNominationList(): Promise<NominationListFinalizeResponse> {
+    throw new CalendarModeNotSupportedError("Nomination list finalization");
+  },
+
+  async submitScorer(): Promise<Scoresheet> {
+    throw new CalendarModeNotSupportedError("Scorer submission");
+  },
+
+  async updateScoresheet(): Promise<Scoresheet> {
+    throw new CalendarModeNotSupportedError("Scoresheet updates");
+  },
+
+  async finalizeScoresheet(): Promise<Scoresheet> {
+    throw new CalendarModeNotSupportedError("Scoresheet finalization");
+  },
+
+  async uploadResource(): Promise<FileResource[]> {
+    throw new CalendarModeNotSupportedError("File uploads");
+  },
+
+  async switchRoleAndAttribute(): Promise<void> {
+    throw new CalendarModeNotSupportedError("Role switching");
+  },
+};

--- a/web-app/src/api/calendar-client.ts
+++ b/web-app/src/api/calendar-client.ts
@@ -19,6 +19,20 @@
  * - Role switching (switchRoleAndAttribute)
  */
 
+// Calendar mode settings constants
+/** Default hours after game start when referees can edit game list */
+export const DEFAULT_REFEREE_EDIT_HOURS = 6;
+
+// Volleyball season date constants (0-indexed months)
+/** September - month when volleyball season starts */
+const SEASON_START_MONTH = 8;
+/** June - month when volleyball season ends */
+const SEASON_END_MONTH = 5;
+/** Day of month when season starts (September 1st) */
+const SEASON_START_DAY = 1;
+/** Day of month when season ends (June 30th) */
+const SEASON_END_DAY = 30;
+
 import type {
   SearchConfiguration,
   Assignment,
@@ -230,7 +244,7 @@ export const calendarApi = {
   async getAssociationSettings(): Promise<AssociationSettings> {
     // Return sensible defaults for calendar mode
     return {
-      hoursAfterGameStartForRefereeToEditGameList: 6,
+      hoursAfterGameStartForRefereeToEditGameList: DEFAULT_REFEREE_EDIT_HOURS,
     } as AssociationSettings;
   },
 
@@ -242,10 +256,19 @@ export const calendarApi = {
     const currentMonth = now.getMonth();
 
     // If we're before September, we're in the previous season
-    const seasonStartYear = currentMonth < 8 ? currentYear - 1 : currentYear;
+    const seasonStartYear =
+      currentMonth < SEASON_START_MONTH ? currentYear - 1 : currentYear;
 
-    const seasonStart = new Date(seasonStartYear, 8, 1); // September 1st
-    const seasonEnd = new Date(seasonStartYear + 1, 5, 30); // June 30th next year
+    const seasonStart = new Date(
+      seasonStartYear,
+      SEASON_START_MONTH,
+      SEASON_START_DAY,
+    );
+    const seasonEnd = new Date(
+      seasonStartYear + 1,
+      SEASON_END_MONTH,
+      SEASON_END_DAY,
+    );
 
     return {
       seasonStartDate: seasonStart.toISOString(),

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -6,6 +6,7 @@ import {
   validateResponse,
 } from "./validation";
 import { mockApi } from "./mock-api";
+import { calendarApi } from "./calendar-client";
 import {
   buildFormData,
   setCsrfToken as setToken,
@@ -668,7 +669,6 @@ import type { DataSource } from "@/stores/auth";
  *   - boolean (deprecated): true = demo mode, false = api mode
  *
  * @returns The API client for the specified data source
- * @throws Error if calendar mode is requested (not yet implemented)
  */
 export function getApiClient(dataSource: DataSource | boolean): ApiClient {
   // Handle legacy boolean parameter for backwards compatibility
@@ -680,8 +680,7 @@ export function getApiClient(dataSource: DataSource | boolean): ApiClient {
     case "demo":
       return mockApi;
     case "calendar":
-      // Calendar mode API will be implemented in a future PR
-      throw new Error("Calendar API not yet implemented");
+      return calendarApi;
     case "api":
       return api;
     default: {

--- a/web-app/src/utils/calendar-helpers.test.ts
+++ b/web-app/src/utils/calendar-helpers.test.ts
@@ -169,6 +169,53 @@ describe("extractCalendarCode", () => {
       ).toBeNull();
     });
   });
+
+  describe("iOS/Safari edge cases", () => {
+    it("handles zero-width characters from iOS copy-paste", () => {
+      // Zero-width space (U+200B) that iOS sometimes adds
+      expect(extractCalendarCode("\u200BABC123")).toBe("ABC123");
+      expect(extractCalendarCode("ABC123\u200B")).toBe("ABC123");
+      expect(extractCalendarCode("\u200BABC123\u200B")).toBe("ABC123");
+    });
+
+    it("handles non-breaking spaces", () => {
+      // Non-breaking space (U+00A0) that can appear on iOS
+      expect(extractCalendarCode("\u00A0ABC123")).toBe("ABC123");
+      expect(extractCalendarCode("ABC123\u00A0")).toBe("ABC123");
+    });
+
+    it("handles URLs with query strings via fallback", () => {
+      expect(
+        extractCalendarCode(
+          "https://volleymanager.volleyball.ch/indoor/iCal/referee/ABC123?source=share",
+        ),
+      ).toBe("ABC123");
+    });
+
+    it("handles URLs with fragments via fallback", () => {
+      expect(
+        extractCalendarCode(
+          "https://volleymanager.volleyball.ch/indoor/iCal/referee/ABC123#top",
+        ),
+      ).toBe("ABC123");
+    });
+
+    it("handles URLs with query strings and fragments", () => {
+      expect(
+        extractCalendarCode(
+          "https://volleymanager.volleyball.ch/calendar/XYZ789?utm_source=app#section",
+        ),
+      ).toBe("XYZ789");
+    });
+
+    it("handles invisible characters in URLs", () => {
+      expect(
+        extractCalendarCode(
+          "https://volleymanager.volleyball.ch/indoor/iCal/referee/BLYMVF\u200B",
+        ),
+      ).toBe("BLYMVF");
+    });
+  });
 });
 
 describe("validateCalendarCode", () => {


### PR DESCRIPTION
## Summary
- Implement calendar API client that provides read-only access to assignments via iCal feed
- Fix "Calendar API not yet implemented" error when logging in with calendar URLs
- Improve URL parsing robustness for iOS Safari edge cases

## Changes
- Add calendar-client.ts with CalendarModeNotSupportedError for unsupported operations
- Wire calendarApi to getApiClient() for the "calendar" data source
- Improve extractCalendarCode() to handle iOS Safari quirks (invisible Unicode characters, URLs with query strings/fragments)
- Add comprehensive tests for Safari/iOS edge cases

## Test Plan
- [ ] Log in with calendar URL (e.g., indoor/iCal/referee/XXXXXX)
- [ ] Verify assignments load correctly from iCal feed
- [ ] Verify unsupported features (compensations, exchanges) show appropriate errors
- [ ] Test on iOS Safari with copy-pasted calendar URLs
- [ ] Verify existing full login flow still works