### PR TITLE
fix(ocr): extract table content from Mistral's object format

### DIFF
--- a/ocr-poc/src/services/ocr/MistralOCR.js
+++ b/ocr-poc/src/services/ocr/MistralOCR.js
@@ -53,11 +53,18 @@ const ESTIMATED_LINE_HEIGHT_PX = 20;
  */
 
 /**
+ * @typedef {Object} MistralTable
+ * @property {string} [id] - Table identifier (e.g., "tbl-0.html")
+ * @property {string} [content] - HTML table content
+ * @property {string} [html] - Alternative property for HTML content
+ */
+
+/**
  * @typedef {Object} MistralOCRPage
  * @property {number} index - Page index
  * @property {string} markdown - Extracted text in markdown format
  * @property {string[]} [images] - Base64 encoded images (if requested)
- * @property {string[]} [tables] - HTML table content (when table_format="html")
+ * @property {(string | MistralTable)[]} [tables] - HTML table content (when table_format="html")
  * @property {Object} dimensions - Page dimensions
  */
 
@@ -168,9 +175,45 @@ export class MistralOCR {
   }
 
   /**
+   * Extract HTML content from a table entry
+   * Handles both string format and object format (e.g., {id, content} or {html})
+   * @param {string | MistralTable} table - Table entry from Mistral response
+   * @returns {string} HTML content
+   */
+  #getTableHtml(table) {
+    if (typeof table === 'string') {
+      return table;
+    }
+
+    // Handle object format - try common property names
+    if (typeof table === 'object' && table !== null) {
+      // Log the structure for debugging
+      console.log('Table object structure:', JSON.stringify(table, null, 2));
+
+      if (typeof table.content === 'string') {
+        return table.content;
+      }
+      if (typeof table.html === 'string') {
+        return table.html;
+      }
+      // Last resort: try to find any string property that looks like HTML
+      for (const key of Object.keys(table)) {
+        const value = table[key];
+        if (typeof value === 'string' && value.includes('<')) {
+          console.log(`Using table property "${key}" for HTML content`);
+          return value;
+        }
+      }
+    }
+
+    console.warn('Could not extract HTML from table:', table);
+    return '';
+  }
+
+  /**
    * Replace table placeholders in markdown with actual table content
    * @param {string} markdown - Markdown text with placeholders like [tbl-0.html](tbl-0.html)
-   * @param {string[]} tables - Array of HTML table strings
+   * @param {(string | MistralTable)[]} tables - Array of HTML table entries
    * @returns {string} Markdown with table content inlined
    */
   #inlineTables(markdown, tables) {
@@ -184,7 +227,8 @@ export class MistralOCR {
     // Placeholders are in format: [tbl-N.html](tbl-N.html)
     for (let i = 0; i < tables.length; i++) {
       const placeholder = `[tbl-${i}.html](tbl-${i}.html)`;
-      const tableLines = this.#parseHtmlTable(tables[i]);
+      const tableHtml = this.#getTableHtml(tables[i]);
+      const tableLines = this.#parseHtmlTable(tableHtml);
       const tableText = tableLines.join('\n');
 
       result = result.replace(placeholder, tableText);

--- a/ocr-poc/src/services/ocr/MistralOCR.js
+++ b/ocr-poc/src/services/ocr/MistralOCR.js
@@ -54,9 +54,9 @@ const ESTIMATED_LINE_HEIGHT_PX = 20;
 
 /**
  * @typedef {Object} MistralTable
- * @property {string} [id] - Table identifier (e.g., "tbl-0.html")
- * @property {string} [content] - HTML table content
- * @property {string} [html] - Alternative property for HTML content
+ * @property {string} id - Table identifier (e.g., "tbl-0.html")
+ * @property {string} content - HTML table content
+ * @property {"html" | "markdown"} format - Table format
  */
 
 /**
@@ -176,37 +176,22 @@ export class MistralOCR {
 
   /**
    * Extract HTML content from a table entry
-   * Handles both string format and object format (e.g., {id, content} or {html})
+   * Mistral returns tables as objects with {id, content, format}
    * @param {string | MistralTable} table - Table entry from Mistral response
    * @returns {string} HTML content
    */
   #getTableHtml(table) {
+    // Handle string format (legacy/fallback)
     if (typeof table === 'string') {
       return table;
     }
 
-    // Handle object format - try common property names
-    if (typeof table === 'object' && table !== null) {
-      // Log the structure for debugging
-      console.log('Table object structure:', JSON.stringify(table, null, 2));
-
-      if (typeof table.content === 'string') {
-        return table.content;
-      }
-      if (typeof table.html === 'string') {
-        return table.html;
-      }
-      // Last resort: try to find any string property that looks like HTML
-      for (const key of Object.keys(table)) {
-        const value = table[key];
-        if (typeof value === 'string' && value.includes('<')) {
-          console.log(`Using table property "${key}" for HTML content`);
-          return value;
-        }
-      }
+    // Handle Mistral's object format: {id, content, format}
+    if (typeof table === 'object' && table !== null && typeof table.content === 'string') {
+      return table.content;
     }
 
-    console.warn('Could not extract HTML from table:', table);
+    console.warn('Unexpected table format:', table);
     return '';
   }
 


### PR DESCRIPTION
## Summary

- Fixed `[object Object]` output when parsing Mistral OCR tables
- Mistral returns tables as objects with `{id, content, format}`, not strings
- Added `#getTableHtml` method to extract the `content` property
- Updated `MistralTable` typedef to match actual API response

## Test Plan

- [ ] Run OCR on a scoresheet with tables
- [ ] Verify player names and team data are extracted correctly
- [ ] Confirm no `[object Object]` appears in output