### PR TITLE
fix(ocr-poc): use landscape aspect ratio for roster-only capture

### DIFF
--- a/ocr-poc/src/components/CameraGuide.js
+++ b/ocr-poc/src/components/CameraGuide.js
@@ -23,6 +23,12 @@ export const TABLE_ASPECT_RATIO = 4 / 5;
  */
 export const MANUSCRIPT_ASPECT_RATIO = 7 / 5;
 
+/**
+ * Aspect ratio for roster-only capture (width:height)
+ * 23:20 landscape format matches both teams' roster section of manuscript scoresheets
+ */
+export const ROSTER_ASPECT_RATIO = 23 / 20;
+
 /** Padding from container edge in pixels */
 const FRAME_PADDING_PX = 24;
 
@@ -32,10 +38,13 @@ const FRAME_HEIGHT_RATIO = 0.7;
 /** Frame size as ratio of available width when container is taller */
 const FRAME_WIDTH_RATIO = 0.85;
 
+/** @typedef {'full' | 'roster-only'} ManuscriptCaptureMode */
+
 /**
  * @typedef {Object} CameraGuideOptions
  * @property {HTMLElement} container - Container element to render into
  * @property {SheetType} [sheetType='electronic'] - Type of scoresheet (affects aspect ratio)
+ * @property {ManuscriptCaptureMode} [captureMode] - Capture mode for manuscript sheets
  */
 
 export class CameraGuide {
@@ -54,15 +63,42 @@ export class CameraGuide {
   /**
    * @param {CameraGuideOptions} options
    */
-  constructor({ container, sheetType = 'electronic' }) {
+  constructor({ container, sheetType = 'electronic', captureMode }) {
     this.#container = container;
-    this.#aspectRatio = sheetType === 'manuscript' ? MANUSCRIPT_ASPECT_RATIO : TABLE_ASPECT_RATIO;
-    this.#labelText = sheetType === 'manuscript' ? 'Align full scoresheet here' : 'Align player list here';
+    this.#aspectRatio = this.#determineAspectRatio(sheetType, captureMode);
+    this.#labelText = this.#determineLabelText(sheetType, captureMode);
     this.#render();
     this.#updateGuideSize();
 
     // Update guide size on window resize
     window.addEventListener('resize', this.#handleResize);
+  }
+
+  /**
+   * Determine the aspect ratio based on sheet type and capture mode
+   * @param {SheetType} sheetType
+   * @param {ManuscriptCaptureMode} [captureMode]
+   * @returns {number}
+   */
+  #determineAspectRatio(sheetType, captureMode) {
+    if (sheetType === 'manuscript') {
+      // Roster-only mode uses a wider landscape ratio for the roster area
+      return captureMode === 'roster-only' ? ROSTER_ASPECT_RATIO : MANUSCRIPT_ASPECT_RATIO;
+    }
+    return TABLE_ASPECT_RATIO;
+  }
+
+  /**
+   * Determine the label text based on sheet type and capture mode
+   * @param {SheetType} sheetType
+   * @param {ManuscriptCaptureMode} [captureMode]
+   * @returns {string}
+   */
+  #determineLabelText(sheetType, captureMode) {
+    if (sheetType === 'manuscript') {
+      return captureMode === 'roster-only' ? 'Align roster area here' : 'Align full scoresheet here';
+    }
+    return 'Align player list here';
   }
 
   /**

--- a/ocr-poc/src/components/ImageEditor.js
+++ b/ocr-poc/src/components/ImageEditor.js
@@ -11,9 +11,10 @@
  * - Manuscript (7:5 landscape): For full physical scoresheet
  */
 
-import { TABLE_ASPECT_RATIO, MANUSCRIPT_ASPECT_RATIO } from './CameraGuide.js';
+import { TABLE_ASPECT_RATIO, MANUSCRIPT_ASPECT_RATIO, ROSTER_ASPECT_RATIO } from './CameraGuide.js';
 
 /** @typedef {import('../types.js').SheetType} SheetType */
+/** @typedef {'full' | 'roster-only'} ManuscriptCaptureMode */
 
 /** Minimum zoom level */
 const MIN_ZOOM = 0.1;
@@ -38,6 +39,7 @@ const FRAME_SIZE_RATIO = 0.85;
  * @property {HTMLElement} container - Container element to render into
  * @property {Blob} imageBlob - The image to edit
  * @property {SheetType} [sheetType='electronic'] - Type of scoresheet (affects aspect ratio)
+ * @property {ManuscriptCaptureMode} [captureMode] - Capture mode for manuscript sheets
  * @property {(croppedBlob: Blob) => void} onConfirm - Callback when crop is confirmed
  * @property {() => void} onCancel - Callback when editing is cancelled
  */
@@ -97,10 +99,10 @@ export class ImageEditor {
   /**
    * @param {ImageEditorOptions} options
    */
-  constructor({ container, imageBlob, sheetType = 'electronic', onConfirm, onCancel }) {
+  constructor({ container, imageBlob, sheetType = 'electronic', captureMode, onConfirm, onCancel }) {
     this.#container = container;
     this.#imageBlob = imageBlob;
-    this.#aspectRatio = sheetType === 'manuscript' ? MANUSCRIPT_ASPECT_RATIO : TABLE_ASPECT_RATIO;
+    this.#aspectRatio = this.#determineAspectRatio(sheetType, captureMode);
     this.#onConfirm = onConfirm;
     this.#onCancel = onCancel;
 
@@ -110,6 +112,20 @@ export class ImageEditor {
 
     // Add resize listener (arrow function is already bound to `this`)
     window.addEventListener('resize', this.#handleResize);
+  }
+
+  /**
+   * Determine the aspect ratio based on sheet type and capture mode
+   * @param {SheetType} sheetType
+   * @param {ManuscriptCaptureMode} [captureMode]
+   * @returns {number}
+   */
+  #determineAspectRatio(sheetType, captureMode) {
+    if (sheetType === 'manuscript') {
+      // Roster-only mode uses a wider landscape ratio for the roster area
+      return captureMode === 'roster-only' ? ROSTER_ASPECT_RATIO : MANUSCRIPT_ASPECT_RATIO;
+    }
+    return TABLE_ASPECT_RATIO;
   }
 
   #render() {

--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -219,6 +219,7 @@ function renderCaptureState(container) {
     imageCapture = new ImageCapture({
       container: captureContainer,
       sheetType: appContext.sheetType,
+      captureMode: appContext.captureMode,
       onCapture: handleImageCapture,
       onBack: backHandler,
     });


### PR DESCRIPTION
## Summary
- Add `ROSTER_ASPECT_RATIO` constant (12:5 = 2.4) for the roster section of manuscript scoresheets
- Pass `captureMode` through the component chain (main.js → ImageCapture → CameraGuide/ImageEditor)
- Update camera guide and image editor to use the wider landscape aspect ratio when in "roster-only" mode
- Update hint text to say "Capture the roster area in landscape"

## Test Plan
- [ ] Select Manuscript → Roster Only and verify the camera guide shows a wide landscape frame (12:5 aspect ratio)
- [ ] Upload an image in roster-only mode and verify the crop frame is in wide landscape orientation
- [ ] Verify the hint text shows "Capture the roster area in landscape"
- [ ] Verify full manuscript mode still uses the original 7:5 aspect ratio
- [ ] Verify electronic mode still uses the 4:5 portrait aspect ratio