### PR TITLE
refactor(web-app): show only association code in occupation dropdown

### DIFF
--- a/web-app/src/shared/components/layout/AppShell.error.test.tsx
+++ b/web-app/src/shared/components/layout/AppShell.error.test.tsx
@@ -92,9 +92,9 @@ describe("AppShell Error Handling", () => {
 
     renderAppShell();
 
-    await user.click(screen.getByRole("button", { name: /referee.*SV/i }));
+    await user.click(screen.getByRole("button", { name: "SV" }));
     const svrbaOption = await screen.findByRole("option", {
-      name: /SVRBA/i,
+      name: "SVRBA",
     });
     await user.click(svrbaOption);
 

--- a/web-app/src/shared/components/layout/AppShell.integration.test.tsx
+++ b/web-app/src/shared/components/layout/AppShell.integration.test.tsx
@@ -76,9 +76,9 @@ describe("AppShell Integration", () => {
       const user = userEvent.setup();
       renderAppShell();
 
-      // Find and click the dropdown button (shows current association)
+      // Find and click the dropdown button (shows current association code)
       const dropdownButton = screen.getByRole("button", {
-        name: /referee.*SV/i,
+        name: "SV",
       });
       expect(dropdownButton).toBeInTheDocument();
 
@@ -102,9 +102,9 @@ describe("AppShell Integration", () => {
       const user = userEvent.setup();
       renderAppShell();
 
-      // Initial state should show SV
+      // Initial state should show SV association code
       const dropdownButton = screen.getByRole("button", {
-        name: /referee.*SV/i,
+        name: "SV",
       });
       await user.click(dropdownButton);
 
@@ -132,7 +132,7 @@ describe("AppShell Integration", () => {
 
       // Open dropdown and switch
       const dropdownButton = screen.getByRole("button", {
-        name: /referee.*SV/i,
+        name: "SV",
       });
       await user.click(dropdownButton);
 
@@ -155,12 +155,12 @@ describe("AppShell Integration", () => {
       renderAppShell();
 
       const dropdownButton = screen.getByRole("button", {
-        name: /referee.*SV/i,
+        name: "SV",
       });
       await user.click(dropdownButton);
 
       const svrbaOption = await screen.findByRole("option", {
-        name: /SVRBA/i,
+        name: "SVRBA",
       });
       await user.click(svrbaOption);
 
@@ -180,7 +180,7 @@ describe("AppShell Integration", () => {
       renderAppShell();
 
       const dropdownButton = screen.getByRole("button", {
-        name: /referee.*SV/i,
+        name: "SV",
       });
       await user.click(dropdownButton);
 
@@ -189,7 +189,7 @@ describe("AppShell Integration", () => {
       expect(listbox).toBeVisible();
 
       // Select an option
-      const svrbaOption = screen.getByRole("option", { name: /SVRBA/i });
+      const svrbaOption = screen.getByRole("option", { name: "SVRBA" });
       await user.click(svrbaOption);
 
       // Dropdown should close
@@ -202,14 +202,14 @@ describe("AppShell Integration", () => {
       const user = userEvent.setup();
       renderAppShell();
 
-      // Initially shows SV
+      // Initially shows SV association code
       expect(
-        screen.getByRole("button", { name: /referee.*SV/i }),
+        screen.getByRole("button", { name: "SV" }),
       ).toBeInTheDocument();
 
       // Open dropdown and select SVRBA
-      await user.click(screen.getByRole("button", { name: /referee.*SV/i }));
-      await user.click(screen.getByRole("option", { name: /SVRBA/i }));
+      await user.click(screen.getByRole("button", { name: "SV" }));
+      await user.click(screen.getByRole("option", { name: "SVRBA" }));
 
       // State is updated AFTER the API call succeeds (not optimistically)
       // This prevents race conditions where queries refetch with wrong context

--- a/web-app/src/shared/components/layout/AppShell.tsx
+++ b/web-app/src/shared/components/layout/AppShell.tsx
@@ -93,15 +93,16 @@ export function AppShell() {
 
   const getOccupationLabel = useCallback(
     (occupation: Occupation): string => {
-      const labelKey = getOccupationLabelKey(occupation.type);
-      const baseLabel = t(labelKey);
+      // Prioritize showing the association/club identifier for easier differentiation
+      // Only fall back to occupation type if no identifier is available
       if (occupation.clubName) {
-        return `${baseLabel} (${occupation.clubName})`;
+        return occupation.clubName;
       }
       if (occupation.associationCode) {
-        return `${baseLabel} (${occupation.associationCode})`;
+        return occupation.associationCode;
       }
-      return baseLabel;
+      const labelKey = getOccupationLabelKey(occupation.type);
+      return t(labelKey);
     },
     [t],
   );


### PR DESCRIPTION
## Summary

- Remove occupation type prefix (e.g., "Referee") from the header dropdown button
- Display just the association code (e.g., "SV", "SVRBA") for easier identification
- Update tests to match the new label format

## Test Plan

- [x] Lint passes
- [x] All unit tests pass
- [x] Build succeeds