### PR TITLE
fix(settings): use dummy association for transport settings in calendar mode

### DIFF
--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/stores/settings", () => ({
 
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn(),
+  CALENDAR_ASSOCIATION: "CAL",
 }));
 
 vi.mock("@/hooks/useTravelTime", () => ({

--- a/web-app/src/components/features/settings/TransportSection.tsx
+++ b/web-app/src/components/features/settings/TransportSection.tsx
@@ -10,6 +10,7 @@ import {
 import { useTranslation } from "@/hooks/useTranslation";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
 import { useTravelTimeAvailable } from "@/hooks/useTravelTime";
+import { CALENDAR_ASSOCIATION } from "@/stores/auth";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { queryKeys } from "@/api/queryKeys";
 import {
@@ -224,7 +225,9 @@ function TransportSectionComponent() {
                 <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
                   {t("settings.transport.enableCalculations")}
                 </span>
-                {associationCode && <AssociationBadge code={associationCode} />}
+                {associationCode && associationCode !== CALENDAR_ASSOCIATION && (
+                  <AssociationBadge code={associationCode} />
+                )}
               </div>
             </div>
 
@@ -270,7 +273,9 @@ function TransportSectionComponent() {
                   <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
                     {t("settings.transport.arrivalTime")}
                   </span>
-                  {associationCode && <AssociationBadge code={associationCode} />}
+                  {associationCode && associationCode !== CALENDAR_ASSOCIATION && (
+                    <AssociationBadge code={associationCode} />
+                  )}
                 </div>
                 <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5">
                   {t("settings.transport.arrivalTimeDescription")}

--- a/web-app/src/hooks/useActiveAssociation.ts
+++ b/web-app/src/hooks/useActiveAssociation.ts
@@ -3,22 +3,32 @@
  */
 
 import { useShallow } from "zustand/react/shallow";
-import { useAuthStore } from "@/stores/auth";
+import { useAuthStore, CALENDAR_ASSOCIATION } from "@/stores/auth";
 
 /**
  * Returns the association code of the currently active occupation.
  * Falls back to the first occupation if no active occupation is set.
  *
- * @returns The association code (e.g., "SV", "SVRBA") or undefined if not available
+ * In calendar mode, returns a dummy association code (CALENDAR_ASSOCIATION)
+ * to keep transport settings separate from real API login settings.
+ *
+ * @returns The association code (e.g., "SV", "SVRBA", "CAL") or undefined if not available
  */
 export function useActiveAssociationCode(): string | undefined {
   // Use useShallow to prevent infinite re-renders from object selector
-  const { user, activeOccupationId } = useAuthStore(
+  const { user, activeOccupationId, dataSource } = useAuthStore(
     useShallow((state) => ({
       user: state.user,
       activeOccupationId: state.activeOccupationId,
+      dataSource: state.dataSource,
     })),
   );
+
+  // In calendar mode, use a dummy association so settings don't interfere
+  // with real API association settings if the user logs in later
+  if (dataSource === "calendar") {
+    return CALENDAR_ASSOCIATION;
+  }
 
   const activeOccupation =
     user?.occupations?.find((o) => o.id === activeOccupationId) ??

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -110,6 +110,13 @@ const SESSION_CHECK_GRACE_PERIOD_MS = 5_000;
 const CALENDAR_CODE_PATTERN = /^[a-zA-Z0-9]{6}$/;
 
 /**
+ * Dummy association code for calendar mode transport settings.
+ * Using a dedicated code ensures calendar mode settings don't interfere
+ * with real API association settings if the user logs in later.
+ */
+export const CALENDAR_ASSOCIATION = "CAL";
+
+/**
  * Error key for users without a referee role.
  * This key is used by LoginPage to display a translated error message.
  * The actual translations are in i18n/locales under auth.noRefereeRole.


### PR DESCRIPTION
## Summary

- Use a dedicated "CAL" association code for transport settings in calendar mode
- This ensures calendar mode settings don't interfere with real API login settings
- Hide the association badge in TransportSection when in calendar mode

## Details

In calendar mode, transport settings were previously tied to real association codes extracted from the calendar (like "SVRZ"). This meant that if a user configured transport settings in calendar mode, those settings would be shared when they later logged in with the real API using the same association.

Now, calendar mode uses a dummy `CALENDAR_ASSOCIATION = "CAL"` code, keeping settings isolated between calendar mode and real API mode.

## Test plan

- [x] All existing tests pass
- [x] New tests added for calendar mode association handling
- [x] Lint, knip, and build pass