### PR TITLE
feat(settings): improve transport toggle UX with hints and debug panel

### DIFF
--- a/web-app/src/components/debug/DebugPanel.tsx
+++ b/web-app/src/components/debug/DebugPanel.tsx
@@ -677,12 +677,16 @@ function TransportDebugSection() {
                 <td style={{ padding: "4px", color: "#888" }}>Longitude</td>
                 <td style={{ padding: "4px", color: "#e0e0e0" }}>{homeLocation.longitude.toFixed(6)}</td>
               </tr>
-              {homeLocation.address && (
+              {homeLocation.label && (
                 <tr style={{ borderBottom: "1px solid #222" }}>
-                  <td style={{ padding: "4px", color: "#888" }}>Address</td>
-                  <td style={{ padding: "4px", color: "#e0e0e0" }}>{homeLocation.address}</td>
+                  <td style={{ padding: "4px", color: "#888" }}>Label</td>
+                  <td style={{ padding: "4px", color: "#e0e0e0" }}>{homeLocation.label}</td>
                 </tr>
               )}
+              <tr style={{ borderBottom: "1px solid #222" }}>
+                <td style={{ padding: "4px", color: "#888" }}>Source</td>
+                <td style={{ padding: "4px", color: "#e0e0e0" }}>{homeLocation.source}</td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/web-app/src/components/debug/DebugPanel.tsx
+++ b/web-app/src/components/debug/DebugPanel.tsx
@@ -19,6 +19,9 @@
  * 3. Ensure styles work regardless of app theme/CSS state
  */
 import { useAuthStore, type Occupation } from "@/stores/auth";
+import { useSettingsStore } from "@/stores/settings";
+import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
+import { isOjpConfigured } from "@/services/transport";
 import {
   type AttributeValue,
   type ActivePartyDiagnostic,
@@ -302,6 +305,16 @@ export function DebugPanel() {
         />
       </Section>
 
+      {/* Transport Toggle Debug */}
+      <Section
+        id="transport"
+        title="Transport Toggle"
+        expanded={expandedSections.has("transport")}
+        onToggle={() => toggleSection("transport")}
+      >
+        <TransportDebugSection />
+      </Section>
+
       {/* Full Profile Details - fetched from API */}
       <Section
         id="profile"
@@ -537,6 +550,141 @@ function UserIdentitySection({ user, activeOccupationId, isDemoMode }: UserIdent
           <div style={{ color: "#e0e0e0" }}>
             {user.firstName} {user.lastName}
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Debug section for transport toggle conditions.
+ * Shows home location, API configuration, and association status.
+ */
+function TransportDebugSection() {
+  const homeLocation = useSettingsStore((state) => state.homeLocation);
+  const associationCode = useActiveAssociationCode();
+  const { isDemoMode, dataSource } = useAuthStore(
+    useShallow((state) => ({
+      isDemoMode: state.isDemoMode,
+      dataSource: state.dataSource,
+    })),
+  );
+
+  const isCalendarMode = dataSource === "calendar";
+  const ojpConfigured = isOjpConfigured();
+  const apiKeyPresent = Boolean(import.meta.env.VITE_OJP_API_KEY);
+
+  // Compute the same conditions as TransportSection
+  const hasHomeLocation = Boolean(homeLocation);
+  const hasAssociation = Boolean(associationCode);
+  const isAvailable = isDemoMode || isCalendarMode || ojpConfigured;
+  const canEnable = hasHomeLocation && isAvailable && hasAssociation;
+
+  return (
+    <div style={{ fontSize: "10px" }}>
+      <div style={{ marginBottom: "8px", padding: "8px", backgroundColor: "#111122", borderRadius: "4px", border: "1px solid #333" }}>
+        <div style={{ color: "#00d4ff", fontWeight: "bold", marginBottom: "8px" }}>Toggle Conditions</div>
+        <table style={{ width: "100%", fontSize: "9px", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ display: "none" }}>
+              <th>Condition</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr style={{ borderBottom: "1px solid #222" }}>
+              <td style={{ padding: "4px", color: "#888" }}>Home Location</td>
+              <td style={{ padding: "4px", color: hasHomeLocation ? "#4eff4e" : "#ff6b6b" }}>
+                {hasHomeLocation ? "✓ Set" : "✗ Not set"}
+              </td>
+            </tr>
+            <tr style={{ borderBottom: "1px solid #222" }}>
+              <td style={{ padding: "4px", color: "#888" }}>Association Code</td>
+              <td style={{ padding: "4px", color: hasAssociation ? "#4eff4e" : "#ff6b6b" }}>
+                {associationCode ?? "✗ None"}
+              </td>
+            </tr>
+            <tr style={{ borderBottom: "1px solid #222" }}>
+              <td style={{ padding: "4px", color: "#888" }}>API Available</td>
+              <td style={{ padding: "4px", color: isAvailable ? "#4eff4e" : "#ff6b6b" }}>
+                {isAvailable ? "✓ Yes" : "✗ No"}
+              </td>
+            </tr>
+            <tr style={{ borderTop: "2px solid #333" }}>
+              <td style={{ padding: "4px", color: "#888", fontWeight: "bold" }}>Can Enable Toggle</td>
+              <td style={{ padding: "4px", color: canEnable ? "#4eff4e" : "#ff6b6b", fontWeight: "bold" }}>
+                {canEnable ? "✓ Yes" : "✗ No"}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ marginBottom: "8px", padding: "8px", backgroundColor: "#111122", borderRadius: "4px", border: "1px solid #333" }}>
+        <div style={{ color: "#00d4ff", fontWeight: "bold", marginBottom: "8px" }}>API Details</div>
+        <table style={{ width: "100%", fontSize: "9px", borderCollapse: "collapse" }}>
+          <thead>
+            <tr style={{ display: "none" }}>
+              <th>Setting</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr style={{ borderBottom: "1px solid #222" }}>
+              <td style={{ padding: "4px", color: "#888" }}>VITE_OJP_API_KEY</td>
+              <td style={{ padding: "4px", color: apiKeyPresent ? "#4eff4e" : "#ff6b6b" }}>
+                {apiKeyPresent ? "✓ Present" : "✗ Missing"}
+              </td>
+            </tr>
+            <tr style={{ borderBottom: "1px solid #222" }}>
+              <td style={{ padding: "4px", color: "#888" }}>isOjpConfigured()</td>
+              <td style={{ padding: "4px", color: ojpConfigured ? "#4eff4e" : "#ff6b6b" }}>
+                {ojpConfigured ? "✓ true" : "✗ false"}
+              </td>
+            </tr>
+            <tr style={{ borderBottom: "1px solid #222" }}>
+              <td style={{ padding: "4px", color: "#888" }}>Demo Mode</td>
+              <td style={{ padding: "4px", color: isDemoMode ? "#ffaa00" : "#888" }}>
+                {isDemoMode ? "Yes (bypasses API check)" : "No"}
+              </td>
+            </tr>
+            <tr style={{ borderBottom: "1px solid #222" }}>
+              <td style={{ padding: "4px", color: "#888" }}>Calendar Mode</td>
+              <td style={{ padding: "4px", color: isCalendarMode ? "#ffaa00" : "#888" }}>
+                {isCalendarMode ? "Yes (bypasses API check)" : "No"}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {homeLocation && (
+        <div style={{ padding: "8px", backgroundColor: "#111122", borderRadius: "4px", border: "1px solid #333" }}>
+          <div style={{ color: "#00d4ff", fontWeight: "bold", marginBottom: "8px" }}>Home Location Details</div>
+          <table style={{ width: "100%", fontSize: "9px", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ display: "none" }}>
+                <th>Property</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr style={{ borderBottom: "1px solid #222" }}>
+                <td style={{ padding: "4px", color: "#888" }}>Latitude</td>
+                <td style={{ padding: "4px", color: "#e0e0e0" }}>{homeLocation.latitude.toFixed(6)}</td>
+              </tr>
+              <tr style={{ borderBottom: "1px solid #222" }}>
+                <td style={{ padding: "4px", color: "#888" }}>Longitude</td>
+                <td style={{ padding: "4px", color: "#e0e0e0" }}>{homeLocation.longitude.toFixed(6)}</td>
+              </tr>
+              {homeLocation.address && (
+                <tr style={{ borderBottom: "1px solid #222" }}>
+                  <td style={{ padding: "4px", color: "#888" }}>Address</td>
+                  <td style={{ padding: "4px", color: "#e0e0e0" }}>{homeLocation.address}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
         </div>
       )}
     </div>

--- a/web-app/src/components/features/settings/TransportSection.tsx
+++ b/web-app/src/components/features/settings/TransportSection.tsx
@@ -217,37 +217,48 @@ function TransportSectionComponent() {
         )}
 
         {/* Enable toggle */}
-        <div className="flex items-center justify-between py-2">
-          <div className="flex-1">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                {t("settings.transport.enableCalculations")}
-              </span>
-              {associationCode && <AssociationBadge code={associationCode} />}
+        <div className="py-2">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                  {t("settings.transport.enableCalculations")}
+                </span>
+                {associationCode && <AssociationBadge code={associationCode} />}
+              </div>
             </div>
-          </div>
 
-          <button
-            type="button"
-            onClick={handleToggleTransport}
-            disabled={!canEnable}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
-              !canEnable
-                ? "bg-surface-muted dark:bg-surface-subtle-dark cursor-not-allowed opacity-50"
-                : isTransportEnabled
-                  ? "bg-primary-600"
-                  : "bg-surface-muted dark:bg-surface-subtle-dark"
-            }`}
-            role="switch"
-            aria-checked={isTransportEnabled}
-            aria-label={t("settings.transport.enableCalculations")}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                isTransportEnabled ? "translate-x-6" : "translate-x-1"
+            <button
+              type="button"
+              onClick={handleToggleTransport}
+              disabled={!canEnable}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+                !canEnable
+                  ? "bg-surface-muted dark:bg-surface-subtle-dark cursor-not-allowed opacity-50"
+                  : isTransportEnabled
+                    ? "bg-primary-600"
+                    : "bg-surface-muted dark:bg-surface-subtle-dark"
               }`}
-            />
-          </button>
+              role="switch"
+              aria-checked={isTransportEnabled}
+              aria-label={t("settings.transport.enableCalculations")}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                  isTransportEnabled ? "translate-x-6" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </div>
+          {!canEnable && (
+            <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+              {!hasHomeLocation
+                ? t("settings.transport.requiresHomeLocation")
+                : !isAvailable
+                  ? t("settings.transport.apiNotConfigured")
+                  : t("settings.transport.disabledHint")}
+            </p>
+          )}
         </div>
 
         {/* Arrival time setting - only show when transport is enabled */}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -391,6 +391,7 @@ const de: Translations = {
       description:
         "Berechnen Sie Reisezeiten mit dem Schweizer öffentlichen Verkehr, um Tauschangebote nach Anfahrtszeit zu filtern.",
       enableCalculations: "Reisezeitberechnung aktivieren",
+      disabledHint: "Erfordert Heimatstandort und Transport-API",
       requiresHomeLocation: "Legen Sie zuerst Ihren Heimatstandort fest",
       apiNotConfigured: "Transport-API ist nicht konfiguriert",
       maxTravelTime: "Maximale Reisezeit",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -389,6 +389,7 @@ const en: Translations = {
       description:
         "Calculate travel times using Swiss public transport to filter exchange offers by commute time.",
       enableCalculations: "Enable travel time calculations",
+      disabledHint: "Requires home location and transport API",
       requiresHomeLocation: "Set your home location first",
       apiNotConfigured: "Transport API is not configured",
       maxTravelTime: "Maximum travel time",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -390,6 +390,7 @@ const fr: Translations = {
       description:
         "Calculez les temps de trajet avec les transports publics suisses pour filtrer les échanges par temps de déplacement.",
       enableCalculations: "Activer le calcul des temps de trajet",
+      disabledHint: "Nécessite emplacement domicile et API de transport",
       requiresHomeLocation: "Définissez d'abord votre emplacement domicile",
       apiNotConfigured: "L'API de transport n'est pas configurée",
       maxTravelTime: "Temps de trajet maximum",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -388,6 +388,7 @@ const it: Translations = {
       description:
         "Calcola i tempi di viaggio con i trasporti pubblici svizzeri per filtrare gli scambi per tempo di percorrenza.",
       enableCalculations: "Abilita calcolo tempo di viaggio",
+      disabledHint: "Richiede posizione casa e API trasporti",
       requiresHomeLocation: "Imposta prima la tua posizione casa",
       apiNotConfigured: "API trasporti non configurata",
       maxTravelTime: "Tempo di viaggio massimo",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -263,6 +263,7 @@ export interface Translations {
       title: string;
       description: string;
       enableCalculations: string;
+      disabledHint: string;
       requiresHomeLocation: string;
       apiNotConfigured: string;
       maxTravelTime: string;


### PR DESCRIPTION
## Summary

This PR improves the public transport toggle UX by:

- **Dynamic disabled hint**: Added a contextual message below the toggle when it's disabled, explaining the specific reason:
  - "Set your home location first" when home location is not configured
  - "Transport API is not configured" when the OJP API key is missing
- **Debug panel section**: Added a new "Transport Toggle" section to the debug panel (`?debug`) to help diagnose issues with the toggle. Shows:
  - Toggle conditions (home location, association code, API availability)
  - API details (VITE_OJP_API_KEY presence, isOjpConfigured result, demo/calendar mode)
  - Home location coordinates and address when set

## Test Plan

- [x] Lint passes with zero warnings
- [x] Knip reports no dead code
- [x] All unit tests pass
- [x] Production build succeeds
- [ ] Manual testing: verify hint message appears under disabled toggle
- [ ] Manual testing: verify debug panel shows transport toggle section at `?debug`