### PR TITLE
fix(pwa): exclude PDF files from service worker navigation fallback

### DIFF
--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -204,6 +204,8 @@ export default defineConfig(({ mode }) => {
             /\/ocr-poc/,
             // Don't intercept help site routes - it's a separate Astro app
             /\/help/,
+            // Don't intercept PDF files - let browser handle natively
+            /\.pdf$/,
           ],
           // Runtime caching for API responses
           runtimeCaching: [


### PR DESCRIPTION
## Summary
- Add `.pdf` file extension to the service worker's `navigateFallbackDenylist`
- PDF links (like single-ball halls documentation) now open correctly in the browser instead of being intercepted by the service worker

## Test Plan
- Open the app in demo or calendar mode
- Find an assignment at a single-ball hall (NLA/NLB game at a hall like Guntershausen, Liesberg, etc.)
- Click on the PDF link for the single-ball halls documentation
- Verify the PDF opens correctly in the browser/new tab