### PR TITLE
fix(help-site): enable language switching functionality

### DIFF
--- a/help-site/src/components/Footer.astro
+++ b/help-site/src/components/Footer.astro
@@ -31,6 +31,7 @@ const currentYear = new Date().getFullYear();
           target="_blank"
           rel="noopener noreferrer"
           class="text-sm text-text-secondary transition-colors hover:text-primary-600 dark:text-text-secondary-dark dark:hover:text-primary-400"
+          data-i18n="common.openApp"
         >
           Open App
         </a>
@@ -39,6 +40,7 @@ const currentYear = new Date().getFullYear();
           target="_blank"
           rel="noopener noreferrer"
           class="text-sm text-text-secondary transition-colors hover:text-primary-600 dark:text-text-secondary-dark dark:hover:text-primary-400"
+          data-i18n="footer.github"
         >
           GitHub
         </a>
@@ -54,7 +56,7 @@ const currentYear = new Date().getFullYear();
 
       <!-- Copyright -->
       <div class="text-center text-sm text-text-muted dark:text-text-muted-dark md:text-right">
-        <p>Made for Swiss volleyball referees</p>
+        <p data-i18n="footer.forReferees">Made for Swiss volleyball referees</p>
         <p class="mt-1">&copy; {currentYear} VolleyKit</p>
       </div>
     </div>

--- a/help-site/src/components/Footer.astro
+++ b/help-site/src/components/Footer.astro
@@ -56,7 +56,7 @@ const currentYear = new Date().getFullYear();
 
       <!-- Copyright -->
       <div class="text-center text-sm text-text-muted dark:text-text-muted-dark md:text-right">
-        <p data-i18n="footer.forReferees">Made for Swiss volleyball referees</p>
+        <p data-i18n="footer.forReferees">For Swiss volleyball referees</p>
         <p class="mt-1">&copy; {currentYear} VolleyKit</p>
       </div>
     </div>

--- a/help-site/src/components/Header.astro
+++ b/help-site/src/components/Header.astro
@@ -19,6 +19,7 @@ import { BASE_PATH } from '../constants';
       type="button"
       class="flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary hover:bg-surface-subtle hover:text-text-primary dark:text-text-secondary-dark dark:hover:bg-surface-subtle-dark dark:hover:text-text-primary-dark lg:hidden"
       aria-label="Open navigation menu"
+      data-i18n-aria-label="a11y.openMenu"
       data-menu-toggle
     >
       <svg
@@ -42,13 +43,14 @@ import { BASE_PATH } from '../constants';
       class="hidden items-center gap-2 text-text-primary hover:text-primary-600 dark:text-text-primary-dark dark:hover:text-primary-400 lg:flex"
     >
       <img src={`${BASE_PATH}/favicon.svg`} alt="" class="h-7 w-7" aria-hidden="true" />
-      <span class="font-semibold">VolleyKit Help</span>
+      <span class="font-semibold" data-i18n="home.title">VolleyKit Help</span>
     </a>
 
     <!-- Mobile: Centered title -->
     <a
       href={`${BASE_PATH}/`}
       class="font-semibold text-text-primary dark:text-text-primary-dark lg:hidden"
+      data-i18n="home.title"
     >
       VolleyKit Help
     </a>
@@ -67,7 +69,7 @@ import { BASE_PATH } from '../constants';
         rel="noopener noreferrer"
         class="flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-primary-950 transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
       >
-        Open App
+        <span data-i18n="common.openApp">Open App</span>
         <svg
           class="h-4 w-4"
           fill="none"

--- a/help-site/src/components/LanguageSwitcher.astro
+++ b/help-site/src/components/LanguageSwitcher.astro
@@ -145,8 +145,7 @@ const { compact = false } = Astro.props;
           updateChecks(lang);
           closeMenu();
           // Reload page to apply translations (since Astro is SSG)
-          // For a more seamless experience, you could use client-side hydration
-          // window.location.reload();
+          window.location.reload();
         });
       });
 

