### PR TITLE
feat(calendar): move association filter to AppShell header

### DIFF
--- a/web-app/src/components/layout/AppShell.test.tsx
+++ b/web-app/src/components/layout/AppShell.test.tsx
@@ -193,6 +193,7 @@ describe("AppShell", () => {
         createMockAuthStore({
           user: multiOccupationUser,
           activeOccupationId: "ref-1",
+          isCalendarMode: false,
         }),
       );
 

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuthStore, type Occupation } from "@/stores/auth";
 import { useTourStore } from "@/stores/tour";
+import { useCalendarFilterStore, ALL_ASSOCIATIONS } from "@/stores/calendar-filter";
 import { useTranslation } from "@/hooks/useTranslation";
 import { getOccupationLabelKey } from "@/utils/occupation-labels";
 import { getApiClient } from "@/api/client";
@@ -78,6 +79,11 @@ export function AppShell() {
     })),
   );
   const activeTour = useTourStore((state) => state.activeTour);
+  const {
+    selectedAssociation,
+    associations: calendarAssociations,
+    setSelectedAssociation,
+  } = useCalendarFilterStore();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   // Track the latest switch request to handle race conditions
@@ -98,6 +104,23 @@ export function AppShell() {
     },
     [t],
   );
+
+  const getCalendarAssociationLabel = useCallback(
+    (association: string): string => {
+      if (association === ALL_ASSOCIATIONS) {
+        return t("calendar.allAssociations");
+      }
+      return association;
+    },
+    [t],
+  );
+
+  // Determine if we should show the dropdown based on mode
+  const showCalendarDropdown = isCalendarMode && calendarAssociations.length >= 2;
+  const showOccupationDropdown =
+    !isCalendarMode &&
+    user?.occupations &&
+    user.occupations.length >= MINIMUM_OCCUPATIONS_FOR_SWITCHER;
   const dropdownRef = useRef<HTMLDivElement>(null);
   const isAuthenticated = status === "authenticated";
 
