### PR TITLE
docs(help): update help site to match actual app features

### DIFF
--- a/help-site/src/pages/assignments.astro
+++ b/help-site/src/pages/assignments.astro
@@ -43,14 +43,6 @@ import InfoBox from '../components/InfoBox.astro';
     instructions="Take a screenshot of the assignments page showing at least 3-4 games. Show the date grouping, team names, times, and venue info. Ensure the layout is clear on mobile."
   />
 
-  <h3>List vs. Card View</h3>
-
-  <p>
-    Toggle between list view (compact) and card view (detailed) using the view
-    switcher in the top right. Card view shows more information at a glance,
-    while list view lets you see more games on screen.
-  </p>
-
   <h2>Assignment Details</h2>
 
   <p>
@@ -62,7 +54,7 @@ import InfoBox from '../components/InfoBox.astro';
     <li>Venue address with map link</li>
     <li>Travel time from your home location</li>
     <li>Other referees assigned to the same game</li>
-    <li>Action buttons (confirm, request exchange, etc.)</li>
+    <li>Available actions via swipe gestures</li>
   </ul>
 
   <Screenshot
@@ -76,12 +68,6 @@ import InfoBox from '../components/InfoBox.astro';
 
   <p>
     Depending on the game status, you may have different actions available:
-  </p>
-
-  <h3>Confirm Assignment</h3>
-  <p>
-    Confirm that you'll be attending the game. This updates your status in
-    the volleymanager system.
   </p>
 
   <h3>Request Exchange</h3>
@@ -104,28 +90,26 @@ import InfoBox from '../components/InfoBox.astro';
 
   <Screenshot
     id="assignment-actions"
-    alt="Assignment action buttons including confirm, exchange, and directions"
+    alt="Assignment card showing swipe actions for exchange and validation"
     caption="Available actions for an assignment"
-    instructions="Take a screenshot showing the action buttons at the bottom of an assignment detail page. Include confirm, request exchange, and directions buttons."
+    instructions="Take a screenshot showing the swipe actions revealed on an assignment card. Show exchange and other available actions."
   />
 
-  <h2>Filtering and Sorting</h2>
+  <h2>Upcoming and Past Games</h2>
 
   <p>
-    Use the filter options to:
+    Use the tabs at the top to switch between:
   </p>
 
   <ul>
-    <li>Show only unconfirmed games</li>
-    <li>Filter by role (1st referee, 2nd referee, line judge)</li>
-    <li>Filter by league</li>
-    <li>Change the date range</li>
+    <li><strong>Upcoming</strong> – Games that haven't happened yet</li>
+    <li><strong>Validation Closed</strong> – Past games where validation is complete</li>
   </ul>
 
   <InfoBox type="tip">
     <p>
-      Enable travel time display in Settings to see how long it takes to reach
-      each venue from your home location.
+      Set your home location in Settings to see travel time estimates on each
+      assignment card.
     </p>
   </InfoBox>
 </DocLayout>

--- a/help-site/src/pages/compensations.astro
+++ b/help-site/src/pages/compensations.astro
@@ -64,67 +64,49 @@ import InfoBox from '../components/InfoBox.astro';
     <li><strong>Paid</strong> – Payment has been made to your account</li>
   </ul>
 
-  <h2>Filtering by Date</h2>
+  <h2>Filtering by Status</h2>
 
   <p>
-    Use the date filter to view compensations for a specific time period:
+    Use the tabs at the top to filter compensations by their status:
   </p>
 
   <ul>
-    <li><strong>This month</strong> – Current month's compensations</li>
-    <li><strong>Last month</strong> – Previous month's compensations</li>
-    <li><strong>This season</strong> – Current volleyball season</li>
-    <li><strong>Custom range</strong> – Select specific start and end dates</li>
+    <li><strong>Pending (Past)</strong> – Past games awaiting payment</li>
+    <li><strong>Pending (Future)</strong> – Upcoming games not yet played</li>
+    <li><strong>Closed</strong> – Completed and paid compensations</li>
   </ul>
 
   <Screenshot
     id="compensations-filters"
