### PR TITLE
docs(help): fix incorrect gesture descriptions on exchanges page

### DIFF
--- a/help-site/src/pages/exchanges.astro
+++ b/help-site/src/pages/exchanges.astro
@@ -48,12 +48,12 @@ import StepList from '../components/StepList.astro';
   <StepList
     steps={[
       {
-        title: 'Open the assignment',
-        description: 'Navigate to the game you want to exchange and open the detail view.',
+        title: 'Find the assignment',
+        description: 'Go to your Assignments tab and locate the game you want to exchange.',
       },
       {
-        title: 'Tap "Request Exchange"',
-        description: 'Click the exchange button to open the request form.',
+        title: 'Swipe right on the card',
+        description: 'Swipe the assignment card to the right to reveal the exchange action, then tap it.',
       },
       {
         title: 'Add a reason (optional)',
@@ -131,8 +131,8 @@ import StepList from '../components/StepList.astro';
         description: 'Check the date, time, venue, and travel requirements.',
       },
       {
-        title: 'Tap "Accept Exchange"',
-        description: 'Click to indicate you want to take this game.',
+        title: 'Swipe left on the card',
+        description: 'Swipe the exchange card to the left to reveal the take over action, then tap it.',
       },
       {
         title: 'Confirm your acceptance',


### PR DESCRIPTION
## Summary
- Fix incorrect "Tap" and "Click" instructions for exchange actions on help site
- Replace with accurate swipe gesture descriptions that match actual app behavior
- Request exchange: swipe right on assignment card (not tap/click button)
- Accept exchange: swipe left on exchange card (not tap/click button)

## Test plan
- [ ] Verify help-site builds successfully
- [ ] Review exchanges page instructions match actual app swipe gestures
- [ ] Check mobile and desktop rendering of updated content