### PR TITLE
fix(auth): prevent double login by avoiding redundant session checks

### DIFF
--- a/web-app/src/App.test.tsx
+++ b/web-app/src/App.test.tsx
@@ -350,6 +350,7 @@ describe("ProtectedRoute", () => {
       status: "authenticated",
       checkSession: mockCheckSession,
       isDemoMode: true,
+      dataSource: "demo",
       logout: mockLogout,
     } as ReturnType<typeof useAuthStore>);
 
@@ -366,11 +367,34 @@ describe("ProtectedRoute", () => {
     });
   });
 
-  it("calls checkSession when not in demo mode", async () => {
+  it("does not call checkSession in calendar mode", async () => {
     vi.mocked(useAuthStore).mockReturnValue({
       status: "authenticated",
       checkSession: mockCheckSession,
       isDemoMode: false,
+      dataSource: "calendar",
+      logout: mockLogout,
+    } as ReturnType<typeof useAuthStore>);
+
+    vi.mocked(useDemoStore).mockReturnValue({
+      assignments: [],
+      initializeDemoData: mockInitializeDemoData,
+    } as unknown as ReturnType<typeof useDemoStore>);
+
+    render(<App />);
+
+    // Wait for any potential async operations to complete
+    await waitFor(() => {
+      expect(mockCheckSession).not.toHaveBeenCalled();
+    });
+  });
+
+  it("calls checkSession in API mode", async () => {
+    vi.mocked(useAuthStore).mockReturnValue({
+      status: "authenticated",
+      checkSession: mockCheckSession,
+      isDemoMode: false,
+      dataSource: "api",
       logout: mockLogout,
     } as ReturnType<typeof useAuthStore>);
 

--- a/web-app/src/App.test.tsx
+++ b/web-app/src/App.test.tsx
@@ -349,7 +349,6 @@ describe("ProtectedRoute", () => {
     vi.mocked(useAuthStore).mockReturnValue({
       status: "authenticated",
       checkSession: mockCheckSession,
-      isDemoMode: true,
       dataSource: "demo",
       logout: mockLogout,
     } as ReturnType<typeof useAuthStore>);
@@ -371,7 +370,6 @@ describe("ProtectedRoute", () => {
     vi.mocked(useAuthStore).mockReturnValue({
       status: "authenticated",
       checkSession: mockCheckSession,
-      isDemoMode: false,
       dataSource: "calendar",
       logout: mockLogout,
     } as ReturnType<typeof useAuthStore>);
@@ -393,7 +391,6 @@ describe("ProtectedRoute", () => {
     vi.mocked(useAuthStore).mockReturnValue({
       status: "authenticated",
       checkSession: mockCheckSession,
-      isDemoMode: false,
       dataSource: "api",
       logout: mockLogout,
     } as ReturnType<typeof useAuthStore>);

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -102,11 +102,12 @@ const queryClient = new QueryClient({
 });
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { status, checkSession, isDemoMode } = useAuthStore(
+  const { status, checkSession, isDemoMode, dataSource } = useAuthStore(
     useShallow((state) => ({
       status: state.status,
       checkSession: state.checkSession,
       isDemoMode: state.isDemoMode,
+      dataSource: state.dataSource,
     })),
   );
   const { assignments, activeAssociationCode, initializeDemoData } =
@@ -118,7 +119,8 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
       })),
     );
   const { t } = useTranslation();
-  const shouldVerifySession = status === "authenticated" && !isDemoMode;
+  // Only verify session for API mode - demo and calendar modes don't need server verification
+  const shouldVerifySession = status === "authenticated" && dataSource === "api";
   const [isVerifying, setIsVerifying] = useState(() => shouldVerifySession);
   const [verifyError, setVerifyError] = useState<string | null>(null);
 
@@ -134,7 +136,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 
   // Verify persisted session is still valid on mount
   useEffect(() => {
-    if (!isVerifying || isDemoMode) return;
+    if (!isVerifying || dataSource !== "api") return;
 
     const controller = new AbortController();
 
@@ -160,7 +162,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
     return () => {
       controller.abort();
     };
-  }, [isVerifying, checkSession, isDemoMode]);
+  }, [isVerifying, checkSession, dataSource]);
 
   // Show loading state while verifying session
   if (status === "loading" || isVerifying) {
@@ -210,12 +212,13 @@ const BASE_PATH = getBasename();
 function QueryErrorHandler({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
   const logout = useAuthStore((state) => state.logout);
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
   const isRedirectingRef = useRef(false);
 
   useEffect(() => {
     const handleQueryError = (error: unknown) => {
-      if (isDemoMode || isRedirectingRef.current) return;
+      // Only handle auth errors for API mode - demo and calendar modes don't use server auth
+      if (dataSource !== "api" || isRedirectingRef.current) return;
 
       if (isAuthError(error)) {
         isRedirectingRef.current = true;
@@ -248,7 +251,7 @@ function QueryErrorHandler({ children }: { children: React.ReactNode }) {
       unsubscribeQueries();
       unsubscribeMutations();
     };
-  }, [navigate, logout, isDemoMode]);
+  }, [navigate, logout, dataSource]);
 
   return <>{children}</>;
 }

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -102,11 +102,10 @@ const queryClient = new QueryClient({
 });
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { status, checkSession, isDemoMode, dataSource } = useAuthStore(
+  const { status, checkSession, dataSource } = useAuthStore(
     useShallow((state) => ({
       status: state.status,
       checkSession: state.checkSession,
-      isDemoMode: state.isDemoMode,
       dataSource: state.dataSource,
     })),
   );
@@ -119,6 +118,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
       })),
     );
   const { t } = useTranslation();
+  const isDemoMode = dataSource === "demo";
   // Only verify session for API mode - demo and calendar modes don't need server verification
   const shouldVerifySession = status === "authenticated" && dataSource === "api";
   const [isVerifying, setIsVerifying] = useState(() => shouldVerifySession);

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -108,6 +108,7 @@ function createMockAuthStore(
     isDemoMode: false,
     isAssociationSwitching: false,
     _checkSessionPromise: null,
+    _lastAuthTimestamp: null,
     eligibleAttributeValues: null,
     groupedEligibleAttributeValues: null,
     eligibleRoles: null,

--- a/web-app/src/stores/auth.test.ts
+++ b/web-app/src/stores/auth.test.ts
@@ -8,23 +8,6 @@ vi.mock("@/api/client", () => ({
   clearSession: vi.fn(),
 }));
 
-// Mock the calendar API validation
-const mockValidateCalendarCode = vi.fn();
-vi.mock("@/api/calendar-api", () => ({
-  validateCalendarCode: (...args: unknown[]) => mockValidateCalendarCode(...args),
-  InvalidCalendarCodeError: class InvalidCalendarCodeError extends Error {
-    constructor(code: string) {
-      super(`Invalid calendar code: ${code}`);
-      this.name = "InvalidCalendarCodeError";
-    }
-  },
-  CalendarNotFoundError: class CalendarNotFoundError extends Error {
-    constructor(code: string) {
-      super(`Calendar not found: ${code}`);
-      this.name = "CalendarNotFoundError";
-    }
-  },
-}));
 
 // Mock fetch
 const mockFetch = vi.fn();
@@ -148,6 +131,7 @@ describe("useAuthStore", () => {
       isDemoMode: false,
       activeOccupationId: null,
       _checkSessionPromise: null,
+      _lastAuthTimestamp: null,
     });
     vi.clearAllMocks();
   });
@@ -866,9 +850,10 @@ describe("useAuthStore", () => {
   });
 
   describe("loginWithCalendar", () => {
-    it("sets calendar mode with the provided code", async () => {
-      mockValidateCalendarCode.mockResolvedValueOnce(true);
+    // Note: Calendar code validation is now done by LoginPage before calling loginWithCalendar.
+    // This function only performs format validation as a safeguard for direct API calls.
 
+    it("sets calendar mode with the provided code", async () => {
       await useAuthStore.getState().loginWithCalendar("ABC123");
 
       const state = useAuthStore.getState();
@@ -880,8 +865,6 @@ describe("useAuthStore", () => {
     });
 
     it("trims whitespace from calendar code", async () => {
-      mockValidateCalendarCode.mockResolvedValueOnce(true);
-
       await useAuthStore.getState().loginWithCalendar("  ABC123  ");
 
       const state = useAuthStore.getState();
@@ -896,8 +879,6 @@ describe("useAuthStore", () => {
       expect(state.status).toBe("error");
       expect(state.error).toBe("auth.invalidCalendarCode");
       expect(state.calendarCode).toBeNull();
-      // Validation should not be called for invalid format
-      expect(mockValidateCalendarCode).not.toHaveBeenCalled();
     });
 
     it("rejects code that is too long", async () => {
@@ -906,7 +887,6 @@ describe("useAuthStore", () => {
       const state = useAuthStore.getState();
       expect(state.status).toBe("error");
       expect(state.error).toBe("auth.invalidCalendarCode");
-      expect(mockValidateCalendarCode).not.toHaveBeenCalled();
     });
 
     it("rejects code with special characters", async () => {
@@ -915,12 +895,9 @@ describe("useAuthStore", () => {
       const state = useAuthStore.getState();
       expect(state.status).toBe("error");
       expect(state.error).toBe("auth.invalidCalendarCode");
-      expect(mockValidateCalendarCode).not.toHaveBeenCalled();
     });
 
     it("accepts lowercase alphanumeric codes", async () => {
-      mockValidateCalendarCode.mockResolvedValueOnce(true);
-
       await useAuthStore.getState().loginWithCalendar("abc123");
 
       const state = useAuthStore.getState();
@@ -928,31 +905,10 @@ describe("useAuthStore", () => {
       expect(state.calendarCode).toBe("abc123");
     });
 
-    it("shows error when calendar code is not found", async () => {
-      mockValidateCalendarCode.mockResolvedValueOnce(false);
-
-      await useAuthStore.getState().loginWithCalendar("NOTFND");
-
-      const state = useAuthStore.getState();
-      expect(state.status).toBe("error");
-      expect(state.error).toBe("auth.calendarNotFound");
-      expect(state.calendarCode).toBeNull();
-    });
-
-    it("shows loading state while validating", async () => {
-      let resolveValidation!: (value: boolean) => void;
-      mockValidateCalendarCode.mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveValidation = resolve;
-        }),
-      );
-
-      const promise = useAuthStore.getState().loginWithCalendar("ABC123");
-      expect(useAuthStore.getState().status).toBe("loading");
-
-      resolveValidation(true);
-      await promise;
-
+    it("sets authenticated state immediately without loading state", async () => {
+      // loginWithCalendar is now synchronous (no API validation)
+      // since validation is done by LoginPage before calling this
+      await useAuthStore.getState().loginWithCalendar("ABC123");
       expect(useAuthStore.getState().status).toBe("authenticated");
     });
   });
@@ -960,7 +916,6 @@ describe("useAuthStore", () => {
   describe("logoutCalendar", () => {
     it("clears calendar mode and resets state", async () => {
       // Set up calendar mode
-      mockValidateCalendarCode.mockResolvedValueOnce(true);
       await useAuthStore.getState().loginWithCalendar("ABC123");
 
       // Logout from calendar
@@ -996,7 +951,6 @@ describe("useAuthStore", () => {
     });
 
     it("returns 'calendar' for calendar mode", async () => {
-      mockValidateCalendarCode.mockResolvedValueOnce(true);
       await useAuthStore.getState().loginWithCalendar("ABC123");
 
       expect(useAuthStore.getState().getAuthMode()).toBe("calendar");
@@ -1016,7 +970,6 @@ describe("useAuthStore", () => {
     });
 
     it("clears calendarCode when logging out from calendar mode", async () => {
-      mockValidateCalendarCode.mockResolvedValueOnce(true);
       await useAuthStore.getState().loginWithCalendar("ABC123");
       expect(useAuthStore.getState().calendarCode).toBe("ABC123");
 

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -102,6 +102,8 @@ const LOGIN_PAGE_URL = `${API_BASE}/login`;
 const AUTH_URL = `${API_BASE}/sportmanager.security/authentication/authenticate`;
 const LOGOUT_URL = `${API_BASE}/logout`;
 const SESSION_CHECK_TIMEOUT_MS = 10_000;
+/** Grace period after login during which session checks are skipped */
+const SESSION_CHECK_GRACE_PERIOD_MS = 5_000;
 
 /** Calendar codes are exactly 6 alphanumeric characters */
 const CALENDAR_CODE_PATTERN = /^[a-zA-Z0-9]{6}$/;
@@ -356,11 +358,11 @@ export const useAuthStore = create<AuthState>()(
           return true;
         }
 
-        // Skip session check if authentication happened very recently (within 5 seconds).
+        // Skip session check if authentication happened very recently.
         // This prevents redundant network requests right after login.
         const lastAuth = get()._lastAuthTimestamp;
-        if (lastAuth && Date.now() - lastAuth < 5000) {
-          logger.info("Session check: skipping, authenticated within last 5 seconds");
+        if (lastAuth && Date.now() - lastAuth < SESSION_CHECK_GRACE_PERIOD_MS) {
+          logger.info("Session check: skipping, authenticated recently");
           return true;
         }
 


### PR DESCRIPTION
## Summary
- Fixed issue where users had to login twice, especially in calendar mode
- Removed duplicate calendar code validation that caused unnecessary network requests
- Added timestamp tracking to skip redundant session checks after successful login
- Updated ProtectedRoute and QueryErrorHandler to properly handle calendar mode

## Changes
- Remove duplicate calendar validation in auth.ts:loginWithCalendar() - validation now done once by LoginPage
- Update ProtectedRoute to check dataSource === "api" instead of !isDemoMode
- Add _lastAuthTimestamp to auth store to track when authentication last succeeded
- Skip session checks if authentication happened within the last 5 seconds
- Update QueryErrorHandler to use dataSource for consistent auth error handling

## Test Plan
- [ ] Test calendar mode login - should only require entering code once
- [ ] Test regular API login - should only require entering credentials once
- [ ] Test stale session handling - expired sessions should still be detected
- [ ] Test demo mode - should work without session checks
- [ ] Verify all tests pass