### PR TITLE
docs(help): recommend calendar mode over full login

### DIFF
--- a/help-site/src/pages/getting-started.astro
+++ b/help-site/src/pages/getting-started.astro
@@ -45,7 +45,7 @@ import { BASE_PATH } from '../constants';
     VolleyKit offers two ways to access your assignments:
   </p>
 
-  <h3>Option 1: Full Login (Recommended)</h3>
+  <h3>Option 1: Full Login</h3>
 
   <p>
     Use your volleymanager.volleyball.ch credentials for full access to all features.
@@ -82,7 +82,7 @@ import { BASE_PATH } from '../constants';
     </p>
   </InfoBox>
 
-  <h3>Option 2: Calendar Mode (Read-Only)</h3>
+  <h3>Option 2: Calendar Mode (Recommended)</h3>
 
   <p>
     For quick access to view your schedule without entering your password, you can use

--- a/help-site/src/pages/getting-started.astro
+++ b/help-site/src/pages/getting-started.astro
@@ -45,7 +45,39 @@ import { BASE_PATH } from '../constants';
     VolleyKit offers two ways to access your assignments:
   </p>
 
-  <h3>Option 1: Full Login</h3>
+  <h3>Option 1: Calendar Mode (Recommended)</h3>
+
+  <p>
+    For quick access to view your schedule without entering your password, you can use
+    Calendar Mode with your unique calendar URL or code from volleymanager.
+  </p>
+
+  <StepList
+    steps={[
+      {
+        title: 'Find your calendar URL',
+        description: 'In volleymanager, go to "My Assignments" and copy your calendar subscription URL.',
+      },
+      {
+        title: 'Select Calendar Mode',
+        description: 'On the VolleyKit login page, tap the "Calendar Mode" tab.',
+      },
+      {
+        title: 'Paste your URL or code',
+        description: 'Enter your calendar URL or just the code portion to access your schedule.',
+      },
+    ]}
+  />
+
+  <InfoBox type="info">
+    <p>
+      Calendar Mode provides read-only access – you can view assignments but cannot
+      confirm games, request exchanges, or access compensations. See the
+      <a href={`${BASE_PATH}/calendar-mode/`}>Calendar Mode guide</a> for more details.
+    </p>
+  </InfoBox>
+
+  <h3>Option 2: Full Login</h3>
 
   <p>
     Use your volleymanager.volleyball.ch credentials for full access to all features.
@@ -79,38 +111,6 @@ import { BASE_PATH } from '../constants';
     <p>
       VolleyKit uses the same credentials as volleymanager.volleyball.ch. Use the password
       reset function on the official site if you've forgotten your password.
-    </p>
-  </InfoBox>
-
-  <h3>Option 2: Calendar Mode (Recommended)</h3>
-
-  <p>
-    For quick access to view your schedule without entering your password, you can use
-    Calendar Mode with your unique calendar URL or code from volleymanager.
-  </p>
-
-  <StepList
-    steps={[
-      {
-        title: 'Find your calendar URL',
-        description: 'In volleymanager, go to "My Assignments" and copy your calendar subscription URL.',
-      },
-      {
-        title: 'Select Calendar Mode',
-        description: 'On the VolleyKit login page, tap the "Calendar Mode" tab.',
-      },
-      {
-        title: 'Paste your URL or code',
-        description: 'Enter your calendar URL or just the code portion to access your schedule.',
-      },
-    ]}
-  />
-
-  <InfoBox type="info">
-    <p>
-      Calendar Mode provides read-only access – you can view assignments but cannot
-      confirm games, request exchanges, or access compensations. See the
-      <a href={`${BASE_PATH}/calendar-mode/`}>Calendar Mode guide</a> for more details.
     </p>
   </InfoBox>
 


### PR DESCRIPTION
## Summary
- Switch the recommendation on the getting started page from full login to calendar mode
- Reorder the login options so calendar mode appears first as Option 1
- This change is temporary until formal API approval is obtained

## Test plan
- [ ] Verify help site builds successfully
- [ ] Check that the getting started page displays calendar mode as Option 1 (Recommended)
- [ ] Check that full login appears as Option 2