-    alt="Date filter options for compensation list"
-    caption="Filtering compensations by date range"
-    instructions="Take a screenshot showing the date filter controls. Include the filter dropdown or date picker interface with the available options visible."
+    alt="Compensation tabs showing pending and closed options"
+    caption="Filtering compensations by status"
+    instructions="Take a screenshot showing the compensation page tabs. Include the pending past, pending future, and closed tabs."
   />
-
-  <h2>Summary Statistics</h2>
-
-  <p>
-    At the top of the compensation list, you'll see summary statistics for the
-    selected date range:
-  </p>
-
-  <ul>
-    <li><strong>Total earned</strong> – Sum of all compensations</li>
-    <li><strong>Games officiated</strong> – Number of games</li>
-    <li><strong>Average per game</strong> – Average compensation amount</li>
-  </ul>
 
   <InfoBox type="tip">
     <p>
-      Use the season filter at the end of each season to get a complete overview
-      of your referee earnings.
+      Compensations are automatically filtered to the current season (September
+      to May) so you can focus on recent games.
     </p>
   </InfoBox>
 
-  <h2>Export Options</h2>
+  <h2>Export to PDF</h2>
 
   <p>
-    You can export your compensation data for your records or tax purposes.
-    The export feature supports:
+    You can export individual compensation records as PDF documents. Swipe left
+    on any compensation card to reveal the PDF export action.
   </p>
 
-  <ul>
-    <li><strong>PDF</strong> – Formatted document suitable for printing</li>
-    <li><strong>CSV</strong> – Spreadsheet-compatible data format</li>
-  </ul>
-
   <p>
-    The export includes all compensations for the currently selected date range,
-    with full game details and payment information.
+    The exported PDF includes the game details and compensation information
+    in a formatted document. This is useful for providing to teams that need
+    to pay the referee directly.
   </p>
 
   <InfoBox type="info">
     <p>
-      Keep your compensation records for at least the current tax year.
-      The export feature makes it easy to maintain accurate records.
+      The PDF export creates an official-looking document with all the game
+      and compensation details that teams may require for their records.
     </p>
   </InfoBox>
 

--- a/help-site/src/pages/exchanges.astro
+++ b/help-site/src/pages/exchanges.astro
@@ -97,15 +97,26 @@ import StepList from '../components/StepList.astro';
   <h3>Filtering Exchanges</h3>
 
   <p>
-    Filter the exchange list to find games that work for you:
+    Filter the exchange list to find games that work for you. Filters become
+    available after you configure the required settings:
   </p>
 
   <ul>
-    <li><strong>Date range</strong> – Show games within specific dates</li>
-    <li><strong>Distance</strong> – Filter by travel distance from your home</li>
-    <li><strong>League</strong> – Filter by competition level</li>
-    <li><strong>Role</strong> – Filter by referee role</li>
+    <li><strong>Distance</strong> – Filter by maximum distance from your home location. Requires setting your home location in Settings.</li>
+    <li><strong>Travel time</strong> – Filter by maximum travel time using public transport. Requires both a home location and enabling the public transport API in Settings.</li>
   </ul>
+
+  <p>
+    Once filters are available, they appear as toggle chips next to the settings
+    gear icon. Tap the gear to configure the maximum values for each filter.
+  </p>
+
+  <InfoBox type="tip">
+    <p>
+      Set your home location in Settings to unlock distance filtering. Enable the
+      public transport API to also filter by travel time.
+    </p>
+  </InfoBox>
 
   <h2>Accepting an Exchange</h2>
 

--- a/help-site/src/pages/getting-started.astro
+++ b/help-site/src/pages/getting-started.astro
@@ -42,8 +42,13 @@ import { BASE_PATH } from '../constants';
   <h2>How to Login</h2>
 
   <p>
-    To use VolleyKit, you need valid credentials for the volleymanager.volleyball.ch system.
-    These are the same credentials you use to access the official website.
+    VolleyKit offers two ways to access your assignments:
+  </p>
+
+  <h3>Option 1: Full Login (Recommended)</h3>
+
+  <p>
+    Use your volleymanager.volleyball.ch credentials for full access to all features.
   </p>
 
   <StepList
@@ -74,6 +79,38 @@ import { BASE_PATH } from '../constants';
     <p>
       VolleyKit uses the same credentials as volleymanager.volleyball.ch. Use the password
       reset function on the official site if you've forgotten your password.
