### PR TITLE
fix(help): make help site links work correctly in all environments

### DIFF
--- a/web-app/src/components/features/settings/HelpSection.tsx
+++ b/web-app/src/components/features/settings/HelpSection.tsx
@@ -1,7 +1,7 @@
 import { BookOpen } from "lucide-react";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
-import { HELP_SITE_URL } from "@/utils/constants";
+import { getHelpSiteUrl } from "@/utils/constants";
 
 export function HelpSection() {
   const { t } = useTranslation();
@@ -24,7 +24,7 @@ export function HelpSection() {
           {t("settings.help.description")}
         </p>
         <a
-          href={HELP_SITE_URL}
+          href={getHelpSiteUrl()}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:text-primary-500 dark:hover:text-primary-300 underline underline-offset-2 text-sm transition-colors"

--- a/web-app/src/components/features/settings/HelpSection.tsx
+++ b/web-app/src/components/features/settings/HelpSection.tsx
@@ -27,7 +27,7 @@ export function HelpSection() {
           href={getHelpSiteUrl()}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:text-primary-500 dark:hover:text-primary-300 underline underline-offset-2 text-sm transition-colors"
+          className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:underline text-sm"
         >
           {t("settings.help.openDocs")} &rarr;
         </a>

--- a/web-app/src/components/features/settings/HelpSection.tsx
+++ b/web-app/src/components/features/settings/HelpSection.tsx
@@ -27,7 +27,7 @@ export function HelpSection() {
           href={HELP_SITE_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:underline text-sm"
+          className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:text-primary-500 dark:hover:text-primary-300 underline underline-offset-2 text-sm transition-colors"
         >
           {t("settings.help.openDocs")} &rarr;
         </a>

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -510,7 +510,7 @@ export function LoginPage() {
             href={getHelpSiteUrl()}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-primary-400 hover:text-primary-300 dark:text-primary-400 dark:hover:text-primary-300 transition-colors underline underline-offset-2"
+            className="text-xs text-text-muted dark:text-text-muted-dark hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
           >
             {t("auth.learnHowItWorks")} &rarr;
           </a>

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -510,7 +510,7 @@ export function LoginPage() {
             href={HELP_SITE_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs text-text-muted dark:text-text-muted-dark hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+            className="text-sm text-primary-400 hover:text-primary-300 dark:text-primary-400 dark:hover:text-primary-300 transition-colors underline underline-offset-2"
           >
             {t("auth.learnHowItWorks")} &rarr;
           </a>

--- a/web-app/src/pages/LoginPage.tsx
+++ b/web-app/src/pages/LoginPage.tsx
@@ -12,7 +12,7 @@ import {
   extractCalendarCode,
   validateCalendarCode,
 } from "@/utils/calendar-helpers";
-import { HELP_SITE_URL } from "@/utils/constants";
+import { getHelpSiteUrl } from "@/utils/constants";
 
 // Demo-only mode restricts the app to demo mode (used in PR preview deployments)
 const DEMO_MODE_ONLY = import.meta.env.VITE_DEMO_MODE_ONLY === "true";
@@ -507,7 +507,7 @@ export function LoginPage() {
         {/* Help link */}
         <p className="mt-4 text-center">
           <a
-            href={HELP_SITE_URL}
+            href={getHelpSiteUrl()}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-primary-400 hover:text-primary-300 dark:text-primary-400 dark:hover:text-primary-300 transition-colors underline underline-offset-2"

--- a/web-app/src/utils/constants.ts
+++ b/web-app/src/utils/constants.ts
@@ -4,5 +4,7 @@
 
 /**
  * URL to the VolleyKit help documentation site.
+ * Uses BASE_URL to work correctly in PR previews (e.g., /volleykit/pr-123/help/)
+ * and production (e.g., /volleykit/help/).
  */
-export const HELP_SITE_URL = "https://takishima.github.io/volleykit/help";
+export const HELP_SITE_URL = `${import.meta.env.BASE_URL}help/`;

--- a/web-app/src/utils/constants.ts
+++ b/web-app/src/utils/constants.ts
@@ -3,8 +3,16 @@
  */
 
 /**
- * URL to the VolleyKit help documentation site.
- * Uses BASE_URL to work correctly in PR previews (e.g., /volleykit/pr-123/help/)
- * and production (e.g., /volleykit/help/).
+ * Returns the absolute URL to the VolleyKit help documentation site.
+ * Must be absolute (not relative) to bypass the service worker which would
+ * otherwise intercept the request and serve the web app instead of the help site.
+ *
+ * Uses window.location.origin + BASE_URL to work correctly in:
+ * - Production: https://takishima.github.io/volleykit/help/
+ * - PR previews: https://takishima.github.io/volleykit/pr-123/help/
+ * - Local dev: http://localhost:5173/help/
  */
-export const HELP_SITE_URL = `${import.meta.env.BASE_URL}help/`;
+export function getHelpSiteUrl(): string {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  return `${origin}${import.meta.env.BASE_URL}help/`;
+}

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -202,6 +202,8 @@ export default defineConfig(({ mode }) => {
             /\/pr-\d+/,
             // Don't intercept OCR POC routes - it's a separate app
             /\/ocr-poc/,
+            // Don't intercept help site routes - it's a separate Astro app
+            /\/help/,
           ],
           // Runtime caching for API responses
           runtimeCaching: [


### PR DESCRIPTION
## Summary

Fixes help site links that were redirecting to the login page instead of opening the documentation.

## Root Cause

The service worker was intercepting navigation to `/help/` and returning the web app's `index.html` instead of letting requests reach the separate Astro help site.

## Changes

- **Service Worker**: Add `/help/` to `navigateFallbackDenylist` so navigation to the help site bypasses the service worker
- **Dynamic URL**: Change `HELP_SITE_URL` to `getHelpSiteUrl()` function that returns an absolute URL, ensuring correct paths in:
  - Production: `https://takishima.github.io/volleykit/help/`
  - PR previews: `https://takishima.github.io/volleykit/pr-123/help/`
  - Local dev: `http://localhost:5173/help/`

## Test Plan

- [ ] Click help link on login page - should open help site in new tab
- [ ] Click help link in settings page HelpSection - should open help site in new tab
- [ ] Test in Safari (was specifically broken)
- [ ] Test in PR preview environment
- [ ] Test after PWA is installed

## Note for existing users

Users who already have the PWA installed may need to wait for the service worker to auto-update, or manually clear site data.