### PR TITLE
fix(calendar): parse hall name from X-APPLE-STRUCTURED-LOCATION

### DIFF
--- a/web-app/src/api/ical/types.ts
+++ b/web-app/src/api/ical/types.ts
@@ -41,8 +41,11 @@ export interface ICalEvent {
   /** End date/time from DTEND property (ISO 8601 format after parsing) */
   dtend: string;
 
-  /** Location string from LOCATION property */
+  /** Location string from LOCATION property (contains full address in real API) */
   location: string | null;
+
+  /** Hall/venue name extracted from X-APPLE-STRUCTURED-LOCATION X-TITLE parameter */
+  appleLocationTitle: string | null;
 
   /** Geographic coordinates from GEO property */
   geo: {


### PR DESCRIPTION
## Summary

- Fixes calendar address parsing to correctly extract hall name and address from iCal data
- The parser was incorrectly splitting the `LOCATION` field by comma to get the hall name
- In the real volleymanager API, `LOCATION` contains only the street address, while the hall name is in `X-APPLE-STRUCTURED-LOCATION`'s `X-TITLE` parameter

## Changes

- Add `extractAppleLocationTitle()` function to parse `X-TITLE` from the Apple structured location property
- Update `parseLocation()` to use the full `LOCATION` as address (no comma splitting)
- Strip `, Suisse` suffix from addresses for cleaner display
- Add `appleLocationTitle` field to `ICalEvent` interface
- Hall name priority: description-based (`Salle: #123 | Hall Name`) > `X-TITLE` > null

## Before/After

**Before:**
```
MZH Löhrenacker (A)
4147 Aesch, Suisse, Aesch, Suisse
```

**After:**
```
MZH Löhrenacker
Landskronstrasse 41, 4147 Aesch
```

## Test plan

- [x] All 2918 existing tests pass
- [x] New tests added for `X-APPLE-STRUCTURED-LOCATION` parsing
- [x] Updated existing location parsing tests to use real API format
- [x] Lint, build, and knip checks pass