### PR TITLE
feat(ci): add auto-retry for Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review-retry.yml
+++ b/.github/workflows/claude-code-review-retry.yml
@@ -1,0 +1,149 @@
+name: Auto-Retry Claude Code Review
+on:
+  workflow_run:
+    workflows: ['Claude Code Review']
+    types: [completed]
+
+jobs:
+  retry-on-failure:
+    # Only run if the workflow failed and was triggered by a PR (not workflow_dispatch)
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get PR information
+        id: pr-info
+        run: |
+          # Get PR number from the workflow run
+          PR_NUMBER=$(gh run view ${{ github.event.workflow_run.id }} --json jobs -q '.jobs[0].steps[0].name' 2>/dev/null || echo "")
+
+          # Alternative: search for the PR associated with this head SHA
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          PR_DATA=$(gh pr list --state open --json number,headRefOid -q ".[] | select(.headRefOid == \"$HEAD_SHA\")")
+
+          if [ -z "$PR_DATA" ]; then
+            echo "Could not find PR for SHA $HEAD_SHA"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "Found PR #$PR_NUMBER"
+
+          # Get base ref for checking changed files
+          BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
+          echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check if retry should be skipped
+        id: check-guidelines
+        if: steps.pr-info.outputs.skip != 'true'
+        run: |
+          PR_NUMBER="${{ steps.pr-info.outputs.pr_number }}"
+
+          # Get changed files in the PR
+          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only)
+
+          # Skip retry if guidelines files were modified (expected failures during review)
+          if echo "$CHANGED_FILES" | grep -qE "^(CLAUDE\.md|docs/SECURITY_CHECKLIST\.md|docs/CODE_PATTERNS\.md)$"; then
+            echo "Guidelines files were modified - skipping retry"
+            echo "skip_retry=true" >> $GITHUB_OUTPUT
+            echo "skip_reason=guidelines_modified" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Skip retry if workflow files were modified (GitHub security restriction)
+          # When workflow files change, GitHub requires them to match the default branch
+          if echo "$CHANGED_FILES" | grep -qE "^\.github/workflows/.*\.ya?ml$"; then
+            echo "Workflow files were modified - skipping retry (GitHub security restriction)"
+            echo "skip_retry=true" >> $GITHUB_OUTPUT
+            echo "skip_reason=workflow_modified" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "No special files modified - retry is allowed"
+          echo "skip_retry=false" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check retry count
+        id: check-retry
+        if: |
+          steps.pr-info.outputs.skip != 'true' &&
+          steps.check-guidelines.outputs.skip_retry != 'true'
+        run: |
+          PR_NUMBER="${{ steps.pr-info.outputs.pr_number }}"
+          MAX_RETRIES=3
+
+          # Count recent failed runs for this PR (within last hour)
+          # This prevents infinite retry loops
+          FAILED_RUNS=$(gh run list \
+            --workflow "Claude Code Review" \
+            --status failure \
+            --limit 10 \
+            --json createdAt,headSha \
+            -q "[.[] | select(.headSha == \"${{ github.event.workflow_run.head_sha }}\")] | length")
+
+          echo "Failed runs for this commit: $FAILED_RUNS"
+
+          if [ "$FAILED_RUNS" -ge "$MAX_RETRIES" ]; then
+            echo "Max retries ($MAX_RETRIES) reached - not retrying"
+            echo "should_retry=false" >> $GITHUB_OUTPUT
+          else
+            echo "Retry $((FAILED_RUNS + 1)) of $MAX_RETRIES"
+            echo "should_retry=true" >> $GITHUB_OUTPUT
+            echo "retry_attempt=$((FAILED_RUNS + 1))" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Trigger retry
+        if: |
+          steps.pr-info.outputs.skip != 'true' &&
+          steps.check-guidelines.outputs.skip_retry != 'true' &&
+          steps.check-retry.outputs.should_retry == 'true'
+        run: |
+          PR_NUMBER="${{ steps.pr-info.outputs.pr_number }}"
+          RETRY_ATTEMPT="${{ steps.check-retry.outputs.retry_attempt }}"
+
+          echo "Triggering retry $RETRY_ATTEMPT for PR #$PR_NUMBER..."
+
+          # Wait before retrying to avoid rate limits
+          sleep 30
+
+          gh workflow run "Claude Code Review" \
+            --ref "${{ github.event.workflow_run.head_branch }}" \
+            -f pr_number="$PR_NUMBER" \
+            -f retry_attempt="$RETRY_ATTEMPT"
+
+          echo "Retry triggered successfully"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Log skip reason
+        if: |
+          steps.pr-info.outputs.skip == 'true' ||
+          steps.check-guidelines.outputs.skip_retry == 'true' ||
+          steps.check-retry.outputs.should_retry == 'false'
+        run: |
+          if [ "${{ steps.pr-info.outputs.skip }}" = "true" ]; then
+            echo "Skipped: Could not find associated PR"
+          elif [ "${{ steps.check-guidelines.outputs.skip_reason }}" = "guidelines_modified" ]; then
+            echo "Skipped: Guidelines files (CLAUDE.md, SECURITY_CHECKLIST.md, CODE_PATTERNS.md) were modified"
+          elif [ "${{ steps.check-guidelines.outputs.skip_reason }}" = "workflow_modified" ]; then
+            echo "Skipped: Workflow files (.github/workflows/*.yml) were modified - GitHub security restriction prevents retrying"
+          elif [ "${{ steps.check-retry.outputs.should_retry }}" = "false" ]; then
+            echo "Skipped: Maximum retry attempts reached"
+          fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,19 +2,19 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+      retry_attempt:
+        description: 'Retry attempt number (used by auto-retry)'
+        required: false
+        default: '1'
+        type: string
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -25,7 +25,48 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0 # Need full history to check changed files
+
+      - name: Check if CLAUDE.md was modified
+        id: check-claude-md
+        run: |
+          # For workflow_dispatch, we need to fetch the PR info
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            # Fetch the PR branch
+            gh pr checkout "$PR_NUMBER" --detach 2>/dev/null || true
+            BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
+          else
+            BASE_REF="${{ github.base_ref }}"
+          fi
+
+          # Get the list of changed files in this PR
+          CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF"...HEAD 2>/dev/null || echo "")
+
+          # Check for guidelines files
+          if echo "$CHANGED_FILES" | grep -qE "^(CLAUDE\.md|docs/SECURITY_CHECKLIST\.md|docs/CODE_PATTERNS\.md)$"; then
+            echo "Guidelines files modified - retries disabled"
+            echo "guidelines_changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check for workflow files (GitHub security restriction prevents retrying)
+          if echo "$CHANGED_FILES" | grep -qE "^\.github/workflows/.*\.ya?ml$"; then
+            echo "Workflow files modified - retries disabled (GitHub security restriction)"
+            echo "guidelines_changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "No special files modified - retries enabled"
+          echo "guidelines_changed=false" >> $GITHUB_OUTPUT
+
+          # Output retry info
+          RETRY_ATTEMPT="${{ inputs.retry_attempt || '1' }}"
+          echo "retry_attempt=$RETRY_ATTEMPT" >> $GITHUB_OUTPUT
+          echo "Current retry attempt: $RETRY_ATTEMPT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -33,7 +74,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
             EVENT TYPE: ${{ github.event.action }}
 
             CRITICAL: You MUST read these files FIRST and strictly enforce all guidelines during this review:
