### PR TITLE
fix(help): fix dark mode contrast for InfoBox on iOS

### DIFF
--- a/help-site/src/styles/global.css
+++ b/help-site/src/styles/global.css
@@ -37,6 +37,7 @@
   --color-success-600: #0d9488;
   --color-success-800: #115e59;
   --color-success-900: #134e4a;
+  --color-success-950: #042f2e;
 
   /* Warning color (orange) */
   --color-warning-50: #fff7ed;
@@ -47,6 +48,7 @@
   --color-warning-600: #ea580c;
   --color-warning-800: #9a3412;
   --color-warning-900: #7c2d12;
+  --color-warning-950: #431407;
 
   /* Danger color (red) */
   --color-danger-50: #fef2f2;


### PR DESCRIPTION
## Summary
- Fixes poor text contrast in InfoBox components (tip, warning) when viewed in dark mode on iPhone
- Added missing `-950` color shades that were referenced but not defined in the theme

## Problem
The InfoBox component uses `dark:bg-success-950/50` and `dark:bg-warning-950/50` for dark mode backgrounds, but these color values were not defined in `global.css`. This caused the dark mode background to not render, leaving a light background with light-colored text - resulting in unreadable content.

## Changes
Added to `help-site/src/styles/global.css`:
- `--color-success-950: #042f2e` (dark teal for tip boxes)
- `--color-warning-950: #431407` (dark orange for warning boxes)

## Test plan
- [ ] View the Getting Started page in dark mode on iOS Safari
- [ ] Verify InfoBox (tip about password reset) has dark background with readable text
- [ ] Test on desktop browsers in dark mode as well