### PR TITLE
feat(validation): add safe validation mode

### DIFF
--- a/web-app/src/components/features/ValidateGameModal.tsx
+++ b/web-app/src/components/features/ValidateGameModal.tsx
@@ -10,6 +10,7 @@ import { WizardStepIndicator } from "@/components/ui/WizardStepIndicator";
 import {
   UnsavedChangesDialog,
   RosterValidationWarningDialog,
+  SafeValidationCompleteModal,
   ValidationSuccessToast,
   StepRenderer,
   ValidatedModeButtons,
@@ -215,6 +216,11 @@ function ValidateGameModalComponent({
         onGoBack={wizard.handleRosterWarningGoBack}
         onProceedAnyway={wizard.handleRosterWarningProceed}
         isProceedingAnyway={wizard.isFinalizing}
+      />
+
+      <SafeValidationCompleteModal
+        isOpen={wizard.showSafeValidationComplete}
+        onClose={wizard.handleSafeValidationCompleteClose}
       />
     </>
   );

--- a/web-app/src/components/features/settings/SafeValidationSection.test.tsx
+++ b/web-app/src/components/features/settings/SafeValidationSection.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SafeValidationSection } from "./SafeValidationSection";
+
+// Mock useTranslation hook
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "settings.safeValidation": "Safe Validation Mode",
+        "settings.safeValidationDescription":
+          "When enabled, validation saves your changes but does not finalize the game.",
+        "settings.safeValidationEnabled": "Safe validation is enabled",
+        "settings.safeValidationDisabled":
+          "Safe validation is disabled - games will be finalized directly",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe("SafeValidationSection", () => {
+  const defaultProps = {
+    isSafeValidationEnabled: true,
+    onSetSafeValidation: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders section heading", () => {
+    render(<SafeValidationSection {...defaultProps} />);
+
+    expect(screen.getByText("Safe Validation Mode")).toBeInTheDocument();
+  });
+
+  it("renders description text", () => {
+    render(<SafeValidationSection {...defaultProps} />);
+
+    expect(
+      screen.getByText(/When enabled, validation saves your changes/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows enabled status when safe validation is on", () => {
+    render(
+      <SafeValidationSection {...defaultProps} isSafeValidationEnabled={true} />
+    );
+
+    expect(screen.getByText("Safe validation is enabled")).toBeInTheDocument();
+  });
+
+  it("shows disabled status when safe validation is off", () => {
+    render(
+      <SafeValidationSection
+        {...defaultProps}
+        isSafeValidationEnabled={false}
+      />
+    );
+
+    expect(
+      screen.getByText("Safe validation is disabled - games will be finalized directly")
+    ).toBeInTheDocument();
+  });
+
+  it("has toggle switch with correct aria attributes when enabled", () => {
+    render(
+      <SafeValidationSection {...defaultProps} isSafeValidationEnabled={true} />
+    );
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(toggle).toHaveAttribute("aria-label", "Safe Validation Mode");
+  });
+
+  it("has toggle switch with correct aria attributes when disabled", () => {
+    render(
+      <SafeValidationSection
+        {...defaultProps}
+        isSafeValidationEnabled={false}
+      />
+    );
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("toggles safe validation when clicked", async () => {
+    const onSetSafeValidation = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <SafeValidationSection
+        isSafeValidationEnabled={true}
+        onSetSafeValidation={onSetSafeValidation}
+      />
+    );
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(onSetSafeValidation).toHaveBeenCalledWith(false);
+  });
+
+  it("enables safe validation when toggling from off to on", async () => {
+    const onSetSafeValidation = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <SafeValidationSection
+        isSafeValidationEnabled={false}
+        onSetSafeValidation={onSetSafeValidation}
+      />
+    );
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(onSetSafeValidation).toHaveBeenCalledWith(true);
+  });
+
+  it("applies correct styling to toggle when enabled", () => {
+    render(
+      <SafeValidationSection {...defaultProps} isSafeValidationEnabled={true} />
+    );
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveClass("bg-success-600");
+  });
+
+  it("applies correct styling to toggle when disabled", () => {
+    render(
+      <SafeValidationSection
+        {...defaultProps}
+        isSafeValidationEnabled={false}
+      />
+    );
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveClass("bg-surface-muted");
+  });
+});

--- a/web-app/src/components/features/settings/SafeValidationSection.tsx
+++ b/web-app/src/components/features/settings/SafeValidationSection.tsx
@@ -1,0 +1,65 @@
+import { memo, useCallback } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+
+interface SafeValidationSectionProps {
+  isSafeValidationEnabled: boolean;
+  onSetSafeValidation: (enabled: boolean) => void;
+}
+
+function SafeValidationSectionComponent({
+  isSafeValidationEnabled,
+  onSetSafeValidation,
+}: SafeValidationSectionProps) {
+  const { t } = useTranslation();
+
+  const handleToggle = useCallback(() => {
+    onSetSafeValidation(!isSafeValidationEnabled);
+  }, [isSafeValidationEnabled, onSetSafeValidation]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
+          {t("settings.safeValidation")}
+        </h2>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t("settings.safeValidationDescription")}
+        </p>
+
+        <div className="flex items-center justify-between py-2">
+          <div className="flex-1">
+            <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+              {isSafeValidationEnabled
+                ? t("settings.safeValidationEnabled")
+                : t("settings.safeValidationDisabled")}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleToggle}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+              isSafeValidationEnabled
+                ? "bg-success-600"
+                : "bg-surface-muted dark:bg-surface-subtle-dark"
+            }`}
+            role="switch"
+            aria-checked={isSafeValidationEnabled}
+            aria-label={t("settings.safeValidation")}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                isSafeValidationEnabled ? "translate-x-6" : "translate-x-1"
+              }`}
+            />
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export const SafeValidationSection = memo(SafeValidationSectionComponent);