+    </p>
+  </InfoBox>
+
+  <h3>Option 2: Calendar Mode (Read-Only)</h3>
+
+  <p>
+    For quick access to view your schedule without entering your password, you can use
+    Calendar Mode with your unique calendar URL or code from volleymanager.
+  </p>
+
+  <StepList
+    steps={[
+      {
+        title: 'Find your calendar URL',
+        description: 'In volleymanager, go to "My Assignments" and copy your calendar subscription URL.',
+      },
+      {
+        title: 'Select Calendar Mode',
+        description: 'On the VolleyKit login page, tap the "Calendar Mode" tab.',
+      },
+      {
+        title: 'Paste your URL or code',
+        description: 'Enter your calendar URL or just the code portion to access your schedule.',
+      },
+    ]}
+  />
+
+  <InfoBox type="info">
+    <p>
+      Calendar Mode provides read-only access – you can view assignments but cannot
+      confirm games, request exchanges, or access compensations. See the
+      <a href={`${BASE_PATH}/calendar-mode/`}>Calendar Mode guide</a> for more details.
     </p>
   </InfoBox>
 

--- a/help-site/src/pages/settings.astro
+++ b/help-site/src/pages/settings.astro
@@ -13,7 +13,7 @@ import { BASE_PATH } from '../constants';
 
   <p class="lead text-text-secondary dark:text-text-secondary-dark">
     Customize VolleyKit to match your preferences. Configure language, home
-    location, theme, and privacy options.
+    location, and privacy options.
   </p>
 
   <h2>Accessing Settings</h2>
@@ -27,7 +27,7 @@ import { BASE_PATH } from '../constants';
     id="settings-overview"
     alt="Settings page showing all available options"
     caption="VolleyKit settings page"
-    instructions="Take a screenshot of the full settings page showing all sections: profile, language, location, appearance, and data settings. Show the organized layout with clear section headers."
+    instructions="Take a screenshot of the full settings page showing all sections: profile, language, location, and data settings. Show the organized layout with clear section headers."
   />
 
   <h2>Profile Section</h2>
@@ -106,27 +106,6 @@ import { BASE_PATH } from '../constants';
     See the <a href={`${BASE_PATH}/travel-time/`}>Travel Time guide</a> for more
     details on this feature.
   </p>
-
-  <h2>Appearance</h2>
-
-  <p>
-    Customize how VolleyKit looks:
-  </p>
-
-  <h3>Theme</h3>
-
-  <ul>
-    <li><strong>Light</strong> – Light background with dark text</li>
-    <li><strong>Dark</strong> – Dark background with light text</li>
-    <li><strong>System</strong> – Match your device's theme setting</li>
-  </ul>
-
-  <Screenshot
-    id="theme-settings"
-    alt="Theme selection with light, dark, and system options"
-    caption="Theme settings"
-    instructions="Take a screenshot showing the theme toggle or dropdown. If possible, show a side-by-side or preview of light vs dark mode."
-  />
 
   <h2>Data & Privacy</h2>
 


### PR DESCRIPTION
## Summary

- Add Calendar Mode as a second authentication method in the Getting Started guide
- Remove documentation for features that don't exist in the app
- Update filter descriptions to match actual implementation
- Correct compensation PDF export purpose (for teams, not tax)

## Changes

### getting-started.astro
- Added Calendar Mode as Option 2 for authentication alongside username/password

### assignments.astro
- Removed non-existent "Confirm Assignment" action
- Removed "List vs Card View" toggle
- Removed filter options (role, league, date range) that aren't implemented
- Updated to describe actual "Upcoming" and "Validation Closed" tabs

### compensations.astro
- Removed CSV export option (only PDF exists)
- Removed summary statistics section
- Changed date filters to actual status-based tabs
- Updated PDF export purpose: for teams to pay referees

### exchanges.astro
- Updated filter options to show actual filters: Distance and Travel Time
- Clarified filter prerequisites: home location for distance, transport API for travel time

### settings.astro
- Removed Appearance/Theme section (dark mode follows system settings)

## Test plan

- [ ] Verify help site builds without errors
- [ ] Review each updated page for accuracy against the app