--- a/help-site/src/components/MobileNav.astro
+++ b/help-site/src/components/MobileNav.astro
@@ -35,6 +35,7 @@ const icons: Record<string, string> = {
   role="dialog"
   aria-modal="true"
   aria-label="Navigation menu"
+  data-i18n-aria-label="a11y.mobileNavigation"
 >
   <!-- Backdrop overlay -->
   <div
@@ -52,12 +53,13 @@ const icons: Record<string, string> = {
     <div class="flex h-14 items-center justify-between border-b border-border-default px-4 dark:border-border-default-dark">
       <a href={`${BASE_PATH}/`} class="flex items-center gap-2">
         <img src={`${BASE_PATH}/favicon.svg`} alt="" class="h-7 w-7" aria-hidden="true" />
-        <span class="font-semibold text-text-primary dark:text-text-primary-dark">VolleyKit Help</span>
+        <span class="font-semibold text-text-primary dark:text-text-primary-dark" data-i18n="home.title">VolleyKit Help</span>
       </a>
       <button
         type="button"
         class="flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary hover:bg-surface-subtle hover:text-text-primary dark:text-text-secondary-dark dark:hover:bg-surface-subtle-dark dark:hover:text-text-primary-dark"
         aria-label="Close menu"
+        data-i18n-aria-label="a11y.closeMenu"
         data-mobile-nav-close
       >
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -67,7 +69,7 @@ const icons: Record<string, string> = {
     </div>
 
     <!-- Navigation links -->
-    <nav class="flex-1 overflow-y-auto p-4" aria-label="Mobile navigation">
+    <nav class="flex-1 overflow-y-auto p-4" aria-label="Mobile navigation" data-i18n-aria-label="a11y.mobileNavigation">
       <ul class="space-y-1">
         {
           navItems.map((item) => {
@@ -93,7 +95,7 @@ const icons: Record<string, string> = {
                     aria-hidden="true"
                     set:html={icons[item.icon]}
                   />
-                  <span>{item.title}</span>
+                  <span data-i18n={item.i18nKey}>{item.title}</span>
                 </a>
               </li>
             );
@@ -111,7 +113,7 @@ const icons: Record<string, string> = {
         rel="noopener noreferrer"
         class="flex items-center justify-center gap-2 rounded-lg bg-primary-500 px-4 py-2.5 text-sm font-medium text-primary-950 transition-colors hover:bg-primary-600"
       >
-        Open App
+        <span data-i18n="common.openApp">Open App</span>
         <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path
             stroke-linecap="round"

--- a/help-site/src/components/Sidebar.astro
+++ b/help-site/src/components/Sidebar.astro
@@ -29,7 +29,7 @@ const icons: Record<string, string> = {
 ---
 
 <aside class="hidden w-64 shrink-0 border-r border-border-default bg-surface-card dark:border-border-default-dark dark:bg-surface-card-dark lg:block" data-pagefind-ignore>
-  <nav class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto p-4" aria-label="Main navigation">
+  <nav class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto p-4" aria-label="Main navigation" data-i18n-aria-label="a11y.mainNavigation">
     <ul class="space-y-1">
       {
         navItems.map((item) => {
@@ -54,7 +54,7 @@ const icons: Record<string, string> = {
                   aria-hidden="true"
                   set:html={icons[item.icon]}
                 />
-                <span>{item.title}</span>
+                <span data-i18n={item.i18nKey}>{item.title}</span>
               </a>
             </li>
           );

--- a/help-site/src/data/navItems.ts
+++ b/help-site/src/data/navItems.ts
@@ -1,7 +1,10 @@
 import { BASE_PATH } from '../constants';
 
 export interface NavItem {
+  /** Default title (English) - used as fallback */
   title: string;
+  /** Translation key for i18n lookup */
+  i18nKey: string;
   href: string;
   icon: string;
 }
@@ -9,46 +12,55 @@ export interface NavItem {
 export const navItems: NavItem[] = [
   {
     title: 'Home',
+    i18nKey: 'nav.home',
     href: `${BASE_PATH}/`,
     icon: 'home',
   },
   {
     title: 'Getting Started',
+    i18nKey: 'nav.gettingStarted',
     href: `${BASE_PATH}/getting-started/`,
     icon: 'rocket',
   },
   {
     title: 'Assignments',
+    i18nKey: 'nav.assignments',
     href: `${BASE_PATH}/assignments/`,
     icon: 'calendar-check',
   },
   {
     title: 'Exchanges',
+    i18nKey: 'nav.exchanges',
     href: `${BASE_PATH}/exchanges/`,
     icon: 'arrow-left-right',
   },
   {
     title: 'Compensations',
+    i18nKey: 'nav.compensations',
     href: `${BASE_PATH}/compensations/`,
     icon: 'wallet',
   },
   {
     title: 'Calendar Mode',
+    i18nKey: 'nav.calendarMode',
     href: `${BASE_PATH}/calendar-mode/`,
     icon: 'calendar',
   },
   {
     title: 'Travel Time',
+    i18nKey: 'nav.travelTime',
     href: `${BASE_PATH}/travel-time/`,
     icon: 'train',
   },
   {
     title: 'Offline & PWA',
+    i18nKey: 'nav.offlinePwa',
     href: `${BASE_PATH}/offline-pwa/`,
     icon: 'wifi-off',
   },
   {
     title: 'Settings',
+    i18nKey: 'nav.settings',
     href: `${BASE_PATH}/settings/`,
     icon: 'settings',
   },

--- a/help-site/src/layouts/BaseLayout.astro
+++ b/help-site/src/layouts/BaseLayout.astro
@@ -77,5 +77,61 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
         }
       });
     </script>
+
+    <!-- Global translations script -->
+    <script>
+      import { t, getLanguage, languages } from '../i18n';
+
+      /**
+       * Apply translations to all elements with data-i18n attributes
+       * This runs client-side to translate static HTML based on user's language preference
+       */
+      function applyTranslations() {
+        const lang = getLanguage();
+
+        // Update HTML lang attribute
+        document.documentElement.lang = lang;
+
+        // Translate all elements with data-i18n attribute
+        document.querySelectorAll('[data-i18n]').forEach((el) => {
+          const key = el.getAttribute('data-i18n');
+          if (key) {
+            const translated = t(key);
+            // Only update if translation was found (not returning the key itself)
+            if (translated !== key) {
+              el.textContent = translated;
+            }
+          }
+        });
+
+        // Translate elements with data-i18n-placeholder attribute (for inputs)
+        document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+          const key = el.getAttribute('data-i18n-placeholder');
+          if (key && el instanceof HTMLInputElement) {
+            const translated = t(key);
+            if (translated !== key) {
+              el.placeholder = translated;
+            }
+          }
+        });
+
+        // Translate elements with data-i18n-aria-label attribute
+        document.querySelectorAll('[data-i18n-aria-label]').forEach((el) => {
+          const key = el.getAttribute('data-i18n-aria-label');
+          if (key) {
+            const translated = t(key);
+            if (translated !== key) {
+              el.setAttribute('aria-label', translated);
+            }
+          }
+        });
+      }
+
+      // Apply translations on page load
+      applyTranslations();
+
+      // Re-apply on Astro page transitions
+      document.addEventListener('astro:after-swap', applyTranslations);
+    </script>
   </body>
 </html>

--- a/help-site/src/layouts/BaseLayout.astro
+++ b/help-site/src/layouts/BaseLayout.astro
@@ -80,7 +80,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
     <!-- Global translations script -->
     <script>
-      import { t, getLanguage, languages } from '../i18n';
+      import { t, getLanguage } from '../i18n';
 
       /**
        * Apply translations to all elements with data-i18n attributes


### PR DESCRIPTION
## Summary
- Enable page reload in LanguageSwitcher when language changes
- Add global translation script to BaseLayout that applies translations on page load
- Add data-i18n attributes to translatable elements across Header, Sidebar, MobileNav, and Footer components
- Add i18nKey property to navItems for translation lookup

## Test Plan
- [ ] Verify language switcher dropdown works on help site
- [ ] Change language and confirm page reloads
- [ ] Verify navigation items, header title, and footer text translate correctly
- [ ] Test all 4 languages (de, en, fr, it)
- [ ] Verify translations persist across page navigation