### PR TITLE
fix(worker): correct wrangler.jsonc config keys for rate limiting

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -40,14 +40,14 @@ Configure in `wrangler.toml` or Cloudflare Dashboard:
 This worker implements rate limiting using Cloudflare's Rate Limiter binding:
 
 - **Limit**: 100 requests per minute per IP
-- **Configuration**: Set in `wrangler.toml` via `[[rate_limits]]` binding
+- **Configuration**: Set in `wrangler.toml` via `[[ratelimits]]` binding
 - **Response**: Returns HTTP 429 with `Retry-After: 60` header when exceeded
 
 The rate limiter is configured in `wrangler.toml`:
 
 ```toml
-[[rate_limits]]
-binding = "RATE_LIMITER"
+[[ratelimits]]
+name = "RATE_LIMITER"
 namespace_id = "1001"
 simple = { limit = 100, period = 60 }
 ```

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,4 +1,6 @@
 {
+  "$schema": "node_modules/wrangler/config-schema.json",
+
   // Root-level wrangler config for Cloudflare CI deployment
   // This file redirects wrangler to the worker/ subdirectory
   // For local development, use: cd worker && npx wrangler dev
@@ -16,9 +18,10 @@
   },
 
   // Rate limiting: 100 requests per minute per IP
-  "rate_limits": [
+  // Note: Use "ratelimits" (no underscore) and "name" to match TOML format
+  "ratelimits": [
     {
-      "binding": "RATE_LIMITER",
+      "name": "RATE_LIMITER",
       "namespace_id": "1001",
       "simple": { "limit": 100, "period": 60 }
     }


### PR DESCRIPTION
## Summary

- Fixed `wrangler.jsonc` configuration that was causing Cloudflare CI deployment failures
- Changed `"rate_limits"` to `"ratelimits"` (no underscore) to match TOML format
- Changed `"binding"` to `"name"` inside rate limit config to match TOML format
- Added `$schema` reference for config validation
- Updated `worker/README.md` to reflect correct wrangler.toml syntax

## Test Plan

- [x] Worker lint passes
- [x] Worker tests pass (156 tests)
- [x] Verified wrangler can parse the config and recognizes the `RATE_LIMITER` binding
- [ ] Verify Cloudflare CI deployment succeeds after merge