### PR TITLE
feat(ocr-poc): restructure OCR workflow with type selection first

### DIFF
--- a/ocr-poc/src/components/CameraGuide.js
+++ b/ocr-poc/src/components/CameraGuide.js
@@ -9,6 +9,8 @@
  * - Manuscript (7:5 landscape): For full physical scoresheet capture
  */
 
+/** @typedef {import('../types.js').SheetType} SheetType */
+
 /**
  * Aspect ratio for electronic scoresheet player list (width:height)
  * 4:5 portrait format matches Swiss volleyball scoresheet tables
@@ -29,10 +31,6 @@ const FRAME_HEIGHT_RATIO = 0.7;
 
 /** Frame size as ratio of available width when container is taller */
 const FRAME_WIDTH_RATIO = 0.85;
-
-/**
- * @typedef {'electronic' | 'manuscript'} SheetType
- */
 
 /**
  * @typedef {Object} CameraGuideOptions
@@ -86,11 +84,17 @@ export class CameraGuide {
           <div class="camera-guide__corner camera-guide__corner--bl"></div>
           <div class="camera-guide__corner camera-guide__corner--br"></div>
           <div class="camera-guide__label">
-            <span>${this.#labelText}</span>
+            <span></span>
           </div>
         </div>
       </div>
     `;
+
+    // Set label text safely via textContent to prevent XSS
+    const labelSpan = this.#guideElement.querySelector('.camera-guide__label span');
+    if (labelSpan) {
+      labelSpan.textContent = this.#labelText;
+    }
 
     this.#container.appendChild(this.#guideElement);
   }

--- a/ocr-poc/src/components/ImageCapture.js
+++ b/ocr-poc/src/components/ImageCapture.js
@@ -16,9 +16,7 @@
 import { CameraGuide } from './CameraGuide.js';
 import { ImageEditor } from './ImageEditor.js';
 
-/**
- * @typedef {'electronic' | 'manuscript'} SheetType
- */
+/** @typedef {import('../types.js').SheetType} SheetType */
 
 /**
  * @typedef {Object} ImageCaptureOptions
@@ -99,7 +97,7 @@ export class ImageCapture {
           >
             ← Back
           </button>
-          <span class="image-capture__hint">${captureHint}</span>
+          <span class="image-capture__hint"></span>
         </div>
 
         <div class="image-capture__buttons">
@@ -184,6 +182,12 @@ export class ImageCapture {
         <div id="editor-container" class="image-capture__editor" hidden></div>
       </div>
     `;
+
+    // Set hint text safely via textContent to prevent XSS
+    const hintSpan = this.#container.querySelector('.image-capture__hint');
+    if (hintSpan) {
+      hintSpan.textContent = captureHint;
+    }
 
     this.#bindEvents();
   }

--- a/ocr-poc/src/components/ImageEditor.js
+++ b/ocr-poc/src/components/ImageEditor.js
@@ -13,6 +13,8 @@
 
 import { TABLE_ASPECT_RATIO, MANUSCRIPT_ASPECT_RATIO } from './CameraGuide.js';
 
+/** @typedef {import('../types.js').SheetType} SheetType */
+
 /** Minimum zoom level */
 const MIN_ZOOM = 0.1;
 
@@ -30,10 +32,6 @@ const FRAME_PADDING_PX = 24;
 
 /** Frame size as ratio of available space */
 const FRAME_SIZE_RATIO = 0.85;
-
-/**
- * @typedef {'electronic' | 'manuscript'} SheetType
- */
 
 /**
  * @typedef {Object} ImageEditorOptions

--- a/ocr-poc/src/components/SheetTypeSelector.js
+++ b/ocr-poc/src/components/SheetTypeSelector.js
@@ -8,9 +8,7 @@
  * This selection determines the capture guide aspect ratio and whether OCR is available.
  */
 
