### PR TITLE
feat(ocr): integrate Mistral OCR to replace stub implementation

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,38 @@
+name: Deploy Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker/**'
+      - '.github/workflows/deploy-worker.yml'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: worker/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Deploy to Cloudflare Workers
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/ocr-poc/src/services/ocr/MistralOCR.js
+++ b/ocr-poc/src/services/ocr/MistralOCR.js
@@ -1,0 +1,236 @@
+/**
+ * Mistral OCR Service
+ *
+ * OCR service using Mistral's OCR API via Cloudflare Worker proxy.
+ * Provides high-quality text extraction from images and documents.
+ *
+ * @see https://docs.mistral.ai/capabilities/document_ai/basic_ocr
+ */
+
+/**
+ * @typedef {Object} OCRWord
+ * @property {string} text - The recognized word
+ * @property {number} confidence - Confidence score (0-100)
+ * @property {Object} bbox - Bounding box { x0, y0, x1, y1 }
+ */
+
+/**
+ * @typedef {Object} OCRLine
+ * @property {string} text - The full line text
+ * @property {number} confidence - Average confidence for the line
+ * @property {OCRWord[]} words - Individual words in the line
+ */
+
+/**
+ * @typedef {Object} OCRResult
+ * @property {string} fullText - Complete extracted text
+ * @property {OCRLine[]} lines - Lines with words and confidence
+ * @property {OCRWord[]} words - All words with confidence scores
+ */
+
+/**
+ * @typedef {Object} OCRProgress
+ * @property {string} status - Human-readable status message
+ * @property {number} progress - Progress percentage (0-100)
+ */
+
+/**
+ * @callback OnProgressCallback
+ * @param {OCRProgress} progress
+ */
+
+/**
+ * @typedef {Object} MistralOCRPage
+ * @property {number} index - Page index
+ * @property {string} markdown - Extracted text in markdown format
+ * @property {Object} dimensions - Page dimensions
+ */
+
+/**
+ * @typedef {Object} MistralOCRResponse
+ * @property {MistralOCRPage[]} pages - Array of processed pages
+ * @property {string} model - Model used for OCR
+ * @property {Object} usage_info - Usage information
+ */
+
+// Default OCR proxy endpoint (Cloudflare Worker)
+const DEFAULT_OCR_ENDPOINT = 'https://volleykit-proxy.takishima.workers.dev/ocr';
+
+export class MistralOCR {
+  /** @type {OnProgressCallback | undefined} */
+  #onProgress;
+
+  /** @type {boolean} */
+  #initialized = false;
+
+  /** @type {string} */
+  #endpoint;
+
+  /** @type {AbortController | null} */
+  #abortController = null;
+
+  /**
+   * @param {OnProgressCallback} [onProgress] - Callback for progress updates
+   * @param {string} [endpoint] - OCR proxy endpoint URL
+   */
+  constructor(onProgress, endpoint = DEFAULT_OCR_ENDPOINT) {
+    this.#onProgress = onProgress;
+    this.#endpoint = endpoint;
+  }
+
+  /**
+   * Report progress to callback
+   * @param {string} status
+   * @param {number} progress - Progress 0-100
+   */
+  #reportProgress(status, progress) {
+    if (this.#onProgress) {
+      this.#onProgress({ status, progress });
+    }
+  }
+
+  /**
+   * Initialize the OCR service
+   * @returns {Promise<void>}
+   */
+  async initialize() {
+    if (this.#initialized) {
+      return;
+    }
+
+    this.#reportProgress('Initializing Mistral OCR...', 0);
+
+    // Verify the OCR endpoint is reachable
+    try {
+      const response = await fetch(this.#endpoint.replace('/ocr', '/health'), {
+        method: 'GET',
+      });
+
+      if (!response.ok) {
+        throw new Error('OCR service health check failed');
+      }
+
+      this.#reportProgress('Mistral OCR ready', 10);
+      this.#initialized = true;
+    } catch (error) {
+      console.warn('OCR service health check failed, will attempt OCR anyway:', error);
+      this.#reportProgress('Mistral OCR ready (health check skipped)', 10);
+      this.#initialized = true;
+    }
+  }
+
+  /**
+   * Convert Mistral OCR response to our internal format
+   * @param {MistralOCRResponse} mistralResponse - Response from Mistral API
+   * @returns {OCRResult}
+   */
+  #convertResponse(mistralResponse) {
+    // Combine all pages' markdown into full text
+    const fullText = mistralResponse.pages
+      .map((page) => page.markdown)
+      .join('\n\n--- Page Break ---\n\n')
+      .trim();
+
+    // Parse markdown into lines
+    // Mistral returns markdown, so we split by newlines
+    const rawLines = fullText.split('\n');
+
+    /** @type {OCRLine[]} */
+    const lines = rawLines.map((lineText) => {
+      // Parse words from the line
+      const wordTexts = lineText.split(/\s+/).filter((w) => w.length > 0);
+
+      /** @type {OCRWord[]} */
+      const words = wordTexts.map((text, idx) => ({
+        text,
+        confidence: 95, // Mistral doesn't provide per-word confidence, use high default
+        bbox: {
+          x0: idx * 50, // Approximate bounding boxes (Mistral doesn't provide coordinates)
+          y0: 0,
+          x1: idx * 50 + text.length * 8,
+          y1: 20,
+        },
+      }));
+
+      return {
+        text: lineText,
+        confidence: 95, // High confidence for Mistral OCR
+        words,
+      };
+    });
+
+    // Flatten all words
+    const words = lines.flatMap((line) => line.words);
+
+    return {
+      fullText,
+      lines,
+      words,
+    };
+  }
+
+  /**
+   * Perform OCR on an image
+   * @param {Blob} imageBlob - The image to process
+   * @returns {Promise<OCRResult>}
+   */
+  async recognize(imageBlob) {
+    if (!this.#initialized) {
+      throw new Error('MistralOCR not initialized. Call initialize() first.');
+    }
+
+    this.#reportProgress('Uploading image...', 20);
+
+    // Create abort controller for cancellation
+    this.#abortController = new AbortController();
+
+    try {
+      // Prepare form data
+      const formData = new FormData();
+      formData.append('image', imageBlob, 'scoresheet.jpg');
+
+      this.#reportProgress('Processing with Mistral OCR...', 40);
+
+      // Send to OCR proxy
+      const response = await fetch(this.#endpoint, {
+        method: 'POST',
+        body: formData,
+        signal: this.#abortController.signal,
+      });
+
+      this.#reportProgress('Receiving results...', 80);
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || `OCR request failed: ${response.status}`);
+      }
+
+      const mistralResponse = /** @type {MistralOCRResponse} */ (await response.json());
+
+      this.#reportProgress('Processing complete', 100);
+
+      // Convert Mistral response to our format
+      return this.#convertResponse(mistralResponse);
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error('OCR cancelled');
+      }
+      throw error;
+    } finally {
+      this.#abortController = null;
+    }
+  }
+
+  /**
+   * Terminate the OCR service and cancel any pending requests
+   * @returns {Promise<void>}
+   */
+  async terminate() {
+    // Cancel any pending request
+    if (this.#abortController) {
+      this.#abortController.abort();
+      this.#abortController = null;
+    }
+    this.#initialized = false;
+  }
+}

