### PR TITLE
feat(calendar): add association dropdown filter for calendar mode

### DIFF
--- a/web-app/src/api/calendar-client.test.ts
+++ b/web-app/src/api/calendar-client.test.ts
@@ -65,6 +65,7 @@ describe("calendar-client", () => {
       hallId: null,
       mapsUrl: null,
       referees: {},
+      association: null,
     });
 
     beforeEach(() => {
@@ -145,6 +146,7 @@ describe("calendar-client", () => {
         coordinates: { latitude: 47.3769, longitude: 8.5417 },
         mapsUrl: null,
         referees: { referee1: "Max Mustermann", referee2: "Anna Schmidt" },
+        association: "SVRZ",
       };
 
       vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
@@ -199,6 +201,7 @@ describe("calendar-client", () => {
         hallId: null,
         mapsUrl: null,
         referees: {},
+        association: null,
       };
 
       vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
@@ -230,6 +233,7 @@ describe("calendar-client", () => {
         hallId: null,
         mapsUrl: null,
         referees: {},
+        association: null,
       };
 
       vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
@@ -261,6 +265,7 @@ describe("calendar-client", () => {
         hallId: null,
         mapsUrl: null,
         referees: {},
+        association: null,
       };
 
       vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
@@ -292,6 +297,7 @@ describe("calendar-client", () => {
         hallId: null,
         mapsUrl: null,
         referees: {},
+        association: null,
       };
 
       vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
@@ -321,6 +327,7 @@ describe("calendar-client", () => {
         coordinates: null,
         mapsUrl: null,
         referees: {},
+        association: null,
       };
 
       vi.mocked(calendarApiModule.fetchCalendarAssignments).mockResolvedValue([
@@ -371,6 +378,7 @@ describe("calendar-client", () => {
           hallId: null,
           mapsUrl: null,
           referees: {},
+          association: null,
         },
       ]);
 
@@ -418,6 +426,7 @@ describe("calendar-client", () => {
           hallId: null,
           mapsUrl: null,
           referees: {},
+          association: null,
         },
       ]);
 

--- a/web-app/src/api/ical/types.ts
+++ b/web-app/src/api/ical/types.ts
@@ -134,6 +134,9 @@ export interface CalendarAssignment {
     lineReferee1?: string;
     lineReferee2?: string;
   };
+
+  /** Regional association code extracted from team info (e.g., "SVRZ", "SVRBA", "SVRI") */
+  association: string | null;
 }
 
 /**

--- a/web-app/src/components/features/CalendarAssociationDropdown.test.tsx
+++ b/web-app/src/components/features/CalendarAssociationDropdown.test.tsx
@@ -1,0 +1,336 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CalendarAssociationDropdown } from './CalendarAssociationDropdown';
+import { ALL_ASSOCIATIONS } from '@/hooks/useCalendarAssociationFilter';
+
+// Mock the useTranslation hook
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'calendar.allAssociations': 'All associations',
+        'calendar.filterByAssociation': 'Filter by association',
+        'calendar.selectAssociation': 'Select association',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe('CalendarAssociationDropdown', () => {
+  const defaultProps = {
+    associations: ['SVRBA', 'SVRZ'],
+    selected: ALL_ASSOCIATIONS,
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders nothing when associations array has less than 2 items', () => {
+      const { container } = render(
+        <CalendarAssociationDropdown
+          associations={['SVRZ']}
+          selected={ALL_ASSOCIATIONS}
+          onChange={vi.fn()}
+        />
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when associations array is empty', () => {
+      const { container } = render(
+        <CalendarAssociationDropdown
+          associations={[]}
+          selected={ALL_ASSOCIATIONS}
+          onChange={vi.fn()}
+        />
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders dropdown button when 2+ associations', () => {
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      expect(
+        screen.getByRole('button', { name: /filter by association/i })
+      ).toBeInTheDocument();
+    });
+
+    it('displays "All associations" when ALL_ASSOCIATIONS is selected', () => {
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      expect(screen.getByText('All associations')).toBeInTheDocument();
+    });
+
+    it('displays association code when specific association is selected', () => {
+      render(
+        <CalendarAssociationDropdown {...defaultProps} selected="SVRZ" />
+      );
+
+      expect(screen.getByText('SVRZ')).toBeInTheDocument();
+    });
+  });
+
+  describe('dropdown toggle', () => {
+    it('opens dropdown when button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      const button = screen.getByRole('button', {
+        name: /filter by association/i,
+      });
+      await user.click(button);
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('closes dropdown when button is clicked again', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      const button = screen.getByRole('button', {
+        name: /filter by association/i,
+      });
+
+      // Open
+      await user.click(button);
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+      // Close
+      await user.click(button);
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('sets aria-expanded correctly', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      const button = screen.getByRole('button', {
+        name: /filter by association/i,
+      });
+
+      expect(button).toHaveAttribute('aria-expanded', 'false');
+
+      await user.click(button);
+      expect(button).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  describe('option selection', () => {
+    it('calls onChange with ALL_ASSOCIATIONS when "All associations" is clicked', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <CalendarAssociationDropdown
+          {...defaultProps}
+          selected="SVRZ"
+          onChange={onChange}
+        />
+      );
+
+      // Open dropdown
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      // Click "All associations"
+      await user.click(screen.getByRole('option', { name: 'All associations' }));
+
+      expect(onChange).toHaveBeenCalledWith(ALL_ASSOCIATIONS);
+    });
+
+    it('calls onChange with association code when association is clicked', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <CalendarAssociationDropdown {...defaultProps} onChange={onChange} />
+      );
+
+      // Open dropdown
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      // Click SVRZ option
+      await user.click(screen.getByRole('option', { name: 'SVRZ' }));
+
+      expect(onChange).toHaveBeenCalledWith('SVRZ');
+    });
+
+    it('closes dropdown after selection', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      // Open dropdown
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      // Click an option
+      await user.click(screen.getByRole('option', { name: 'SVRBA' }));
+
+      // Dropdown should be closed
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('displays all association options in the dropdown', async () => {
+      const user = userEvent.setup();
+      render(
+        <CalendarAssociationDropdown
+          associations={['SVRBA', 'SVRI', 'SVRZ']}
+          selected={ALL_ASSOCIATIONS}
+          onChange={vi.fn()}
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      expect(screen.getByRole('option', { name: 'All associations' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'SVRBA' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'SVRI' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'SVRZ' })).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has aria-haspopup attribute', () => {
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      expect(
+        screen.getByRole('button', { name: /filter by association/i })
+      ).toHaveAttribute('aria-haspopup', 'listbox');
+    });
+
+    it('has listbox role on dropdown menu', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('has option role on each item', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      const options = screen.getAllByRole('option');
+      // "All associations" + 2 association codes
+      expect(options).toHaveLength(3);
+    });
+
+    it('sets aria-selected correctly on options', async () => {
+      const user = userEvent.setup();
+      render(
+        <CalendarAssociationDropdown {...defaultProps} selected="SVRZ" />
+      );
+
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      expect(screen.getByRole('option', { name: 'All associations' })).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
+      expect(screen.getByRole('option', { name: 'SVRBA' })).toHaveAttribute(
+        'aria-selected',
+        'false'
+      );
+      expect(screen.getByRole('option', { name: 'SVRZ' })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    it('has aria-label on listbox', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      expect(screen.getByRole('listbox')).toHaveAttribute(
+        'aria-label',
+        'Select association'
+      );
+    });
+  });
+
+  describe('click outside', () => {
+    it('closes dropdown when clicking outside', async () => {
+      const user = userEvent.setup();
+      render(
+        <div>
+          <CalendarAssociationDropdown {...defaultProps} />
+          <button data-testid="outside">Outside</button>
+        </div>
+      );
+
+      // Open dropdown
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+      // Click outside
+      fireEvent.mouseDown(screen.getByTestId('outside'));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+    });
+
+    it('does not close dropdown when clicking inside', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      // Open dropdown
+      await user.click(
+        screen.getByRole('button', { name: /filter by association/i })
+      );
+
+      // Click inside the listbox (but not on an option)
+      fireEvent.mouseDown(screen.getByRole('listbox'));
+
+      // Dropdown should still be open
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('visual states', () => {
+    it('rotates chevron icon when dropdown is open', async () => {
+      const user = userEvent.setup();
+      render(<CalendarAssociationDropdown {...defaultProps} />);
+
+      const button = screen.getByRole('button', {
+        name: /filter by association/i,
+      });
+
+      // ChevronDown has aria-hidden, find by class
+      const chevron = button.querySelector('svg');
+      expect(chevron).not.toHaveClass('rotate-180');
+
+      await user.click(button);
+
+      expect(chevron).toHaveClass('rotate-180');
+    });
+  });
+});

--- a/web-app/src/components/features/CalendarAssociationDropdown.tsx
+++ b/web-app/src/components/features/CalendarAssociationDropdown.tsx
@@ -1,0 +1,144 @@
+/**
+ * Dropdown for filtering calendar assignments by regional association.
+ *
+ * This component provides a filter UI similar to the occupation switcher
+ * in API mode, but for filtering by association codes extracted from
+ * calendar data (e.g., SVRZ, SVRBA, SVRI).
+ */
+
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDown } from '@/components/ui/icons';
+import { useTranslation } from '@/hooks/useTranslation';
+import { ALL_ASSOCIATIONS } from '@/hooks/useCalendarAssociationFilter';
+
+interface CalendarAssociationDropdownProps {
+  /** List of available associations to filter by */
+  associations: string[];
+
+  /** Currently selected association (or ALL_ASSOCIATIONS for all) */
+  selected: string;
+
+  /** Callback when selection changes */
+  onChange: (association: string) => void;
+}
+
+/**
+ * Dropdown component for filtering calendar assignments by association.
+ *
+ * Only renders when there are 2+ associations available.
+ *
+ * @example
+ * ```tsx
+ * <CalendarAssociationDropdown
+ *   associations={['SVRBA', 'SVRZ']}
+ *   selected={selectedAssociation}
+ *   onChange={setSelectedAssociation}
+ * />
+ * ```
+ */
+export function CalendarAssociationDropdown({
+  associations,
+  selected,
+  onChange,
+}: CalendarAssociationDropdownProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Don't render if only one or no associations
+  if (associations.length < 2) {
+    return null;
+  }
+
+  const getDisplayLabel = (value: string): string => {
+    if (value === ALL_ASSOCIATIONS) {
+      return t('calendar.allAssociations');
+    }
+    return value;
+  };
+
+  const handleSelect = (value: string) => {
+    onChange(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={`
+          flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-lg
+          transition-colors border
+          ${
+            selected === ALL_ASSOCIATIONS
+              ? 'text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark border-border-default dark:border-border-default-dark'
+              : 'text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 border-primary-200 dark:border-primary-800'
+          }
+          hover:bg-primary-100 dark:hover:bg-primary-900/50
+        `}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-label={t('calendar.filterByAssociation')}
+      >
+        <span>{getDisplayLabel(selected)}</span>
+        <ChevronDown
+          className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute left-0 mt-1 w-40 bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-lg border border-border-default dark:border-border-default-dark py-1 z-50"
+          role="listbox"
+          aria-label={t('calendar.selectAssociation')}
+        >
+          {/* All option */}
+          <button
+            onClick={() => handleSelect(ALL_ASSOCIATIONS)}
+            className={`w-full text-left px-3 py-2 text-sm transition-colors ${
+              selected === ALL_ASSOCIATIONS
+                ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
+                : 'text-text-secondary dark:text-text-secondary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark'
+            }`}
+            role="option"
+            aria-selected={selected === ALL_ASSOCIATIONS}
+          >
+            {t('calendar.allAssociations')}
+          </button>
+
+          {/* Association options */}
+          {associations.map((association) => (
+            <button
+              key={association}
+              onClick={() => handleSelect(association)}
+              className={`w-full text-left px-3 py-2 text-sm transition-colors ${
+                selected === association
+                  ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
+                  : 'text-text-secondary dark:text-text-secondary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark'
+              }`}
+              role="option"
+              aria-selected={selected === association}
+            >
+              {association}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-app/src/hooks/useCalendarAssociationFilter.test.ts
+++ b/web-app/src/hooks/useCalendarAssociationFilter.test.ts
@@ -1,0 +1,307 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import {
+  useCalendarAssociationFilter,
+  ALL_ASSOCIATIONS,
+} from './useCalendarAssociationFilter';
+import type { CalendarAssignment } from '@/api/calendar-api';
+
+function createMockCalendarAssignment(
+  overrides: Partial<CalendarAssignment> = {}
+): CalendarAssignment {
+  return {
+    gameId: `game-${Math.random()}`,
+    gameNumber: 123456,
+    startTime: '2025-02-15T19:30:00+01:00',
+    endTime: '2025-02-15T22:30:00+01:00',
+    league: 'NLA Men',
+    leagueCategory: 'NLA',
+    homeTeam: 'VBC Zürich',
+    awayTeam: 'Volley Luzern',
+    role: 'referee1',
+    roleRaw: 'ARB 1',
+    gender: 'men',
+    hallName: 'Sporthalle Hardau',
+    hallId: '3661',
+    address: 'Hardaustrasse 10, 8005 Zürich',
+    coordinates: { latitude: 47.3769, longitude: 8.5417 },
+    mapsUrl: 'https://maps.google.com/?q=47.3769,8.5417',
+    referees: {},
+    association: null,
+    ...overrides,
+  };
+}
+
+describe('useCalendarAssociationFilter', () => {
+  describe('associations extraction', () => {
+    it('returns empty array when no calendar data', () => {
+      const { result } = renderHook(() => useCalendarAssociationFilter([]));
+
+      expect(result.current.associations).toEqual([]);
+    });
+
+    it('extracts unique associations from calendar data', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: 'SVRBA' }),
+        createMockCalendarAssignment({ association: 'SVRZ' }), // duplicate
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      expect(result.current.associations).toEqual(['SVRBA', 'SVRZ']); // sorted
+    });
+
+    it('excludes null associations', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: null }),
+        createMockCalendarAssignment({ association: 'SVRBA' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      expect(result.current.associations).toEqual(['SVRBA', 'SVRZ']);
+    });
+
+    it('sorts associations alphabetically', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: 'SVRI' }),
+        createMockCalendarAssignment({ association: 'SVRBA' }),
+        createMockCalendarAssignment({ association: 'SVRNO' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      expect(result.current.associations).toEqual([
+        'SVRBA',
+        'SVRI',
+        'SVRNO',
+        'SVRZ',
+      ]);
+    });
+  });
+
+  describe('hasMultipleAssociations', () => {
+    it('returns false when no associations', () => {
+      const { result } = renderHook(() => useCalendarAssociationFilter([]));
+
+      expect(result.current.hasMultipleAssociations).toBe(false);
+    });
+
+    it('returns false when only one association', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      expect(result.current.hasMultipleAssociations).toBe(false);
+    });
+
+    it('returns true when two or more associations', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: 'SVRBA' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      expect(result.current.hasMultipleAssociations).toBe(true);
+    });
+  });
+
+  describe('selectedAssociation', () => {
+    it('defaults to ALL_ASSOCIATIONS', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      expect(result.current.selectedAssociation).toBe(ALL_ASSOCIATIONS);
+    });
+
+    it('updates when setSelectedAssociation is called', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: 'SVRBA' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      act(() => {
+        result.current.setSelectedAssociation('SVRZ');
+      });
+
+      expect(result.current.selectedAssociation).toBe('SVRZ');
+    });
+
+    it('reverts to ALL_ASSOCIATIONS when selected association is no longer available', () => {
+      const initialData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: 'SVRBA' }),
+      ];
+
+      const { result, rerender } = renderHook(
+        ({ data }) => useCalendarAssociationFilter(data),
+        { initialProps: { data: initialData } }
+      );
+
+      // Select SVRZ
+      act(() => {
+        result.current.setSelectedAssociation('SVRZ');
+      });
+      expect(result.current.selectedAssociation).toBe('SVRZ');
+
+      // Update data to remove SVRZ
+      const newData = [createMockCalendarAssignment({ association: 'SVRBA' })];
+      rerender({ data: newData });
+
+      // Should revert to ALL_ASSOCIATIONS
+      expect(result.current.selectedAssociation).toBe(ALL_ASSOCIATIONS);
+    });
+  });
+
+  describe('filterByAssociation', () => {
+    it('returns all items when ALL_ASSOCIATIONS is selected', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ gameId: '1', association: 'SVRZ' }),
+        createMockCalendarAssignment({ gameId: '2', association: 'SVRBA' }),
+        createMockCalendarAssignment({ gameId: '3', association: null }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      const filtered = result.current.filterByAssociation(calendarData);
+      expect(filtered).toHaveLength(3);
+    });
+
+    it('filters items by selected association', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ gameId: '1', association: 'SVRZ' }),
+        createMockCalendarAssignment({ gameId: '2', association: 'SVRBA' }),
+        createMockCalendarAssignment({ gameId: '3', association: 'SVRZ' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      act(() => {
+        result.current.setSelectedAssociation('SVRZ');
+      });
+
+      const filtered = result.current.filterByAssociation(calendarData);
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every((item) => item.association === 'SVRZ')).toBe(true);
+    });
+
+    it('returns empty array when no items match selected association', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ gameId: '1', association: 'SVRBA' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      act(() => {
+        result.current.setSelectedAssociation('SVRZ');
+      });
+
+      // Since SVRZ is not in the data, it should revert to ALL_ASSOCIATIONS
+      // due to the effectiveSelection logic
+      const filtered = result.current.filterByAssociation(calendarData);
+      expect(filtered).toHaveLength(1);
+    });
+
+    it('works with generic types extending association interface', () => {
+      interface ExtendedItem {
+        id: string;
+        association: string | null;
+        extra: number;
+      }
+
+      const items: ExtendedItem[] = [
+        { id: '1', association: 'SVRZ', extra: 100 },
+        { id: '2', association: 'SVRBA', extra: 200 },
+      ];
+
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: 'SVRBA' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      act(() => {
+        result.current.setSelectedAssociation('SVRZ');
+      });
+
+      const filtered = result.current.filterByAssociation(items);
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.id).toBe('1');
+      expect(filtered[0]?.extra).toBe(100);
+    });
+  });
+
+  describe('memoization', () => {
+    it('maintains stable filterByAssociation reference when selection unchanged', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+      ];
+
+      const { result, rerender } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      const firstFilter = result.current.filterByAssociation;
+      rerender();
+      const secondFilter = result.current.filterByAssociation;
+
+      expect(firstFilter).toBe(secondFilter);
+    });
+
+    it('updates filterByAssociation reference when selection changes', () => {
+      const calendarData = [
+        createMockCalendarAssignment({ association: 'SVRZ' }),
+        createMockCalendarAssignment({ association: 'SVRBA' }),
+      ];
+
+      const { result } = renderHook(() =>
+        useCalendarAssociationFilter(calendarData)
+      );
+
+      const firstFilter = result.current.filterByAssociation;
+
+      act(() => {
+        result.current.setSelectedAssociation('SVRZ');
+      });
+
+      const secondFilter = result.current.filterByAssociation;
+
+      expect(firstFilter).not.toBe(secondFilter);
+    });
+  });
+});