@@ -44,7 +85,7 @@ jobs:
             ## CONSISTENCY REQUIREMENTS
 
             BEFORE reviewing, check for previous review comments on this PR:
-            1. Run `gh pr view ${{ github.event.pull_request.number }} --comments` to see all previous comments
+            1. Run `gh pr view ${{ github.event.pull_request.number || inputs.pr_number }} --comments` to see all previous comments
             2. Identify any previous Claude Code Review comments (they follow the format below)
             3. Track which issues were previously raised
 
@@ -102,3 +143,7 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+
+    outputs:
+      guidelines_changed: ${{ steps.check-claude-md.outputs.guidelines_changed }}
+      retry_attempt: ${{ steps.check-claude-md.outputs.retry_attempt }}


### PR DESCRIPTION
## Summary

- Add automatic retry mechanism for transient Claude API failures
- Retries only when guideline files (CLAUDE.md, SECURITY_CHECKLIST.md, CODE_PATTERNS.md) are not modified
- Maximum 3 retry attempts with 30-second delays

## Changes

- Modified `.github/workflows/claude-code-review.yml` to support workflow_dispatch for retries
- Added step to detect if guideline files were modified in the PR
- Created new `.github/workflows/claude-code-review-retry.yml` workflow that:
  - Listens for failed Claude Code Review runs
  - Checks if guidelines files were modified (skips retry if so)
  - Tracks retry count to prevent infinite loops
  - Triggers retry via workflow_dispatch with 30s delay

## Test Plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Test that normal PR reviews still work
- [ ] Verify retry triggers on transient failure
- [ ] Confirm retry is skipped when CLAUDE.md is modified
- [ ] Confirm max 3 retries are enforced