--- a/ocr-poc/src/services/ocr/MistralOCR.js
+++ b/ocr-poc/src/services/ocr/MistralOCR.js
@@ -7,6 +7,19 @@
  * @see https://docs.mistral.ai/capabilities/document_ai/basic_ocr
  */
 
+// Configuration constants
+const DEFAULT_OCR_ENDPOINT = 'https://volleykit-proxy.takishima.workers.dev/ocr';
+
+// Mistral OCR doesn't provide per-word confidence scores, so we use a high default
+// since the model is generally very accurate
+const DEFAULT_CONFIDENCE_SCORE = 95;
+
+// Approximate bounding box dimensions for word positioning
+// Mistral doesn't provide coordinates, so these are estimates for UI compatibility
+const ESTIMATED_WORD_SPACING_PX = 50;
+const ESTIMATED_CHAR_WIDTH_PX = 8;
+const ESTIMATED_LINE_HEIGHT_PX = 20;
+
 /**
  * @typedef {Object} OCRWord
  * @property {string} text - The recognized word
@@ -52,9 +65,6 @@
  * @property {string} model - Model used for OCR
  * @property {Object} usage_info - Usage information
  */
-
-// Default OCR proxy endpoint (Cloudflare Worker)
-const DEFAULT_OCR_ENDPOINT = 'https://volleykit-proxy.takishima.workers.dev/ocr';
 
 export class MistralOCR {
   /** @type {OnProgressCallback | undefined} */
@@ -143,18 +153,18 @@ export class MistralOCR {
       /** @type {OCRWord[]} */
       const words = wordTexts.map((text, idx) => ({
         text,
-        confidence: 95, // Mistral doesn't provide per-word confidence, use high default
+        confidence: DEFAULT_CONFIDENCE_SCORE,
         bbox: {
-          x0: idx * 50, // Approximate bounding boxes (Mistral doesn't provide coordinates)
+          x0: idx * ESTIMATED_WORD_SPACING_PX,
           y0: 0,
-          x1: idx * 50 + text.length * 8,
-          y1: 20,
+          x1: idx * ESTIMATED_WORD_SPACING_PX + text.length * ESTIMATED_CHAR_WIDTH_PX,
+          y1: ESTIMATED_LINE_HEIGHT_PX,
         },
       }));
 
       return {
         text: lineText,
-        confidence: 95, // High confidence for Mistral OCR
+        confidence: DEFAULT_CONFIDENCE_SCORE,
         words,
       };
     });