--- a/web-app/src/components/features/settings/TransportSection.test.tsx
+++ b/web-app/src/components/features/settings/TransportSection.test.tsx
@@ -55,6 +55,10 @@ function createMockSettingsStore(
     isSafeModeEnabled: false,
     setSafeMode: vi.fn(),
 
+    // Safe validation mode
+    isSafeValidationEnabled: true,
+    setSafeValidation: vi.fn(),
+
     // Accessibility
     preventZoom: false,
     setPreventZoom: vi.fn(),

--- a/web-app/src/components/features/settings/index.ts
+++ b/web-app/src/components/features/settings/index.ts
@@ -8,6 +8,7 @@ export { HelpSection } from "./HelpSection";
 export { DemoSection } from "./DemoSection";
 export { AccessibilitySection } from "./AccessibilitySection";
 export { SafeModeSection } from "./SafeModeSection";
+export { SafeValidationSection } from "./SafeValidationSection";
 export { UpdateSection } from "./UpdateSection";
 export { AboutSection } from "./AboutSection";
 export { ExperimentalSection } from "./ExperimentalSection";

--- a/web-app/src/components/features/validation/SafeValidationCompleteModal.test.tsx
+++ b/web-app/src/components/features/validation/SafeValidationCompleteModal.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SafeValidationCompleteModal } from "./SafeValidationCompleteModal";
+
+// Mock useTranslation hook
+vi.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "settings.safeValidationCompleteTitle": "Validation Saved",
+        "settings.safeValidationCompleteMessage":
+          "Your changes have been saved. Please go to VolleyManager to complete the validation.",
+        "settings.safeValidationCompleteButton": "Open VolleyManager",
+        "common.close": "Close",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe("SafeValidationCompleteModal", () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when not open", () => {
+    render(<SafeValidationCompleteModal {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByText("Validation Saved")).not.toBeInTheDocument();
+  });
+
+  it("renders modal title when open", () => {
+    render(<SafeValidationCompleteModal {...defaultProps} />);
+
+    expect(screen.getByText("Validation Saved")).toBeInTheDocument();
+  });
+
+  it("renders message explaining next steps", () => {
+    render(<SafeValidationCompleteModal {...defaultProps} />);
+
+    expect(
+      screen.getByText(/Your changes have been saved/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders close button", () => {
+    render(<SafeValidationCompleteModal {...defaultProps} />);
+
+    // Modal uses aria-hidden on backdrop, so use hidden: true option
+    const buttons = screen.getAllByRole("button", { hidden: true });
+    const closeButton = buttons.find((btn) => btn.textContent === "Close");
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it("renders Open VolleyManager button", () => {
+    render(<SafeValidationCompleteModal {...defaultProps} />);
+
+    const buttons = screen.getAllByRole("button", { hidden: true });
+    const openButton = buttons.find(
+      (btn) => btn.textContent === "Open VolleyManager"
+    );
+    expect(openButton).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const onClose = vi.fn();
+
+    render(<SafeValidationCompleteModal isOpen={true} onClose={onClose} />);
+
+    const buttons = screen.getAllByRole("button", { hidden: true });
+    const closeButton = buttons.find((btn) => btn.textContent === "Close");
+    expect(closeButton).toBeDefined();
+    fireEvent.click(closeButton!);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens VolleyManager and closes when Open VolleyManager button is clicked", () => {
+    const onClose = vi.fn();
+    const windowOpenSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => null);
+
+    render(<SafeValidationCompleteModal isOpen={true} onClose={onClose} />);
+
+    const buttons = screen.getAllByRole("button", { hidden: true });
+    const openButton = buttons.find(
+      (btn) => btn.textContent === "Open VolleyManager"
+    );
+    expect(openButton).toBeDefined();
+    fireEvent.click(openButton!);
+
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      "https://volleymanager.volleyball.ch",
+      "_blank",
+      "noopener,noreferrer"
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    windowOpenSpy.mockRestore();
+  });
+
+  it("renders with proper heading structure", () => {
+    render(<SafeValidationCompleteModal {...defaultProps} />);
+
+    // The title should be rendered with the correct ID
+    const title = screen.getByText("Validation Saved");
+    expect(title).toHaveAttribute("id", "safe-validation-complete-title");
+  });
+
+  it("displays success icon container", () => {
+    render(<SafeValidationCompleteModal {...defaultProps} />);
+
+    // Check for the success icon container with SVG
+    const svgElements = document.querySelectorAll("svg[aria-hidden='true']");
+    expect(svgElements.length).toBeGreaterThan(0);
+  });
+});

--- a/web-app/src/components/features/validation/SafeValidationCompleteModal.tsx
+++ b/web-app/src/components/features/validation/SafeValidationCompleteModal.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useRef } from "react";
+import { useTranslation } from "@/hooks/useTranslation";
+import { Modal } from "@/components/ui/Modal";
+import { ModalHeader } from "@/components/ui/ModalHeader";
+import { ModalFooter } from "@/components/ui/ModalFooter";
+import { Button } from "@/components/ui/Button";
+
+const MODAL_TITLE_ID = "safe-validation-complete-title";
+const VOLLEYMANAGER_URL = "https://volleymanager.volleyball.ch";
+
+interface SafeValidationCompleteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SafeValidationCompleteModal({
+  isOpen,
+  onClose,
+}: SafeValidationCompleteModalProps) {
+  const { t } = useTranslation();
+  const isOpeningRef = useRef(false);
+
+  const handleOpenVolleyManager = useCallback(() => {
+    if (isOpeningRef.current) return;
+    isOpeningRef.current = true;
+    try {
+      window.open(VOLLEYMANAGER_URL, "_blank", "noopener,noreferrer");
+      onClose();
+    } finally {
+      isOpeningRef.current = false;
+    }
+  }, [onClose]);
+
+  const successIcon = (
+    <div className="flex-shrink-0 w-12 h-12 rounded-full bg-success-100 dark:bg-success-900 flex items-center justify-center">
+      <svg
+        className="w-6 h-6 text-success-600 dark:text-success-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 13l4 4L19 7"
+        />
+      </svg>
+    </div>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} titleId={MODAL_TITLE_ID} size="md">
+      <ModalHeader
+        title={t("settings.safeValidationCompleteTitle")}
+        titleId={MODAL_TITLE_ID}
+        icon={successIcon}
+      />
+
+      <div className="mb-6">
+        <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
+          {t("settings.safeValidationCompleteMessage")}
+        </p>
+      </div>
+
+      <ModalFooter divider>
+        <Button variant="secondary" className="flex-1 rounded-md" onClick={onClose}>
+          {t("common.close")}
+        </Button>
+        <Button variant="primary" className="flex-1 rounded-md" onClick={handleOpenVolleyManager}>
+          {t("settings.safeValidationCompleteButton")}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/web-app/src/components/features/validation/index.ts
+++ b/web-app/src/components/features/validation/index.ts
@@ -11,6 +11,7 @@ export { PlayerListItem } from "./PlayerListItem";
 export { CoachesSection } from "./CoachesSection";
 export { UnsavedChangesDialog } from "./UnsavedChangesDialog";
 export { RosterValidationWarningDialog } from "./RosterValidationWarningDialog";
+export { SafeValidationCompleteModal } from "./SafeValidationCompleteModal";
 export { ValidationSuccessToast } from "./ValidationSuccessToast";
 export { StepRenderer } from "./StepRenderer";
 export { ValidatedModeButtons, EditModeButtons } from "./WizardButtons";

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -455,6 +455,15 @@ const de: Translations = {
     safeModeDangerous: "Gefährliche Operationen sind aktiviert",
     safeModeBlocked:
       "Diese Operation ist im Sicherheitsmodus gesperrt. Deaktivieren Sie den Sicherheitsmodus in den Einstellungen, um fortzufahren.",
+    safeValidation: "Sichere Validierung",
+    safeValidationDescription:
+      "Wenn aktiviert, speichert die Validierung Ihre Änderungen, aber schliesst das Spiel nicht ab. Sie werden aufgefordert, die Validierung im VolleyManager abzuschliessen.",
+    safeValidationEnabled: "Sichere Validierung ist aktiviert",
+    safeValidationDisabled: "Sichere Validierung ist deaktiviert - Spiele werden direkt abgeschlossen",
+    safeValidationCompleteTitle: "Validierung gespeichert",
+    safeValidationCompleteMessage:
+      "Ihre Änderungen wurden gespeichert. Bitte gehen Sie zum VolleyManager, um die Validierung abzuschliessen und das Spiel zu finalisieren.",
+    safeValidationCompleteButton: "VolleyManager öffnen",
     privacy: "Datenschutz",
     privacyNoCollection:
       "VolleyKit sammelt oder speichert keine persönlichen Daten.",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -453,6 +453,15 @@ const en: Translations = {
     safeModeDangerous: "Dangerous operations are enabled",
     safeModeBlocked:
       "This operation is blocked in safe mode. Disable safe mode in Settings to proceed.",
+    safeValidation: "Safe Validation Mode",
+    safeValidationDescription:
+      "When enabled, validation saves your changes but does not finalize the game. You will be directed to complete the validation on VolleyManager.",
+    safeValidationEnabled: "Safe validation is enabled",
+    safeValidationDisabled: "Safe validation is disabled - games will be finalized directly",
+    safeValidationCompleteTitle: "Validation Saved",
+    safeValidationCompleteMessage:
+      "Your changes have been saved. Please go to VolleyManager to complete the validation and finalize the game.",
+    safeValidationCompleteButton: "Open VolleyManager",
     privacy: "Privacy",
     privacyNoCollection:
       "VolleyKit does not collect or store any personal data.",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -454,6 +454,15 @@ const fr: Translations = {
     safeModeDangerous: "Les opérations dangereuses sont activées",
     safeModeBlocked:
       "Cette opération est bloquée en mode sécurisé. Désactivez le mode sécurisé dans les paramètres pour continuer.",
+    safeValidation: "Validation sécurisée",
+    safeValidationDescription:
+      "Lorsque activé, la validation enregistre vos modifications mais ne finalise pas le match. Vous serez invité à compléter la validation sur VolleyManager.",
+    safeValidationEnabled: "Validation sécurisée activée",
+    safeValidationDisabled: "Validation sécurisée désactivée - les matchs seront finalisés directement",
+    safeValidationCompleteTitle: "Validation enregistrée",
+    safeValidationCompleteMessage:
+      "Vos modifications ont été enregistrées. Veuillez aller sur VolleyManager pour compléter la validation et finaliser le match.",
+    safeValidationCompleteButton: "Ouvrir VolleyManager",
     privacy: "Confidentialité",
     privacyNoCollection:
       "VolleyKit ne collecte ni ne stocke aucune donnée personnelle.",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -452,6 +452,15 @@ const it: Translations = {
     safeModeDangerous: "Le operazioni pericolose sono abilitate",
     safeModeBlocked:
       "Questa operazione è bloccata in modalità sicura. Disattiva la modalità sicura nelle Impostazioni per procedere.",
+    safeValidation: "Convalida sicura",
+    safeValidationDescription:
+      "Quando attivata, la convalida salva le modifiche ma non finalizza la partita. Sarai invitato a completare la convalida su VolleyManager.",
+    safeValidationEnabled: "Convalida sicura attivata",
+    safeValidationDisabled: "Convalida sicura disattivata - le partite verranno finalizzate direttamente",
+    safeValidationCompleteTitle: "Convalida salvata",
+    safeValidationCompleteMessage:
+      "Le tue modifiche sono state salvate. Vai su VolleyManager per completare la convalida e finalizzare la partita.",
+    safeValidationCompleteButton: "Apri VolleyManager",
     privacy: "Privacy",
     privacyNoCollection:
       "VolleyKit non raccoglie né memorizza alcun dato personale.",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -313,6 +313,13 @@ export interface Translations {
     safeModeConfirmButton: string;
     safeModeDangerous: string;
     safeModeBlocked: string;
+    safeValidation: string;
+    safeValidationDescription: string;
+    safeValidationEnabled: string;
+    safeValidationDisabled: string;
+    safeValidationCompleteTitle: string;
+    safeValidationCompleteMessage: string;
+    safeValidationCompleteButton: string;
     privacy: string;
     privacyNoCollection: string;
     privacyDirectComm: string;

--- a/web-app/src/pages/SettingsPage.tsx
+++ b/web-app/src/pages/SettingsPage.tsx
@@ -16,6 +16,7 @@ import {
   DemoSection,
   AccessibilitySection,
   SafeModeSection,
+  SafeValidationSection,
   UpdateSection,
   ExperimentalSection,
   AboutSection,
@@ -36,10 +37,19 @@ export function SettingsPage() {
       refreshData: state.refreshData,
     })),
   );
-  const { isSafeModeEnabled, setSafeMode, preventZoom, setPreventZoom } = useSettingsStore(
+  const {
+    isSafeModeEnabled,
+    setSafeMode,
+    isSafeValidationEnabled,
+    setSafeValidation,
+    preventZoom,
+    setPreventZoom,
+  } = useSettingsStore(
     useShallow((state) => ({
       isSafeModeEnabled: state.isSafeModeEnabled,
       setSafeMode: state.setSafeMode,
+      isSafeValidationEnabled: state.isSafeValidationEnabled,
+      setSafeValidation: state.setSafeValidation,
       preventZoom: state.preventZoom,
       setPreventZoom: state.setPreventZoom,
     })),
@@ -82,10 +92,16 @@ export function SettingsPage() {
       )}
 
       {!isDemoMode && (
-        <SafeModeSection
-          isSafeModeEnabled={isSafeModeEnabled}
-          onSetSafeMode={setSafeMode}
-        />
+        <>
+          <SafeModeSection
+            isSafeModeEnabled={isSafeModeEnabled}
+            onSetSafeMode={setSafeMode}
+          />
+          <SafeValidationSection
+            isSafeValidationEnabled={isSafeValidationEnabled}
+            onSetSafeValidation={setSafeValidation}
+          />
+        </>
       )}
 
       {__PWA_ENABLED__ && <UpdateSection />}

--- a/web-app/src/stores/settings.test.ts
+++ b/web-app/src/stores/settings.test.ts
@@ -30,6 +30,7 @@ function resetStore(mode: DataSource = "api") {
   useSettingsStore.setState({
     // Global settings
     isSafeModeEnabled: true,
+    isSafeValidationEnabled: true,
     preventZoom: false,
     // Mode tracking
     currentMode: mode,
@@ -90,6 +91,45 @@ describe("useSettingsStore", () => {
     if (persistedData) {
       const parsed = JSON.parse(persistedData);
       expect(parsed.state.isSafeModeEnabled).toBe(false);
+    }
+  });
+
+  it("should have safe validation enabled by default", () => {
+    const { isSafeValidationEnabled } = useSettingsStore.getState();
+    expect(isSafeValidationEnabled).toBe(true);
+  });
+
+  it("should allow disabling safe validation", () => {
+    const { setSafeValidation } = useSettingsStore.getState();
+
+    setSafeValidation(false);
+
+    const { isSafeValidationEnabled } = useSettingsStore.getState();
+    expect(isSafeValidationEnabled).toBe(false);
+  });
+
+  it("should allow enabling safe validation", () => {
+    const { setSafeValidation } = useSettingsStore.getState();
+
+    setSafeValidation(false);
+    setSafeValidation(true);
+
+    const { isSafeValidationEnabled } = useSettingsStore.getState();
+    expect(isSafeValidationEnabled).toBe(true);
+  });
+
+  it("should persist safe validation setting", () => {
+    const { setSafeValidation } = useSettingsStore.getState();
+
+    setSafeValidation(false);
+
+    const storageKey = "volleykit-settings";
+    const persistedData = localStorage.getItem(storageKey);
+    expect(persistedData).toBeTruthy();
+
+    if (persistedData) {
+      const parsed = JSON.parse(persistedData);
+      expect(parsed.state.isSafeValidationEnabled).toBe(false);
     }
   });
 

--- a/web-app/src/stores/settings.ts
+++ b/web-app/src/stores/settings.ts
@@ -119,6 +119,10 @@ interface SettingsState {
   isSafeModeEnabled: boolean;
   setSafeMode: (enabled: boolean) => void;
 
+  // Safe validation mode (save only, don't finalize - redirect to VolleyManager)
+  isSafeValidationEnabled: boolean;
+  setSafeValidation: (enabled: boolean) => void;
+
   // Accessibility settings
   preventZoom: boolean;
   setPreventZoom: (enabled: boolean) => void;
@@ -215,6 +219,7 @@ export const useSettingsStore = create<SettingsState>()(
       (set, get) => ({
         // Global settings
         isSafeModeEnabled: true,
+        isSafeValidationEnabled: true,
         preventZoom: false,
 
         // Mode tracking
@@ -244,6 +249,10 @@ export const useSettingsStore = create<SettingsState>()(
 
         setSafeMode: (enabled: boolean) => {
           set({ isSafeModeEnabled: enabled });
+        },
+
+        setSafeValidation: (enabled: boolean) => {
+          set({ isSafeValidationEnabled: enabled });
         },
 
         setPreventZoom: (enabled: boolean) => {
@@ -383,6 +392,7 @@ export const useSettingsStore = create<SettingsState>()(
         partialize: (state) => ({
           // Global settings
           isSafeModeEnabled: state.isSafeModeEnabled,
+          isSafeValidationEnabled: state.isSafeValidationEnabled,
           preventZoom: state.preventZoom,
           // Mode-specific settings stored per mode
           settingsByMode: state.settingsByMode,
@@ -431,6 +441,7 @@ export const useSettingsStore = create<SettingsState>()(
           const persistedState = persisted as
             | {
                 isSafeModeEnabled?: boolean;
+                isSafeValidationEnabled?: boolean;
                 preventZoom?: boolean;
                 settingsByMode?: Record<DataSource, Partial<ModeSettings>>;
               }
@@ -475,6 +486,8 @@ export const useSettingsStore = create<SettingsState>()(
             ...current,
             // Preserve global settings
             isSafeModeEnabled: persistedState?.isSafeModeEnabled ?? current.isSafeModeEnabled,
+            isSafeValidationEnabled:
+              persistedState?.isSafeValidationEnabled ?? current.isSafeValidationEnabled,
             preventZoom: persistedState?.preventZoom ?? current.preventZoom,
             // Preserve mode-specific settings
             settingsByMode: mergedSettingsByMode,


### PR DESCRIPTION
## Summary

- Add "Safe Validation Mode" setting that saves validation changes without finalizing the game
- When enabled, shows a popup directing users to complete validation on VolleyManager
- New toggle in settings page next to Safe Mode toggle
- Translations for all 4 languages (de, en, fr, it)

## Test Plan

- [ ] Enable Safe Validation Mode in Settings
- [ ] Validate a game and click Finish
- [ ] Verify popup appears with "Open VolleyManager" button
- [ ] Verify changes are saved but game is not finalized
- [ ] Disable Safe Validation Mode and verify normal finalization works