### PR TITLE
refactor(auth): remove deprecated isDemoMode property from auth store

### DIFF
--- a/web-app/src/App.test.tsx
+++ b/web-app/src/App.test.tsx
@@ -251,7 +251,7 @@ describe("QueryErrorHandler", () => {
   it("redirects to login on 406 query error", async () => {
     vi.mocked(useAuthStore).mockReturnValue({
       logout: mockLogout,
-      isDemoMode: false,
+      dataSource: "api",
     } as ReturnType<typeof useAuthStore>);
 
     // Create a query that will fail with 406
@@ -281,7 +281,7 @@ describe("QueryErrorHandler", () => {
   it("redirects to login on 403 query error", async () => {
     vi.mocked(useAuthStore).mockReturnValue({
       logout: mockLogout,
-      isDemoMode: false,
+      dataSource: "api",
     } as ReturnType<typeof useAuthStore>);
 
     await waitFor(() => {
@@ -292,18 +292,18 @@ describe("QueryErrorHandler", () => {
   it("does not redirect in demo mode", async () => {
     vi.mocked(useAuthStore).mockReturnValue({
       logout: mockLogout,
-      isDemoMode: true,
+      dataSource: "demo",
     } as ReturnType<typeof useAuthStore>);
 
     // Even with auth error, should not redirect in demo mode
     expect(isAuthError(new Error("401 Unauthorized"))).toBe(true);
-    // In actual implementation, isDemoMode check prevents redirect
+    // In actual implementation, dataSource check prevents redirect
   });
 
   it("redirects on mutation auth errors", async () => {
     vi.mocked(useAuthStore).mockReturnValue({
       logout: mockLogout,
-      isDemoMode: false,
+      dataSource: "api",
     } as ReturnType<typeof useAuthStore>);
 
     // Verify mutation errors are also auth errors
@@ -316,7 +316,7 @@ describe("QueryErrorHandler", () => {
 
     vi.mocked(useAuthStore).mockReturnValue({
       logout: mockLogout,
-      isDemoMode: false,
+      dataSource: "api",
     } as ReturnType<typeof useAuthStore>);
 
     // Error classification should still work

--- a/web-app/src/components/debug/DebugPanel.tsx
+++ b/web-app/src/components/debug/DebugPanel.tsx
@@ -198,7 +198,7 @@ export function DebugPanel() {
     user,
     activeOccupationId,
     csrfToken,
-    isDemoMode,
+    dataSource,
     eligibleAttributeValues,
     groupedEligibleAttributeValues,
   } = useAuthStore(
@@ -207,11 +207,12 @@ export function DebugPanel() {
       user: state.user,
       activeOccupationId: state.activeOccupationId,
       csrfToken: state.csrfToken,
-      isDemoMode: state.isDemoMode,
+      dataSource: state.dataSource,
       eligibleAttributeValues: state.eligibleAttributeValues,
       groupedEligibleAttributeValues: state.groupedEligibleAttributeValues,
     })),
   );
+  const isDemoMode = dataSource === "demo";
 
   const refreshPersistedState = useCallback(() => {
     setPersistedState(getPersistedState());
@@ -462,13 +463,8 @@ function UserIdentitySection({ user, activeOccupationId, isDemoMode }: UserIdent
 function TransportDebugSection() {
   const homeLocation = useSettingsStore((state) => state.homeLocation);
   const associationCode = useActiveAssociationCode();
-  const { isDemoMode, dataSource } = useAuthStore(
-    useShallow((state) => ({
-      isDemoMode: state.isDemoMode,
-      dataSource: state.dataSource,
-    })),
-  );
-
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const isCalendarMode = dataSource === "calendar";
   const ojpConfigured = isOjpConfigured();
   const apiKeyPresent = Boolean(import.meta.env.VITE_OJP_API_KEY);

--- a/web-app/src/components/features/EditCompensationModal.test.tsx
+++ b/web-app/src/components/features/EditCompensationModal.test.tsx
@@ -115,7 +115,7 @@ describe("EditCompensationModal", () => {
     });
 
     (useAuthStore as unknown as Mock).mockImplementation((selector) =>
-      selector({ dataSource: "api", isDemoMode: false }),
+      selector({ dataSource: "api" }),
     );
 
     // Mock useDemoStore to return getAssignmentCompensation
@@ -605,7 +605,7 @@ describe("EditCompensationModal", () => {
   describe("demo mode", () => {
     beforeEach(() => {
       (useAuthStore as unknown as Mock).mockImplementation((selector) =>
-        selector({ dataSource: "demo", isDemoMode: true }),
+        selector({ dataSource: "demo" }),
       );
 
       // In demo mode, also mock getAssignmentCompensation with demo values

--- a/web-app/src/components/features/settings/ProfileSection.tsx
+++ b/web-app/src/components/features/settings/ProfileSection.tsx
@@ -32,7 +32,8 @@ const DEMO_LAST_NAME = "User";
 
 function ProfileSectionComponent({ user }: ProfileSectionProps) {
   const { t } = useTranslation();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const [profilePictureUrl, setProfilePictureUrl] = useState<string | null>(
     user.profilePictureUrl ?? null,
   );

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -106,7 +106,6 @@ function createMockAuthStore(
     csrfToken: null,
     dataSource: "api" as const,
     calendarCode: null,
-    isDemoMode: false,
     isAssociationSwitching: false,
     _checkSessionPromise: null,
     _lastAuthTimestamp: null,

--- a/web-app/src/components/features/validation/ScoresheetPanel.tsx
+++ b/web-app/src/components/features/validation/ScoresheetPanel.tsx
@@ -49,7 +49,8 @@ export function ScoresheetPanel({
   scoresheetNotRequired = false,
 }: ScoresheetPanelProps) {
   const { t } = useTranslation();
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const onScoresheetChangeRef = useRef(onScoresheetChange);
 
   // Keep ref in sync with prop

--- a/web-app/src/components/layout/AppShell.error.test.tsx
+++ b/web-app/src/components/layout/AppShell.error.test.tsx
@@ -67,7 +67,6 @@ describe("AppShell Error Handling", () => {
       status: "idle",
       user: null,
       dataSource: "api",
-      isDemoMode: false,
       activeOccupationId: null,
       isAssociationSwitching: false,
       error: null,

--- a/web-app/src/components/layout/AppShell.integration.test.tsx
+++ b/web-app/src/components/layout/AppShell.integration.test.tsx
@@ -37,7 +37,6 @@ describe("AppShell Integration", () => {
       status: "idle",
       user: null,
       dataSource: "api",
-      isDemoMode: false,
       activeOccupationId: null,
       isAssociationSwitching: false,
       error: null,

--- a/web-app/src/hooks/useActiveAssociation.test.ts
+++ b/web-app/src/hooks/useActiveAssociation.test.ts
@@ -36,7 +36,6 @@ describe("useActiveAssociationCode", () => {
         user: null,
         error: null,
         csrfToken: null,
-        isDemoMode: false,
         dataSource: "api",
         calendarCode: null,
         activeOccupationId: null,

--- a/web-app/src/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/hooks/useAssignmentActions.test.ts
@@ -73,7 +73,7 @@ describe("useAssignmentActions", () => {
 
     // Default: not in demo mode, safe mode disabled
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -358,7 +358,7 @@ describe("useAssignmentActions", () => {
   describe("demo mode guards", () => {
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -392,7 +392,7 @@ describe("useAssignmentActions", () => {
   describe("safe mode guards", () => {
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -452,7 +452,7 @@ describe("useAssignmentActions", () => {
 
     it("should not block operations in demo mode even with safe mode enabled", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );

--- a/web-app/src/hooks/useAssignments.ts
+++ b/web-app/src/hooks/useAssignments.ts
@@ -231,7 +231,8 @@ export function useValidationClosedAssignments(): UseQueryResult<
   Assignment[],
   Error
 > {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
   const demoAssignments = useDemoStore((state) => state.assignments);
   const demoAssociationCode = useDemoStore(

--- a/web-app/src/hooks/useCompensationActions.test.ts
+++ b/web-app/src/hooks/useCompensationActions.test.ts
@@ -59,7 +59,7 @@ describe("useCompensationActions", () => {
 
     // Default: not in demo mode
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -229,7 +229,7 @@ describe("useCompensationActions", () => {
   describe("demo mode guards", () => {
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -272,7 +272,7 @@ describe("useCompensationActions", () => {
     beforeEach(() => {
       // Not in demo mode, safe mode enabled
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );

--- a/web-app/src/hooks/useExchangeActions.test.ts
+++ b/web-app/src/hooks/useExchangeActions.test.ts
@@ -66,7 +66,7 @@ describe("useExchangeActions", () => {
 
     // Default: not in demo mode, safe mode disabled
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -351,7 +351,7 @@ describe("useExchangeActions", () => {
     beforeEach(() => {
       vi.useRealTimers();
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -418,7 +418,7 @@ describe("useExchangeActions", () => {
     beforeEach(() => {
       vi.useRealTimers();
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -453,7 +453,7 @@ describe("useExchangeActions", () => {
 
     it("should not block operations in demo mode even with safe mode enabled", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );

--- a/web-app/src/hooks/useNominationList.test.ts
+++ b/web-app/src/hooks/useNominationList.test.ts
@@ -60,7 +60,7 @@ describe("useNominationList", () => {
   describe("demo mode", () => {
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -211,7 +211,7 @@ describe("useNominationList", () => {
   describe("prefetched data", () => {
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -272,7 +272,7 @@ describe("useNominationList", () => {
   describe("no data available", () => {
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: false } as ReturnType<
+        selector({ dataSource: "api" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );

--- a/web-app/src/hooks/useNominationList.ts
+++ b/web-app/src/hooks/useNominationList.ts
@@ -101,7 +101,8 @@ export function useNominationList({
   team,
   prefetchedData,
 }: UseNominationListOptions): UseNominationListResult {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const nominationLists = useDemoStore((state) => state.nominationLists);
   // Check for both null and undefined - API may return null for some validated games
   const hasPrefetchedData = prefetchedData != null;

--- a/web-app/src/hooks/useSafeModeGuard.test.ts
+++ b/web-app/src/hooks/useSafeModeGuard.test.ts
@@ -25,7 +25,7 @@ describe("useSafeModeGuard", () => {
 
     // Default: not in demo mode, safe mode disabled
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -59,7 +59,7 @@ describe("useSafeModeGuard", () => {
 
     it("should return false when in demo mode, even with safe mode enabled", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -144,7 +144,7 @@ describe("useSafeModeGuard", () => {
   describe("state exposure", () => {
     it("should expose isDemoMode state", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -184,7 +184,7 @@ describe("useSafeModeGuard", () => {
       const firstGuard = result.current.guard;
 
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );

--- a/web-app/src/hooks/useSafeModeGuard.ts
+++ b/web-app/src/hooks/useSafeModeGuard.ts
@@ -41,7 +41,8 @@ interface UseSafeModeGuardResult {
  * }, [guard]);
  */
 export function useSafeModeGuard(): UseSafeModeGuardResult {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const isSafeModeEnabled = useSettingsStore(
     (state) => state.isSafeModeEnabled,
   );

--- a/web-app/src/hooks/useSafeMutation.test.ts
+++ b/web-app/src/hooks/useSafeMutation.test.ts
@@ -39,7 +39,7 @@ describe("useSafeMutation", () => {
 
     // Default: not in demo mode, safe mode disabled
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-      selector({ isDemoMode: false } as ReturnType<
+      selector({ dataSource: "api" } as ReturnType<
         typeof authStore.useAuthStore.getState
       >),
     );
@@ -235,7 +235,7 @@ describe("useSafeMutation", () => {
 
     it("should allow execution in demo mode even with safe mode enabled", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -262,7 +262,7 @@ describe("useSafeMutation", () => {
   describe("skipSuccessToastInDemoMode", () => {
     it("should skip success toast in demo mode when configured", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );
@@ -287,7 +287,7 @@ describe("useSafeMutation", () => {
 
     it("should show success toast in demo mode when not configured to skip", async () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ isDemoMode: true } as ReturnType<
+        selector({ dataSource: "demo" } as ReturnType<
           typeof authStore.useAuthStore.getState
         >),
       );

--- a/web-app/src/hooks/useSbbUrl.test.ts
+++ b/web-app/src/hooks/useSbbUrl.test.ts
@@ -4,7 +4,9 @@ import { useSbbUrl } from "./useSbbUrl";
 
 // Mock stores - simple mocks that return fixed values
 vi.mock("@/stores/auth", () => ({
-  useAuthStore: vi.fn(() => true), // isDemoMode = true
+  useAuthStore: vi.fn((selector: (state: { dataSource: string }) => unknown) =>
+    selector({ dataSource: "demo" })
+  ),
 }));
 
 vi.mock("@/stores/settings", () => ({

--- a/web-app/src/hooks/useSbbUrl.ts
+++ b/web-app/src/hooks/useSbbUrl.ts
@@ -59,7 +59,8 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
   const [originStation, setOriginStation] = useState<StationInfo | undefined>();
   const [destinationStation, setDestinationStation] = useState<StationInfo | undefined>();
 
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const homeLocation = useSettingsStore((state) => state.homeLocation);
   const associationCode = useActiveAssociationCode();
   const arrivalBuffer = useSettingsStore((state) =>

--- a/web-app/src/hooks/useSettings.test.tsx
+++ b/web-app/src/hooks/useSettings.test.tsx
@@ -20,7 +20,7 @@ vi.mock("@/api/client", () => ({
 
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector: AnyFunction) =>
-    selector({ isDemoMode: false, activeOccupationId: "occupation-123" }),
+    selector({ dataSource: "api", activeOccupationId: "occupation-123" }),
   ),
 }));
 
@@ -40,9 +40,9 @@ function createWrapper() {
   };
 }
 
-/** Configure auth store mock with specified demo mode and occupation */
+/** Configure auth store mock with specified data source and occupation */
 async function setupAuthStore(config: {
-  isDemoMode: boolean;
+  dataSource: "api" | "demo" | "calendar";
   activeOccupationId: string | null;
 }) {
   const { useAuthStore } = await import("@/stores/auth");
@@ -83,7 +83,7 @@ describe("useAssociationSettings", () => {
   });
 
   it("is disabled in demo mode", async () => {
-    await setupAuthStore({ isDemoMode: true, activeOccupationId: null });
+    await setupAuthStore({ dataSource: "demo", activeOccupationId: null });
     const api = await getApi();
 
     const { result } = renderHook(() => useAssociationSettings(), {
@@ -107,7 +107,7 @@ describe("useAssociationSettings", () => {
 
     // First render with one occupation
     await setupAuthStore({
-      isDemoMode: false,
+      dataSource: "api",
       activeOccupationId: "occupation-1",
     });
 
@@ -124,7 +124,7 @@ describe("useAssociationSettings", () => {
 
     // Second render with different occupation - should trigger new fetch
     await setupAuthStore({
-      isDemoMode: false,
+      dataSource: "api",
       activeOccupationId: "occupation-2",
     });
 
@@ -143,7 +143,7 @@ describe("useAssociationSettings", () => {
 
   it("handles API errors gracefully", async () => {
     await setupAuthStore({
-      isDemoMode: false,
+      dataSource: "api",
       activeOccupationId: "occupation-123",
     });
 
@@ -172,7 +172,7 @@ describe("useActiveSeason", () => {
 
   it("fetches active season when not in demo mode", async () => {
     await setupAuthStore({
-      isDemoMode: false,
+      dataSource: "api",
       activeOccupationId: "occupation-123",
     });
 
@@ -198,7 +198,7 @@ describe("useActiveSeason", () => {
   });
 
   it("is disabled in demo mode", async () => {
-    await setupAuthStore({ isDemoMode: true, activeOccupationId: null });
+    await setupAuthStore({ dataSource: "demo", activeOccupationId: null });
     const api = await getApi();
 
     const { result } = renderHook(() => useActiveSeason(), {
@@ -224,7 +224,7 @@ describe("useActiveSeason", () => {
 
     // First render with one occupation
     await setupAuthStore({
-      isDemoMode: false,
+      dataSource: "api",
       activeOccupationId: "occupation-1",
     });
 
@@ -241,7 +241,7 @@ describe("useActiveSeason", () => {
 
     // Second render with different occupation - should trigger new fetch
     await setupAuthStore({
-      isDemoMode: false,
+      dataSource: "api",
       activeOccupationId: "occupation-2",
     });
 
@@ -260,7 +260,7 @@ describe("useActiveSeason", () => {
 
   it("handles API errors gracefully", async () => {
     await setupAuthStore({
-      isDemoMode: false,
+      dataSource: "api",
       activeOccupationId: "occupation-123",
     });
 

--- a/web-app/src/hooks/useSettings.ts
+++ b/web-app/src/hooks/useSettings.ts
@@ -14,7 +14,8 @@ export function useAssociationSettings(): UseQueryResult<
   AssociationSettings,
   Error
 > {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
 
   return useQuery({
@@ -33,7 +34,8 @@ export function useAssociationSettings(): UseQueryResult<
  * Includes activeOccupationId in the query key to refetch when switching associations.
  */
 export function useActiveSeason(): UseQueryResult<Season, Error> {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
 
   return useQuery({

--- a/web-app/src/hooks/useTravelTime.test.tsx
+++ b/web-app/src/hooks/useTravelTime.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@/services/transport", () => ({
 // Mock the stores - using AnyFunction to avoid strict type checking in tests
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector: AnyFunction) =>
-    selector({ isDemoMode: false, user: null, activeOccupationId: null }),
+    selector({ dataSource: "api", user: null, activeOccupationId: null }),
   ),
 }));
 
@@ -176,7 +176,7 @@ describe("useTravelTime", () => {
       const { useSettingsStore } = await import("@/stores/settings");
 
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: true, user: null, activeOccupationId: null }),
+        selector({ dataSource: "demo", user: null, activeOccupationId: null }),
       );
 
       vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -213,7 +213,7 @@ describe("useTravelTime", () => {
       const { useSettingsStore } = await import("@/stores/settings");
 
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: false }),
+        selector({ dataSource: "api" }),
       );
 
       vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -250,7 +250,7 @@ describe("useTravelTime", () => {
       const { useSettingsStore } = await import("@/stores/settings");
 
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: false }),
+        selector({ dataSource: "api" }),
       );
 
       vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -281,7 +281,7 @@ describe("useTravelTime", () => {
       const { useSettingsStore } = await import("@/stores/settings");
 
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: true, user: null, activeOccupationId: null }),
+        selector({ dataSource: "demo", user: null, activeOccupationId: null }),
       );
 
       vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -341,7 +341,7 @@ describe("useTravelTimeAvailable", () => {
     const { isOjpConfigured } = await import("@/services/transport");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
+      selector({ dataSource: "demo", user: null, activeOccupationId: null }),
     );
     vi.mocked(isOjpConfigured).mockReturnValue(false);
 
@@ -355,7 +355,7 @@ describe("useTravelTimeAvailable", () => {
     const { isOjpConfigured } = await import("@/services/transport");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: false }),
+      selector({ dataSource: "api" }),
     );
     vi.mocked(isOjpConfigured).mockReturnValue(true);
 
@@ -369,7 +369,7 @@ describe("useTravelTimeAvailable", () => {
     const { isOjpConfigured } = await import("@/services/transport");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: false }),
+      selector({ dataSource: "api" }),
     );
     vi.mocked(isOjpConfigured).mockReturnValue(false);
 
@@ -407,7 +407,7 @@ describe("day type caching", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
+      selector({ dataSource: "demo", user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -442,7 +442,7 @@ describe("day type caching", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
+      selector({ dataSource: "demo", user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -499,7 +499,7 @@ describe("localStorage persistence", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
+      selector({ dataSource: "demo", user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -539,7 +539,7 @@ describe("localStorage persistence", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
+      selector({ dataSource: "demo", user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -584,7 +584,7 @@ describe("localStorage persistence", () => {
     const { useSettingsStore } = await import("@/stores/settings");
 
     vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-      selector({ isDemoMode: true, user: null, activeOccupationId: null }),
+      selector({ dataSource: "demo", user: null, activeOccupationId: null }),
     );
 
     vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>

--- a/web-app/src/hooks/useTravelTime.ts
+++ b/web-app/src/hooks/useTravelTime.ts
@@ -7,7 +7,6 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
-import { useShallow } from "zustand/react/shallow";
 import { useAuthStore } from "@/stores/auth";
 import { useSettingsStore } from "@/stores/settings";
 import { useActiveAssociationCode } from "@/hooks/useActiveAssociation";
@@ -50,12 +49,8 @@ export function useTravelTime(
   options: UseTravelTimeOptions = {},
 ) {
   const { date, targetArrivalTime } = options;
-  const { isDemoMode, dataSource } = useAuthStore(
-    useShallow((state) => ({
-      isDemoMode: state.isDemoMode,
-      dataSource: state.dataSource,
-    })),
-  );
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const isCalendarMode = dataSource === "calendar";
   const homeLocation = useSettingsStore((state) => state.homeLocation);
   const transportEnabled = useSettingsStore((state) => state.transportEnabled);
@@ -194,12 +189,6 @@ export function formatTravelTime(minutes: number): string {
  * enabling transport calculations when OJP is configured.
  */
 export function useTravelTimeAvailable(): boolean {
-  const { isDemoMode, dataSource } = useAuthStore(
-    useShallow((state) => ({
-      isDemoMode: state.isDemoMode,
-      dataSource: state.dataSource,
-    })),
-  );
-  const isCalendarMode = dataSource === "calendar";
-  return isDemoMode || isCalendarMode || isOjpConfigured();
+  const dataSource = useAuthStore((state) => state.dataSource);
+  return dataSource === "demo" || dataSource === "calendar" || isOjpConfigured();
 }

--- a/web-app/src/hooks/useTravelTimeFilter.test.tsx
+++ b/web-app/src/hooks/useTravelTimeFilter.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/services/transport", () => ({
 
 vi.mock("@/stores/auth", () => ({
   useAuthStore: vi.fn((selector: AnyFunction) =>
-    selector({ isDemoMode: false }),
+    selector({ dataSource: "api" }),
   ),
 }));
 
@@ -200,7 +200,7 @@ describe("useTravelTimeFilter", () => {
       const { calculateMockTravelTime } = await import("@/services/transport");
 
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: true }),
+        selector({ dataSource: "demo" }),
       );
 
       const mockResult: TravelTimeResult = {
@@ -269,7 +269,7 @@ describe("useTravelTimeFilter", () => {
       const { calculateMockTravelTime } = await import("@/services/transport");
 
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: true }),
+        selector({ dataSource: "demo" }),
       );
 
       vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>
@@ -544,7 +544,7 @@ describe("useTravelTimeFilter", () => {
 
       vi.mocked(useActiveAssociationCode).mockReturnValue("SPECIAL");
       vi.mocked(useAuthStore).mockImplementation((selector: AnyFunction) =>
-        selector({ isDemoMode: true }),
+        selector({ dataSource: "demo" }),
       );
 
       vi.mocked(useSettingsStore).mockImplementation((selector: AnyFunction) =>

--- a/web-app/src/hooks/useTravelTimeFilter.ts
+++ b/web-app/src/hooks/useTravelTimeFilter.ts
@@ -67,7 +67,8 @@ function getHallInfo(exchange: GameExchange): HallInfo | null {
  * @returns Object with travel time data for each exchange and filter helper
  */
 export function useTravelTimeFilter<T extends GameExchange>(exchanges: T[] | null) {
-  const isDemoMode = useAuthStore((state) => state.isDemoMode);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
   const homeLocation = useSettingsStore((state) => state.homeLocation);
   const transportEnabled = useSettingsStore((state) => state.transportEnabled);
   const transportEnabledByAssociation = useSettingsStore(

--- a/web-app/src/pages/ExchangePage.test.tsx
+++ b/web-app/src/pages/ExchangePage.test.tsx
@@ -109,7 +109,7 @@ describe("ExchangePage", () => {
     // Default: not in demo mode, not in calendar mode
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
       selector({
-        isDemoMode: false,
+        dataSource: "api",
         isAssociationSwitching: false,
         isCalendarMode: () => false,
       } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
@@ -154,7 +154,7 @@ describe("ExchangePage", () => {
     it("should not show level filter when not in demo mode", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({
-          isDemoMode: false,
+          dataSource: "api",
           isAssociationSwitching: false,
           isCalendarMode: () => false,
         } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
@@ -171,7 +171,7 @@ describe("ExchangePage", () => {
     it("should show level filter when in demo mode with user level", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({
-          isDemoMode: true,
+          dataSource: "demo",
           isAssociationSwitching: false,
           isCalendarMode: () => false,
         } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
@@ -193,7 +193,7 @@ describe("ExchangePage", () => {
     it("should not show level filter on Added by Me tab", () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({
-          isDemoMode: true,
+          dataSource: "demo",
           isAssociationSwitching: false,
           isCalendarMode: () => false,
         } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),
@@ -238,7 +238,7 @@ describe("ExchangePage", () => {
     beforeEach(() => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({
-          isDemoMode: true,
+          dataSource: "demo",
           isAssociationSwitching: false,
           isCalendarMode: () => false,
         } as unknown as ReturnType<typeof authStore.useAuthStore.getState>),

--- a/web-app/src/pages/ExchangePage.tsx
+++ b/web-app/src/pages/ExchangePage.tsx
@@ -51,13 +51,14 @@ export function ExchangePage() {
   // Use showDummyData to show dummy data immediately, avoiding race condition with empty states
   const { showDummyData } = useTour("exchange");
 
-  const { isDemoMode, isAssociationSwitching, isCalendarMode } = useAuthStore(
+  const { dataSource, isAssociationSwitching, isCalendarMode } = useAuthStore(
     useShallow((state) => ({
-      isDemoMode: state.isDemoMode,
+      dataSource: state.dataSource,
       isAssociationSwitching: state.isAssociationSwitching,
       isCalendarMode: state.isCalendarMode(),
     })),
   );
+  const isDemoMode = dataSource === "demo";
   const { userRefereeLevel, userRefereeLevelGradationValue } = useDemoStore(
     useShallow((state) => ({
       userRefereeLevel: state.userRefereeLevel,

--- a/web-app/src/pages/SettingsPage.test.tsx
+++ b/web-app/src/pages/SettingsPage.test.tsx
@@ -51,7 +51,7 @@ function mockAuthStore(overrides = {}) {
   const state = {
     user: mockUser,
     logout: mockLogout,
-    isDemoMode: false,
+    dataSource: "api" as const,
     ...overrides,
   };
   vi.mocked(authStore.useAuthStore).mockImplementation((selector?: unknown) => {
@@ -126,7 +126,7 @@ describe("SettingsPage", () => {
 
   describe("Safe Mode Section", () => {
     it("hides safe mode section in demo mode", () => {
-      mockAuthStore({ isDemoMode: true });
+      mockAuthStore({ dataSource: "demo" });
       render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.queryByText("settings.safeMode")).not.toBeInTheDocument();
     });

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -22,13 +22,14 @@ import {
 } from "@/components/features/settings";
 
 export function SettingsPage() {
-  const { user, logout, isDemoMode } = useAuthStore(
+  const { user, logout, dataSource } = useAuthStore(
     useShallow((state) => ({
       user: state.user,
       logout: state.logout,
-      isDemoMode: state.isDemoMode,
+      dataSource: state.dataSource,
     })),
   );
+  const isDemoMode = dataSource === "demo";
   const { activeAssociationCode, refreshData } = useDemoStore(
     useShallow((state) => ({
       activeAssociationCode: state.activeAssociationCode,

--- a/web-app/src/stores/auth.test.ts
+++ b/web-app/src/stores/auth.test.ts
@@ -128,7 +128,6 @@ describe("useAuthStore", () => {
       csrfToken: null,
       dataSource: "api",
       calendarCode: null,
-      isDemoMode: false,
       activeOccupationId: null,
       _checkSessionPromise: null,
       _lastAuthTimestamp: null,
@@ -700,7 +699,7 @@ describe("useAuthStore", () => {
     });
 
     it("returns true immediately in demo mode", async () => {
-      useAuthStore.setState({ dataSource: "demo", isDemoMode: true });
+      useAuthStore.setState({ dataSource: "demo" });
 
       const result = await useAuthStore.getState().checkSession();
 
@@ -826,7 +825,6 @@ describe("useAuthStore", () => {
       const state = useAuthStore.getState();
       expect(state.status).toBe("authenticated");
       expect(state.dataSource).toBe("demo");
-      expect(state.isDemoMode).toBe(true);
       expect(state.user).toBeTruthy();
       expect(state.user?.firstName).toBe("Demo");
       expect(state.activeOccupationId).toBeTruthy();
@@ -860,7 +858,6 @@ describe("useAuthStore", () => {
       expect(state.status).toBe("authenticated");
       expect(state.dataSource).toBe("calendar");
       expect(state.calendarCode).toBe("ABC123");
-      expect(state.isDemoMode).toBe(false);
       expect(state.user?.id).toBe("calendar-ABC123");
     });
 
@@ -869,6 +866,7 @@ describe("useAuthStore", () => {
 
       const state = useAuthStore.getState();
       expect(state.status).toBe("authenticated");
+      expect(state.dataSource).toBe("calendar");
       expect(state.calendarCode).toBe("ABC123");
     });
 
@@ -966,7 +964,6 @@ describe("useAuthStore", () => {
 
       const state = useAuthStore.getState();
       expect(state.dataSource).toBe("api");
-      expect(state.isDemoMode).toBe(false);
     });
 
     it("clears calendarCode when logging out from calendar mode", async () => {

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -62,8 +62,6 @@ interface AuthState {
   user: UserProfile | null;
   error: string | null;
   csrfToken: string | null;
-  /** @deprecated Use dataSource === 'demo' instead. Kept for backwards compatibility. */
-  isDemoMode: boolean;
   /** The current data source for assignments and compensations */
   dataSource: DataSource;
   /** Calendar code for calendar mode (6 characters) */
@@ -207,8 +205,6 @@ export const useAuthStore = create<AuthState>()(
       csrfToken: null,
       dataSource: "api",
       calendarCode: null,
-      // isDemoMode kept in sync with dataSource for backwards compatibility
-      isDemoMode: false,
       activeOccupationId: null,
       isAssociationSwitching: false,
       _checkSessionPromise: null,
@@ -346,7 +342,6 @@ export const useAuthStore = create<AuthState>()(
           csrfToken: null,
           dataSource: "api",
           calendarCode: null,
-          isDemoMode: false,
           eligibleAttributeValues: null,
           groupedEligibleAttributeValues: null,
           eligibleRoles: null,
@@ -554,7 +549,6 @@ export const useAuthStore = create<AuthState>()(
         set({
           status: "authenticated",
           dataSource: "demo",
-          isDemoMode: true, // Kept in sync for backwards compatibility
           user: {
             id: "demo-user",
             firstName: "Demo",
@@ -625,7 +619,6 @@ export const useAuthStore = create<AuthState>()(
             status: "authenticated",
             dataSource: "calendar",
             calendarCode: trimmedCode,
-            isDemoMode: false,
             user: {
               id: `calendar-${trimmedCode}`,
               firstName: "Calendar",
@@ -645,7 +638,6 @@ export const useAuthStore = create<AuthState>()(
             status: "authenticated",
             dataSource: "calendar",
             calendarCode: trimmedCode,
-            isDemoMode: false,
             user: {
               id: `calendar-${trimmedCode}`,
               firstName: "Calendar",
@@ -692,7 +684,6 @@ export const useAuthStore = create<AuthState>()(
         _wasAuthenticated: state.status === "authenticated",
         dataSource: state.dataSource,
         calendarCode: state.calendarCode,
-        isDemoMode: state.isDemoMode, // Kept for backwards compatibility
         activeOccupationId: state.activeOccupationId,
         eligibleAttributeValues: state.eligibleAttributeValues,
         groupedEligibleAttributeValues: state.groupedEligibleAttributeValues,
@@ -738,7 +729,6 @@ export const useAuthStore = create<AuthState>()(
           status: persistedState?._wasAuthenticated ? "authenticated" : "idle",
           dataSource,
           calendarCode: persistedState?.calendarCode ?? null,
-          isDemoMode: dataSource === "demo",
           activeOccupationId: persistedState?.activeOccupationId ?? null,
           eligibleAttributeValues: persistedState?.eligibleAttributeValues ?? null,
           groupedEligibleAttributeValues: persistedState?.groupedEligibleAttributeValues ?? null,


### PR DESCRIPTION
## Summary

- Remove `isDemoMode` from `AuthState` interface in favor of `dataSource`
- Update all hooks and components to derive `isDemoMode` locally: `dataSource === "demo"`
- Update all test files to mock `dataSource` instead of `isDemoMode`
- Keep backwards compatibility in persist merge for old localStorage data

## Test Plan

- [x] All 2984 tests pass
- [x] Lint passes with 0 warnings
- [x] Knip detects no dead code
- [x] Production build succeeds