-/**
- * @typedef {'electronic' | 'manuscript'} SheetType
- */
+/** @typedef {import('../types.js').SheetType} SheetType */
 
 /**
  * @typedef {Object} SheetTypeSelectorOptions

--- a/ocr-poc/src/components/SheetTypeSelector.js
+++ b/ocr-poc/src/components/SheetTypeSelector.js
@@ -1,74 +1,42 @@
 /**
  * SheetTypeSelector Component
  *
- * Allows the user to specify the type of scoresheet they captured:
- * - Electronic/Printed: Screenshots or printed forms
- * - Handwritten: Physical forms filled by hand
+ * First step in the workflow - allows the user to specify the type of scoresheet:
+ * - Electronic: Screenshots or printed forms with typed text
+ * - Manuscript: Physical paper forms filled by hand (large landscape format)
  *
- * This distinction helps optimize OCR processing for different text styles.
+ * This selection determines the capture guide aspect ratio and whether OCR is available.
  */
 
 /**
- * @typedef {'electronic' | 'handwritten'} SheetType
- */
-
-/**
- * @typedef {Object} SheetSelection
- * @property {SheetType} type - The selected sheet type
- * @property {Blob} imageBlob - The captured image
+ * @typedef {'electronic' | 'manuscript'} SheetType
  */
 
 /**
  * @typedef {Object} SheetTypeSelectorOptions
  * @property {HTMLElement} container - Container element to render into
- * @property {Blob} imageBlob - The captured image to display
- * @property {(selection: SheetSelection) => void} onSelect - Callback when type is selected
- * @property {() => void} [onBack] - Optional callback to go back to capture
+ * @property {(type: SheetType) => void} onSelect - Callback when type is selected
  */
 
 export class SheetTypeSelector {
   /** @type {HTMLElement} */
   #container;
 
-  /** @type {Blob} */
-  #imageBlob;
-
-  /** @type {(selection: SheetSelection) => void} */
+  /** @type {(type: SheetType) => void} */
   #onSelect;
-
-  /** @type {(() => void) | undefined} */
-  #onBack;
-
-  /** @type {string | null} */
-  #previewUrl = null;
 
   /**
    * @param {SheetTypeSelectorOptions} options
    */
-  constructor({ container, imageBlob, onSelect, onBack }) {
+  constructor({ container, onSelect }) {
     this.#container = container;
-    this.#imageBlob = imageBlob;
     this.#onSelect = onSelect;
-    this.#onBack = onBack;
     this.#render();
   }
 
   #render() {
-    // Create object URL for thumbnail preview
-    this.#previewUrl = URL.createObjectURL(this.#imageBlob);
-
     this.#container.innerHTML = `
       <div class="sheet-type-selector">
-        <div class="sheet-type-selector__preview">
-          <img
-            src="${this.#previewUrl}"
-            alt="Captured scoresheet"
-            class="sheet-type-selector__thumbnail"
-          />
-        </div>
-
-        <h3 class="sheet-type-selector__title">What type of scoresheet is this?</h3>
-
         <div class="sheet-type-selector__options">
           <button
             type="button"
@@ -76,8 +44,8 @@ export class SheetTypeSelector {
             id="btn-electronic"
             aria-describedby="desc-electronic"
           >
-            <span class="sheet-type-selector__option-icon" aria-hidden="true">🖥️</span>
-            <span class="sheet-type-selector__option-label">Electronic / Printed</span>
+            <span class="sheet-type-selector__option-icon" aria-hidden="true">📱</span>
+            <span class="sheet-type-selector__option-label">Electronic</span>
             <span class="sheet-type-selector__option-desc" id="desc-electronic">
               Screenshots or printed forms with typed text
             </span>
@@ -86,24 +54,16 @@ export class SheetTypeSelector {
           <button
             type="button"
             class="sheet-type-selector__option"
-            id="btn-handwritten"
-            aria-describedby="desc-handwritten"
+            id="btn-manuscript"
+            aria-describedby="desc-manuscript"
           >
-            <span class="sheet-type-selector__option-icon" aria-hidden="true">✍️</span>
-            <span class="sheet-type-selector__option-label">Handwritten</span>
-            <span class="sheet-type-selector__option-desc" id="desc-handwritten">
-              Physical forms filled in by hand
+            <span class="sheet-type-selector__option-icon" aria-hidden="true">📝</span>
+            <span class="sheet-type-selector__option-label">Manuscript</span>
+            <span class="sheet-type-selector__option-desc" id="desc-manuscript">
+              Physical paper forms filled in by hand
             </span>
           </button>
         </div>
-
-        <button
-          type="button"
-          class="btn btn-secondary btn-block sheet-type-selector__back"
-          id="btn-back"
-        >
-          ← Capture Different Image
-        </button>
       </div>
     `;
 
@@ -112,35 +72,20 @@ export class SheetTypeSelector {
 
   #bindEvents() {
     const electronicBtn = this.#container.querySelector('#btn-electronic');
-    const handwrittenBtn = this.#container.querySelector('#btn-handwritten');
-    const backBtn = this.#container.querySelector('#btn-back');
+    const manuscriptBtn = this.#container.querySelector('#btn-manuscript');
 
     electronicBtn?.addEventListener('click', () => this.#handleSelect('electronic'));
-    handwrittenBtn?.addEventListener('click', () => this.#handleSelect('handwritten'));
-    backBtn?.addEventListener('click', () => this.#handleBack());
+    manuscriptBtn?.addEventListener('click', () => this.#handleSelect('manuscript'));
   }
 
   /**
    * @param {SheetType} type
    */
   #handleSelect(type) {
-    this.#onSelect({
-      type,
-      imageBlob: this.#imageBlob,
-    });
-  }
-
-  #handleBack() {
-    if (this.#onBack) {
-      this.#onBack();
-    }
+    this.#onSelect(type);
   }
 
   destroy() {
-    if (this.#previewUrl) {
-      URL.revokeObjectURL(this.#previewUrl);
-      this.#previewUrl = null;
-    }
     this.#container.innerHTML = '';
   }
 }

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -305,6 +305,18 @@ body {
   padding-right: max(var(--spacing-xl), env(safe-area-inset-right));
 }
 
+.image-capture__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+}
+
+.image-capture__hint {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
 .image-capture__buttons {
   display: flex;
   flex-direction: column;

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -363,6 +363,11 @@ body {
   padding-right: env(safe-area-inset-right);
 }
 
+/* Hidden attribute must override display:flex */
+.image-capture__camera[hidden] {
+  display: none;
+}
+
 .image-capture__video-wrapper {
   position: relative;
   flex: 1;
@@ -1121,6 +1126,11 @@ body {
   padding-bottom: env(safe-area-inset-bottom);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
+}
+
+/* Hidden attribute must override display:flex */
+.image-capture__editor[hidden] {
+  display: none;
 }
 
 .image-editor__viewport {

--- a/ocr-poc/src/types.js
+++ b/ocr-poc/src/types.js
@@ -1,0 +1,13 @@
+/**
+ * Shared type definitions for the OCR PoC application
+ */
+
+/**
+ * Type of scoresheet being processed
+ * @typedef {'electronic' | 'manuscript'} SheetType
+ * - electronic: Screenshots or printed forms with typed text (4:5 portrait aspect ratio)
+ * - manuscript: Physical paper forms filled in by hand (7:5 landscape aspect ratio)
+ */
+
+// Export empty object to make this a module
+export {};


### PR DESCRIPTION
## Summary
- Move scoresheet type selection to first step in workflow
- Rename 'handwritten' to 'manuscript' for clarity
- Add support for different aspect ratios per type:
  - Electronic: 4:5 portrait for player list table capture
  - Manuscript: 7:5 landscape for full physical scoresheet capture
- Add back button to navigate from capture to type selection
- Skip OCR for manuscript scoresheets (capture only for now)
- Add header with context hint on capture screen

## Code Quality Improvements
- Fix CSS `display:flex` overriding HTML `hidden` attribute on camera/editor containers
- Address XSS concerns by using `textContent` instead of `innerHTML` interpolation
- Extract `SheetType` typedef to shared `types.js` file (DRY principle)

## New Workflow
1. **Type Selection** - User chooses Electronic or Manuscript
2. **Capture** - Camera/upload with type-appropriate aspect ratio guide
3. **Processing** (Electronic only) - OCR extraction
4. **Results/Comparison** (Electronic) or **Manuscript Complete** (Manuscript)

## Test Plan
- [x] Verify type selection screen appears first on app load
- [ ] Test electronic flow: type selection → capture → OCR → comparison
- [ ] Test manuscript flow: type selection → capture → manuscript-complete
- [ ] Verify back button returns to type selection
- [ ] Verify correct aspect ratio guides for each type
- [ ] Test both camera and file upload paths