--- a/web-app/src/hooks/useCalendarAssociationFilter.ts
+++ b/web-app/src/hooks/useCalendarAssociationFilter.ts
@@ -1,0 +1,119 @@
+/**
+ * Hook for filtering calendar assignments by association.
+ *
+ * Extracts unique associations from calendar data and provides
+ * filtering functionality similar to the association switcher in API mode.
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import type { CalendarAssignment } from '@/api/calendar-api';
+
+/** Special value meaning "show all associations" */
+export const ALL_ASSOCIATIONS = '__all__';
+
+export interface UseCalendarAssociationFilterResult {
+  /** List of unique associations found in calendar data */
+  associations: string[];
+
+  /** Currently selected association filter (or ALL_ASSOCIATIONS) */
+  selectedAssociation: string;
+
+  /** Set the selected association filter */
+  setSelectedAssociation: (association: string) => void;
+
+  /** Filter calendar assignments by the selected association */
+  filterByAssociation: <T extends { association: string | null }>(
+    items: T[]
+  ) => T[];
+
+  /** Whether there are multiple associations to filter */
+  hasMultipleAssociations: boolean;
+}
+
+/**
+ * Hook for filtering calendar assignments by regional association.
+ *
+ * @param calendarData - Array of calendar assignments to extract associations from
+ * @returns Filter state and helpers for association-based filtering
+ *
+ * @example
+ * ```tsx
+ * function CalendarAssignmentsPage() {
+ *   const { data: calendarData } = useCalendarAssignments();
+ *   const {
+ *     associations,
+ *     selectedAssociation,
+ *     setSelectedAssociation,
+ *     filterByAssociation,
+ *     hasMultipleAssociations,
+ *   } = useCalendarAssociationFilter(calendarData ?? []);
+ *
+ *   const filteredData = filterByAssociation(calendarData ?? []);
+ *
+ *   return (
+ *     <>
+ *       {hasMultipleAssociations && (
+ *         <AssociationDropdown
+ *           associations={associations}
+ *           selected={selectedAssociation}
+ *           onChange={setSelectedAssociation}
+ *         />
+ *       )}
+ *       <AssignmentList data={filteredData} />
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+export function useCalendarAssociationFilter(
+  calendarData: CalendarAssignment[]
+): UseCalendarAssociationFilterResult {
+  const [selectedAssociation, setSelectedAssociation] =
+    useState<string>(ALL_ASSOCIATIONS);
+
+  // Extract unique associations from calendar data
+  const associations = useMemo(() => {
+    const uniqueAssociations = new Set<string>();
+
+    for (const item of calendarData) {
+      if (item.association) {
+        uniqueAssociations.add(item.association);
+      }
+    }
+
+    // Sort alphabetically for consistent ordering
+    return Array.from(uniqueAssociations).sort();
+  }, [calendarData]);
+
+  const hasMultipleAssociations = associations.length >= 2;
+
+  // Derive effective selection: if selected association is no longer available,
+  // treat as "all" without modifying state (derived during render)
+  const effectiveSelection = useMemo(() => {
+    if (
+      selectedAssociation !== ALL_ASSOCIATIONS &&
+      !associations.includes(selectedAssociation)
+    ) {
+      return ALL_ASSOCIATIONS;
+    }
+    return selectedAssociation;
+  }, [associations, selectedAssociation]);
+
+  const filterByAssociation = useCallback(
+    <T extends { association: string | null }>(items: T[]): T[] => {
+      if (effectiveSelection === ALL_ASSOCIATIONS) {
+        return items;
+      }
+      return items.filter((item) => item.association === effectiveSelection);
+    },
+    [effectiveSelection]
+  );
+
+  return {
+    associations,
+    selectedAssociation: effectiveSelection,
+    setSelectedAssociation,
+    filterByAssociation,
+    hasMultipleAssociations,
+  };
+}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -194,6 +194,11 @@ const de: Translations = {
     ok: "OK",
     loggedOutToast: "Aufgrund eines Kalenderfehlers abgemeldet",
   },
+  calendar: {
+    allAssociations: "Alle Verbände",
+    filterByAssociation: "Nach Verband filtern",
+    selectAssociation: "Verband auswählen",
+  },
   occupations: {
     referee: "Schiedsrichter",
     linesmen: "Linienrichter",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -194,6 +194,11 @@ const en: Translations = {
     ok: "OK",
     loggedOutToast: "Logged out due to calendar error",
   },
+  calendar: {
+    allAssociations: "All associations",
+    filterByAssociation: "Filter by association",
+    selectAssociation: "Select association",
+  },
   occupations: {
     referee: "Referee",
     linesmen: "Line Judges",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -194,6 +194,11 @@ const fr: Translations = {
     ok: "OK",
     loggedOutToast: "Déconnecté en raison d'une erreur de calendrier",
   },
+  calendar: {
+    allAssociations: "Toutes les associations",
+    filterByAssociation: "Filtrer par association",
+    selectAssociation: "Sélectionner une association",
+  },
   occupations: {
     referee: "Arbitre",
     linesmen: "Juges de ligne",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -194,6 +194,11 @@ const it: Translations = {
     ok: "OK",
     loggedOutToast: "Disconnesso a causa di un errore del calendario",
   },
+  calendar: {
+    allAssociations: "Tutte le associazioni",
+    filterByAssociation: "Filtra per associazione",
+    selectAssociation: "Seleziona associazione",
+  },
   occupations: {
     referee: "Arbitro",
     linesmen: "Giudici di linea",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -86,6 +86,11 @@ export interface Translations {
     ok: string;
     loggedOutToast: string;
   };
+  calendar: {
+    allAssociations: string;
+    filterByAssociation: string;
+    selectAssociation: string;
+  };
   occupations: {
     referee: string;
     linesmen: string;

--- a/web-app/src/pages/AssignmentsPage.test.tsx
+++ b/web-app/src/pages/AssignmentsPage.test.tsx
@@ -456,6 +456,7 @@ describe("AssignmentsPage", () => {
           referee1: "Max Mustermann",
           referee2: "Anna Schmidt",
         },
+        association: null,
         ...overrides,
       };
     }

--- a/web-app/src/utils/calendar-helpers.test.ts
+++ b/web-app/src/utils/calendar-helpers.test.ts
@@ -358,6 +358,7 @@ describe("mapCalendarAssignmentToAssignment", () => {
         referee1: "Max Mustermann",
         referee2: "Anna Schmidt",
       },
+      association: null,
       ...overrides,
     };
   }


### PR DESCRIPTION
## Summary
- Parse regional association codes (SVRZ, SVRBA, SVRI, etc.) from iCal description
- Add dropdown to filter calendar assignments by association in calendar mode
- Only shows when multiple associations are present in the calendar data

## Changes
- Add association field to CalendarAssignment type in types.ts
- Add parseAssociation function to parser.ts to extract from team info
- Create useCalendarAssociationFilter hook for filtering logic
- Add CalendarAssociationDropdown component with accessible UI
- Integrate dropdown into AssignmentsPage for calendar mode
- Add translations for all 4 languages (de, en, fr, it)
- Update tests with association field

## Test Plan
- [ ] Enter calendar mode with a calendar code that has assignments from multiple associations
- [ ] Verify dropdown appears when 2+ associations are present
- [ ] Select an association and verify only matching assignments are shown
- [ ] Select "All associations" and verify all assignments appear
- [ ] Verify dropdown does not appear with only one association
- [ ] Test translations in all 4 languages