### PR TITLE
fix(worker): add CORS headers to 403 error responses for origin validation

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -144,10 +144,19 @@ export default {
       }
 
       // Check origin for health endpoint (required for CORS)
+      // Include CORS headers even in error responses so browsers can read the error
       if (!isAllowedOrigin(origin, allowedOrigins)) {
+        const errorHeaders: HeadersInit = {
+          "Content-Type": "text/plain",
+          ...securityHeaders(),
+        };
+        // If origin was provided, include CORS headers so browser can read the error
+        if (origin) {
+          Object.assign(errorHeaders, corsHeaders(origin));
+        }
         return new Response("Forbidden: Origin not allowed", {
           status: 403,
-          headers: { "Content-Type": "text/plain" },
+          headers: errorHeaders,
         });
       }
 
@@ -190,10 +199,19 @@ export default {
       }
 
       // Check origin for OCR endpoint
+      // Include CORS headers even in error responses so browsers can read the error
       if (!isAllowedOrigin(origin, allowedOrigins)) {
+        const errorHeaders: HeadersInit = {
+          "Content-Type": "text/plain",
+          ...securityHeaders(),
+        };
+        // If origin was provided, include CORS headers so browser can read the error
+        if (origin) {
+          Object.assign(errorHeaders, corsHeaders(origin));
+        }
         return new Response("Forbidden: Origin not allowed", {
           status: 403,
-          headers: { "Content-Type": "text/plain" },
+          headers: errorHeaders,
         });
       }
 
@@ -454,10 +472,19 @@ export default {
     const origin = request.headers.get("Origin");
 
     // Check if origin is allowed
+    // Include CORS headers even in error responses so browsers can read the error
     if (!isAllowedOrigin(origin, allowedOrigins)) {
+      const errorHeaders: HeadersInit = {
+        "Content-Type": "text/plain",
+        ...securityHeaders(),
+      };
+      // If origin was provided, include CORS headers so browser can read the error
+      if (origin) {
+        Object.assign(errorHeaders, corsHeaders(origin));
+      }
       return new Response("Forbidden: Origin not allowed", {
         status: 403,
-        headers: { "Content-Type": "text/plain" },
+        headers: errorHeaders,
       });
     }
 


### PR DESCRIPTION
## Summary

- Add CORS headers to 403 error responses when origin validation fails
- Fixes Safari (especially iPhone) reporting status 0 and TypeError instead of actual 403 error
- Applied fix to /health, /ocr, and general proxy endpoints

## Test Plan

- [ ] All 156 worker tests pass
- [ ] Test OCR endpoint from iPhone Safari - should now see proper 403 error instead of status 0
- [ ] Test health endpoint from allowed origin - should return 200
- [ ] Test health endpoint from disallowed origin - should return 403 with readable error