### PR TITLE
feat(validation): add roster validation with warning for insufficient players/coaches

### DIFF
--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -9,6 +9,7 @@ import { WizardStepContainer } from "@/components/ui/WizardStepContainer";
 import { WizardStepIndicator } from "@/components/ui/WizardStepIndicator";
 import {
   UnsavedChangesDialog,
+  RosterValidationWarningDialog,
   ValidationSuccessToast,
   StepRenderer,
   ValidatedModeButtons,
@@ -85,7 +86,7 @@ function ValidateGameModalComponent({
         onClose={wizard.attemptClose}
         titleId={modalTitleId}
         size="lg"
-        isLoading={wizard.showUnsavedDialog}
+        isLoading={wizard.showUnsavedDialog || wizard.showRosterWarningDialog}
       >
         <ModalHeader
           title={t("assignments.validateGame")}
@@ -204,6 +205,16 @@ function ValidateGameModalComponent({
         onDiscard={wizard.handleDiscardAndClose}
         onCancel={wizard.handleCancelClose}
         isSaving={wizard.isSaving}
+      />
+
+      <RosterValidationWarningDialog
+        isOpen={wizard.showRosterWarningDialog}
+        rosterValidation={wizard.rosterValidation}
+        homeTeamName={homeTeam}
+        awayTeamName={awayTeam}
+        onGoBack={wizard.handleRosterWarningGoBack}
+        onProceedAnyway={wizard.handleRosterWarningProceed}
+        isProceedingAnyway={wizard.isFinalizing}
       />
     </>
   );

--- a/web-app/src/components/features/validation/RosterValidationWarningDialog.tsx
+++ b/web-app/src/components/features/validation/RosterValidationWarningDialog.tsx
@@ -1,0 +1,169 @@
+import { useRef, useEffect } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { Button } from "@/components/ui/Button";
+import { AlertTriangle } from "@/components/ui/icons";
+import type { RosterValidationStatus } from "@/utils/roster-validation";
+import { MIN_PLAYERS_REQUIRED } from "@/utils/roster-validation";
+
+/** Z-index for warning dialog (above main modal) */
+const Z_INDEX_WARNING_DIALOG = 60;
+
+interface RosterValidationWarningDialogProps {
+  isOpen: boolean;
+  rosterValidation: RosterValidationStatus;
+  homeTeamName: string;
+  awayTeamName: string;
+  onGoBack: () => void;
+  onProceedAnyway: () => void;
+  isProceedingAnyway: boolean;
+}
+
+/**
+ * Warning dialog shown when trying to finalize with invalid rosters.
+ * Warns about missing head coach or insufficient players which would
+ * result in a forfeited game.
+ */
+export function RosterValidationWarningDialog({
+  isOpen,
+  rosterValidation,
+  homeTeamName,
+  awayTeamName,
+  onGoBack,
+  onProceedAnyway,
+  isProceedingAnyway,
+}: RosterValidationWarningDialogProps) {
+  const { t, tInterpolate } = useTranslation();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus first button when dialog opens for accessibility
+  useEffect(() => {
+    if (isOpen && dialogRef.current) {
+      const firstButton = dialogRef.current.querySelector("button");
+      firstButton?.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const { home, away } = rosterValidation;
+
+  // Build list of issues for each team
+  const homeIssues: string[] = [];
+  const awayIssues: string[] = [];
+
+  if (!home.hasHeadCoach) {
+    homeIssues.push(t("validation.rosterWarning.missingHeadCoach"));
+  }
+  if (!home.hasMinPlayers) {
+    homeIssues.push(
+      tInterpolate("validation.rosterWarning.insufficientPlayers", {
+        count: home.playerCount,
+        required: MIN_PLAYERS_REQUIRED,
+      }),
+    );
+  }
+
+  if (!away.hasHeadCoach) {
+    awayIssues.push(t("validation.rosterWarning.missingHeadCoach"));
+  }
+  if (!away.hasMinPlayers) {
+    awayIssues.push(
+      tInterpolate("validation.rosterWarning.insufficientPlayers", {
+        count: away.playerCount,
+        required: MIN_PLAYERS_REQUIRED,
+      }),
+    );
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4"
+      style={{ zIndex: Z_INDEX_WARNING_DIALOG }}
+      aria-hidden="true"
+    >
+      <div
+        ref={dialogRef}
+        className="bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-xl max-w-md w-full p-6"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="roster-warning-title"
+        aria-describedby="roster-warning-description"
+      >
+        <div className="flex items-start gap-3 mb-4">
+          <div className="flex-shrink-0 p-2 bg-warning-100 dark:bg-warning-900/30 rounded-full">
+            <AlertTriangle
+              className="w-6 h-6 text-warning-600 dark:text-warning-400"
+              aria-hidden="true"
+            />
+          </div>
+          <div>
+            <h3
+              id="roster-warning-title"
+              className="text-lg font-semibold text-text-primary dark:text-text-primary-dark"
+            >
+              {t("validation.rosterWarning.title")}
+            </h3>
+            <p
+              id="roster-warning-description"
+              className="text-sm text-text-muted dark:text-text-muted-dark mt-1"
+            >
+              {t("validation.rosterWarning.description")}
+            </p>
+          </div>
+        </div>
+
+        {/* Team issues list */}
+        <div className="space-y-3 mb-6">
+          {homeIssues.length > 0 && (
+            <div className="bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-800 rounded-lg p-3">
+              <p className="text-sm font-medium text-warning-800 dark:text-warning-300 mb-1">
+                {homeTeamName}
+              </p>
+              <ul className="list-disc list-inside text-sm text-warning-700 dark:text-warning-400 space-y-0.5">
+                {homeIssues.map((issue, idx) => (
+                  <li key={idx}>{issue}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {awayIssues.length > 0 && (
+            <div className="bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-800 rounded-lg p-3">
+              <p className="text-sm font-medium text-warning-800 dark:text-warning-300 mb-1">
+                {awayTeamName}
+              </p>
+              <ul className="list-disc list-inside text-sm text-warning-700 dark:text-warning-400 space-y-0.5">
+                {awayIssues.map((issue, idx) => (
+                  <li key={idx}>{issue}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <p className="text-xs text-text-muted dark:text-text-muted-dark mb-4">
+          {t("validation.rosterWarning.forfeitNote")}
+        </p>
+
+        <div className="flex justify-end gap-3">
+          <Button
+            variant="secondary"
+            onClick={onGoBack}
+            disabled={isProceedingAnyway}
+          >
+            {t("validation.rosterWarning.goBack")}
+          </Button>
+          <Button
+            variant="danger"
+            onClick={onProceedAnyway}
+            disabled={isProceedingAnyway}
+          >
+            {isProceedingAnyway
+              ? t("common.loading")
+              : t("validation.rosterWarning.proceedAnyway")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/components/features/validation/index.ts
+++ b/web-app/src/components/features/validation/index.ts
@@ -10,6 +10,7 @@ export type { RosterPanelModifications } from "./RosterVerificationPanel";
 export { PlayerListItem } from "./PlayerListItem";
 export { CoachesSection } from "./CoachesSection";
 export { UnsavedChangesDialog } from "./UnsavedChangesDialog";
+export { RosterValidationWarningDialog } from "./RosterValidationWarningDialog";
 export { ValidationSuccessToast } from "./ValidationSuccessToast";
 export { StepRenderer } from "./StepRenderer";
 export { ValidatedModeButtons, EditModeButtons } from "./WizardButtons";

--- a/web-app/src/hooks/useWizardNavigation.ts
+++ b/web-app/src/hooks/useWizardNavigation.ts
@@ -4,6 +4,8 @@ export interface WizardStep {
   id: string;
   label: string;
   isOptional?: boolean;
+  /** Whether the step has validation errors that should be highlighted */
+  isInvalid?: boolean;
 }
 
 export interface UseWizardNavigationOptions<T extends WizardStep> {

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -154,6 +154,7 @@ const de: Translations = {
     wizardProgress: "Assistentenfortschritt",
     stepIndicatorCurrent: "(aktuell)",
     stepIndicatorDone: "(erledigt)",
+    stepIndicatorInvalid: "(unvollständig)",
     dob: "Geb.",
   },
   auth: {
@@ -625,6 +626,17 @@ const de: Translations = {
       saveError: "Validierung konnte nicht gespeichert werden",
       markAllStepsTooltip:
         "Markieren Sie alle erforderlichen Schritte als geprüft, um abzuschliessen",
+    },
+    rosterWarning: {
+      title: "Unvollständige Aufstellung",
+      description:
+        "Eine oder mehrere Mannschaftsaufstellungen erfüllen nicht die Mindestanforderungen für ein gültiges Spiel.",
+      missingHeadCoach: "Fehlender Cheftrainer",
+      insufficientPlayers: "Nur {count} von {required} erforderlichen Spielern",
+      forfeitNote:
+        "Das Fortfahren mit einer unvollständigen Aufstellung kann zu einem verlorenen Spiel führen.",
+      goBack: "Zurück",
+      proceedAnyway: "Trotzdem fortfahren",
     },
     wizard: {
       previous: "Zurück",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -154,6 +154,7 @@ const en: Translations = {
     wizardProgress: "Wizard progress",
     stepIndicatorCurrent: "(current)",
     stepIndicatorDone: "(done)",
+    stepIndicatorInvalid: "(incomplete)",
     dob: "DOB",
   },
   auth: {
@@ -619,6 +620,17 @@ const en: Translations = {
       saveSuccess: "Validation saved successfully",
       saveError: "Failed to save validation",
       markAllStepsTooltip: "Mark all required steps as reviewed to finish",
+    },
+    rosterWarning: {
+      title: "Incomplete Roster",
+      description:
+        "One or more team rosters do not meet the minimum requirements for a valid game.",
+      missingHeadCoach: "Missing head coach",
+      insufficientPlayers: "Only {count} of {required} required players",
+      forfeitNote:
+        "Proceeding with an incomplete roster may result in a forfeited game.",
+      goBack: "Go Back",
+      proceedAnyway: "Proceed Anyway",
     },
     wizard: {
       previous: "Previous",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -154,6 +154,7 @@ const fr: Translations = {
     wizardProgress: "Progression de l'assistant",
     stepIndicatorCurrent: "(actuel)",
     stepIndicatorDone: "(terminé)",
+    stepIndicatorInvalid: "(incomplet)",
     dob: "DDN",
   },
   auth: {
@@ -624,6 +625,17 @@ const fr: Translations = {
       saveError: "Échec de l'enregistrement de la validation",
       markAllStepsTooltip:
         "Marquez toutes les étapes requises comme vérifiées pour terminer",
+    },
+    rosterWarning: {
+      title: "Liste incomplète",
+      description:
+        "Une ou plusieurs listes d'équipe ne répondent pas aux exigences minimales pour un match valide.",
+      missingHeadCoach: "Entraîneur principal manquant",
+      insufficientPlayers: "Seulement {count} joueurs sur {required} requis",
+      forfeitNote:
+        "Continuer avec une liste incomplète peut entraîner la perte du match par forfait.",
+      goBack: "Retour",
+      proceedAnyway: "Continuer quand même",
     },
     wizard: {
       previous: "Précédent",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -154,6 +154,7 @@ const it: Translations = {
     wizardProgress: "Progresso procedura guidata",
     stepIndicatorCurrent: "(corrente)",
     stepIndicatorDone: "(completato)",
+    stepIndicatorInvalid: "(incompleto)",
     dob: "DDN",
   },
   auth: {
@@ -619,6 +620,17 @@ const it: Translations = {
       saveError: "Impossibile salvare la validazione",
       markAllStepsTooltip:
         "Segna tutti i passaggi richiesti come verificati per terminare",
+    },
+    rosterWarning: {
+      title: "Rosa incompleta",
+      description:
+        "Una o più rose delle squadre non soddisfano i requisiti minimi per una partita valida.",
+      missingHeadCoach: "Allenatore principale mancante",
+      insufficientPlayers: "Solo {count} giocatori su {required} richiesti",
+      forfeitNote:
+        "Procedere con una rosa incompleta può comportare la sconfitta a tavolino.",
+      goBack: "Torna indietro",
+      proceedAnyway: "Procedi comunque",
     },
     wizard: {
       previous: "Precedente",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -46,6 +46,7 @@ export interface Translations {
     wizardProgress: string;
     stepIndicatorCurrent: string;
     stepIndicatorDone: string;
+    stepIndicatorInvalid: string;
     dob: string;
   };
   auth: {
@@ -463,6 +464,15 @@ export interface Translations {
       saveSuccess: string;
       saveError: string;
       markAllStepsTooltip: string;
+    };
+    rosterWarning: {
+      title: string;
+      description: string;
+      missingHeadCoach: string;
+      insufficientPlayers: string;
+      forfeitNote: string;
+      goBack: string;
+      proceedAnyway: string;
     };
     wizard: {
       previous: string;

--- a/web-app/src/utils/roster-validation.test.ts
+++ b/web-app/src/utils/roster-validation.test.ts
@@ -1,0 +1,511 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateRoster,
+  validateBothRosters,
+  MIN_PLAYERS_REQUIRED,
+} from "./roster-validation";
+import type { NominationList } from "@/api/client";
+import type { RosterModifications, CoachModifications, CoachRole } from "@/hooks/useNominationList";
+
+/**
+ * Creates a mock NominationList with the specified number of players and coach.
+ */
+function createMockNominationList(
+  playerCount: number,
+  hasHeadCoach: boolean,
+): NominationList {
+  const nominations = Array.from({ length: playerCount }, (_, i) => ({
+    __identity: `player-${i}`,
+    indoorPlayer: {
+      person: {
+        displayName: `Player ${i}`,
+      },
+    },
+  }));
+
+  return {
+    __identity: "nomination-list-1",
+    indoorPlayerNominations: nominations,
+    coachPerson: hasHeadCoach ? { displayName: "Head Coach" } : undefined,
+  } as NominationList;
+}
+
+/**
+ * Creates empty roster modifications.
+ */
+function createEmptyModifications(): RosterModifications {
+  return {
+    added: [],
+    removed: [],
+  };
+}
+
+/**
+ * Creates empty coach modifications.
+ */
+function createEmptyCoachModifications(): CoachModifications {
+  return {
+    added: new Map(),
+    removed: new Set(),
+  };
+}
+
+describe("roster-validation", () => {
+  describe("MIN_PLAYERS_REQUIRED", () => {
+    it("should be 6", () => {
+      expect(MIN_PLAYERS_REQUIRED).toBe(6);
+    });
+  });
+
+  describe("validateRoster", () => {
+    describe("when nomination list is null", () => {
+      it("returns valid result (loading state)", () => {
+        const result = validateRoster(
+          null,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.playerCount).toBe(0);
+        expect(result.hasHeadCoach).toBe(true);
+        expect(result.hasMinPlayers).toBe(true);
+      });
+    });
+
+    describe("player count validation", () => {
+      it("returns valid when exactly 6 players", () => {
+        const nominationList = createMockNominationList(6, true);
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.playerCount).toBe(6);
+        expect(result.hasMinPlayers).toBe(true);
+      });
+
+      it("returns valid when more than 6 players", () => {
+        const nominationList = createMockNominationList(10, true);
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.playerCount).toBe(10);
+        expect(result.hasMinPlayers).toBe(true);
+      });
+
+      it("returns invalid when fewer than 6 players", () => {
+        const nominationList = createMockNominationList(5, true);
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.playerCount).toBe(5);
+        expect(result.hasMinPlayers).toBe(false);
+      });
+
+      it("returns invalid when zero players", () => {
+        const nominationList = createMockNominationList(0, true);
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.playerCount).toBe(0);
+        expect(result.hasMinPlayers).toBe(false);
+      });
+    });
+
+    describe("player modifications", () => {
+      it("includes added players in count", () => {
+        const nominationList = createMockNominationList(4, true);
+        const modifications: RosterModifications = {
+          added: [
+            { id: "new-1", displayName: "New Player 1" },
+            { id: "new-2", displayName: "New Player 2" },
+          ],
+          removed: [],
+        };
+
+        const result = validateRoster(
+          nominationList,
+          modifications,
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.playerCount).toBe(6);
+        expect(result.hasMinPlayers).toBe(true);
+        expect(result.isValid).toBe(true);
+      });
+
+      it("excludes removed players from count", () => {
+        const nominationList = createMockNominationList(7, true);
+        const modifications: RosterModifications = {
+          added: [],
+          removed: ["player-0", "player-1"],
+        };
+
+        const result = validateRoster(
+          nominationList,
+          modifications,
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.playerCount).toBe(5);
+        expect(result.hasMinPlayers).toBe(false);
+        expect(result.isValid).toBe(false);
+      });
+
+      it("handles both additions and removals", () => {
+        const nominationList = createMockNominationList(5, true);
+        const modifications: RosterModifications = {
+          added: [
+            { id: "new-1", displayName: "New Player 1" },
+            { id: "new-2", displayName: "New Player 2" },
+          ],
+          removed: ["player-0"],
+        };
+
+        const result = validateRoster(
+          nominationList,
+          modifications,
+          createEmptyCoachModifications(),
+        );
+
+        // 5 base + 2 added - 1 removed = 6
+        expect(result.playerCount).toBe(6);
+        expect(result.hasMinPlayers).toBe(true);
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe("head coach validation", () => {
+      it("returns valid when head coach exists", () => {
+        const nominationList = createMockNominationList(6, true);
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.hasHeadCoach).toBe(true);
+        expect(result.isValid).toBe(true);
+      });
+
+      it("returns invalid when no head coach", () => {
+        const nominationList = createMockNominationList(6, false);
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.hasHeadCoach).toBe(false);
+        expect(result.isValid).toBe(false);
+      });
+    });
+
+    describe("coach modifications", () => {
+      it("head coach addition makes roster valid", () => {
+        const nominationList = createMockNominationList(6, false);
+        const coachMods: CoachModifications = {
+          added: new Map([["head" as CoachRole, { id: "coach-1", displayName: "New Coach" }]]),
+          removed: new Set(),
+        };
+
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          coachMods,
+        );
+
+        expect(result.hasHeadCoach).toBe(true);
+        expect(result.isValid).toBe(true);
+      });
+
+      it("head coach removal makes roster invalid", () => {
+        const nominationList = createMockNominationList(6, true);
+        const coachMods: CoachModifications = {
+          added: new Map(),
+          removed: new Set(["head" as CoachRole]),
+        };
+
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          coachMods,
+        );
+
+        expect(result.hasHeadCoach).toBe(false);
+        expect(result.isValid).toBe(false);
+      });
+
+      it("adding head coach after removal makes roster valid", () => {
+        const nominationList = createMockNominationList(6, true);
+        const coachMods: CoachModifications = {
+          added: new Map([["head" as CoachRole, { id: "new-coach", displayName: "New Coach" }]]),
+          removed: new Set(["head" as CoachRole]),
+        };
+
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          coachMods,
+        );
+
+        // Addition takes precedence
+        expect(result.hasHeadCoach).toBe(true);
+        expect(result.isValid).toBe(true);
+      });
+
+      it("assistant coach changes do not affect validation", () => {
+        const nominationList = createMockNominationList(6, true);
+        const coachMods: CoachModifications = {
+          added: new Map([
+            ["firstAssistant" as CoachRole, { id: "asst-1", displayName: "Assistant 1" }],
+          ]),
+          removed: new Set(["secondAssistant" as CoachRole]),
+        };
+
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          coachMods,
+        );
+
+        expect(result.hasHeadCoach).toBe(true);
+        expect(result.isValid).toBe(true);
+      });
+    });
+
+    describe("combined validation", () => {
+      it("returns invalid when both coach and players are insufficient", () => {
+        const nominationList = createMockNominationList(3, false);
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.hasHeadCoach).toBe(false);
+        expect(result.hasMinPlayers).toBe(false);
+        expect(result.playerCount).toBe(3);
+      });
+
+      it("requires both coach and minimum players for validity", () => {
+        // Has coach but not enough players
+        const list1 = createMockNominationList(5, true);
+        const result1 = validateRoster(
+          list1,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+        expect(result1.isValid).toBe(false);
+
+        // Has enough players but no coach
+        const list2 = createMockNominationList(6, false);
+        const result2 = validateRoster(
+          list2,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+        expect(result2.isValid).toBe(false);
+
+        // Has both
+        const list3 = createMockNominationList(6, true);
+        const result3 = validateRoster(
+          list3,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+        expect(result3.isValid).toBe(true);
+      });
+    });
+
+    describe("edge cases", () => {
+      it("handles empty indoorPlayerNominations array", () => {
+        const nominationList = {
+          __identity: "nl-1",
+          indoorPlayerNominations: [],
+          coachPerson: { displayName: "Coach" },
+        } as NominationList;
+
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.playerCount).toBe(0);
+        expect(result.hasMinPlayers).toBe(false);
+      });
+
+      it("handles undefined indoorPlayerNominations", () => {
+        const nominationList = {
+          __identity: "nl-1",
+          coachPerson: { displayName: "Coach" },
+        } as NominationList;
+
+        const result = validateRoster(
+          nominationList,
+          createEmptyModifications(),
+          createEmptyCoachModifications(),
+        );
+
+        expect(result.playerCount).toBe(0);
+        expect(result.hasMinPlayers).toBe(false);
+      });
+    });
+  });
+
+  describe("validateBothRosters", () => {
+    it("returns allValid true when both rosters are valid", () => {
+      const homeList = createMockNominationList(6, true);
+      const awayList = createMockNominationList(8, true);
+
+      const result = validateBothRosters(
+        homeList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+        awayList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+      );
+
+      expect(result.allValid).toBe(true);
+      expect(result.home.isValid).toBe(true);
+      expect(result.away.isValid).toBe(true);
+    });
+
+    it("returns allValid false when home roster is invalid", () => {
+      const homeList = createMockNominationList(5, true); // Not enough players
+      const awayList = createMockNominationList(6, true);
+
+      const result = validateBothRosters(
+        homeList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+        awayList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+      );
+
+      expect(result.allValid).toBe(false);
+      expect(result.home.isValid).toBe(false);
+      expect(result.away.isValid).toBe(true);
+    });
+
+    it("returns allValid false when away roster is invalid", () => {
+      const homeList = createMockNominationList(6, true);
+      const awayList = createMockNominationList(6, false); // No head coach
+
+      const result = validateBothRosters(
+        homeList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+        awayList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+      );
+
+      expect(result.allValid).toBe(false);
+      expect(result.home.isValid).toBe(true);
+      expect(result.away.isValid).toBe(false);
+    });
+
+    it("returns allValid false when both rosters are invalid", () => {
+      const homeList = createMockNominationList(3, false);
+      const awayList = createMockNominationList(4, false);
+
+      const result = validateBothRosters(
+        homeList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+        awayList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+      );
+
+      expect(result.allValid).toBe(false);
+      expect(result.home.isValid).toBe(false);
+      expect(result.away.isValid).toBe(false);
+    });
+
+    it("handles null nomination lists (loading state)", () => {
+      const result = validateBothRosters(
+        null,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+        null,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+      );
+
+      expect(result.allValid).toBe(true);
+      expect(result.home.isValid).toBe(true);
+      expect(result.away.isValid).toBe(true);
+    });
+
+    it("handles mixed null and valid nomination lists", () => {
+      const awayList = createMockNominationList(6, true);
+
+      const result = validateBothRosters(
+        null, // Home loading
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+        awayList,
+        createEmptyModifications(),
+        createEmptyCoachModifications(),
+      );
+
+      expect(result.allValid).toBe(true);
+      expect(result.home.isValid).toBe(true); // Loading = valid
+      expect(result.away.isValid).toBe(true);
+    });
+
+    it("applies modifications independently to each team", () => {
+      const homeList = createMockNominationList(5, true);
+      const awayList = createMockNominationList(7, true);
+
+      const homePlayerMods: RosterModifications = {
+        added: [{ id: "new-1", displayName: "New" }],
+        removed: [],
+      };
+      const awayPlayerMods: RosterModifications = {
+        added: [],
+        removed: ["player-0", "player-1"],
+      };
+
+      const result = validateBothRosters(
+        homeList,
+        homePlayerMods,
+        createEmptyCoachModifications(),
+        awayList,
+        awayPlayerMods,
+        createEmptyCoachModifications(),
+      );
+
+      // Home: 5 + 1 = 6 (valid)
+      expect(result.home.playerCount).toBe(6);
+      expect(result.home.isValid).toBe(true);
+
+      // Away: 7 - 2 = 5 (invalid)
+      expect(result.away.playerCount).toBe(5);
+      expect(result.away.isValid).toBe(false);
+
+      expect(result.allValid).toBe(false);
+    });
+  });
+});

--- a/web-app/src/utils/roster-validation.ts
+++ b/web-app/src/utils/roster-validation.ts
@@ -1,0 +1,102 @@
+/**
+ * Roster validation utilities for game validation wizard.
+ *
+ * A valid roster requires:
+ * - At least 1 head coach
+ * - At least 6 players
+ *
+ * Without these minimums, the game would be forfeited.
+ */
+
+import type { NominationList } from "@/api/client";
+import type { RosterModifications, CoachModifications, CoachRole } from "@/hooks/useNominationList";
+
+/** Minimum number of players required for a valid roster */
+export const MIN_PLAYERS_REQUIRED = 6;
+
+export interface RosterValidationResult {
+  /** Whether the roster meets all minimum requirements */
+  isValid: boolean;
+  /** Effective number of players (base + added - removed) */
+  playerCount: number;
+  /** Whether the team has a head coach */
+  hasHeadCoach: boolean;
+  /** Whether player count is sufficient */
+  hasMinPlayers: boolean;
+}
+
+/**
+ * Validates a team roster against minimum requirements.
+ *
+ * @param nominationList - The base nomination list data (may be null if loading)
+ * @param playerModifications - Player additions and removals
+ * @param coachModifications - Coach additions and removals
+ * @returns Validation result with details about what's missing
+ */
+export function validateRoster(
+  nominationList: NominationList | null,
+  playerModifications: RosterModifications,
+  coachModifications: CoachModifications,
+): RosterValidationResult {
+  // If nomination list is not yet loaded, assume valid (don't show errors during loading)
+  if (!nominationList) {
+    return {
+      isValid: true,
+      playerCount: 0,
+      hasHeadCoach: true,
+      hasMinPlayers: true,
+    };
+  }
+
+  // Calculate effective player count
+  const basePlayerCount = nominationList.indoorPlayerNominations?.length ?? 0;
+  const addedCount = playerModifications.added.length;
+  const removedCount = playerModifications.removed.length;
+  const playerCount = basePlayerCount + addedCount - removedCount;
+
+  // Check for head coach
+  // A team has a head coach if:
+  // 1. Base nomination list has one AND it's not removed, OR
+  // 2. A head coach addition is pending
+  const hasBaseHeadCoach = !!nominationList.coachPerson;
+  const headCoachRemoved = coachModifications.removed.has("head" as CoachRole);
+  const headCoachAdded = coachModifications.added.has("head" as CoachRole);
+
+  const hasHeadCoach = headCoachAdded || (hasBaseHeadCoach && !headCoachRemoved);
+  const hasMinPlayers = playerCount >= MIN_PLAYERS_REQUIRED;
+
+  return {
+    isValid: hasHeadCoach && hasMinPlayers,
+    playerCount,
+    hasHeadCoach,
+    hasMinPlayers,
+  };
+}
+
+export interface RosterValidationStatus {
+  home: RosterValidationResult;
+  away: RosterValidationResult;
+  /** Whether both rosters are valid */
+  allValid: boolean;
+}
+
+/**
+ * Validates both team rosters.
+ */
+export function validateBothRosters(
+  homeNominationList: NominationList | null,
+  homePlayerModifications: RosterModifications,
+  homeCoachModifications: CoachModifications,
+  awayNominationList: NominationList | null,
+  awayPlayerModifications: RosterModifications,
+  awayCoachModifications: CoachModifications,
+): RosterValidationStatus {
+  const home = validateRoster(homeNominationList, homePlayerModifications, homeCoachModifications);
+  const away = validateRoster(awayNominationList, awayPlayerModifications, awayCoachModifications);
+
+  return {
+    home,
+    away,
+    allValid: home.isValid && away.isValid,
+  };
+}


### PR DESCRIPTION
## Summary
- Add validation to the game validation wizard that checks if each team has at least 1 head coach and 6 players
- Step indicators show warning state (amber ring + triangle icon) for invalid rosters
- Warning dialog appears when user clicks "Finish" with invalid rosters
- Users can proceed anyway (forfeit scenario) or go back to fix the issues

## Test Plan
- [ ] Open the validation wizard for a game
- [ ] Remove players until there are fewer than 6 - verify the step indicator shows warning state
- [ ] Remove the head coach - verify the step indicator shows warning state
- [ ] Click "Finish" with an invalid roster - verify warning dialog appears
- [ ] Click "Go Back" - verify navigation to the invalid step
- [ ] Click "Proceed Anyway" - verify game is finalized
- [ ] Verify translations work in all 4 languages (de, en, fr, it)