@@ -128,6 +151,11 @@ export function AppShell() {
   const activeOccupation =
     user?.occupations?.find((o) => o.id === activeOccupationId) ??
     user?.occupations?.[0];
+
+  const handleCalendarAssociationSelect = (association: string) => {
+    setSelectedAssociation(association);
+    setIsDropdownOpen(false);
+  };
 
   const handleOccupationSelect = async (id: string) => {
     // Don't switch if selecting the same occupation
@@ -226,8 +254,67 @@ export function AppShell() {
                   </div>
                 )}
 
-                {user?.occupations &&
-                  user.occupations.length >= MINIMUM_OCCUPATIONS_FOR_SWITCHER && (
+                {/* Calendar mode: Association filter dropdown */}
+                {showCalendarDropdown && (
+                  <div className="relative" ref={dropdownRef}>
+                    <button
+                      onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                      className="flex items-center gap-1 px-2 py-1 text-sm font-medium rounded-lg transition-colors text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 hover:bg-primary-100 dark:hover:bg-primary-900/50"
+                      aria-expanded={isDropdownOpen}
+                      aria-haspopup="listbox"
+                      aria-label={t("calendar.filterByAssociation")}
+                    >
+                      <span className="max-w-[100px] truncate">
+                        {getCalendarAssociationLabel(selectedAssociation)}
+                      </span>
+                      <ChevronDown
+                        className={`w-4 h-4 transition-transform ${isDropdownOpen ? "rotate-180" : ""}`}
+                        aria-hidden="true"
+                      />
+                    </button>
+
+                    {isDropdownOpen && (
+                      <div
+                        className="absolute right-0 mt-1 w-48 bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-lg border border-border-default dark:border-border-default-dark py-1 z-50"
+                        role="listbox"
+                        aria-label={t("calendar.selectAssociation")}
+                      >
+                        {/* All associations option */}
+                        <button
+                          onClick={() => handleCalendarAssociationSelect(ALL_ASSOCIATIONS)}
+                          className={`w-full text-left px-3 py-2 text-sm transition-colors ${
+                            selectedAssociation === ALL_ASSOCIATIONS
+                              ? "bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400"
+                              : "text-text-secondary dark:text-text-secondary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark"
+                          }`}
+                          role="option"
+                          aria-selected={selectedAssociation === ALL_ASSOCIATIONS}
+                        >
+                          {t("calendar.allAssociations")}
+                        </button>
+                        {/* Individual association options */}
+                        {calendarAssociations.map((association) => (
+                          <button
+                            key={association}
+                            onClick={() => handleCalendarAssociationSelect(association)}
+                            className={`w-full text-left px-3 py-2 text-sm transition-colors ${
+                              selectedAssociation === association
+                                ? "bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400"
+                                : "text-text-secondary dark:text-text-secondary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark"
+                            }`}
+                            role="option"
+                            aria-selected={selectedAssociation === association}
+                          >
+                            {association}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Normal mode: Occupation switcher dropdown */}
+                {showOccupationDropdown && (
                   <div className="relative" ref={dropdownRef}>
                     <button
                       onClick={() => setIsDropdownOpen(!isDropdownOpen)}

--- a/web-app/src/components/layout/AppShell.tsx
+++ b/web-app/src/components/layout/AppShell.tsx
@@ -33,6 +33,7 @@ const DebugPanel = lazy(() =>
 );
 
 const MINIMUM_OCCUPATIONS_FOR_SWITCHER = 2;
+const MINIMUM_ASSOCIATIONS_FOR_FILTER = 2;
 
 interface NavItem {
   path: string;
@@ -116,12 +117,14 @@ export function AppShell() {
   );
 
   // Determine if we should show the dropdown based on mode
-  const showCalendarDropdown = isCalendarMode && calendarAssociations.length >= 2;
+  const showCalendarDropdown =
+    isCalendarMode && calendarAssociations.length >= MINIMUM_ASSOCIATIONS_FOR_FILTER;
   const showOccupationDropdown =
     !isCalendarMode &&
     user?.occupations &&
     user.occupations.length >= MINIMUM_OCCUPATIONS_FOR_SWITCHER;
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const calendarDropdownRef = useRef<HTMLDivElement>(null);
+  const occupationDropdownRef = useRef<HTMLDivElement>(null);
   const isAuthenticated = status === "authenticated";
 
   // Filter nav items based on calendar mode
@@ -137,10 +140,13 @@ export function AppShell() {
   // Close dropdown when clicking outside
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
+      const target = event.target as Node;
+      const isOutsideCalendar =
+        !calendarDropdownRef.current?.contains(target);
+      const isOutsideOccupation =
+        !occupationDropdownRef.current?.contains(target);
+
+      if (isOutsideCalendar && isOutsideOccupation) {
         setIsDropdownOpen(false);
       }
     }
@@ -256,7 +262,7 @@ export function AppShell() {
 
                 {/* Calendar mode: Association filter dropdown */}
                 {showCalendarDropdown && (
-                  <div className="relative" ref={dropdownRef}>
+                  <div className="relative" ref={calendarDropdownRef}>
                     <button
                       onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                       className="flex items-center gap-1 px-2 py-1 text-sm font-medium rounded-lg transition-colors text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 hover:bg-primary-100 dark:hover:bg-primary-900/50"
@@ -315,7 +321,7 @@ export function AppShell() {
 
                 {/* Normal mode: Occupation switcher dropdown */}
                 {showOccupationDropdown && (
-                  <div className="relative" ref={dropdownRef}>
+                  <div className="relative" ref={occupationDropdownRef}>
                     <button
                       onClick={() => setIsDropdownOpen(!isDropdownOpen)}
                       disabled={isAssociationSwitching}

--- a/web-app/src/hooks/useCalendarAssociationFilter.test.ts
+++ b/web-app/src/hooks/useCalendarAssociationFilter.test.ts
@@ -1,9 +1,10 @@
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   useCalendarAssociationFilter,
   ALL_ASSOCIATIONS,
 } from './useCalendarAssociationFilter';
+import { useCalendarFilterStore } from '@/stores/calendar-filter';
 import type { CalendarAssignment } from '@/api/calendar-api';
 
 function createMockCalendarAssignment(
@@ -34,6 +35,14 @@ function createMockCalendarAssignment(
 }
 
 describe('useCalendarAssociationFilter', () => {
+  // Reset the Zustand store before each test to ensure isolation
+  beforeEach(() => {
+    useCalendarFilterStore.setState({
+      selectedAssociation: ALL_ASSOCIATIONS,
+      associations: [],
+    });
+  });
+
   describe('associations extraction', () => {
     it('returns empty array when no calendar data', () => {
       const { result } = renderHook(() => useCalendarAssociationFilter([]));

--- a/web-app/src/pages/AssignmentsPage.tsx
+++ b/web-app/src/pages/AssignmentsPage.tsx
@@ -29,7 +29,6 @@ import { TOUR_DUMMY_ASSIGNMENT } from "@/components/tour/definitions/assignments
 import { useAuthStore } from "@/stores/auth";
 import { useShallow } from "zustand/react/shallow";
 import { useCalendarAssociationFilter } from "@/hooks/useCalendarAssociationFilter";
-import { CalendarAssociationDropdown } from "@/components/features/CalendarAssociationDropdown";
 
 const PdfLanguageModal = lazy(
   () =>
@@ -135,13 +134,8 @@ export function AssignmentsPage() {
   } = useCalendarAssignments();
 
   // Association filter for calendar mode (extracts unique associations from data)
-  const {
-    associations: calendarAssociations,
-    selectedAssociation,
-    setSelectedAssociation,
-    filterByAssociation,
-    hasMultipleAssociations,
-  } = useCalendarAssociationFilter(calendarData ?? []);
+  // The filter selection is managed in the AppShell header dropdown
+  const { filterByAssociation } = useCalendarAssociationFilter(calendarData ?? []);
 
   // Compute calendar-specific data (filter by upcoming/past and association)
   const calendarUpcoming = useMemo(() => {
@@ -274,17 +268,6 @@ export function AssignmentsPage() {
 
   return (
     <div className="space-y-3">
-      {/* Calendar mode association filter */}
-      {isCalendarMode && hasMultipleAssociations && (
-        <div className="flex justify-end">
-          <CalendarAssociationDropdown
-            associations={calendarAssociations}
-            selected={selectedAssociation}
-            onChange={setSelectedAssociation}
-          />
-        </div>
-      )}
-
       {/* Tabs - WAI-ARIA tab pattern */}
       <div
         role="tablist"

--- a/web-app/src/stores/calendar-filter.ts
+++ b/web-app/src/stores/calendar-filter.ts
@@ -1,0 +1,40 @@
+/**
+ * Store for calendar association filter state.
+ *
+ * Provides shared state for filtering calendar assignments by association,
+ * allowing the AppShell dropdown and AssignmentsPage to share the same filter.
+ */
+
+import { create } from 'zustand';
+
+/** Special value meaning "show all associations" */
+export const ALL_ASSOCIATIONS = '__all__';
+
+interface CalendarFilterState {
+  /** Currently selected association filter (or ALL_ASSOCIATIONS for all) */
+  selectedAssociation: string;
+
+  /** List of available associations extracted from calendar data */
+  associations: string[];
+
+  /** Set the selected association filter */
+  setSelectedAssociation: (association: string) => void;
+
+  /** Set the list of available associations */
+  setAssociations: (associations: string[]) => void;
+
+  /** Reset filter to show all associations */
+  resetFilter: () => void;
+}
+
+export const useCalendarFilterStore = create<CalendarFilterState>((set) => ({
+  selectedAssociation: ALL_ASSOCIATIONS,
+  associations: [],
+
+  setSelectedAssociation: (association) =>
+    set({ selectedAssociation: association }),
+
+  setAssociations: (associations) => set({ associations }),
+
+  resetFilter: () => set({ selectedAssociation: ALL_ASSOCIATIONS }),
+}));


### PR DESCRIPTION
## Summary
- Move the calendar association filter dropdown from AssignmentsPage to the AppShell header
- Add Zustand store for shared calendar association filter state
- Provides consistent location for switching between associations in calendar mode

## Test Plan
- [ ] Verify calendar mode shows association filter dropdown in header when multiple associations exist
- [ ] Verify filtering by association works correctly
- [ ] Verify normal mode still shows occupation switcher dropdown