### PR TITLE
feat(ocr-poc): replace crosshair guides with table outline

### DIFF
--- a/ocr-poc/src/components/CameraGuide.js
+++ b/ocr-poc/src/components/CameraGuide.js
@@ -79,10 +79,7 @@ export class CameraGuide {
     this.#guideElement.innerHTML = `
       <div class="camera-guide__overlay">
         <div class="camera-guide__frame">
-          <div class="camera-guide__corner camera-guide__corner--tl"></div>
-          <div class="camera-guide__corner camera-guide__corner--tr"></div>
-          <div class="camera-guide__corner camera-guide__corner--bl"></div>
-          <div class="camera-guide__corner camera-guide__corner--br"></div>
+          <div class="camera-guide__table-lines"></div>
           <div class="camera-guide__label">
             <span></span>
           </div>

--- a/ocr-poc/src/components/CameraGuide.js
+++ b/ocr-poc/src/components/CameraGuide.js
@@ -2,7 +2,7 @@
  * CameraGuide Component
  *
  * Provides a visual overlay guide for framing scoresheets when capturing images.
- * Displays corner markers and alignment guides to help users position correctly.
+ * Displays a table outline with row lines to help users align scoresheets correctly.
  *
  * Supports two aspect ratios based on scoresheet type:
  * - Electronic (4:5 portrait): For player list table capture from screenshots

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -1042,52 +1042,25 @@ body {
 
 .camera-guide__frame {
   position: relative;
-  border: 2px solid rgba(255, 255, 255, 0.8);
-  border-radius: var(--radius-md);
-  box-shadow:
-    0 0 0 9999px rgba(0, 0, 0, 0.4),
-    inset 0 0 20px rgba(0, 0, 0, 0.3);
+  border: 3px solid rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
 }
 
-.camera-guide__corner {
+.camera-guide__table-lines {
   position: absolute;
-  width: 24px;
-  height: 24px;
-  border-color: #fff;
-  border-style: solid;
-  border-width: 0;
-}
-
-.camera-guide__corner--tl {
-  top: -2px;
-  left: -2px;
-  border-top-width: 4px;
-  border-left-width: 4px;
-  border-top-left-radius: var(--radius-md);
-}
-
-.camera-guide__corner--tr {
-  top: -2px;
-  right: -2px;
-  border-top-width: 4px;
-  border-right-width: 4px;
-  border-top-right-radius: var(--radius-md);
-}
-
-.camera-guide__corner--bl {
-  bottom: -2px;
-  left: -2px;
-  border-bottom-width: 4px;
-  border-left-width: 4px;
-  border-bottom-left-radius: var(--radius-md);
-}
-
-.camera-guide__corner--br {
-  bottom: -2px;
-  right: -2px;
-  border-bottom-width: 4px;
-  border-right-width: 4px;
-  border-bottom-right-radius: var(--radius-md);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  /* Create horizontal lines to simulate table rows */
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent,
+    transparent calc(100% / 14 - 1px),
+    rgba(255, 255, 255, 0.3) calc(100% / 14 - 1px),
+    rgba(255, 255, 255, 0.3) calc(100% / 14)
+  );
 }
 
 .camera-guide__label {

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -1053,7 +1053,7 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  /* Create horizontal lines to simulate table rows */
+  /* 14 rows matches Swiss volleyball scoresheet player list layout */
   background: repeating-linear-gradient(
     to bottom,
     transparent,


### PR DESCRIPTION
## Summary

- Replace corner markers with horizontal lines that simulate table rows
- Makes it easier to align the camera with actual scoresheet tables
- Cleaner visual that matches the table structure

## Test Plan

- [ ] Open OCR PoC and select a sheet type
- [ ] Tap "Use Camera" and verify the guide shows a rectangular outline with horizontal row lines
- [ ] Verify the outline helps align with the scoresheet table