### PR TITLE
fix(i18n): translate German "tbd" string to native language

### DIFF
--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -136,7 +136,7 @@ const de: Translations = {
     calendarModeBanner: "Kalendermodus",
     calendarModeTooltip: "Kalendermodus - Nur Lesen",
     optional: "Optional",
-    tbd: "TBD",
+    tbd: "Noch offen",
     locationTbd: "Ort unbekannt",
     selectRole: "Rolle wählen",
     selectOccupation: "Funktion wählen",


### PR DESCRIPTION
## Summary
- Translated the German "tbd" string from English "TBD" to the native German "Noch offen" (still open/pending)
- This brings the German translation in line with French ("À déterminer") and Italian ("Da definire") which were already properly translated

## Test Plan
- [x] Lint passes
- [x] All tests pass (2984 tests)
- [x] Build succeeds