### PR TITLE
fix(demo): fix exchange validation errors and UX issues

### DIFF
--- a/web-app/src/features/assignments/AssignmentsPage.test.tsx
+++ b/web-app/src/features/assignments/AssignmentsPage.test.tsx
@@ -78,7 +78,7 @@ function mockAuthStoreState(overrides: Record<string, unknown> = {}) {
     return state as ReturnType<typeof authStore.useAuthStore>;
   });
 }
-vi.mock("@/shared/hooks/useAssignmentActions", () => ({
+vi.mock("./hooks/useAssignmentActions", () => ({
   useAssignmentActions: () => ({
     editCompensationModal: {
       isOpen: false,

--- a/web-app/src/features/assignments/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/features/assignments/hooks/useAssignmentActions.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createElement, type ReactNode } from "react";
 import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAssignmentActions } from "./useAssignmentActions";
 import type { Assignment } from "@/api/client";
 import * as authStore from "@/shared/stores/auth";
@@ -8,6 +10,22 @@ import * as languageStore from "@/shared/stores/language";
 import * as settingsStore from "@/shared/stores/settings";
 import { toast } from "@/shared/stores/toast";
 import { MODAL_CLEANUP_DELAY } from "../utils/assignment-helpers";
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
 
 vi.mock("@/shared/stores/auth");
 vi.mock("@/shared/stores/demo");
@@ -102,7 +120,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should initialize with closed modals", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     expect(result.current.editCompensationModal.isOpen).toBe(false);
     expect(result.current.editCompensationModal.assignment).toBeNull();
@@ -115,7 +133,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should open and close edit compensation modal", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     act(() => {
       result.current.editCompensationModal.open(mockAssignment);
@@ -146,7 +164,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should open and close validate game modal", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     act(() => {
       result.current.validateGameModal.open(mockAssignment);
@@ -173,7 +191,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should cleanup timeout on unmount", () => {
-    const { result, unmount } = renderHook(() => useAssignmentActions());
+    const { result, unmount } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     act(() => {
       result.current.editCompensationModal.open(mockAssignment);
@@ -193,7 +211,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should clear previous timeout when closing multiple times", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     act(() => {
       result.current.editCompensationModal.open(mockAssignment);
@@ -225,7 +243,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should open PDF report modal for NLA/NLB games", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     act(() => {
       result.current.handleGenerateReport(mockAssignment);
@@ -236,7 +254,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should block generate report for non-NLA/NLB games", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     const nonEligibleAssignment = createMockAssignment("1L");
 
@@ -249,7 +267,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should open PDF report modal for NLB games", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     const nlbAssignment = createMockAssignment("NLB");
 
@@ -262,7 +280,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should block generate report when league data is undefined", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     const assignmentWithoutLeague: Assignment = {
       __identity: "test-assignment-1",
@@ -291,7 +309,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should block generate report for second referee (head-two)", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     const secondRefereeAssignment: Assignment = {
       ...createMockAssignment("NLA"),
@@ -307,7 +325,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should block generate report for linesman positions", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     const linesmanAssignment: Assignment = {
       ...createMockAssignment("NLA"),
@@ -323,7 +341,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should open and close PDF report modal", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     act(() => {
       result.current.pdfReportModal.open(mockAssignment);
@@ -346,7 +364,7 @@ describe("useAssignmentActions", () => {
   });
 
   it("should handle add to exchange action", () => {
-    const { result } = renderHook(() => useAssignmentActions());
+    const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
     act(() => {
       result.current.handleAddToExchange(mockAssignment);
@@ -365,7 +383,7 @@ describe("useAssignmentActions", () => {
     });
 
     it("should use demo store for add to exchange in demo mode", () => {
-      const { result } = renderHook(() => useAssignmentActions());
+      const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
       act(() => {
         result.current.handleAddToExchange(mockAssignment);
@@ -378,7 +396,7 @@ describe("useAssignmentActions", () => {
     });
 
     it("should open PDF report modal in demo mode", () => {
-      const { result } = renderHook(() => useAssignmentActions());
+      const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
       act(() => {
         result.current.handleGenerateReport(mockAssignment);
@@ -404,7 +422,7 @@ describe("useAssignmentActions", () => {
     });
 
     it("should block add to exchange when safe mode is enabled", () => {
-      const { result } = renderHook(() => useAssignmentActions());
+      const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
       act(() => {
         result.current.handleAddToExchange(mockAssignment);
@@ -415,7 +433,7 @@ describe("useAssignmentActions", () => {
     });
 
     it("should block validate game when safe mode is enabled for unvalidated games", () => {
-      const { result } = renderHook(() => useAssignmentActions());
+      const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
       act(() => {
         result.current.validateGameModal.open(mockAssignment);
@@ -439,7 +457,7 @@ describe("useAssignmentActions", () => {
         },
       } as Assignment;
 
-      const { result } = renderHook(() => useAssignmentActions());
+      const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
       act(() => {
         result.current.validateGameModal.open(validatedAssignment);
@@ -457,7 +475,7 @@ describe("useAssignmentActions", () => {
         >),
       );
 
-      const { result } = renderHook(() => useAssignmentActions());
+      const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
       act(() => {
         result.current.handleAddToExchange(mockAssignment);

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -343,6 +343,7 @@ const de: Translations = {
     unavailableInCalendarModeTitle: "Im Kalender-Modus nicht verfügbar",
     unavailableInCalendarModeDescription:
       "Tauschbörsen-Funktionen sind im Kalender-Modus nicht verfügbar. Verwenden Sie die vollständige Anmeldung, um Tauschangebote zu durchsuchen und zu bewerben.",
+    hideOwn: "Eigene ausblenden",
     settings: {
       title: "Filtereinstellungen",
       maxDistance: "Maximale Entfernung",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -340,6 +340,7 @@ const en: Translations = {
     unavailableInCalendarModeTitle: "Not available in Calendar Mode",
     unavailableInCalendarModeDescription:
       "Exchange features are not available in calendar mode. Use full login to browse and apply for exchanges.",
+    hideOwn: "Hide own",
     settings: {
       title: "Filter Settings",
       maxDistance: "Maximum distance",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -342,6 +342,7 @@ const fr: Translations = {
     unavailableInCalendarModeTitle: "Non disponible en mode calendrier",
     unavailableInCalendarModeDescription:
       "Les fonctionnalités d'échange ne sont pas disponibles en mode calendrier. Utilisez la connexion complète pour parcourir et postuler aux échanges.",
+    hideOwn: "Masquer les miens",
     settings: {
       title: "Paramètres des filtres",
       maxDistance: "Distance maximale",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -340,6 +340,7 @@ const it: Translations = {
     unavailableInCalendarModeTitle: "Non disponibile in modalità calendario",
     unavailableInCalendarModeDescription:
       "Le funzionalità di scambio non sono disponibili in modalità calendario. Usa l'accesso completo per sfogliare e candidarti agli scambi.",
+    hideOwn: "Nascondi i miei",
     settings: {
       title: "Impostazioni filtri",
       maxDistance: "Distanza massima",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -217,6 +217,7 @@ export interface Translations {
     errorLoading: string;
     unavailableInCalendarModeTitle: string;
     unavailableInCalendarModeDescription: string;
+    hideOwn: string;
     settings: {
       title: string;
       maxDistance: string;

--- a/web-app/src/shared/stores/demo/types.ts
+++ b/web-app/src/shared/stores/demo/types.ts
@@ -10,6 +10,7 @@ import type {
   PersonSearchResult,
 } from "@/api/client";
 import type { MockNominationLists } from "../demo-generators";
+import { generateDemoUuid } from "@/shared/utils/demo-uuid";
 
 // Re-export generator types for consumers
 export type { DemoAssociationCode, MockNominationLists } from "../demo-generators";
@@ -48,7 +49,8 @@ export const DEMO_USER_REFEREE_LEVEL_GRADATION_VALUE = 2;
 
 // Demo user person identity used for filtering "my" exchanges
 // This matches the __identity used in submittedByPerson for demo exchanges
-export const DEMO_USER_PERSON_IDENTITY = "demo-me";
+// Uses generateDemoUuid to ensure a valid UUID format for API validation
+export const DEMO_USER_PERSON_IDENTITY = generateDemoUuid("demo-user-person");
 
 // Demo data is considered stale after 6 hours
 export const DEMO_DATA_STALENESS_MS = 6 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

Fixes several issues with the exchange functionality in demo mode:

### 1. Invalid UUID validation error
- Fixed validation error "Invalid input" for `submittedByPerson.__identity` when adding assignments to exchange
- The `DEMO_USER_PERSON_IDENTITY` constant was using `"demo-me"` which failed Zod UUID validation
- Changed to use `generateDemoUuid()` to produce a valid UUID v4 format
- Added contract tests to catch similar UUID validation issues

### 2. Query cache not invalidating
- After adding an assignment to exchange in demo mode, the exchanges query cache wasn't being invalidated
- This caused the new exchange not to appear when switching to the exchange tab until manual refresh
- Added query invalidation for both exchanges and assignments queries after adding to exchange

### 3. Wrong swipe action for own exchanges
- User's own exchanges in the "open" tab were showing "take over" action instead of "remove"
- The swipe action only checked exchange status, not whether it belonged to the current user
- Added `isOwnExchange` helper to check ownership and show correct action

### 4. New "Hide own" filter (UX improvement)
- Added "Hide own" filter toggle in the open tab (default: on)
- Filters out user's own exchanges from the open tab
- Users can disable this to see their own exchanges alongside others
- Added translations in all 4 languages (de, en, fr, it)

## Test Plan
- [x] Run `npm test` - all tests pass including new contract tests
- [x] Run `npm run build` - production build succeeds
- [ ] Test in demo mode:
  - [ ] Add assignment to exchange, verify no validation error
  - [ ] Switch to exchange tab, verify new exchange appears immediately
  - [ ] Own exchanges in open tab show "remove" action (not "take over")
  - [ ] "Hide own" filter hides user's exchanges in open tab