--- a/ocr-poc/src/services/ocr/index.js
+++ b/ocr-poc/src/services/ocr/index.js
@@ -9,6 +9,9 @@
 import { MistralOCR } from './MistralOCR.js';
 import { StubOCR } from './StubOCR.js';
 
+// Timeout for health check when determining OCR proxy availability
+const HEALTH_CHECK_TIMEOUT_MS = 3000;
+
 /**
  * @typedef {'electronic' | 'handwritten'} OCREngineType
  */
@@ -32,7 +35,7 @@ async function isOCRProxyAvailable(endpoint) {
   try {
     const response = await fetch(endpoint.replace('/ocr', '/health'), {
       method: 'GET',
-      signal: AbortSignal.timeout(3000), // 3 second timeout
+      signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
     });
     return response.ok;
   } catch {

--- a/ocr-poc/src/services/ocr/index.js
+++ b/ocr-poc/src/services/ocr/index.js
@@ -2,10 +2,11 @@
  * OCR Factory
  *
  * Factory for creating OCR engine instances.
- * Currently uses a stub implementation while external OCR services
- * (Google Vision, AWS Textract, PaddleOCR) are being integrated.
+ * Uses Mistral OCR via Cloudflare Worker proxy for production,
+ * with StubOCR available for local development without API access.
  */
 
+import { MistralOCR } from './MistralOCR.js';
 import { StubOCR } from './StubOCR.js';
 
 /**
@@ -17,26 +18,71 @@ import { StubOCR } from './StubOCR.js';
  */
 
 /**
+ * @typedef {import('./MistralOCR.js').MistralOCR | import('./StubOCR.js').StubOCR} OCREngine
+ */
+
+/**
+ * Check if the OCR proxy is available by testing the health endpoint.
+ * This is used to determine whether to use Mistral or fall back to stub.
+ *
+ * @param {string} endpoint - The OCR proxy base URL
+ * @returns {Promise<boolean>} True if the proxy is available
+ */
+async function isOCRProxyAvailable(endpoint) {
+  try {
+    const response = await fetch(endpoint.replace('/ocr', '/health'), {
+      method: 'GET',
+      signal: AbortSignal.timeout(3000), // 3 second timeout
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+// OCR proxy endpoint - uses environment variable or default
+const OCR_ENDPOINT =
+  typeof import.meta !== 'undefined' && import.meta.env?.VITE_OCR_ENDPOINT
+    ? import.meta.env.VITE_OCR_ENDPOINT
+    : 'https://volleykit-proxy.takishima.workers.dev/ocr';
+
+/**
  * Factory for creating OCR engine instances
  */
 export const OCRFactory = {
   /**
    * Create an OCR engine instance based on the sheet type
-   * @param {OCREngineType} type - The type of OCR engine to create
+   * Uses Mistral OCR for production, falls back to stub if unavailable.
+   *
+   * @param {OCREngineType} _type - The type of OCR engine to create (currently unused, both types use same engine)
    * @param {OnProgressCallback} [onProgress] - Optional progress callback
-   * @returns {StubOCR} The OCR engine instance
+   * @returns {OCREngine} The OCR engine instance
    */
-  create(type, onProgress) {
-    // TODO: Integrate external OCR services (Google Vision, AWS Textract, PaddleOCR)
-    // For now, all types use the stub implementation
-    switch (type) {
-      case 'electronic':
-      case 'handwritten':
-      default:
-        return new StubOCR(onProgress);
+  create(_type, onProgress) {
+    // Use Mistral OCR - it handles both electronic and handwritten text well
+    return new MistralOCR(onProgress, OCR_ENDPOINT);
+  },
+
+  /**
+   * Create an OCR engine instance, checking availability first.
+   * Falls back to StubOCR if the OCR proxy is not available.
+   *
+   * @param {OCREngineType} _type - The type of OCR engine to create
+   * @param {OnProgressCallback} [onProgress] - Optional progress callback
+   * @returns {Promise<OCREngine>} The OCR engine instance
+   */
+  async createWithFallback(_type, onProgress) {
+    const isAvailable = await isOCRProxyAvailable(OCR_ENDPOINT);
+
+    if (isAvailable) {
+      return new MistralOCR(onProgress, OCR_ENDPOINT);
     }
+
+    console.warn('OCR proxy not available, falling back to stub implementation');
+    return new StubOCR(onProgress);
   },
 };
 
 // Re-export types and classes for convenience
+export { MistralOCR } from './MistralOCR.js';
 export { StubOCR } from './StubOCR.js';

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -543,6 +543,9 @@ export default {
               },
             },
             include_image_base64: false,
+            // Enable HTML table formatting for structured table extraction
+            // Scoresheets contain player lists and scores that benefit from table structure
+            table_format: "html",
           }),
         });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -35,6 +35,7 @@ interface Env {
   TARGET_HOST: string;
   RATE_LIMITER: RateLimiter;
   KILL_SWITCH?: string; // Set to "true" to disable the proxy
+  MISTRAL_API_KEY?: string; // API key for Mistral OCR
 }
 
 function validateEnv(env: Env): void {
@@ -404,6 +405,218 @@ export default {
           },
         },
       );
+    }
+
+    // OCR endpoint - proxy to Mistral OCR API
+    // Accepts POST with image data and returns OCR results
+    if (url.pathname === "/ocr") {
+      const origin = request.headers.get("Origin");
+      let allowedOrigins: string[];
+      try {
+        allowedOrigins = parseAllowedOrigins(env.ALLOWED_ORIGINS);
+      } catch {
+        return new Response("Server configuration error", {
+          status: 500,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+
+      // Check origin for OCR endpoint
+      if (!isAllowedOrigin(origin, allowedOrigins)) {
+        return new Response("Forbidden: Origin not allowed", {
+          status: 403,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+
+      // Handle CORS preflight for OCR
+      if (request.method === "OPTIONS") {
+        return new Response(null, {
+          status: 204,
+          headers: corsHeaders(origin!),
+        });
+      }
+
+      // Only allow POST for OCR
+      if (request.method !== "POST") {
+        return new Response("Method Not Allowed", {
+          status: 405,
+          headers: {
+            "Content-Type": "text/plain",
+            Allow: "POST",
+            ...corsHeaders(origin!),
+            ...securityHeaders(),
+          },
+        });
+      }
+
+      // Check if Mistral API key is configured
+      if (!env.MISTRAL_API_KEY) {
+        return new Response(
+          JSON.stringify({ error: "OCR service not configured" }),
+          {
+            status: 503,
+            headers: {
+              "Content-Type": "application/json",
+              ...corsHeaders(origin!),
+              ...securityHeaders(),
+            },
+          },
+        );
+      }
+
+      try {
+        // Parse the incoming request - expects multipart form data with 'image' field
+        const formData = await request.formData();
+        const imageFile = formData.get("image") as File | null;
+
+        if (!imageFile) {
+          return new Response(
+            JSON.stringify({ error: "Missing 'image' field in form data" }),
+            {
+              status: 400,
+              headers: {
+                "Content-Type": "application/json",
+                ...corsHeaders(origin!),
+                ...securityHeaders(),
+              },
+            },
+          );
+        }
+
+        // Validate file type
+        const allowedTypes = ["image/jpeg", "image/png", "image/webp", "application/pdf"];
+        if (!allowedTypes.includes(imageFile.type)) {
+          return new Response(
+            JSON.stringify({
+              error: `Unsupported file type: ${imageFile.type}. Allowed: ${allowedTypes.join(", ")}`,
+            }),
+            {
+              status: 400,
+              headers: {
+                "Content-Type": "application/json",
+                ...corsHeaders(origin!),
+                ...securityHeaders(),
+              },
+            },
+          );
+        }
+
+        // Validate file size (max 50MB as per Mistral limits)
+        const MAX_FILE_SIZE = 50 * 1024 * 1024;
+        if (imageFile.size > MAX_FILE_SIZE) {
+          return new Response(
+            JSON.stringify({
+              error: `File too large: ${(imageFile.size / 1024 / 1024).toFixed(1)}MB. Maximum: 50MB`,
+            }),
+            {
+              status: 400,
+              headers: {
+                "Content-Type": "application/json",
+                ...corsHeaders(origin!),
+                ...securityHeaders(),
+              },
+            },
+          );
+        }
+
+        // Convert image to base64 for Mistral API
+        const imageBuffer = await imageFile.arrayBuffer();
+        const base64Image = btoa(
+          String.fromCharCode(...new Uint8Array(imageBuffer)),
+        );
+        const dataUrl = `data:${imageFile.type};base64,${base64Image}`;
+
+        // Call Mistral OCR API
+        const mistralResponse = await fetch("https://api.mistral.ai/v1/ocr", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${env.MISTRAL_API_KEY}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "mistral-ocr-latest",
+            document: {
+              type: "image_url",
+              image_url: {
+                url: dataUrl,
+              },
+            },
+            include_image_base64: false,
+          }),
+        });
+
+        if (!mistralResponse.ok) {
+          const errorText = await mistralResponse.text();
+          console.error("Mistral OCR error:", mistralResponse.status, errorText);
+
+          // Return appropriate error based on status
+          if (mistralResponse.status === 401) {
+            return new Response(
+              JSON.stringify({ error: "OCR service authentication failed" }),
+              {
+                status: 503,
+                headers: {
+                  "Content-Type": "application/json",
+                  ...corsHeaders(origin!),
+                  ...securityHeaders(),
+                },
+              },
+            );
+          }
+
+          if (mistralResponse.status === 429) {
+            return new Response(
+              JSON.stringify({ error: "OCR service rate limit exceeded" }),
+              {
+                status: 429,
+                headers: {
+                  "Content-Type": "application/json",
+                  "Retry-After": "60",
+                  ...corsHeaders(origin!),
+                  ...securityHeaders(),
+                },
+              },
+            );
+          }
+
+          return new Response(
+            JSON.stringify({ error: "OCR processing failed" }),
+            {
+              status: 502,
+              headers: {
+                "Content-Type": "application/json",
+                ...corsHeaders(origin!),
+                ...securityHeaders(),
+              },
+            },
+          );
+        }
+
+        // Return the Mistral OCR response
+        const ocrResult = await mistralResponse.json();
+        return new Response(JSON.stringify(ocrResult), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            ...corsHeaders(origin!),
+            ...securityHeaders(),
+          },
+        });
+      } catch (error) {
+        console.error("OCR proxy error:", error);
+        return new Response(
+          JSON.stringify({ error: "Internal server error during OCR processing" }),
+          {
+            status: 500,
+            headers: {
+              "Content-Type": "application/json",
+              ...corsHeaders(origin!),
+              ...securityHeaders(),
+            },
+          },
+        );
+      }
     }
 
     // Rate limiting check (100 requests per minute per IP)

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -51,6 +51,18 @@ ALLOWED_ORIGINS = "https://takishima.github.io"
 TARGET_HOST = "https://volleymanager.volleyball.ch"
 
 # =============================================================================
+# SECRETS (Configure via Cloudflare Dashboard or wrangler secret)
+# =============================================================================
+# MISTRAL_API_KEY: API key for Mistral OCR service
+#   - Required for the /ocr endpoint to function
+#   - Get a key from: https://console.mistral.ai/
+#   - Set via: npx wrangler secret put MISTRAL_API_KEY
+#   - Or configure in Cloudflare Dashboard > Workers > volleykit-proxy > Settings > Variables
+#
+# Note: Secrets are not stored in this file for security reasons.
+# =============================================================================
+
+# =============================================================================
 # RATE LIMITING BINDING (In-Worker Rate Limiting)
 # =============================================================================
 # Uses Cloudflare's Rate Limiting binding for programmatic rate limiting.


### PR DESCRIPTION
## Summary
- Add `/ocr` endpoint to Cloudflare Worker that proxies requests to Mistral's OCR API, keeping the API key secure server-side
- Create `MistralOCR` service class with progress callbacks and cancellation support
- Update OCR factory to use Mistral OCR by default with fallback to stub when proxy unavailable
- Add `MISTRAL_API_KEY` secret configuration to wrangler.toml

Mistral OCR provides high-quality text extraction for both electronic and handwritten scoresheets at $2/1000 pages.

## Test Plan
- [x] Set API key: `npx wrangler secret put MISTRAL_API_KEY`
- [x] Deploy worker: `cd worker && npx wrangler deploy`
- [ ] Test OCR endpoint with sample scoresheet images
- [ ] Verify fallback to stub when API key not configured