### PR TITLE
fix(ocr-poc): use arrow function for private resize handler

### DIFF
--- a/ocr-poc/src/components/CameraGuide.js
+++ b/ocr-poc/src/components/CameraGuide.js
@@ -48,7 +48,6 @@ export class CameraGuide {
     this.#updateGuideSize();
 
     // Update guide size on window resize
-    this.#handleResize = this.#handleResize.bind(this);
     window.addEventListener('resize', this.#handleResize);
   }
 
@@ -72,9 +71,10 @@ export class CameraGuide {
     this.#container.appendChild(this.#guideElement);
   }
 
-  #handleResize() {
+  /** @type {() => void} */
+  #handleResize = () => {
     this.#updateGuideSize();
-  }
+  };
 
   /**
    * Update the guide frame size to maintain the correct aspect ratio

--- a/ocr-poc/src/components/ImageEditor.js
+++ b/ocr-poc/src/components/ImageEditor.js
@@ -100,8 +100,7 @@ export class ImageEditor {
     this.#render();
     this.#loadImage();
 
-    // Bind event handlers
-    this.#handleResize = this.#handleResize.bind(this);
+    // Add resize listener (arrow function is already bound to `this`)
     window.addEventListener('resize', this.#handleResize);
   }
 
@@ -280,11 +279,12 @@ export class ImageEditor {
     this.#panY = Math.max(-maxPanY, Math.min(maxPanY, this.#panY));
   }
 
-  #handleResize() {
+  /** @type {() => void} */
+  #handleResize = () => {
     this.#calculateSizes();
     this.#centerImage();
     this.#updateTransform();
-  }
+  };
 
   /** @param {TouchEvent} e */
   #handleTouchStart(e) {


### PR DESCRIPTION
## Summary
- Convert `#handleResize` from a private method to an arrow function property in both `CameraGuide.js` and `ImageEditor.js`
- Fix "TypeError: e.set is not a function" error in Safari caused by attempting to reassign a read-only private method with `.bind(this)`
- Arrow function properties are automatically bound to `this` and avoid this issue

## Test Plan
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Test in Safari to verify the error is resolved
- [ ] Test camera guide and image editor resize behavior