### PR TITLE
feat(ocr-poc): add player list comparison with reference data

### DIFF
--- a/ocr-poc/src/components/PlayerComparison.js
+++ b/ocr-poc/src/components/PlayerComparison.js
@@ -1,0 +1,452 @@
+/**
+ * Player Comparison Component
+ *
+ * Displays comparison between OCR-extracted players and reference player lists.
+ * Shows matches, mismatches, and missing players for both teams.
+ */
+
+import { parseGameSheet, getAllPlayers } from '../services/PlayerListParser.js';
+import { getMockReferenceData, findTeamByName } from '../services/MockReferenceData.js';
+
+/**
+ * @typedef {import('../services/PlayerListParser.js').ParsedPlayer} ParsedPlayer
+ * @typedef {import('../services/PlayerListParser.js').ParsedTeam} ParsedTeam
+ * @typedef {import('../services/MockReferenceData.js').ReferencePlayer} ReferencePlayer
+ * @typedef {import('../services/MockReferenceData.js').ReferenceTeam} ReferenceTeam
+ */
+
+/**
+ * @typedef {Object} ComparisonResult
+ * @property {'match' | 'ocr-only' | 'ref-only'} status
+ * @property {ParsedPlayer | null} ocrPlayer
+ * @property {ReferencePlayer | null} refPlayer
+ * @property {number} confidence - Match confidence 0-100
+ */
+
+/**
+ * @typedef {Object} TeamComparison
+ * @property {string} ocrTeamName - Team name from OCR
+ * @property {string} refTeamName - Team name from reference
+ * @property {ComparisonResult[]} results
+ * @property {number} matchCount
+ * @property {number} ocrOnlyCount
+ * @property {number} refOnlyCount
+ */
+
+/**
+ * Normalize a string for comparison (lowercase, remove accents, trim)
+ * @param {string} str
+ * @returns {string}
+ */
+function normalizeForComparison(str) {
+  if (!str) return '';
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // Remove accents
+    .replace(/[^a-z0-9\s]/g, '') // Remove special chars
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Calculate similarity between two names (0-100)
+ * Uses a combination of exact match, starts-with, and contains checks
+ * @param {string} name1
+ * @param {string} name2
+ * @returns {number}
+ */
+function calculateNameSimilarity(name1, name2) {
+  const n1 = normalizeForComparison(name1);
+  const n2 = normalizeForComparison(name2);
+
+  if (!n1 || !n2) return 0;
+  if (n1 === n2) return 100;
+
+  // Check if one contains the other
+  if (n1.includes(n2) || n2.includes(n1)) {
+    const shorter = n1.length < n2.length ? n1 : n2;
+    const longer = n1.length >= n2.length ? n1 : n2;
+    return Math.round((shorter.length / longer.length) * 90);
+  }
+
+  // Check word-by-word overlap
+  const words1 = n1.split(' ').filter((w) => w.length > 1);
+  const words2 = n2.split(' ').filter((w) => w.length > 1);
+
+  let matchingWords = 0;
+  for (const w1 of words1) {
+    for (const w2 of words2) {
+      if (w1 === w2 || w1.includes(w2) || w2.includes(w1)) {
+        matchingWords++;
+        break;
+      }
+    }
+  }
+
+  const totalWords = Math.max(words1.length, words2.length);
+  if (totalWords === 0) return 0;
+
+  return Math.round((matchingWords / totalWords) * 85);
+}
+
+/**
+ * Find the best matching reference player for an OCR player
+ * @param {ParsedPlayer} ocrPlayer
+ * @param {ReferencePlayer[]} refPlayers
+ * @param {Set<string>} usedRefIds - Already matched reference player IDs
+ * @returns {{ player: ReferencePlayer | null, confidence: number }}
+ */
+function findBestMatch(ocrPlayer, refPlayers, usedRefIds) {
+  let bestMatch = null;
+  let bestConfidence = 0;
+
+  for (const refPlayer of refPlayers) {
+    if (usedRefIds.has(refPlayer.id)) continue;
+
+    let confidence = 0;
+
+    // Check shirt number match (strong signal if both have numbers)
+    const numberMatch =
+      ocrPlayer.shirtNumber !== null &&
+      refPlayer.shirtNumber !== null &&
+      ocrPlayer.shirtNumber === refPlayer.shirtNumber;
+
+    if (numberMatch) {
+      confidence += 40;
+    }
+
+    // Check last name similarity
+    const lastNameSim = calculateNameSimilarity(ocrPlayer.lastName, refPlayer.lastName);
+    confidence += lastNameSim * 0.35;
+
+    // Check first name similarity
+    const firstNameSim = calculateNameSimilarity(ocrPlayer.firstName, refPlayer.firstName);
+    confidence += firstNameSim * 0.25;
+
+    // Bonus for libero match
+    if (ocrPlayer.isLibero === refPlayer.isLibero && ocrPlayer.isLibero) {
+      confidence += 5;
+    }
+
+    if (confidence > bestConfidence) {
+      bestConfidence = confidence;
+      bestMatch = refPlayer;
+    }
+  }
+
+  // Require minimum confidence threshold for a match
+  const MATCH_THRESHOLD = 50;
+  if (bestConfidence < MATCH_THRESHOLD) {
+    return { player: null, confidence: 0 };
+  }
+
+  return { player: bestMatch, confidence: Math.min(100, Math.round(bestConfidence)) };
+}
+
+/**
+ * Compare OCR players with reference players
+ * @param {ParsedTeam} ocrTeam
+ * @param {ReferenceTeam} refTeam
+ * @returns {TeamComparison}
+ */
+function compareTeams(ocrTeam, refTeam) {
+  /** @type {ComparisonResult[]} */
+  const results = [];
+  const usedRefIds = new Set();
+
+  const ocrPlayers = getAllPlayers(ocrTeam);
+
+  // First pass: find matches for OCR players
+  for (const ocrPlayer of ocrPlayers) {
+    const { player: matchedRef, confidence } = findBestMatch(
+      ocrPlayer,
+      refTeam.players,
+      usedRefIds,
+    );
+
+    if (matchedRef) {
+      usedRefIds.add(matchedRef.id);
+      results.push({
+        status: 'match',
+        ocrPlayer,
+        refPlayer: matchedRef,
+        confidence,
+      });
+    } else {
+      results.push({
+        status: 'ocr-only',
+        ocrPlayer,
+        refPlayer: null,
+        confidence: 0,
+      });
+    }
+  }
+
+  // Second pass: find unmatched reference players
+  for (const refPlayer of refTeam.players) {
+    if (!usedRefIds.has(refPlayer.id)) {
+      results.push({
+        status: 'ref-only',
+        ocrPlayer: null,
+        refPlayer,
+        confidence: 0,
+      });
+    }
+  }
+
+  // Sort: matches first, then ocr-only, then ref-only
+  results.sort((a, b) => {
+    const order = { match: 0, 'ocr-only': 1, 'ref-only': 2 };
+    return order[a.status] - order[b.status];
+  });
+
+  return {
+    ocrTeamName: ocrTeam.name,
+    refTeamName: refTeam.name,
+    results,
+    matchCount: results.filter((r) => r.status === 'match').length,
+    ocrOnlyCount: results.filter((r) => r.status === 'ocr-only').length,
+    refOnlyCount: results.filter((r) => r.status === 'ref-only').length,
+  };
+}
+
+/**
+ * Try to match OCR teams to reference teams
+ * Since we don't know which column is which team, we try both combinations
+ * and pick the one with more matches
+ * @param {ParsedTeam} ocrTeamA
+ * @param {ParsedTeam} ocrTeamB
+ * @param {ReferenceTeam} refTeamA
+ * @param {ReferenceTeam} refTeamB
+ * @returns {{ team1: TeamComparison, team2: TeamComparison, swapped: boolean }}
+ */
+function findBestTeamMapping(ocrTeamA, ocrTeamB, refTeamA, refTeamB) {
+  // Try mapping: ocrA -> refA, ocrB -> refB
+  const option1Team1 = compareTeams(ocrTeamA, refTeamA);
+  const option1Team2 = compareTeams(ocrTeamB, refTeamB);
+  const option1Score = option1Team1.matchCount + option1Team2.matchCount;
+
+  // Try mapping: ocrA -> refB, ocrB -> refA
+  const option2Team1 = compareTeams(ocrTeamA, refTeamB);
+  const option2Team2 = compareTeams(ocrTeamB, refTeamA);
+  const option2Score = option2Team1.matchCount + option2Team2.matchCount;
+
+  if (option2Score > option1Score) {
+    return { team1: option2Team1, team2: option2Team2, swapped: true };
+  }
+
+  return { team1: option1Team1, team2: option1Team2, swapped: false };
+}
+
+/**
+ * Render a single comparison result row
+ * @param {ComparisonResult} result
+ * @returns {string}
+ */
+function renderComparisonRow(result) {
+  const statusIcons = {
+    match: '✓',
+    'ocr-only': '⚠',
+    'ref-only': '○',
+  };
+
+  const statusClasses = {
+    match: 'comparison-row--match',
+    'ocr-only': 'comparison-row--ocr-only',
+    'ref-only': 'comparison-row--ref-only',
+  };
+
+  const icon = statusIcons[result.status];
+  const rowClass = statusClasses[result.status];
+
+  if (result.status === 'match') {
+    return `
+      <div class="comparison-row ${rowClass}">
+        <span class="comparison-icon">${icon}</span>
+        <span class="comparison-number">${result.ocrPlayer?.shirtNumber ?? '-'}</span>
+        <span class="comparison-name">${result.ocrPlayer?.displayName || ''}</span>
+        <span class="comparison-confidence">${result.confidence}%</span>
+      </div>
+    `;
+  }
+
+  if (result.status === 'ocr-only') {
+    return `
+      <div class="comparison-row ${rowClass}">
+        <span class="comparison-icon">${icon}</span>
+        <span class="comparison-number">${result.ocrPlayer?.shirtNumber ?? '-'}</span>
+        <span class="comparison-name">${result.ocrPlayer?.displayName || ''}</span>
+        <span class="comparison-badge">Not in reference</span>
+      </div>
+    `;
+  }
+
+  // ref-only
+  return `
+    <div class="comparison-row ${rowClass}">
+      <span class="comparison-icon">${icon}</span>
+      <span class="comparison-number">${result.refPlayer?.shirtNumber ?? '-'}</span>
+      <span class="comparison-name">${result.refPlayer?.displayName || ''}</span>
+      <span class="comparison-badge comparison-badge--info">Not on sheet</span>
+    </div>
+  `;
+}
+
+/**
+ * Render team comparison panel
+ * @param {TeamComparison} comparison
+ * @param {string} label
+ * @returns {string}
+ */
+function renderTeamPanel(comparison, label) {
+  const rows = comparison.results.map(renderComparisonRow).join('');
+
+  return `
+    <div class="comparison-panel">
+      <div class="comparison-header">
+        <h3 class="comparison-title">${label}</h3>
+        <div class="comparison-teams">
+          <span class="comparison-team-name" title="From OCR">${comparison.ocrTeamName || 'Unknown Team'}</span>
+          <span class="comparison-arrow">→</span>
+          <span class="comparison-team-name" title="Reference">${comparison.refTeamName}</span>
+        </div>
+      </div>
+      <div class="comparison-stats">
+        <span class="comparison-stat comparison-stat--match">
+          <span class="comparison-stat-icon">✓</span>
+          <span class="comparison-stat-value">${comparison.matchCount}</span>
+          <span class="comparison-stat-label">Matched</span>
+        </span>
+        <span class="comparison-stat comparison-stat--warning">
+          <span class="comparison-stat-icon">⚠</span>
+          <span class="comparison-stat-value">${comparison.ocrOnlyCount}</span>
+          <span class="comparison-stat-label">Not in ref</span>
+        </span>
+        <span class="comparison-stat comparison-stat--info">
+          <span class="comparison-stat-icon">○</span>
+          <span class="comparison-stat-value">${comparison.refOnlyCount}</span>
+          <span class="comparison-stat-label">Not on sheet</span>
+        </span>
+      </div>
+      <div class="comparison-list">
+        ${rows}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * PlayerComparison Component
+ */
+export class PlayerComparison {
+  /**
+   * @param {Object} options
+   * @param {HTMLElement} options.container - Container element
+   * @param {string} options.ocrText - Raw OCR text
+   * @param {Function} [options.onBack] - Callback when back button is clicked
+   */
+  constructor({ container, ocrText, onBack }) {
+    this.container = container;
+    this.ocrText = ocrText;
+    this.onBack = onBack;
+
+    this.render();
+  }
+
+  render() {
+    // Parse OCR text
+    const parsed = parseGameSheet(this.ocrText);
+
+    // Get mock reference data
+    const { teamA: refTeamA, teamB: refTeamB } = getMockReferenceData();
+
+    // Find best team mapping
+    const { team1, team2, swapped } = findBestTeamMapping(
+      parsed.teamA,
+      parsed.teamB,
+      refTeamA,
+      refTeamB,
+    );
+
+    // Render warnings if any
+    const warningsHtml =
+      parsed.warnings.length > 0
+        ? `
+      <div class="comparison-warnings">
+        ${parsed.warnings.map((w) => `<p class="comparison-warning">${escapeHtml(w)}</p>`).join('')}
+      </div>
+    `
+        : '';
+
+    // Render mapping info if swapped
+    const mappingInfo = swapped
+      ? `<p class="comparison-mapping-info">Teams were automatically matched based on player names</p>`
+      : '';
+
+    this.container.innerHTML = `
+      <div class="player-comparison">
+        <div class="comparison-intro">
+          <p class="text-muted">
+            Comparing extracted players with reference roster data.
+            Players are matched by shirt number and name similarity.
+          </p>
+          ${mappingInfo}
+        </div>
+
+        ${warningsHtml}
+
+        <div class="comparison-panels">
+          ${renderTeamPanel(team1, 'Team A (Left Column)')}
+          ${renderTeamPanel(team2, 'Team B (Right Column)')}
+        </div>
+
+        <div class="comparison-legend">
+          <div class="legend-item">
+            <span class="legend-icon legend-icon--match">✓</span>
+            <span>Player matched in reference list</span>
+          </div>
+          <div class="legend-item">
+            <span class="legend-icon legend-icon--warning">⚠</span>
+            <span>Player on sheet but not in reference (verify)</span>
+          </div>
+          <div class="legend-item">
+            <span class="legend-icon legend-icon--info">○</span>
+            <span>Player in reference but not on sheet</span>
+          </div>
+        </div>
+
+        ${
+          this.onBack
+            ? `
+          <button class="btn btn-secondary btn-block mt-lg" id="btn-back-to-results">
+            Back to OCR Results
+          </button>
+        `
+            : ''
+        }
+      </div>
+    `;
+
+    // Bind back button
+    if (this.onBack) {
+      const backBtn = this.container.querySelector('#btn-back-to-results');
+      backBtn?.addEventListener('click', () => this.onBack?.());
+    }
+  }
+
+  destroy() {
+    this.container.innerHTML = '';
+  }
+}
+
+/**
+ * Escape HTML to prevent XSS
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}

--- a/ocr-poc/src/services/MockReferenceData.js
+++ b/ocr-poc/src/services/MockReferenceData.js
@@ -4,6 +4,10 @@
  * Generates fake player reference lists for comparison with OCR results.
  * These lists simulate what would come from the VolleyManager API.
  *
+ * IMPORTANT: VolleyManager API does NOT provide:
+ * - Shirt numbers (players don't have numbers in the nomination list)
+ * - Player positions (libero status is not indicated)
+ *
  * The mock data is designed to:
  * 1. Match most players from the OCR result (successful matches)
  * 2. Have some players missing (player on sheet but not in reference)
@@ -13,49 +17,59 @@
 /**
  * @typedef {Object} ReferencePlayer
  * @property {string} id - Unique identifier
- * @property {number | null} shirtNumber - Player's shirt number
  * @property {string} firstName - Player's first name
  * @property {string} lastName - Player's last name
  * @property {string} displayName - Full display name
  * @property {string} birthday - Birthday in YYYY-MM-DD format
  * @property {string} licenseCategory - License category (e.g., "SEN", "JUN")
- * @property {boolean} isLibero - Whether player is a libero
+ */
+
+/**
+ * @typedef {Object} ReferenceOfficial
+ * @property {string} id - Unique identifier
+ * @property {string} firstName - First name
+ * @property {string} lastName - Last name
+ * @property {string} displayName - Full display name
+ * @property {string} role - Role: 'C' (coach), 'AC' (assistant)
  */
 
 /**
  * @typedef {Object} ReferenceTeam
  * @property {string} id - Team identifier
  * @property {string} name - Team name
- * @property {ReferencePlayer[]} players - All players (including liberos)
+ * @property {ReferencePlayer[]} players - All players
+ * @property {ReferenceOfficial[]} officials - Coaches and assistant coaches
  */
 
-// Helper to create a reference player
-function createPlayer(
-  id,
-  shirtNumber,
-  firstName,
-  lastName,
-  birthday,
-  licenseCategory = 'SEN',
-  isLibero = false,
-) {
+// Helper to create a reference player (no shirt number - API doesn't provide it)
+function createPlayer(id, firstName, lastName, birthday, licenseCategory = 'SEN') {
   return {
     id,
-    shirtNumber,
     firstName,
     lastName,
     displayName: `${firstName} ${lastName}`,
     birthday,
     licenseCategory,
-    isLibero,
+  };
+}
+
+// Helper to create a reference official
+function createOfficial(id, firstName, lastName, role) {
+  return {
+    id,
+    firstName,
+    lastName,
+    displayName: `${firstName} ${lastName}`,
+    role,
   };
 }
 
 /**
  * Mock reference data for Team A (BTV Aarau 1)
- * - Matches most players from OCR
- * - Missing: KADRIU VENERË (17), KOSTADINOVA VIOLETA (19)
- * - Extra: MARTINEZ ELENA (who isn't on the sheet)
+ * Based on sample OCR output.
+ * - Matches most players
+ * - Missing: KADRIU VENERË, KOSTADINOVA VIOLETA (to show "on sheet but not in reference")
+ * - Extra: MARTINEZ ELENA (to show "in reference but not on sheet")
  * @returns {ReferenceTeam}
  */
 export function getMockTeamA() {
@@ -63,33 +77,44 @@ export function getMockTeamA() {
     id: 'team-a-btv-aarau',
     name: 'BTV Aarau 1',
     players: [
-      // Players that MATCH the OCR
-      createPlayer('p-a-1', 5, 'Maria', 'Tortarolo', '1998-03-15', 'SEN'),
-      createPlayer('p-a-2', 6, 'Anna Stefanie', 'Loosli', '1999-07-22', 'SEN'),
-      createPlayer('p-a-3', 7, 'Alina Sarah', 'Stäuble', '2001-11-08', 'JUN'),
-      createPlayer('p-a-4', 9, 'Marina Chiara', 'Baumli', '1997-05-30', 'SEN'),
-      createPlayer('p-a-5', 10, 'Ellen Elisabeth', 'Schibli', '2000-09-12', 'SEN'),
-      createPlayer('p-a-6', 11, 'Jasmin Tian Yi', 'Kuch', '1996-02-18', 'SEN'),
-      createPlayer('p-a-7', 12, 'Luana', 'Petris', '2002-06-25', 'JUN'),
-      createPlayer('p-a-8', 14, 'Renée', 'De Courten', '1998-12-03', 'SEN'),
-      createPlayer('p-a-9', 16, 'Sheyla', 'Bögli', '2000-04-17', 'SEN'),
-      createPlayer('p-a-10', 20, 'Charlotte', 'Schneider', '1999-08-29', 'SEN'),
-      // Liberos that MATCH
-      createPlayer('p-a-11', 1, 'Milena Timea', 'Zoller', '2001-01-11', 'JUN', true),
-      createPlayer('p-a-12', 2, 'Debora', 'Reinhard', '1997-03-05', 'SEN', true),
+      // Players that MATCH the OCR (names only, no numbers)
+      createPlayer('p-a-1', 'Maria', 'Tortarolo', '1998-03-15', 'SEN'),
+      createPlayer('p-a-2', 'Anna Stefanie', 'Loosli', '1999-07-22', 'SEN'),
+      createPlayer('p-a-3', 'Alina Sarah', 'Stäuble', '2001-11-08', 'JUN'),
+      createPlayer('p-a-4', 'Marina Chiara', 'Baumli', '1997-05-30', 'SEN'),
+      createPlayer('p-a-5', 'Ellen Elisabeth', 'Schibli', '2000-09-12', 'SEN'),
+      createPlayer('p-a-6', 'Jasmin Tian Yi', 'Kuch', '1996-02-18', 'SEN'),
+      createPlayer('p-a-7', 'Luana', 'Petris', '2002-06-25', 'JUN'),
+      createPlayer('p-a-8', 'Renée', 'De Courten', '1998-12-03', 'SEN'),
+      createPlayer('p-a-9', 'Sheyla', 'Bögli', '2000-04-17', 'SEN'),
+      createPlayer('p-a-10', 'Charlotte', 'Schneider', '1999-08-29', 'SEN'),
+      // Liberos (also just players in reference, no position indicated)
+      createPlayer('p-a-11', 'Milena Timea', 'Zoller', '2001-01-11', 'JUN'),
+      createPlayer('p-a-12', 'Debora', 'Reinhard', '1997-03-05', 'SEN'),
       // EXTRA player not on sheet (to show "in reference but not on sheet")
-      createPlayer('p-a-extra', 21, 'Elena', 'Martinez', '1998-06-20', 'SEN'),
-      // Note: KADRIU VENERË (17) and KOSTADINOVA VIOLETA (19) are NOT included
+      createPlayer('p-a-extra', 'Elena', 'Martinez', '1998-06-20', 'SEN'),
+      // Note: KADRIU VENERË and KOSTADINOVA VIOLETA are NOT included
       // to demonstrate "on sheet but not in reference"
+    ],
+    officials: [
+      // Coach - matches OCR "Lippuner Timo"
+      createOfficial('o-a-1', 'Timo', 'Lippuner', 'C'),
+      // Assistant Coach - matches OCR "Rosa Geremia Giuliano"
+      createOfficial('o-a-2', 'Giuliano', 'Rosa Geremia', 'AC'),
+      // AC2 - matches OCR "Tasca Denise"
+      createOfficial('o-a-3', 'Denise', 'Tasca', 'AC'),
+      // AC3 - matches OCR "Rohrer Michelle Claudia"
+      createOfficial('o-a-4', 'Michelle Claudia', 'Rohrer', 'AC'),
     ],
   };
 }
 
 /**
  * Mock reference data for Team B (VBC NUC II A)
- * - Matches most players from OCR
- * - Missing: SCRUCCA NINA (14)
- * - Extra: DUBOIS CLAIRE (who isn't on the sheet)
+ * Based on sample OCR output.
+ * - Matches most players
+ * - Missing: SCRUCCA NINA (to show "on sheet but not in reference")
+ * - Extra: DUBOIS CLAIRE (to show "in reference but not on sheet")
  * @returns {ReferenceTeam}
  */
 export function getMockTeamB() {
@@ -98,21 +123,29 @@ export function getMockTeamB() {
     name: 'VBC NUC II A',
     players: [
       // Players that MATCH the OCR
-      createPlayer('p-b-1', 2, 'Sophie', 'Balmer', '1999-03-15', 'SEN'),
-      createPlayer('p-b-2', 3, 'Yvana', 'Modjo', '2000-07-22', 'SEN'),
-      createPlayer('p-b-3', 5, 'Aurélie', 'Fréchelin', '1998-11-08', 'SEN'),
-      createPlayer('p-b-4', 6, 'Anaïs', 'Waeber', '2001-05-30', 'JUN'),
-      createPlayer('p-b-5', 8, 'Sara', 'Milz', '1997-09-12', 'SEN'),
-      createPlayer('p-b-6', 10, 'Julie', 'Bovet', '2000-02-18', 'SEN'),
-      createPlayer('p-b-7', 11, 'Julie', 'Schweizer', '1999-06-25', 'SEN'),
-      createPlayer('p-b-8', 13, 'Jill Ewa', 'Münstermann', '2002-12-03', 'JUN'),
-      createPlayer('p-b-9', 17, 'Amélie', 'Lengweiler', '1998-04-17', 'SEN'),
-      // Liberos that MATCH
-      createPlayer('p-b-10', 7, 'Asia', 'Marzocchella', '2001-08-29', 'JUN', true),
-      createPlayer('p-b-11', 16, 'Nora', 'Sojcic', '2000-01-11', 'SEN', true),
+      createPlayer('p-b-1', 'Sophie', 'Balmer', '1999-03-15', 'SEN'),
+      createPlayer('p-b-2', 'Yvana', 'Modjo', '2000-07-22', 'SEN'),
+      createPlayer('p-b-3', 'Aurélie', 'Fréchelin', '1998-11-08', 'SEN'),
+      createPlayer('p-b-4', 'Anaïs', 'Waeber', '2001-05-30', 'JUN'),
+      createPlayer('p-b-5', 'Sara', 'Milz', '1997-09-12', 'SEN'),
+      createPlayer('p-b-6', 'Julie', 'Bovet', '2000-02-18', 'SEN'),
+      createPlayer('p-b-7', 'Julie', 'Schweizer', '1999-06-25', 'SEN'),
+      createPlayer('p-b-8', 'Jill Ewa', 'Münstermann', '2002-12-03', 'JUN'),
+      createPlayer('p-b-9', 'Amélie', 'Lengweiler', '1998-04-17', 'SEN'),
+      // Liberos
+      createPlayer('p-b-10', 'Asia', 'Marzocchella', '2001-08-29', 'JUN'),
+      createPlayer('p-b-11', 'Nora', 'Sojcic', '2000-01-11', 'SEN'),
       // EXTRA player not on sheet
-      createPlayer('p-b-extra', 18, 'Claire', 'Dubois', '1997-03-05', 'SEN'),
-      // Note: SCRUCCA NINA (14) is NOT included to demonstrate "on sheet but not in reference"
+      createPlayer('p-b-extra', 'Claire', 'Dubois', '1997-03-05', 'SEN'),
+      // Note: SCRUCCA NINA is NOT included to demonstrate "on sheet but not in reference"
+    ],
+    officials: [
+      // Coach - matches OCR "Léonor Guyot"
+      createOfficial('o-b-1', 'Léonor', 'Guyot', 'C'),
+      // Assistant Coach - matches OCR "Girolami Laura"
+      createOfficial('o-b-2', 'Laura', 'Girolami', 'AC'),
+      // AC2 - matches OCR "Meessen Maelle"
+      createOfficial('o-b-3', 'Maelle', 'Meessen', 'AC'),
     ],
   };
 }

--- a/ocr-poc/src/services/MockReferenceData.js
+++ b/ocr-poc/src/services/MockReferenceData.js
@@ -1,0 +1,160 @@
+/**
+ * Mock Reference Data
+ *
+ * Generates fake player reference lists for comparison with OCR results.
+ * These lists simulate what would come from the VolleyManager API.
+ *
+ * The mock data is designed to:
+ * 1. Match most players from the OCR result (successful matches)
+ * 2. Have some players missing (player on sheet but not in reference)
+ * 3. Have some extra players (player in reference but not on sheet)
+ */
+
+/**
+ * @typedef {Object} ReferencePlayer
+ * @property {string} id - Unique identifier
+ * @property {number | null} shirtNumber - Player's shirt number
+ * @property {string} firstName - Player's first name
+ * @property {string} lastName - Player's last name
+ * @property {string} displayName - Full display name
+ * @property {string} birthday - Birthday in YYYY-MM-DD format
+ * @property {string} licenseCategory - License category (e.g., "SEN", "JUN")
+ * @property {boolean} isLibero - Whether player is a libero
+ */
+
+/**
+ * @typedef {Object} ReferenceTeam
+ * @property {string} id - Team identifier
+ * @property {string} name - Team name
+ * @property {ReferencePlayer[]} players - All players (including liberos)
+ */
+
+// Helper to create a reference player
+function createPlayer(
+  id,
+  shirtNumber,
+  firstName,
+  lastName,
+  birthday,
+  licenseCategory = 'SEN',
+  isLibero = false,
+) {
+  return {
+    id,
+    shirtNumber,
+    firstName,
+    lastName,
+    displayName: `${firstName} ${lastName}`,
+    birthday,
+    licenseCategory,
+    isLibero,
+  };
+}
+
+/**
+ * Mock reference data for Team A (BTV Aarau 1)
+ * - Matches most players from OCR
+ * - Missing: KADRIU VENERË (17), KOSTADINOVA VIOLETA (19)
+ * - Extra: MARTINEZ ELENA (who isn't on the sheet)
+ * @returns {ReferenceTeam}
+ */
+export function getMockTeamA() {
+  return {
+    id: 'team-a-btv-aarau',
+    name: 'BTV Aarau 1',
+    players: [
+      // Players that MATCH the OCR
+      createPlayer('p-a-1', 5, 'Maria', 'Tortarolo', '1998-03-15', 'SEN'),
+      createPlayer('p-a-2', 6, 'Anna Stefanie', 'Loosli', '1999-07-22', 'SEN'),
+      createPlayer('p-a-3', 7, 'Alina Sarah', 'Stäuble', '2001-11-08', 'JUN'),
+      createPlayer('p-a-4', 9, 'Marina Chiara', 'Baumli', '1997-05-30', 'SEN'),
+      createPlayer('p-a-5', 10, 'Ellen Elisabeth', 'Schibli', '2000-09-12', 'SEN'),
+      createPlayer('p-a-6', 11, 'Jasmin Tian Yi', 'Kuch', '1996-02-18', 'SEN'),
+      createPlayer('p-a-7', 12, 'Luana', 'Petris', '2002-06-25', 'JUN'),
+      createPlayer('p-a-8', 14, 'Renée', 'De Courten', '1998-12-03', 'SEN'),
+      createPlayer('p-a-9', 16, 'Sheyla', 'Bögli', '2000-04-17', 'SEN'),
+      createPlayer('p-a-10', 20, 'Charlotte', 'Schneider', '1999-08-29', 'SEN'),
+      // Liberos that MATCH
+      createPlayer('p-a-11', 1, 'Milena Timea', 'Zoller', '2001-01-11', 'JUN', true),
+      createPlayer('p-a-12', 2, 'Debora', 'Reinhard', '1997-03-05', 'SEN', true),
+      // EXTRA player not on sheet (to show "in reference but not on sheet")
+      createPlayer('p-a-extra', 21, 'Elena', 'Martinez', '1998-06-20', 'SEN'),
+      // Note: KADRIU VENERË (17) and KOSTADINOVA VIOLETA (19) are NOT included
+      // to demonstrate "on sheet but not in reference"
+    ],
+  };
+}
+
+/**
+ * Mock reference data for Team B (VBC NUC II A)
+ * - Matches most players from OCR
+ * - Missing: SCRUCCA NINA (14)
+ * - Extra: DUBOIS CLAIRE (who isn't on the sheet)
+ * @returns {ReferenceTeam}
+ */
+export function getMockTeamB() {
+  return {
+    id: 'team-b-vbc-nuc',
+    name: 'VBC NUC II A',
+    players: [
+      // Players that MATCH the OCR
+      createPlayer('p-b-1', 2, 'Sophie', 'Balmer', '1999-03-15', 'SEN'),
+      createPlayer('p-b-2', 3, 'Yvana', 'Modjo', '2000-07-22', 'SEN'),
+      createPlayer('p-b-3', 5, 'Aurélie', 'Fréchelin', '1998-11-08', 'SEN'),
+      createPlayer('p-b-4', 6, 'Anaïs', 'Waeber', '2001-05-30', 'JUN'),
+      createPlayer('p-b-5', 8, 'Sara', 'Milz', '1997-09-12', 'SEN'),
+      createPlayer('p-b-6', 10, 'Julie', 'Bovet', '2000-02-18', 'SEN'),
+      createPlayer('p-b-7', 11, 'Julie', 'Schweizer', '1999-06-25', 'SEN'),
+      createPlayer('p-b-8', 13, 'Jill Ewa', 'Münstermann', '2002-12-03', 'JUN'),
+      createPlayer('p-b-9', 17, 'Amélie', 'Lengweiler', '1998-04-17', 'SEN'),
+      // Liberos that MATCH
+      createPlayer('p-b-10', 7, 'Asia', 'Marzocchella', '2001-08-29', 'JUN', true),
+      createPlayer('p-b-11', 16, 'Nora', 'Sojcic', '2000-01-11', 'SEN', true),
+      // EXTRA player not on sheet
+      createPlayer('p-b-extra', 18, 'Claire', 'Dubois', '1997-03-05', 'SEN'),
+      // Note: SCRUCCA NINA (14) is NOT included to demonstrate "on sheet but not in reference"
+    ],
+  };
+}
+
+/**
+ * Get both mock teams
+ * @returns {{ teamA: ReferenceTeam, teamB: ReferenceTeam }}
+ */
+export function getMockReferenceData() {
+  return {
+    teamA: getMockTeamA(),
+    teamB: getMockTeamB(),
+  };
+}
+
+/**
+ * Get mock team by name (fuzzy match)
+ * @param {string} teamName - Team name to search for
+ * @returns {ReferenceTeam | null}
+ */
+export function findTeamByName(teamName) {
+  if (!teamName) return null;
+
+  const normalized = teamName.toLowerCase().trim();
+  const teamA = getMockTeamA();
+  const teamB = getMockTeamB();
+
+  // Check if name contains key parts
+  if (normalized.includes('aarau') || normalized.includes('btv')) {
+    return teamA;
+  }
+  if (normalized.includes('nuc') || normalized.includes('vbc nuc')) {
+    return teamB;
+  }
+
+  // Fallback: check if team name is similar
+  if (teamA.name.toLowerCase().includes(normalized.slice(0, 5))) {
+    return teamA;
+  }
+  if (teamB.name.toLowerCase().includes(normalized.slice(0, 5))) {
+    return teamB;
+  }
+
+  return null;
+}

--- a/ocr-poc/src/services/MockReferenceData.js
+++ b/ocr-poc/src/services/MockReferenceData.js
@@ -167,7 +167,9 @@ export function getMockReferenceData() {
  * @returns {ReferenceTeam | null}
  */
 export function findTeamByName(teamName) {
-  if (!teamName) return null;
+  if (!teamName) {
+    return null;
+  }
 
   const normalized = teamName.toLowerCase().trim();
   const teamA = getMockTeamA();

--- a/ocr-poc/src/services/PlayerListParser.js
+++ b/ocr-poc/src/services/PlayerListParser.js
@@ -52,7 +52,9 @@
  * @returns {string} - Name in title case
  */
 function normalizeName(name) {
-  if (!name) return '';
+  if (!name) {
+    return '';
+  }
   return name
     .toLowerCase()
     .split(/[\s-]+/)

--- a/ocr-poc/src/services/PlayerListParser.js
+++ b/ocr-poc/src/services/PlayerListParser.js
@@ -1,0 +1,332 @@
+/**
+ * Player List Parser
+ *
+ * Parses OCR text output into structured player lists for both teams.
+ * Handles the tab-separated format from Mistral OCR.
+ *
+ * Expected OCR format:
+ * Row 1: TeamA Name<tab>TeamB Name
+ * Row 2: N.<tab>Name of the player<tab>N.<tab>Name of the player (headers)
+ * Row 3+: Number<tab>LASTNAME FIRSTNAME<tab>License<tab>Number<tab>LASTNAME FIRSTNAME<tab>License
+ * ...
+ * LIBERO section: L1<tab>Number LASTNAME FIRSTNAME<tab>License<tab>L1<tab>Number LASTNAME FIRSTNAME<tab>License
+ * OFFICIAL MEMBERS section marks end of player data
+ */
+
+/**
+ * @typedef {Object} ParsedPlayer
+ * @property {number | null} shirtNumber - Player's shirt number
+ * @property {string} lastName - Player's last name (normalized)
+ * @property {string} firstName - Player's first name (normalized)
+ * @property {string} displayName - Full display name
+ * @property {string} rawName - Original name from OCR
+ * @property {string} licenseStatus - License status (NOT/LFP)
+ * @property {boolean} isLibero - Whether player is a libero
+ * @property {'L1' | 'L2' | null} liberoPosition - Libero position if applicable
+ */
+
+/**
+ * @typedef {Object} ParsedTeam
+ * @property {string} name - Team name
+ * @property {ParsedPlayer[]} players - Regular players
+ * @property {ParsedPlayer[]} liberos - Libero players
+ */
+
+/**
+ * @typedef {Object} ParsedGameSheet
+ * @property {ParsedTeam} teamA - First team (left column)
+ * @property {ParsedTeam} teamB - Second team (right column)
+ * @property {string[]} warnings - Any parsing warnings
+ */
+
+/**
+ * Normalize a name from OCR (UPPERCASE) to title case
+ * @param {string} name - Name in uppercase
+ * @returns {string} - Name in title case
+ */
+function normalizeName(name) {
+  if (!name) return '';
+  return name
+    .toLowerCase()
+    .split(/[\s-]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+/**
+ * Parse a player name in "LASTNAME FIRSTNAME [MIDDLENAME]" format
+ * @param {string} rawName - Raw name from OCR
+ * @returns {{ lastName: string, firstName: string, displayName: string }}
+ */
+function parsePlayerName(rawName) {
+  if (!rawName || typeof rawName !== 'string') {
+    return { lastName: '', firstName: '', displayName: '' };
+  }
+
+  const trimmed = rawName.trim();
+  const parts = trimmed.split(/\s+/).filter((p) => p.length > 0);
+
+  if (parts.length === 0) {
+    return { lastName: '', firstName: '', displayName: '' };
+  }
+
+  if (parts.length === 1) {
+    const lastName = normalizeName(parts[0]);
+    return { lastName, firstName: '', displayName: lastName };
+  }
+
+  // First part is always last name, rest are first names
+  const lastName = normalizeName(parts[0]);
+  const firstName = parts.slice(1).map(normalizeName).join(' ');
+  const displayName = `${firstName} ${lastName}`;
+
+  return { lastName, firstName, displayName };
+}
+
+/**
+ * Parse a libero entry which has format "Number LASTNAME FIRSTNAME"
+ * @param {string} entry - Libero entry like "1 ZOLLER MILENA TIMEA"
+ * @returns {{ number: number | null, name: string }}
+ */
+function parseLiberoEntry(entry) {
+  if (!entry || typeof entry !== 'string') {
+    return { number: null, name: '' };
+  }
+
+  const trimmed = entry.trim();
+  const match = trimmed.match(/^(\d+)\s+(.+)$/);
+
+  if (match) {
+    return {
+      number: parseInt(match[1], 10),
+      name: match[2],
+    };
+  }
+
+  return { number: null, name: trimmed };
+}
+
+/**
+ * Check if a line marks the end of player data
+ * @param {string} line - Line to check
+ * @returns {boolean}
+ */
+function isEndMarker(line) {
+  const markers = [
+    'OFFICIAL MEMBERS',
+    'SIGNATURES',
+    'COACH',
+    'ASSISTANT',
+    'Team Captain',
+  ];
+  const upper = line.toUpperCase();
+  return markers.some((marker) => upper.includes(marker.toUpperCase()));
+}
+
+/**
+ * Check if a line is a section header
+ * @param {string} line - Line to check
+ * @returns {boolean}
+ */
+function isSectionHeader(line) {
+  const headers = ['LIBERO', 'N.', 'Name of the player'];
+  return headers.some((h) => line.toUpperCase().includes(h.toUpperCase()));
+}
+
+/**
+ * Parse the OCR text output into structured player lists
+ * @param {string} ocrText - Raw OCR text from Mistral
+ * @returns {ParsedGameSheet}
+ */
+export function parseGameSheet(ocrText) {
+  /** @type {string[]} */
+  const warnings = [];
+
+  /** @type {ParsedTeam} */
+  const teamA = { name: '', players: [], liberos: [] };
+
+  /** @type {ParsedTeam} */
+  const teamB = { name: '', players: [], liberos: [] };
+
+  if (!ocrText || typeof ocrText !== 'string') {
+    warnings.push('No OCR text provided');
+    return { teamA, teamB, warnings };
+  }
+
+  // Split into lines and filter empty ones
+  const lines = ocrText
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  if (lines.length === 0) {
+    warnings.push('OCR text contains no lines');
+    return { teamA, teamB, warnings };
+  }
+
+  let currentSection = 'header'; // 'header' | 'players' | 'libero' | 'done'
+  let headerRowsParsed = 0;
+
+  for (const line of lines) {
+    // Check for end markers
+    if (isEndMarker(line)) {
+      currentSection = 'done';
+      continue;
+    }
+
+    if (currentSection === 'done') {
+      continue;
+    }
+
+    // Split by tabs
+    const parts = line.split('\t').map((p) => p.trim());
+
+    // Check for LIBERO section
+    if (line.toUpperCase().includes('LIBERO') && parts.length <= 2) {
+      currentSection = 'libero';
+      continue;
+    }
+
+    // Parse based on current section
+    if (currentSection === 'header') {
+      // First non-header row should be team names
+      if (headerRowsParsed === 0 && !isSectionHeader(line)) {
+        // Team names row - could be 2 parts (tab-separated) or in various formats
+        if (parts.length >= 2) {
+          teamA.name = parts[0];
+          teamB.name = parts[1];
+        } else if (parts.length === 1) {
+          // Single value - might be combined or just one team
+          teamA.name = parts[0];
+        }
+        headerRowsParsed++;
+        continue;
+      }
+
+      // Skip header row with "N." and "Name of the player"
+      if (isSectionHeader(line)) {
+        currentSection = 'players';
+        continue;
+      }
+
+      headerRowsParsed++;
+      if (headerRowsParsed > 3) {
+        currentSection = 'players';
+      }
+    }
+
+    if (currentSection === 'players') {
+      // Expected format: Number<tab>Name<tab>License<tab>Number<tab>Name<tab>License
+      // Or: Number<tab>Name<tab>License (only one team in row)
+      if (parts.length >= 3) {
+        // Team A player
+        const numA = parseInt(parts[0], 10);
+        const nameA = parts[1];
+        const licenseA = parts[2];
+
+        if (!isNaN(numA) && nameA) {
+          const parsed = parsePlayerName(nameA);
+          teamA.players.push({
+            shirtNumber: numA,
+            lastName: parsed.lastName,
+            firstName: parsed.firstName,
+            displayName: parsed.displayName,
+            rawName: nameA,
+            licenseStatus: licenseA || '',
+            isLibero: false,
+            liberoPosition: null,
+          });
+        }
+
+        // Team B player (if present)
+        if (parts.length >= 6) {
+          const numB = parseInt(parts[3], 10);
+          const nameB = parts[4];
+          const licenseB = parts[5];
+
+          if (!isNaN(numB) && nameB) {
+            const parsed = parsePlayerName(nameB);
+            teamB.players.push({
+              shirtNumber: numB,
+              lastName: parsed.lastName,
+              firstName: parsed.firstName,
+              displayName: parsed.displayName,
+              rawName: nameB,
+              licenseStatus: licenseB || '',
+              isLibero: false,
+              liberoPosition: null,
+            });
+          }
+        }
+      }
+    }
+
+    if (currentSection === 'libero') {
+      // Libero format: L1<tab>Number Name<tab>License<tab>L1<tab>Number Name<tab>License
+      // Or: L1<tab>Number Name<tab>License (only one team)
+      if (parts.length >= 3) {
+        const posA = parts[0]; // L1 or L2
+        const entryA = parseLiberoEntry(parts[1]);
+        const licenseA = parts[2];
+
+        if (entryA.name) {
+          const parsed = parsePlayerName(entryA.name);
+          teamA.liberos.push({
+            shirtNumber: entryA.number,
+            lastName: parsed.lastName,
+            firstName: parsed.firstName,
+            displayName: parsed.displayName,
+            rawName: entryA.name,
+            licenseStatus: licenseA || '',
+            isLibero: true,
+            liberoPosition: /** @type {'L1' | 'L2' | null} */ (
+              posA.toUpperCase().startsWith('L') ? posA.toUpperCase() : null
+            ),
+          });
+        }
+
+        // Team B libero (if present)
+        if (parts.length >= 6) {
+          const posB = parts[3];
+          const entryB = parseLiberoEntry(parts[4]);
+          const licenseB = parts[5];
+
+          if (entryB.name) {
+            const parsed = parsePlayerName(entryB.name);
+            teamB.liberos.push({
+              shirtNumber: entryB.number,
+              lastName: parsed.lastName,
+              firstName: parsed.firstName,
+              displayName: parsed.displayName,
+              rawName: entryB.name,
+              licenseStatus: licenseB || '',
+              isLibero: true,
+              liberoPosition: /** @type {'L1' | 'L2' | null} */ (
+                posB.toUpperCase().startsWith('L') ? posB.toUpperCase() : null
+              ),
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Add warnings if teams have no players
+  if (teamA.players.length === 0 && teamA.liberos.length === 0) {
+    warnings.push('No players found for Team A');
+  }
+  if (teamB.players.length === 0 && teamB.liberos.length === 0) {
+    warnings.push('No players found for Team B');
+  }
+
+  return { teamA, teamB, warnings };
+}
+
+/**
+ * Get all players (regular + liberos) for a team
+ * @param {ParsedTeam} team
+ * @returns {ParsedPlayer[]}
+ */
+export function getAllPlayers(team) {
+  return [...team.players, ...team.liberos];
+}

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -677,3 +677,259 @@ body {
   overflow-y: auto;
   color: var(--color-text-secondary);
 }
+
+/* ==============================================
+ * PLAYER COMPARISON COMPONENT
+ * ============================================== */
+
+.player-comparison {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.comparison-intro {
+  text-align: center;
+}
+
+.comparison-mapping-info {
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-600);
+  font-style: italic;
+  margin-top: var(--spacing-sm);
+}
+
+.comparison-warnings {
+  background-color: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md);
+}
+
+.comparison-warning {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: #92400e;
+}
+
+.comparison-warning + .comparison-warning {
+  margin-top: var(--spacing-xs);
+}
+
+.comparison-panels {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+@media (min-width: 768px) {
+  .comparison-panels {
+    flex-direction: row;
+  }
+
+  .comparison-panel {
+    flex: 1;
+  }
+}
+
+.comparison-panel {
+  background-color: var(--color-surface-card);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.comparison-header {
+  background-color: var(--color-primary-50);
+  padding: var(--spacing-md);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.comparison-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.comparison-teams {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+}
+
+.comparison-team-name {
+  color: var(--color-text-secondary);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.comparison-arrow {
+  color: var(--color-text-muted);
+}
+
+.comparison-stats {
+  display: flex;
+  justify-content: space-around;
+  padding: var(--spacing-md);
+  background-color: var(--color-surface-subtle);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.comparison-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.comparison-stat-icon {
+  font-size: var(--font-size-lg);
+}
+
+.comparison-stat--match .comparison-stat-icon {
+  color: var(--color-success-600);
+}
+
+.comparison-stat--warning .comparison-stat-icon {
+  color: var(--color-warning-600);
+}
+
+.comparison-stat--info .comparison-stat-icon {
+  color: var(--color-primary-500);
+}
+
+.comparison-stat-value {
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.comparison-stat-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.comparison-list {
+  padding: var(--spacing-sm);
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.comparison-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-xs);
+}
+
+.comparison-row:last-child {
+  margin-bottom: 0;
+}
+
+.comparison-row--match {
+  background-color: #dcfce7;
+}
+
+.comparison-row--ocr-only {
+  background-color: #fef3c7;
+}
+
+.comparison-row--ref-only {
+  background-color: #dbeafe;
+}
+
+.comparison-icon {
+  font-size: var(--font-size-base);
+  width: 20px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.comparison-row--match .comparison-icon {
+  color: var(--color-success-600);
+}
+
+.comparison-row--ocr-only .comparison-icon {
+  color: var(--color-warning-600);
+}
+
+.comparison-row--ref-only .comparison-icon {
+  color: var(--color-primary-600);
+}
+
+.comparison-number {
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  min-width: 24px;
+  text-align: right;
+}
+
+.comparison-name {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.comparison-confidence {
+  font-size: var(--font-size-sm);
+  color: var(--color-success-600);
+  font-weight: 500;
+}
+
+.comparison-badge {
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-warning-500);
+  color: white;
+  white-space: nowrap;
+}
+
+.comparison-badge--info {
+  background-color: var(--color-primary-500);
+}
+
+.comparison-legend {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  background-color: var(--color-surface-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.legend-icon {
+  width: 20px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.legend-icon--match {
+  color: var(--color-success-600);
+}
+
+.legend-icon--warning {
+  color: var(--color-warning-600);
+}
+
+.legend-icon--info {
+  color: var(--color-primary-600);
+}

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -933,3 +933,35 @@ body {
 .legend-icon--info {
   color: var(--color-primary-600);
 }
+
+/* Section titles within comparison panels */
+.comparison-section {
+  border-top: 1px solid var(--color-border-default);
+}
+
+.comparison-section:first-of-type {
+  border-top: none;
+}
+
+.comparison-section-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin: 0;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Role badge for officials */
+.comparison-role-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-gray-600);
+  color: white;
+  min-width: 24px;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary

- Add player list comparison feature to the OCR POC that compares OCR-extracted players with mock reference data
- Parse OCR output into structured player and officials lists (coaches, assistant coaches)
- Match players by name only (VolleyManager API doesn't provide shirt numbers or positions)
- Use fuzzy name matching with accent normalization and confidence scoring
- Automatically detect team mapping by trying both column orderings
- Display warnings when officials section parsing fails

## Files Added/Modified

- `ocr-poc/src/services/PlayerListParser.js` - Parses OCR text into structured data
- `ocr-poc/src/services/MockReferenceData.js` - Mock reference data matching sample OCR
- `ocr-poc/src/components/PlayerComparison.js` - Comparison UI component
- `ocr-poc/src/style.css` - Styling for comparison panels
- `ocr-poc/src/main.js` - Integration with "Compare with Reference List" button

## Test plan

- [ ] Upload a game sheet image and run OCR
- [ ] Click "Compare with Reference List" button
- [ ] Verify players are matched by name with confidence scores
- [ ] Verify officials (coaches) are displayed in separate section
- [ ] Verify warning appears if officials section cannot be parsed
- [ ] Verify team mapping auto-detection works correctly