### PR TITLE
fix(ocr-poc): handle partial-width table captures in player list parsing

### DIFF
--- a/ocr-poc/package-lock.json
+++ b/ocr-poc/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "eslint": "^9.0.0",
-        "globals": "^15.0.0",
+        "globals": "^15.15.0",
         "vite": "^6.0.0",
         "vite-plugin-pwa": "^0.21.0",
         "workbox-window": "^7.3.0"

--- a/ocr-poc/package.json
+++ b/ocr-poc/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "eslint": "^9.0.0",
-    "globals": "^15.0.0",
+    "globals": "^15.15.0",
     "vite": "^6.0.0",
     "vite-plugin-pwa": "^0.21.0",
     "workbox-window": "^7.3.0"


### PR DESCRIPTION
## Summary

- Add `findPlayerListStart()` to detect where player data begins by looking for "N." / "Name of the player" header
- Skip score data, set scores, and other non-player content from wider captures
- Extract team names from the line before the header row
- Add warning when non-player lines are skipped for transparency

## Test Plan

- Test with cropped images (existing behavior unchanged)
- Test with wider scoresheet captures that include score boxes
- Verify player list is correctly extracted when preceded by non-player data