### PR TITLE
fix(calendar): unify calendar API with regular API for transport settings

### DIFF
--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -7,6 +7,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useAuthStore } from "@/stores/auth";
 import { useSettingsStore } from "@/stores/settings";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
@@ -49,10 +50,12 @@ export function useTravelTime(
   options: UseTravelTimeOptions = {},
 ) {
   const { date, targetArrivalTime } = options;
-  const { isDemoMode, dataSource } = useAuthStore((state) => ({
-    isDemoMode: state.isDemoMode,
-    dataSource: state.dataSource,
-  }));
+  const { isDemoMode, dataSource } = useAuthStore(
+    useShallow((state) => ({
+      isDemoMode: state.isDemoMode,
+      dataSource: state.dataSource,
+    })),
+  );
   const isCalendarMode = dataSource === "calendar";
   const homeLocation = useSettingsStore((state) => state.homeLocation);
   const transportEnabled = useSettingsStore((state) => state.transportEnabled);
@@ -191,10 +194,12 @@ export function formatTravelTime(minutes: number): string {
  * enabling transport calculations when OJP is configured.
  */
 export function useTravelTimeAvailable(): boolean {
-  const { isDemoMode, dataSource } = useAuthStore((state) => ({
-    isDemoMode: state.isDemoMode,
-    dataSource: state.dataSource,
-  }));
+  const { isDemoMode, dataSource } = useAuthStore(
+    useShallow((state) => ({
+      isDemoMode: state.isDemoMode,
+      dataSource: state.dataSource,
+    })),
+  );
   const isCalendarMode = dataSource === "calendar";
   return isDemoMode || isCalendarMode || isOjpConfigured();
 }


### PR DESCRIPTION
## Summary
- Calendar mode now creates synthetic occupations from calendar data during login, enabling transport settings to work the same as regular API mode
- This fixes the transport toggle being disabled in calendar mode because `useActiveAssociationCode()` returned `undefined` when `occupations` was empty

## Test plan
- [ ] Login with a calendar code that has assignments from multiple associations
- [ ] Verify the association dropdown appears in the header
- [ ] Navigate to Settings → Transport section
- [ ] Verify the transport toggle is enabled (when home location is set)
- [ ] Enable transport for an association and verify it persists
- [ ] Verify transport calculations work on assignment cards