### PR TITLE
docs(help): fix incorrect exchange form and cancel instructions

### DIFF
--- a/help-site/src/pages/exchanges.astro
+++ b/help-site/src/pages/exchanges.astro
@@ -53,24 +53,16 @@ import StepList from '../components/StepList.astro';
       },
       {
         title: 'Swipe right on the card',
-        description: 'Swipe the assignment card to the right to reveal the exchange action, then tap it.',
-      },
-      {
-        title: 'Add a reason (optional)',
-        description: 'Provide a brief reason for the exchange request.',
-      },
-      {
-        title: 'Confirm the request',
-        description: 'Submit your request to post it to the exchange board.',
+        description: 'Swipe the assignment card to the right to reveal the exchange action, then tap it. The game will be posted to the exchange board.',
       },
     ]}
   />
 
   <Screenshot
     id="exchange-request"
-    alt="Exchange request modal with reason field and submit button"
+    alt="Assignment card with exchange swipe action revealed"
     caption="Requesting an exchange for a game"
-    instructions="Take a screenshot of the exchange request modal/dialog. Show the game info at the top, optional reason text field, and submit/cancel buttons."
+    instructions="Take a screenshot showing an assignment card with the exchange swipe action revealed on the right side."
   />
 
   <InfoBox type="warning" title="Request early">
@@ -168,8 +160,8 @@ import StepList from '../components/StepList.astro';
 
   <ol>
     <li>Go to the Exchanges tab</li>
-    <li>Find your pending request in "My Requests"</li>
-    <li>Tap the cancel button</li>
+    <li>Select the "Added by Me" tab to see your pending requests</li>
+    <li>Swipe right on the request card to reveal the remove action, then tap it</li>
     <li>Confirm the cancellation</li>
   </ol>
 


### PR DESCRIPTION
## Summary

- Remove non-existent "Add a reason" step from exchange request flow (the app directly posts to exchange board without a reason modal)
- Fix cancel request instructions to describe swipe action instead of tap button, matching actual app behavior
- Update screenshot description to match simplified flow
- Correct tab name from "My Requests" to "Added by Me"

## Test plan

- [ ] Review the exchanges help page at `/exchanges` to verify instructions match actual app behavior
- [ ] Verify the exchange request flow describes the correct swipe-to-add action
- [ ] Verify the cancel request flow describes the correct swipe-to-remove action