### PR TITLE
feat(settings): separate demo mode settings from real mode settings

### DIFF
--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -30,6 +30,26 @@ vi.mock("@/services/transport", () => ({
 function createMockSettingsStore(
   overrides: Partial<ReturnType<typeof useSettingsStore>> = {},
 ) {
+  const defaultModeSettings = {
+    homeLocation: {
+      latitude: 46.9,
+      longitude: 7.4,
+      label: "Test Location",
+      source: "manual" as const,
+    },
+    distanceFilter: { enabled: false, maxDistanceKm: 50 },
+    transportEnabled: true,
+    transportEnabledByAssociation: {},
+    travelTimeFilter: {
+      enabled: false,
+      maxTravelTimeMinutes: 120,
+      arrivalBufferMinutes: 30,
+      arrivalBufferByAssociation: {},
+      cacheInvalidatedAt: null,
+    },
+    levelFilterEnabled: false,
+  };
+
   return {
     // Safe mode
     isSafeModeEnabled: false,
@@ -39,37 +59,35 @@ function createMockSettingsStore(
     preventZoom: false,
     setPreventZoom: vi.fn(),
 
-    // Home location
-    homeLocation: {
-      latitude: 46.9,
-      longitude: 7.4,
-      label: "Test Location",
-      source: "manual" as const,
+    // Mode tracking (new)
+    currentMode: "api" as const,
+    _setCurrentMode: vi.fn(),
+    settingsByMode: {
+      api: { ...defaultModeSettings },
+      demo: { ...defaultModeSettings, homeLocation: null },
+      calendar: { ...defaultModeSettings, homeLocation: null },
     },
+
+    // Home location
+    homeLocation: defaultModeSettings.homeLocation,
     setHomeLocation: vi.fn(),
 
     // Distance filter
-    distanceFilter: { enabled: false, maxDistanceKm: 50 },
+    distanceFilter: defaultModeSettings.distanceFilter,
     setDistanceFilterEnabled: vi.fn(),
     setMaxDistanceKm: vi.fn(),
 
     // Transport toggle (legacy global)
-    transportEnabled: true,
+    transportEnabled: defaultModeSettings.transportEnabled,
     setTransportEnabled: vi.fn(),
 
     // Per-association transport
-    transportEnabledByAssociation: {},
+    transportEnabledByAssociation: defaultModeSettings.transportEnabledByAssociation,
     setTransportEnabledForAssociation: vi.fn(),
     isTransportEnabledForAssociation: vi.fn().mockReturnValue(true),
 
     // Travel time filter
-    travelTimeFilter: {
-      enabled: false,
-      maxTravelTimeMinutes: 120,
-      arrivalBufferMinutes: 30,
-      arrivalBufferByAssociation: {},
-      cacheInvalidatedAt: null,
-    },
+    travelTimeFilter: defaultModeSettings.travelTimeFilter,
     setTravelTimeFilterEnabled: vi.fn(),
     setMaxTravelTimeMinutes: vi.fn(),
     setArrivalBufferMinutes: vi.fn(),
@@ -78,7 +96,7 @@ function createMockSettingsStore(
     invalidateTravelTimeCache: vi.fn(),
 
     // Level filter
-    levelFilterEnabled: false,
+    levelFilterEnabled: defaultModeSettings.levelFilterEnabled,
     setLevelFilterEnabled: vi.fn(),
 
     // Reset

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -543,9 +543,7 @@ export const useAuthStore = create<AuthState>()(
 
         const demoOccupations = filterRefereeOccupations(rawDemoOccupations);
 
-        // Set demo home location for distance filtering showcase
-        useSettingsStore.getState().setHomeLocation(DEMO_HOME_LOCATION);
-
+        // Set auth state to demo mode first
         set({
           status: "authenticated",
           dataSource: "demo",
@@ -559,6 +557,13 @@ export const useAuthStore = create<AuthState>()(
           activeOccupationId: demoOccupations[0]!.id,
           error: null,
         });
+
+        // Set demo home location for distance filtering showcase
+        // Must be called after dataSource is set to "demo" so the settings
+        // store's mode is synced and the location is stored in demo settings
+        const settingsStore = useSettingsStore.getState();
+        settingsStore._setCurrentMode("demo");
+        settingsStore.setHomeLocation(DEMO_HOME_LOCATION);
       },
 
       setActiveOccupation: (id: string) => {

--- a/web-app/src/stores/auth.ts
+++ b/web-app/src/stores/auth.ts
@@ -560,7 +560,10 @@ export const useAuthStore = create<AuthState>()(
 
         // Set demo home location for distance filtering showcase
         // Must be called after dataSource is set to "demo" so the settings
-        // store's mode is synced and the location is stored in demo settings
+        // store's mode is synced and the location is stored in demo settings.
+        // Note: We explicitly call _setCurrentMode here for immediate sync because
+        // the App.tsx subscription fires asynchronously after state updates.
+        // The idempotent nature of _setCurrentMode makes this double-call safe.
         const settingsStore = useSettingsStore.getState();
         settingsStore._setCurrentMode("demo");
         settingsStore.setHomeLocation(DEMO_HOME_LOCATION);


### PR DESCRIPTION
## Summary
- Settings like homeLocation, distanceFilter, transportEnabled, and travelTimeFilter are now stored separately for each data source mode (api, demo, calendar)
- This prevents demo mode settings from affecting real API mode and vice versa
- Existing settings migrated to API mode, demo/calendar get defaults
- Clear data button only clears current mode's settings

## Test Plan
- [x] Run `npm run lint` - passes
- [x] Run `npm run knip` - passes
- [x] Run `npm test` - all 2991 tests pass
- [x] Run `npm run build` - succeeds
- [ ] Manual testing: Login to demo mode, set home location, logout, login with real credentials - home location should be null
- [ ] Manual testing: Clear data in demo mode should not affect API mode settings