### PR TITLE
feat(ocr-poc): improve image capture UX with full-screen modals

### DIFF
--- a/ocr-poc/src/components/ImageCapture.js
+++ b/ocr-poc/src/components/ImageCapture.js
@@ -104,7 +104,7 @@ export class ImageCapture {
           aria-hidden="true"
         />
 
-        <div id="camera-container" class="image-capture__camera" hidden>
+        <div id="camera-container" class="image-capture__camera" role="dialog" aria-modal="true" aria-label="Camera capture" hidden>
           <div class="image-capture__video-wrapper">
             <video
               id="camera-preview"

--- a/ocr-poc/src/components/ImageEditor.js
+++ b/ocr-poc/src/components/ImageEditor.js
@@ -106,7 +106,7 @@ export class ImageEditor {
 
   #render() {
     this.#container.innerHTML = `
-      <div class="image-editor">
+      <div class="image-editor" role="dialog" aria-modal="true" aria-label="Image editor">
         <div class="image-editor__viewport" id="editor-viewport">
           <img
             class="image-editor__image"

--- a/ocr-poc/src/components/ImageEditor.js
+++ b/ocr-poc/src/components/ImageEditor.js
@@ -13,7 +13,7 @@
 import { TABLE_ASPECT_RATIO } from './CameraGuide.js';
 
 /** Minimum zoom level */
-const MIN_ZOOM = 0.5;
+const MIN_ZOOM = 0.1;
 
 /** Maximum zoom level */
 const MAX_ZOOM = 4;

--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -175,10 +175,6 @@ function renderState(state) {
  */
 function renderCaptureState(container) {
   container.innerHTML = `
-    <h2 class="text-center mb-md">Capture Scoresheet</h2>
-    <p class="text-muted text-center mb-lg">
-      Take a photo or select an image from your library to extract player information.
-    </p>
     <div id="image-capture-container"></div>
   `;
 
@@ -197,8 +193,14 @@ function renderCaptureState(container) {
  */
 function renderSelectTypeState(container) {
   container.innerHTML = `
-    <h2 class="text-center mb-md">Select Sheet Type</h2>
-    <div id="sheet-type-container"></div>
+    <div class="main-content">
+      <div class="container">
+        <div class="card">
+          <h2 class="text-center mb-md">Select Sheet Type</h2>
+          <div id="sheet-type-container"></div>
+        </div>
+      </div>
+    </div>
   `;
 
   const typeContainer = document.getElementById('sheet-type-container');
@@ -218,11 +220,17 @@ function renderSelectTypeState(container) {
  */
 function renderProcessingState(container) {
   container.innerHTML = `
-    <h2 class="text-center mb-md">Processing Scoresheet</h2>
-    <p class="text-muted text-center mb-lg">
-      Extracting text using ${appContext.sheetType === 'electronic' ? 'print' : 'handwriting'} recognition...
-    </p>
-    <div id="ocr-progress-container"></div>
+    <div class="main-content">
+      <div class="container">
+        <div class="card">
+          <h2 class="text-center mb-md">Processing Scoresheet</h2>
+          <p class="text-muted text-center mb-lg">
+            Extracting text using ${appContext.sheetType === 'electronic' ? 'print' : 'handwriting'} recognition...
+          </p>
+          <div id="ocr-progress-container"></div>
+        </div>
+      </div>
+    </div>
   `;
 
   const progressContainer = document.getElementById('ocr-progress-container');
@@ -320,43 +328,49 @@ function renderResultsState(container) {
       : 0;
 
   container.innerHTML = `
-    <h2 class="text-center mb-md">OCR Complete</h2>
+    <div class="main-content">
+      <div class="container">
+        <div class="card">
+          <h2 class="text-center mb-md">OCR Complete</h2>
 
-    <div class="ocr-results__stats mb-lg">
-      <div class="ocr-results__stat">
-        <span class="ocr-results__stat-value">${lineCount}</span>
-        <span class="ocr-results__stat-label">Lines</span>
+          <div class="ocr-results__stats mb-lg">
+            <div class="ocr-results__stat">
+              <span class="ocr-results__stat-value">${lineCount}</span>
+              <span class="ocr-results__stat-label">Lines</span>
+            </div>
+            <div class="ocr-results__stat">
+              <span class="ocr-results__stat-value">${wordCount}</span>
+              <span class="ocr-results__stat-label">Words</span>
+            </div>
+            <div class="ocr-results__stat">
+              <span class="ocr-results__stat-value">${avgConfidence}%</span>
+              <span class="ocr-results__stat-label">Confidence</span>
+            </div>
+          </div>
+
+          <div class="sheet-type-selector__preview mb-md">
+            <img
+              id="result-preview"
+              class="sheet-type-selector__thumbnail"
+              alt="Processed scoresheet"
+            />
+          </div>
+
+          <details class="ocr-results__details mb-lg">
+            <summary class="ocr-results__summary">View Extracted Text</summary>
+            <pre class="ocr-results__text">${escapeHtml(result?.fullText || 'No text extracted')}</pre>
+          </details>
+
+          <div class="flex flex-col gap-md">
+            <button class="btn btn-primary btn-block" id="btn-compare-players">
+              Compare with Reference List
+            </button>
+            <button class="btn btn-secondary btn-block" id="btn-new-scan">
+              Scan Another Sheet
+            </button>
+          </div>
+        </div>
       </div>
-      <div class="ocr-results__stat">
-        <span class="ocr-results__stat-value">${wordCount}</span>
-        <span class="ocr-results__stat-label">Words</span>
-      </div>
-      <div class="ocr-results__stat">
-        <span class="ocr-results__stat-value">${avgConfidence}%</span>
-        <span class="ocr-results__stat-label">Confidence</span>
-      </div>
-    </div>
-
-    <div class="sheet-type-selector__preview mb-md">
-      <img
-        id="result-preview"
-        class="sheet-type-selector__thumbnail"
-        alt="Processed scoresheet"
-      />
-    </div>
-
-    <details class="ocr-results__details mb-lg">
-      <summary class="ocr-results__summary">View Extracted Text</summary>
-      <pre class="ocr-results__text">${escapeHtml(result?.fullText || 'No text extracted')}</pre>
-    </details>
-
-    <div class="flex flex-col gap-md">
-      <button class="btn btn-primary btn-block" id="btn-compare-players">
-        Compare with Reference List
-      </button>
-      <button class="btn btn-secondary btn-block" id="btn-new-scan">
-        Scan Another Sheet
-      </button>
     </div>
   `;
 
@@ -381,8 +395,14 @@ function renderResultsState(container) {
  */
 function renderComparisonState(container) {
   container.innerHTML = `
-    <h2 class="text-center mb-md">Player List Comparison</h2>
-    <div id="player-comparison-container"></div>
+    <div class="main-content">
+      <div class="container">
+        <div class="card">
+          <h2 class="text-center mb-md">Player List Comparison</h2>
+          <div id="player-comparison-container"></div>
+        </div>
+      </div>
+    </div>
   `;
 
   const comparisonContainer = document.getElementById('player-comparison-container');
@@ -491,11 +511,7 @@ function init() {
 
   // Render app shell
   app.innerHTML = `
-    <div class="container">
-      <div class="card">
-        <div id="content-container"></div>
-      </div>
-    </div>
+    <div id="content-container"></div>
   `;
 
   // Render initial state

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -1077,17 +1077,27 @@ body {
  * ============================================== */
 
 .image-editor {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-md);
+  background-color: var(--color-gray-900);
+  /* iOS safe area support */
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
 .image-editor__viewport {
   position: relative;
-  width: 100%;
-  aspect-ratio: 4 / 3;
+  flex: 1;
+  min-height: 0;
   background-color: var(--color-gray-900);
-  border-radius: var(--radius-xl);
   overflow: hidden;
   cursor: grab;
   touch-action: none;
@@ -1172,13 +1182,15 @@ body {
 
 .image-editor__hint {
   text-align: center;
+  padding: var(--spacing-sm) var(--spacing-md);
+  flex-shrink: 0;
 }
 
 .image-editor__hint span {
   display: inline-block;
   padding: var(--spacing-xs) var(--spacing-sm);
-  background-color: var(--color-surface-subtle);
-  color: var(--color-text-muted);
+  background-color: rgba(255, 255, 255, 0.1);
+  color: var(--color-gray-300);
   font-size: var(--font-size-sm);
   border-radius: var(--radius-sm);
 }
@@ -1186,6 +1198,9 @@ body {
 .image-editor__controls {
   display: flex;
   gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background-color: var(--color-surface-card);
+  flex-shrink: 0;
 }
 
 .image-editor__btn {

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -296,6 +296,13 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-lg);
+  max-width: 400px;
+  margin: 0 auto;
+  padding: var(--spacing-xl);
+  padding-top: max(var(--spacing-xl), env(safe-area-inset-top));
+  padding-bottom: max(var(--spacing-xl), env(safe-area-inset-bottom));
+  padding-left: max(var(--spacing-xl), env(safe-area-inset-left));
+  padding-right: max(var(--spacing-xl), env(safe-area-inset-right));
 }
 
 .image-capture__buttons {
@@ -326,24 +333,34 @@ body {
   border: 0;
 }
 
-/* Camera preview container */
+/* Camera preview container - full screen modal */
 .image-capture__camera {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-md);
   background-color: var(--color-gray-900);
-  border-radius: var(--radius-xl);
-  overflow: hidden;
+  /* iOS safe area support */
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
 .image-capture__video-wrapper {
   position: relative;
-  width: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .image-capture__video {
   width: 100%;
-  aspect-ratio: 4 / 3;
+  height: 100%;
   object-fit: cover;
   background-color: var(--color-gray-800);
   display: block;
@@ -361,8 +378,9 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
   background-color: var(--color-gray-900);
+  flex-shrink: 0;
 }
 
 .image-capture__capture-btn {


### PR DESCRIPTION
## Summary
- Lowered minimum zoom from 0.5 to 0.1 to allow users to zoom out further when framing large images
- Made image editor a full-screen modal overlay for more space during crop step
- Made camera capture a full-screen modal overlay for better framing
- Simplified main page by removing card wrapper from capture state
- Added ARIA attributes (role="dialog", aria-modal) to both modals for accessibility
- Added iOS safe area support to full-screen modals

## Test Plan
- [ ] Open OCR POC and verify main page shows just the buttons
- [ ] Tap "Use Camera" and verify camera takes full screen
- [ ] Upload an image and verify editor takes full screen
- [ ] Test zoom out in image editor - should allow much more zoom out
- [ ] Verify pinch-to-zoom and drag work correctly
- [ ] Test on iOS to verify safe areas are respected
- [ ] Test with screen reader to verify modals are announced