### PR TITLE
feat(ocr-poc): add team confirmation modal for low-confidence detection

### DIFF
--- a/ocr-poc/src/components/PlayerComparison.js
+++ b/ocr-poc/src/components/PlayerComparison.js
@@ -321,6 +321,15 @@ function compareTeams(ocrTeam, refTeam) {
  */
 const CONFIDENCE_THRESHOLD = 2;
 
+/** Weight for match ratio in confidence calculation (0-100 scale contribution) */
+const MATCH_RATIO_WEIGHT = 50;
+
+/** Weight for score difference ratio in confidence calculation (0-100 scale contribution) */
+const DIFF_RATIO_WEIGHT = 50;
+
+/** Minimum confidence score required to skip user confirmation */
+const MINIMUM_CONFIDENCE_SCORE = 50;
+
 /**
  * Try to match OCR teams to reference teams
  * Since we don't know which column is which team, we try both combinations
@@ -363,11 +372,11 @@ function findBestTeamMapping(ocrTeamA, ocrTeamB, refTeamA, refTeamB) {
   if (totalPossible > 0) {
     const matchRatio = maxScore / totalPossible;
     const diffRatio = scoreDiff / Math.max(1, maxScore);
-    confidenceScore = Math.round((matchRatio * 50) + (diffRatio * 50));
+    confidenceScore = Math.round((matchRatio * MATCH_RATIO_WEIGHT) + (diffRatio * DIFF_RATIO_WEIGHT));
   }
 
   // Determine if we're confident in the mapping
-  const isConfident = scoreDiff >= CONFIDENCE_THRESHOLD && confidenceScore >= 50;
+  const isConfident = scoreDiff >= CONFIDENCE_THRESHOLD && confidenceScore >= MINIMUM_CONFIDENCE_SCORE;
 
   if (option2Score > option1Score) {
     return {
@@ -599,15 +608,6 @@ export class PlayerComparison {
       this.referenceData.teamA,
       this.referenceData.teamB,
     );
-
-    console.log('Team mapping analysis:', {
-      isConfident: mapping.isConfident,
-      confidenceScore: mapping.confidenceScore,
-      option1Score: mapping.option1Score,
-      option2Score: mapping.option2Score,
-      autoSwapped: mapping.swapped,
-      isManuscript: this.isManuscript,
-    });
 
     // Show confirmation modal if:
     // 1. Confidence is low (scores are close)

--- a/ocr-poc/src/components/TeamConfirmationModal.js
+++ b/ocr-poc/src/components/TeamConfirmationModal.js
@@ -24,6 +24,9 @@
  * @property {() => void} [onCancel] - Called when user cancels
  */
 
+/** Duration of the swap button rotation animation in milliseconds */
+const SWAP_ANIMATION_DURATION_MS = 300;
+
 /**
  * Escape HTML to prevent XSS
  * @param {string} text
@@ -235,7 +238,7 @@ export class TeamConfirmationModal {
     swapBtn?.classList.add('team-confirm__swap-btn--animating');
     setTimeout(() => {
       swapBtn?.classList.remove('team-confirm__swap-btn--animating');
-    }, 300);
+    }, SWAP_ANIMATION_DURATION_MS);
   }
 
   /**

--- a/ocr-poc/src/components/TeamConfirmationModal.js
+++ b/ocr-poc/src/components/TeamConfirmationModal.js
@@ -1,0 +1,272 @@
+/**
+ * Team Confirmation Modal Component
+ *
+ * A modal dialog that asks the user to confirm which team is on the left
+ * and which is on the right when OCR team detection has low confidence.
+ *
+ * This is particularly useful for manuscript scoresheets where OCR
+ * success rates may be lower.
+ */
+
+/**
+ * @typedef {Object} TeamInfo
+ * @property {string} name - Team name from OCR
+ * @property {number} playerCount - Number of players detected
+ */
+
+/**
+ * @typedef {Object} TeamConfirmationModalOptions
+ * @property {HTMLElement} container - Container element for the modal
+ * @property {TeamInfo} leftTeam - Team detected on the left side
+ * @property {TeamInfo} rightTeam - Team detected on the right side
+ * @property {number} confidenceScore - Confidence score (0-100) for the auto-mapping
+ * @property {(swapped: boolean) => void} onConfirm - Called when user confirms
+ * @property {() => void} [onCancel] - Called when user cancels
+ */
+
+/**
+ * Escape HTML to prevent XSS
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+/**
+ * TeamConfirmationModal Component
+ */
+export class TeamConfirmationModal {
+  /**
+   * @param {TeamConfirmationModalOptions} options
+   */
+  constructor({ container, leftTeam, rightTeam, confidenceScore, onConfirm, onCancel }) {
+    this.container = container;
+    this.leftTeam = leftTeam;
+    this.rightTeam = rightTeam;
+    this.confidenceScore = confidenceScore;
+    this.onConfirm = onConfirm;
+    this.onCancel = onCancel;
+
+    /** @type {boolean} */
+    this.swapped = false;
+
+    /** @type {HTMLElement | null} */
+    this.backdropEl = null;
+
+    /** @type {HTMLElement | null} */
+    this.dialogEl = null;
+
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleBackdropClick = this.handleBackdropClick.bind(this);
+
+    this.render();
+    this.bindEvents();
+  }
+
+  render() {
+    const leftName = escapeHtml(this.leftTeam.name || 'Unknown Team');
+    const rightName = escapeHtml(this.rightTeam.name || 'Unknown Team');
+    const leftCount = this.leftTeam.playerCount;
+    const rightCount = this.rightTeam.playerCount;
+
+    // Show warning based on confidence
+    const confidenceWarning =
+      this.confidenceScore < 50
+        ? `<p class="team-confirm__warning">
+            <span class="team-confirm__warning-icon">⚠</span>
+            Low confidence in automatic team detection (${this.confidenceScore}%)
+          </p>`
+        : '';
+
+    this.container.innerHTML = `
+      <div class="team-confirm__backdrop" role="presentation">
+        <div
+          class="team-confirm__dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="team-confirm-title"
+          aria-describedby="team-confirm-description"
+        >
+          <h2 id="team-confirm-title" class="team-confirm__title">
+            Confirm Team Positions
+          </h2>
+
+          <p id="team-confirm-description" class="team-confirm__description">
+            Please verify which team is on the left and right sides of the scoresheet.
+          </p>
+
+          ${confidenceWarning}
+
+          <div class="team-confirm__teams" id="team-options">
+            <div class="team-confirm__team-card team-confirm__team-card--left">
+              <span class="team-confirm__team-label">Left Column (Team A)</span>
+              <span class="team-confirm__team-name" id="left-team-name">${leftName}</span>
+              <span class="team-confirm__team-count" id="left-team-count">${leftCount} players</span>
+            </div>
+
+            <button
+              type="button"
+              class="team-confirm__swap-btn"
+              id="btn-swap-teams"
+              aria-label="Swap teams"
+              title="Swap team positions"
+            >
+              <svg class="team-confirm__swap-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M7 16V4M7 4L3 8M7 4L11 8"></path>
+                <path d="M17 8V20M17 20L21 16M17 20L13 16"></path>
+              </svg>
+            </button>
+
+            <div class="team-confirm__team-card team-confirm__team-card--right">
+              <span class="team-confirm__team-label">Right Column (Team B)</span>
+              <span class="team-confirm__team-name" id="right-team-name">${rightName}</span>
+              <span class="team-confirm__team-count" id="right-team-count">${rightCount} players</span>
+            </div>
+          </div>
+
+          <div class="team-confirm__actions">
+            <button type="button" class="btn btn-secondary" id="btn-cancel">
+              Cancel
+            </button>
+            <button type="button" class="btn btn-primary" id="btn-confirm">
+              Confirm
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+
+    this.backdropEl = this.container.querySelector('.team-confirm__backdrop');
+    this.dialogEl = this.container.querySelector('.team-confirm__dialog');
+
+    // Focus the confirm button by default
+    const confirmBtn = this.container.querySelector('#btn-confirm');
+    confirmBtn?.focus();
+  }
+
+  bindEvents() {
+    // Swap button
+    const swapBtn = this.container.querySelector('#btn-swap-teams');
+    swapBtn?.addEventListener('click', () => this.handleSwap());
+
+    // Confirm button
+    const confirmBtn = this.container.querySelector('#btn-confirm');
+    confirmBtn?.addEventListener('click', () => this.handleConfirm());
+
+    // Cancel button
+    const cancelBtn = this.container.querySelector('#btn-cancel');
+    cancelBtn?.addEventListener('click', () => this.handleCancel());
+
+    // Keyboard events
+    document.addEventListener('keydown', this.handleKeyDown);
+
+    // Backdrop click
+    this.backdropEl?.addEventListener('click', this.handleBackdropClick);
+  }
+
+  /**
+   * Handle keyboard events
+   * @param {KeyboardEvent} event
+   */
+  handleKeyDown(event) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.handleCancel();
+    }
+
+    // Tab trapping
+    if (event.key === 'Tab') {
+      const focusableElements = this.dialogEl?.querySelectorAll(
+        'button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusableElements && focusableElements.length > 0) {
+        const firstEl = focusableElements[0];
+        const lastEl = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey && document.activeElement === firstEl) {
+          event.preventDefault();
+          lastEl.focus();
+        } else if (!event.shiftKey && document.activeElement === lastEl) {
+          event.preventDefault();
+          firstEl.focus();
+        }
+      }
+    }
+  }
+
+  /**
+   * Handle backdrop click (close modal)
+   * @param {MouseEvent} event
+   */
+  handleBackdropClick(event) {
+    // Only close if clicking directly on backdrop, not dialog
+    if (event.target === this.backdropEl) {
+      this.handleCancel();
+    }
+  }
+
+  /**
+   * Swap team positions
+   */
+  handleSwap() {
+    this.swapped = !this.swapped;
+
+    // Update the displayed names
+    const leftNameEl = this.container.querySelector('#left-team-name');
+    const rightNameEl = this.container.querySelector('#right-team-name');
+    const leftCountEl = this.container.querySelector('#left-team-count');
+    const rightCountEl = this.container.querySelector('#right-team-count');
+
+    if (leftNameEl && rightNameEl && leftCountEl && rightCountEl) {
+      const displayLeft = this.swapped ? this.rightTeam : this.leftTeam;
+      const displayRight = this.swapped ? this.leftTeam : this.rightTeam;
+
+      leftNameEl.textContent = displayLeft.name || 'Unknown Team';
+      rightNameEl.textContent = displayRight.name || 'Unknown Team';
+      leftCountEl.textContent = `${displayLeft.playerCount} players`;
+      rightCountEl.textContent = `${displayRight.playerCount} players`;
+    }
+
+    // Animate the swap button
+    const swapBtn = this.container.querySelector('#btn-swap-teams');
+    swapBtn?.classList.add('team-confirm__swap-btn--animating');
+    setTimeout(() => {
+      swapBtn?.classList.remove('team-confirm__swap-btn--animating');
+    }, 300);
+  }
+
+  /**
+   * Handle confirm action
+   */
+  handleConfirm() {
+    this.cleanup();
+    this.onConfirm(this.swapped);
+  }
+
+  /**
+   * Handle cancel action
+   */
+  handleCancel() {
+    this.cleanup();
+    this.onCancel?.();
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  cleanup() {
+    document.removeEventListener('keydown', this.handleKeyDown);
+    this.backdropEl?.removeEventListener('click', this.handleBackdropClick);
+  }
+
+  /**
+   * Destroy the component
+   */
+  destroy() {
+    this.cleanup();
+    this.container.innerHTML = '';
+  }
+}

--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -510,9 +510,12 @@ function renderComparisonState(container) {
 
   const comparisonContainer = document.getElementById('player-comparison-container');
   if (comparisonContainer && appContext.ocrResult) {
+    // Pass isManuscript flag so the component knows to show confirmation modal
+    // for manuscript scoresheets (which may have lower OCR accuracy)
     playerComparison = new PlayerComparison({
       container: comparisonContainer,
       ocrText: appContext.ocrResult.fullText,
+      isManuscript: appContext.sheetType === 'manuscript',
       onBack: handleBackToResults,
     });
   }

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -1423,3 +1423,211 @@ body {
     min-width: 80px;
   }
 }
+
+/* ==============================================
+ * TEAM CONFIRMATION MODAL COMPONENT
+ * ============================================== */
+
+.team-confirm__backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.6);
+  padding: var(--spacing-md);
+  /* iOS safe area support */
+  padding-top: max(var(--spacing-md), env(safe-area-inset-top));
+  padding-bottom: max(var(--spacing-md), env(safe-area-inset-bottom));
+  padding-left: max(var(--spacing-md), env(safe-area-inset-left));
+  padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+}
+
+.team-confirm__dialog {
+  background-color: var(--color-surface-card);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  padding: var(--spacing-lg);
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.team-confirm__title {
+  margin: 0 0 var(--spacing-sm) 0;
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  text-align: center;
+}
+
+.team-confirm__description {
+  margin: 0 0 var(--spacing-md) 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.team-confirm__warning {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  margin: 0 0 var(--spacing-md) 0;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: #92400e;
+}
+
+.team-confirm__warning-icon {
+  font-size: var(--font-size-base);
+}
+
+.team-confirm__teams {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+}
+
+.team-confirm__team-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-md);
+  background-color: var(--color-surface-subtle);
+  border: 2px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  min-width: 0;
+}
+
+.team-confirm__team-card--left {
+  border-color: var(--color-primary-300);
+  background-color: var(--color-primary-50);
+}
+
+.team-confirm__team-card--right {
+  border-color: var(--color-success-500);
+  background-color: #dcfce7;
+}
+
+.team-confirm__team-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.team-confirm__team-name {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.team-confirm__team-count {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.team-confirm__swap-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  background-color: var(--color-gray-200);
+  border: 2px solid var(--color-border-strong);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.team-confirm__swap-btn:hover {
+  background-color: var(--color-gray-300);
+  border-color: var(--color-gray-400);
+}
+
+.team-confirm__swap-btn:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}
+
+.team-confirm__swap-btn:active {
+  transform: scale(0.95);
+}
+
+.team-confirm__swap-btn--animating {
+  animation: swap-rotate 0.3s ease;
+}
+
+@keyframes swap-rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(180deg);
+  }
+}
+
+.team-confirm__swap-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--color-text-secondary);
+}
+
+.team-confirm__actions {
+  display: flex;
+  gap: var(--spacing-md);
+  justify-content: flex-end;
+}
+
+.team-confirm__actions .btn {
+  min-width: 100px;
+}
+
+/* Small screen adjustments for team cards */
+@media (max-width: 400px) {
+  .team-confirm__teams {
+    flex-direction: column;
+  }
+
+  .team-confirm__team-card {
+    width: 100%;
+  }
+
+  .team-confirm__swap-btn {
+    transform: rotate(90deg);
+  }
+
+  .team-confirm__swap-btn--animating {
+    animation: swap-rotate-vertical 0.3s ease;
+  }
+
+  @keyframes swap-rotate-vertical {
+    0% {
+      transform: rotate(90deg);
+    }
+    100% {
+      transform: rotate(270deg);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add TeamConfirmationModal component that asks users to confirm team positions (left/right) when OCR detection is uncertain
- Update PlayerComparison to calculate confidence scores and show modal when confidence is low
- Show confirmation modal for manuscript scoresheets (lower OCR reliability) or when mapping scores are close
- Add swap button to easily switch team positions with animation

## Test Plan

- [ ] Test electronic scoresheet with high-confidence detection (modal should NOT appear)
- [ ] Test manuscript scoresheet (modal should appear)
- [ ] Test swap button updates team names correctly
- [ ] Test Escape key closes modal
- [ ] Test backdrop click closes modal
- [ ] Verify comparison results reflect user's team choice