### PR TITLE
feat(help): add help documentation links to web-app

### DIFF
--- a/web-app/src/components/features/settings/HelpSection.tsx
+++ b/web-app/src/components/features/settings/HelpSection.tsx
@@ -1,8 +1,7 @@
 import { BookOpen } from "lucide-react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
-
-const HELP_SITE_URL = "https://takishima.github.io/volleykit/help";
+import { HELP_SITE_URL } from "@/utils/constants";
 
 export function HelpSection() {
   const { t } = useTranslation();

--- a/web-app/src/components/features/settings/HelpSection.tsx
+++ b/web-app/src/components/features/settings/HelpSection.tsx
@@ -1,0 +1,38 @@
+import { BookOpen } from "lucide-react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+
+const HELP_SITE_URL = "https://takishima.github.io/volleykit/help";
+
+export function HelpSection() {
+  const { t } = useTranslation();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <BookOpen
+            className="w-5 h-5 text-primary-600 dark:text-primary-400"
+            aria-hidden="true"
+          />
+          <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
+            {t("settings.help.title")}
+          </h2>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t("settings.help.description")}
+        </p>
+        <a
+          href={HELP_SITE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:underline text-sm"
+        >
+          {t("settings.help.openDocs")} &rarr;
+        </a>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web-app/src/components/features/settings/index.ts
+++ b/web-app/src/components/features/settings/index.ts
@@ -4,6 +4,7 @@ export { HomeLocationSection } from "./HomeLocationSection";
 export { TransportSection } from "./TransportSection";
 export { DataRetentionSection } from "./DataRetentionSection";
 export { TourSection } from "./TourSection";
+export { HelpSection } from "./HelpSection";
 export { DemoSection } from "./DemoSection";
 export { AccessibilitySection } from "./AccessibilitySection";
 export { SafeModeSection } from "./SafeModeSection";

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -184,6 +184,7 @@ const de: Translations = {
     enteringCalendarMode: "Wird gestartet...",
     calendarModeInfo: "Nur-Lese-Zugriff auf Ihre Spieleinsätze",
     calendarModeHint: "Finden Sie Ihre Kalender-URL im VolleyManager auf der Seite Meine Einsätze",
+    learnHowItWorks: "So funktioniert VolleyKit",
   },
   calendarError: {
     title: "Kalenderfehler",
@@ -422,6 +423,12 @@ const de: Translations = {
         "Deaktiviert Pinch-to-Zoom und Doppeltippen zum Zoomen auf Touch-Geräten. Dies kann versehentliches Zoomen verhindern. Hinweis: Einige Benutzer sind auf Zoom für die Barrierefreiheit angewiesen, verwenden Sie diese Einstellung daher mit Bedacht.",
       preventZoomEnabled: "Zoom-Verhinderung ist aktiviert",
       preventZoomDisabled: "Zoom-Verhinderung ist deaktiviert",
+    },
+    help: {
+      title: "Hilfe & Dokumentation",
+      description:
+        "Erfahren Sie, wie Sie VolleyKit nutzen können, mit detaillierten Anleitungen und Tipps.",
+      openDocs: "Dokumentation öffnen",
     },
     safeMode: "Sicherheitsmodus",
     safeModeDescription:

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -184,6 +184,7 @@ const en: Translations = {
     enteringCalendarMode: "Entering...",
     calendarModeInfo: "Read-only access to your assignments",
     calendarModeHint: "Find your calendar URL in VolleyManager on the My Assignments page",
+    learnHowItWorks: "Learn how VolleyKit works",
   },
   calendarError: {
     title: "Calendar Error",
@@ -420,6 +421,12 @@ const en: Translations = {
         "Disable pinch-to-zoom and double-tap zoom on touch devices. This can help prevent accidental zooming. Note: Some users rely on zoom for accessibility, so use this setting thoughtfully.",
       preventZoomEnabled: "Zoom prevention is enabled",
       preventZoomDisabled: "Zoom prevention is disabled",
+    },
+    help: {
+      title: "Help & Documentation",
+      description:
+        "Learn how to use VolleyKit with detailed guides and tips.",
+      openDocs: "Open Documentation",
     },
     safeMode: "Safe Mode",
     safeModeDescription:

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -184,6 +184,7 @@ const fr: Translations = {
     enteringCalendarMode: "Chargement...",
     calendarModeInfo: "Accès en lecture seule à vos désignations",
     calendarModeHint: "Trouvez votre URL de calendrier dans VolleyManager sur la page Mes désignations",
+    learnHowItWorks: "Découvrir comment VolleyKit fonctionne",
   },
   calendarError: {
     title: "Erreur de calendrier",
@@ -421,6 +422,12 @@ const fr: Translations = {
         "Désactive le pincement pour zoomer et le double appui pour zoomer sur les appareils tactiles. Cela peut aider à éviter les zooms accidentels. Remarque: Certains utilisateurs dépendent du zoom pour l'accessibilité, utilisez donc ce paramètre avec discernement.",
       preventZoomEnabled: "La prévention du zoom est activée",
       preventZoomDisabled: "La prévention du zoom est désactivée",
+    },
+    help: {
+      title: "Aide et documentation",
+      description:
+        "Apprenez à utiliser VolleyKit avec des guides et conseils détaillés.",
+      openDocs: "Ouvrir la documentation",
     },
     safeMode: "Mode sécurisé",
     safeModeDescription:

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -184,6 +184,7 @@ const it: Translations = {
     enteringCalendarMode: "Caricamento...",
     calendarModeInfo: "Accesso in sola lettura alle tue designazioni",
     calendarModeHint: "Trova l'URL del calendario in VolleyManager sulla pagina Le mie designazioni",
+    learnHowItWorks: "Scopri come funziona VolleyKit",
   },
   calendarError: {
     title: "Errore calendario",
@@ -419,6 +420,12 @@ const it: Translations = {
         "Disabilita il pizzico per zoomare e il doppio tocco per zoomare sui dispositivi touch. Questo può aiutare a prevenire zoom accidentali. Nota: Alcuni utenti dipendono dallo zoom per l'accessibilità, quindi usa questa impostazione con attenzione.",
       preventZoomEnabled: "La prevenzione dello zoom è attivata",
       preventZoomDisabled: "La prevenzione dello zoom è disattivata",
+    },
+    help: {
+      title: "Aiuto e documentazione",
+      description:
+        "Scopri come usare VolleyKit con guide e suggerimenti dettagliati.",
+      openDocs: "Apri documentazione",
     },
     safeMode: "Modalità sicura",
     safeModeDescription:

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -76,6 +76,7 @@ export interface Translations {
     enteringCalendarMode: string;
     calendarModeInfo: string;
     calendarModeHint: string;
+    learnHowItWorks: string;
   };
   calendarError: {
     title: string;
@@ -287,6 +288,11 @@ export interface Translations {
       preventZoomDescription: string;
       preventZoomEnabled: string;
       preventZoomDisabled: string;
+    };
+    help: {
+      title: string;
+      description: string;
+      openDocs: string;
     };
     safeMode: string;
     safeModeDescription: string;

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -12,6 +12,7 @@ import {
   extractCalendarCode,
   validateCalendarCode,
 } from "@/utils/calendar-helpers";
+import { HELP_SITE_URL } from "@/utils/constants";
 
 // Demo-only mode restricts the app to demo mode (used in PR preview deployments)
 const DEMO_MODE_ONLY = import.meta.env.VITE_DEMO_MODE_ONLY === "true";
@@ -506,7 +507,7 @@ export function LoginPage() {
         {/* Help link */}
         <p className="mt-4 text-center">
           <a
-            href="https://takishima.github.io/volleykit/help"
+            href={HELP_SITE_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="text-xs text-text-muted dark:text-text-muted-dark hover:text-primary-600 dark:hover:text-primary-400 transition-colors"

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -502,6 +502,18 @@ export function LoginPage() {
             t("auth.calendarModeInfo")
           )}
         </p>
+
+        {/* Help link */}
+        <p className="mt-4 text-center">
+          <a
+            href="https://takishima.github.io/volleykit/help"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-text-muted dark:text-text-muted-dark hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+          >
+            {t("auth.learnHowItWorks")} &rarr;
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   TransportSection,
   DataRetentionSection,
   TourSection,
+  HelpSection,
   DemoSection,
   AccessibilitySection,
   SafeModeSection,
@@ -64,6 +65,8 @@ export function SettingsPage() {
       <DataRetentionSection />
 
       <TourSection isDemoMode={isDemoMode} />
+
+      <HelpSection />
 
       <AccessibilitySection
         preventZoom={preventZoom}

--- a/web-app/src/utils/constants.ts
+++ b/web-app/src/utils/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Application-wide constants.
+ */
+
+/**
+ * URL to the VolleyKit help documentation site.
+ */
+export const HELP_SITE_URL = "https://takishima.github.io/volleykit/help";


### PR DESCRIPTION
## Summary
- Add links to the help documentation site in the web-app
- HelpSection component in Settings page with BookOpen icon
- Subtle help link on the Login page

## Changes
- Created HelpSection.tsx component with Card, BookOpen icon, and external link
- Updated SettingsPage.tsx to include HelpSection after TourSection
- Updated LoginPage.tsx with "Learn how VolleyKit works" link
- Added translation keys to i18n/types.ts
- Added translations to all 4 locale files (de, en, fr, it)
- Updated settings components index to export HelpSection

## Test Plan
- [ ] Verify HelpSection appears in Settings page after Guided Tours
- [ ] Verify help link on Login page is visible and styled correctly
- [ ] Verify external links open in new tab
- [ ] Verify translations display correctly in all 4 languages
- [ ] Verify lint, tests, and build pass