### PR TITLE
fix(ci): skip worker deployment when Cloudflare credentials are not configured

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -12,6 +12,8 @@ jobs:
   deploy:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
+    # Only deploy if Cloudflare secrets are configured
+    if: ${{ vars.CLOUDFLARE_ACCOUNT_ID != '' }}
     defaults:
       run:
         working-directory: worker
@@ -39,3 +41,4 @@ jobs:
         run: npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- Add conditional check to only run the deploy job when `CLOUDFLARE_ACCOUNT_ID` repository variable is set
- This prevents CI failures on forks or repos without Cloudflare credentials configured
- Aligns with the pattern used in `deploy-web.yml`

## Test Plan
- [ ] Verify workflow syntax is valid
- [ ] On repos without `CLOUDFLARE_ACCOUNT_ID` variable, deploy job should be skipped
- [ ] On repos with credentials configured, deployment works as before