### PR TITLE
feat(tour): add auto-swipe demo for guided tour swipe steps

### DIFF
--- a/web-app/src/features/assignments/assignments.ts
+++ b/web-app/src/features/assignments/assignments.ts
@@ -18,6 +18,7 @@ export const assignmentsTour: TourDefinition = {
       descriptionKey: "tour.assignments.swipeValidate.description",
       placement: "bottom",
       completionEvent: { type: "swipe" },
+      autoSwipe: { direction: "left" },
     },
     {
       id: "swipe-exchange",
@@ -26,6 +27,7 @@ export const assignmentsTour: TourDefinition = {
       descriptionKey: "tour.assignments.swipeExchange.description",
       placement: "bottom",
       completionEvent: { type: "swipe" },
+      autoSwipe: { direction: "right" },
     },
     {
       id: "tap-details",

--- a/web-app/src/features/compensations/compensations.ts
+++ b/web-app/src/features/compensations/compensations.ts
@@ -18,6 +18,7 @@ export const compensationsTour: TourDefinition = {
       descriptionKey: "tour.compensations.swipeEdit.description",
       placement: "bottom",
       completionEvent: { type: "swipe" },
+      autoSwipe: { direction: "left" },
     },
     {
       id: "tap-details",

--- a/web-app/src/features/exchanges/exchange.ts
+++ b/web-app/src/features/exchanges/exchange.ts
@@ -18,6 +18,7 @@ export const exchangeTour: TourDefinition = {
       descriptionKey: "tour.exchange.apply.description",
       placement: "bottom",
       completionEvent: { type: "swipe" },
+      autoSwipe: { direction: "left" },
     },
     {
       id: "filters",

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -110,6 +110,9 @@ const de: Translations = {
       swipeSuccess: "Tolle Wischbewegung! Sie haben den Dreh raus.",
       tapSuccess: "Perfekt! Tippen Sie, um mehr Details zu entdecken.",
     },
+    accessibility: {
+      swipeDemoInProgress: "Wischgeste wird demonstriert",
+    },
   },
   common: {
     loading: "Laden...",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -110,6 +110,9 @@ const en: Translations = {
       swipeSuccess: "Great swipe! You've got the hang of it.",
       tapSuccess: "Perfect! Tap to explore more details.",
     },
+    accessibility: {
+      swipeDemoInProgress: "Demonstrating swipe gesture",
+    },
   },
   common: {
     loading: "Loading...",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -110,6 +110,9 @@ const fr: Translations = {
       swipeSuccess: "Excellent glissement ! Vous avez compris le principe.",
       tapSuccess: "Parfait ! Appuyez pour découvrir plus de détails.",
     },
+    accessibility: {
+      swipeDemoInProgress: "Démonstration du geste de glissement",
+    },
   },
   common: {
     loading: "Chargement...",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -110,6 +110,9 @@ const it: Translations = {
       swipeSuccess: "Ottimo scorrimento! Hai capito come funziona.",
       tapSuccess: "Perfetto! Tocca per esplorare più dettagli.",
     },
+    accessibility: {
+      swipeDemoInProgress: "Dimostrazione del gesto di scorrimento",
+    },
   },
   common: {
     loading: "Caricamento...",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -604,5 +604,8 @@ export interface Translations {
       swipeSuccess: string;
       tapSuccess: string;
     };
+    accessibility: {
+      swipeDemoInProgress: string;
+    };
   };
 }

--- a/web-app/src/shared/components/tour/TourAutoSwipe.test.tsx
+++ b/web-app/src/shared/components/tour/TourAutoSwipe.test.tsx
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { TourAutoSwipe } from "./TourAutoSwipe";
+
+// Mock the translation hook
+vi.mock("@/shared/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "tour.accessibility.swipeDemoInProgress": "Demonstrating swipe gesture",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+describe("TourAutoSwipe", () => {
+  let container: HTMLDivElement;
+  let swipeableContent: HTMLDivElement;
+
+  beforeEach(() => {
+    // Create a mock SwipeableCard structure
+    container = document.createElement("div");
+    container.setAttribute("data-tour", "test-card");
+    container.style.width = "300px";
+
+    swipeableContent = document.createElement("div");
+    swipeableContent.className = "z-10 bg-white";
+    swipeableContent.style.transform = "translateX(0px)";
+
+    container.appendChild(swipeableContent);
+    document.body.appendChild(container);
+
+    // Mock getBoundingClientRect
+    container.getBoundingClientRect = vi.fn(() => ({
+      width: 300,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 300,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+
+    vi.useFakeTimers();
+
+    // Mock requestAnimationFrame to execute callback synchronously
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const defaultProps = {
+    targetSelector: "[data-tour='test-card']",
+    direction: "left" as const,
+    onComplete: vi.fn(),
+  };
+
+  describe("animation", () => {
+    it("applies swipe animation after delay", async () => {
+      render(<TourAutoSwipe {...defaultProps} delay={500} duration={1000} />);
+
+      // Before delay, transform should be unchanged
+      expect(swipeableContent.style.transform).toBe("translateX(0px)");
+
+      // Advance past delay
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // Run animation frame
+      await act(async () => {
+        vi.advanceTimersByTime(16); // One frame
+      });
+
+      // Transform should now be applied (left swipe = negative translateX)
+      expect(swipeableContent.style.transform).toContain("translateX(-");
+    });
+
+    it("swipes left when direction is left", async () => {
+      render(
+        <TourAutoSwipe {...defaultProps} direction="left" delay={100} duration={500} />
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+
+      // Left swipe should have negative translateX
+      expect(swipeableContent.style.transform).toMatch(/translateX\(-\d+/);
+    });
+
+    it("swipes right when direction is right", async () => {
+      render(
+        <TourAutoSwipe {...defaultProps} direction="right" delay={100} duration={500} />
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+
+      // Right swipe should have positive translateX (no minus sign after the opening paren)
+      expect(swipeableContent.style.transform).toMatch(/translateX\(\d+/);
+    });
+
+    it("blocks pointer events during animation", async () => {
+      render(<TourAutoSwipe {...defaultProps} delay={100} duration={1000} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+
+      expect(swipeableContent.style.pointerEvents).toBe("none");
+    });
+
+    it("restores pointer events after animation completes", async () => {
+      render(<TourAutoSwipe {...defaultProps} delay={100} duration={500} />);
+
+      // Start animation
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+
+      // Complete animation
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(swipeableContent.style.pointerEvents).toBe("");
+    });
+  });
+
+  describe("onComplete callback", () => {
+    it("calls onComplete after animation duration", async () => {
+      const onComplete = vi.fn();
+
+      render(
+        <TourAutoSwipe
+          {...defaultProps}
+          onComplete={onComplete}
+          delay={100}
+          duration={500}
+        />
+      );
+
+      // Before animation completes
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+      expect(onComplete).not.toHaveBeenCalled();
+
+      // After animation completes
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it("dispatches tour-swipe-complete event on container", async () => {
+      const eventHandler = vi.fn();
+      container.addEventListener("tour-swipe-complete", eventHandler);
+
+      render(<TourAutoSwipe {...defaultProps} delay={100} duration={500} />);
+
+      await act(async () => {
+        vi.advanceTimersByTime(620); // delay + duration
+      });
+
+      expect(eventHandler).toHaveBeenCalledTimes(1);
+
+      container.removeEventListener("tour-swipe-complete", eventHandler);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("cleans up animation on unmount during delay", async () => {
+      const { unmount } = render(
+        <TourAutoSwipe {...defaultProps} delay={1000} duration={500} />
+      );
+
+      // Unmount before delay completes
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+      unmount();
+
+      // Advance past when animation would have started
+      await act(async () => {
+        vi.advanceTimersByTime(1500);
+      });
+
+      // Transform should be unchanged (animation never started)
+      expect(swipeableContent.style.transform).toBe("translateX(0px)");
+    });
+
+    it("restores original styles on unmount during animation", async () => {
+      const originalTransform = swipeableContent.style.transform;
+
+      const { unmount } = render(
+        <TourAutoSwipe {...defaultProps} delay={100} duration={2000} />
+      );
+
+      // Start animation
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+
+      // Unmount during animation
+      unmount();
+
+      // Styles should be restored
+      expect(swipeableContent.style.transform).toBe(originalTransform);
+      expect(swipeableContent.style.pointerEvents).toBe("");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("does not animate when target element is not found", async () => {
+      const onComplete = vi.fn();
+
+      render(
+        <TourAutoSwipe
+          {...defaultProps}
+          targetSelector=".nonexistent"
+          onComplete={onComplete}
+          delay={100}
+          duration={500}
+        />
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(700);
+      });
+
+      // onComplete should not be called since target wasn't found
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it("does not animate when swipeable content is not found", async () => {
+      // Remove the swipeable content
+      container.removeChild(swipeableContent);
+
+      const onComplete = vi.fn();
+
+      render(
+        <TourAutoSwipe {...defaultProps} onComplete={onComplete} delay={100} duration={500} />
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(700);
+      });
+
+      expect(onComplete).not.toHaveBeenCalled();
+
+      // Restore for cleanup
+      container.appendChild(swipeableContent);
+    });
+
+    it("only animates once even if re-rendered", async () => {
+      const onComplete = vi.fn();
+
+      const { rerender } = render(
+        <TourAutoSwipe {...defaultProps} onComplete={onComplete} delay={100} duration={500} />
+      );
+
+      // Start first animation
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+
+      // Rerender
+      rerender(
+        <TourAutoSwipe {...defaultProps} onComplete={onComplete} delay={100} duration={500} />
+      );
+
+      // Complete animation
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // Should only complete once
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("accessibility", () => {
+    it("renders aria-live region with announcement", async () => {
+      render(<TourAutoSwipe {...defaultProps} />);
+
+      // The aria-live region should be rendered immediately
+      const announcement = screen.getByRole("status");
+      expect(announcement).toBeInTheDocument();
+      expect(announcement).toHaveAttribute("aria-live", "polite");
+      expect(announcement).toHaveAttribute("aria-atomic", "true");
+      expect(announcement).toHaveTextContent("Demonstrating swipe gesture");
+    });
+
+    it("renders announcement as visually hidden (sr-only)", () => {
+      render(<TourAutoSwipe {...defaultProps} />);
+
+      const announcement = screen.getByRole("status");
+      expect(announcement).toHaveClass("sr-only");
+    });
+  });
+
+  describe("default values", () => {
+    it("uses default duration of 1500ms", async () => {
+      const onComplete = vi.fn();
+
+      render(
+        <TourAutoSwipe
+          targetSelector={defaultProps.targetSelector}
+          direction="left"
+          onComplete={onComplete}
+          delay={100}
+        />
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+
+      // Should not complete before 1500ms
+      await act(async () => {
+        vi.advanceTimersByTime(1400);
+      });
+      expect(onComplete).not.toHaveBeenCalled();
+
+      // Should complete after 1500ms
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    it("uses default delay of 800ms", async () => {
+      render(
+        <TourAutoSwipe
+          targetSelector={defaultProps.targetSelector}
+          direction="left"
+          onComplete={vi.fn()}
+          duration={100}
+        />
+      );
+
+      // Transform should be unchanged before delay
+      await act(async () => {
+        vi.advanceTimersByTime(700);
+      });
+      expect(swipeableContent.style.transform).toBe("translateX(0px)");
+
+      // Transform should change after delay
+      await act(async () => {
+        vi.advanceTimersByTime(120);
+      });
+      expect(swipeableContent.style.transform).not.toBe("translateX(0px)");
+    });
+  });
+});

--- a/web-app/src/shared/components/tour/TourAutoSwipe.tsx
+++ b/web-app/src/shared/components/tour/TourAutoSwipe.tsx
@@ -60,33 +60,26 @@ export function TourAutoSwipe({
       swipeableContent.style.transform = `translateX(${targetTranslate}px)`;
     });
 
-    // Set up cleanup function
+    // Set up cleanup function (resets styles if component unmounts during animation)
     cleanupRef.current = () => {
       swipeableContent.style.transition = originalTransition;
       swipeableContent.style.transform = originalTransform;
       swipeableContent.style.pointerEvents = originalPointerEvents;
     };
 
-    // After animation completes, return to original position and dispatch event
-    const returnTimer = setTimeout(() => {
-      // Quick return animation
-      swipeableContent.style.transition = "transform 300ms cubic-bezier(0.25, 0.1, 0.25, 1)";
-      swipeableContent.style.transform = originalTransform || "translateX(0px)";
+    // After animation completes, leave drawer open and dispatch completion event
+    const completeTimer = setTimeout(() => {
+      // Restore transition and pointer events, but keep the drawer open
+      swipeableContent.style.transition = originalTransition;
+      swipeableContent.style.pointerEvents = originalPointerEvents;
+      cleanupRef.current = null;
 
-      // Wait for return animation, then complete
-      setTimeout(() => {
-        // Restore original styles
-        swipeableContent.style.transition = originalTransition;
-        swipeableContent.style.pointerEvents = originalPointerEvents;
-        cleanupRef.current = null;
-
-        // Dispatch completion event on the container
-        container.dispatchEvent(new CustomEvent("tour-swipe-complete"));
-        onComplete();
-      }, 350);
+      // Dispatch completion event on the container
+      container.dispatchEvent(new CustomEvent("tour-swipe-complete"));
+      onComplete();
     }, duration);
 
-    return () => clearTimeout(returnTimer);
+    return () => clearTimeout(completeTimer);
   }, [targetSelector, direction, duration, onComplete]);
 
   useEffect(() => {

--- a/web-app/src/shared/components/tour/TourAutoSwipe.tsx
+++ b/web-app/src/shared/components/tour/TourAutoSwipe.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "@/shared/hooks/useTranslation";
 
 interface TourAutoSwipeProps {
   targetSelector: string;
@@ -21,6 +23,7 @@ export function TourAutoSwipe({
   delay = DEFAULT_DELAY_MS,
   onComplete,
 }: TourAutoSwipeProps) {
+  const { t } = useTranslation();
   const animationRef = useRef<number | null>(null);
   const hasAnimatedRef = useRef(false);
   const cleanupRef = useRef<(() => void) | null>(null);
@@ -100,6 +103,16 @@ export function TourAutoSwipe({
     };
   }, [delay, runAnimation]);
 
-  // This component doesn't render anything visible
-  return null;
+  // Render a visually hidden aria-live region to announce the demo to screen readers
+  return createPortal(
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+    >
+      {t("tour.accessibility.swipeDemoInProgress")}
+    </div>,
+    document.body,
+  );
 }

--- a/web-app/src/shared/components/tour/TourAutoSwipe.tsx
+++ b/web-app/src/shared/components/tour/TourAutoSwipe.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useCallback } from "react";
+
+interface TourAutoSwipeProps {
+  targetSelector: string;
+  direction: "left" | "right";
+  duration?: number;
+  delay?: number;
+  onComplete: () => void;
+}
+
+// Default timing values
+const DEFAULT_DURATION_MS = 1500;
+const DEFAULT_DELAY_MS = 800;
+// Swipe distance as percentage of container width
+const SWIPE_DISTANCE_RATIO = 0.35;
+
+export function TourAutoSwipe({
+  targetSelector,
+  direction,
+  duration = DEFAULT_DURATION_MS,
+  delay = DEFAULT_DELAY_MS,
+  onComplete,
+}: TourAutoSwipeProps) {
+  const animationRef = useRef<number | null>(null);
+  const hasAnimatedRef = useRef(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const runAnimation = useCallback(() => {
+    if (hasAnimatedRef.current) return;
+
+    const container = document.querySelector(targetSelector);
+    if (!container) return;
+
+    // Find the swipeable content div (has z-10 and bg-white classes)
+    const swipeableContent = container.querySelector(
+      ".z-10.bg-white, .z-10.bg-gray-800",
+    ) as HTMLElement | null;
+    if (!swipeableContent) return;
+
+    hasAnimatedRef.current = true;
+
+    // Calculate swipe distance
+    const containerWidth = container.getBoundingClientRect().width;
+    const swipeDistance = containerWidth * SWIPE_DISTANCE_RATIO;
+    const targetTranslate = direction === "left" ? -swipeDistance : swipeDistance;
+
+    // Store original styles for cleanup
+    const originalTransition = swipeableContent.style.transition;
+    const originalTransform = swipeableContent.style.transform;
+    const originalPointerEvents = swipeableContent.style.pointerEvents;
+
+    // Block user interactions during animation
+    swipeableContent.style.pointerEvents = "none";
+
+    // Apply slow easing transition
+    swipeableContent.style.transition = `transform ${duration}ms cubic-bezier(0.25, 0.1, 0.25, 1)`;
+
+    // Start the swipe animation
+    requestAnimationFrame(() => {
+      swipeableContent.style.transform = `translateX(${targetTranslate}px)`;
+    });
+
+    // Set up cleanup function
+    cleanupRef.current = () => {
+      swipeableContent.style.transition = originalTransition;
+      swipeableContent.style.transform = originalTransform;
+      swipeableContent.style.pointerEvents = originalPointerEvents;
+    };
+
+    // After animation completes, return to original position and dispatch event
+    const returnTimer = setTimeout(() => {
+      // Quick return animation
+      swipeableContent.style.transition = "transform 300ms cubic-bezier(0.25, 0.1, 0.25, 1)";
+      swipeableContent.style.transform = originalTransform || "translateX(0px)";
+
+      // Wait for return animation, then complete
+      setTimeout(() => {
+        // Restore original styles
+        swipeableContent.style.transition = originalTransition;
+        swipeableContent.style.pointerEvents = originalPointerEvents;
+        cleanupRef.current = null;
+
+        // Dispatch completion event on the container
+        container.dispatchEvent(new CustomEvent("tour-swipe-complete"));
+        onComplete();
+      }, 350);
+    }, duration);
+
+    return () => clearTimeout(returnTimer);
+  }, [targetSelector, direction, duration, onComplete]);
+
+  useEffect(() => {
+    // Delay before starting animation
+    const delayTimer = setTimeout(() => {
+      animationRef.current = requestAnimationFrame(runAnimation);
+    }, delay);
+
+    return () => {
+      clearTimeout(delayTimer);
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+      // Clean up any in-progress animation styles
+      if (cleanupRef.current) {
+        cleanupRef.current();
+      }
+    };
+  }, [delay, runAnimation]);
+
+  // This component doesn't render anything visible
+  return null;
+}

--- a/web-app/src/shared/components/tour/TourSpotlight.tsx
+++ b/web-app/src/shared/components/tour/TourSpotlight.tsx
@@ -30,6 +30,9 @@ const ARROW_SIZE = 12;
 const VIEWPORT_MARGIN = 16;
 const MUTATION_OBSERVER_DEBOUNCE_MS = 100;
 const INITIAL_POSITION_DELAY_MS = 100;
+// Z-index layers for tour overlay (must be between backdrop z-40 and tooltip z-50)
+const TARGET_ELEVATION_Z_INDEX = "45";
+const INTERACTION_BLOCKER_Z_INDEX = "z-[46]";
 
 function calculateTargetRect(target: Element): TargetRect {
   const rect = target.getBoundingClientRect();
@@ -138,7 +141,7 @@ export function TourSpotlight({
 
     // Elevate the element
     element.style.position = "relative";
-    element.style.zIndex = "45";
+    element.style.zIndex = TARGET_ELEVATION_Z_INDEX;
 
     // Also elevate SwipeableCard container if target is inside one
     // This ensures the swipe drawer actions are also above the overlay
@@ -150,7 +153,7 @@ export function TourSpotlight({
       originalContainerPosition = swipeableContainer.style.position;
       originalContainerZIndex = swipeableContainer.style.zIndex;
       swipeableContainer.style.position = "relative";
-      swipeableContainer.style.zIndex = "45";
+      swipeableContainer.style.zIndex = TARGET_ELEVATION_Z_INDEX;
     }
 
     return () => {
@@ -303,7 +306,7 @@ export function TourSpotlight({
       {/* Interaction blocker - covers target area during auto-swipe demo */}
       {blockInteraction && (
         <div
-          className="fixed z-[46] pointer-events-auto"
+          className={`fixed ${INTERACTION_BLOCKER_Z_INDEX} pointer-events-auto`}
           style={{
             top: targetRect.top,
             left: targetRect.left,

--- a/web-app/src/shared/components/tour/TourSpotlight.tsx
+++ b/web-app/src/shared/components/tour/TourSpotlight.tsx
@@ -20,6 +20,8 @@ interface TourSpotlightProps {
   freezePosition?: boolean;
   /** When true, disables backdrop blur so drawer buttons are clearly visible */
   disableBlur?: boolean;
+  /** When true, blocks all interaction with the target element (during auto-swipe demo) */
+  blockInteraction?: boolean;
 }
 
 const SPOTLIGHT_PADDING = 8;
@@ -85,6 +87,7 @@ export function TourSpotlight({
   children,
   freezePosition = false,
   disableBlur = false,
+  blockInteraction = false,
 }: TourSpotlightProps) {
   // Start with null - position will be set after mount when element is ready
   const [targetRect, setTargetRect] = useState<TargetRect | null>(null);
@@ -296,6 +299,20 @@ export function TourSpotlight({
         style={{ clipPath }}
         aria-hidden="true"
       />
+
+      {/* Interaction blocker - covers target area during auto-swipe demo */}
+      {blockInteraction && (
+        <div
+          className="fixed z-[46] pointer-events-auto"
+          style={{
+            top: targetRect.top,
+            left: targetRect.left,
+            width: targetRect.width,
+            height: targetRect.height,
+          }}
+          aria-hidden="true"
+        />
+      )}
 
       {/* Tooltip - needs pointer-events-auto to be interactive */}
       <div

--- a/web-app/src/shared/components/tour/definitions/types.ts
+++ b/web-app/src/shared/components/tour/definitions/types.ts
@@ -25,6 +25,17 @@ export interface TourStep {
     // Delay in ms for "auto" type
     delay?: number;
   };
+
+  // Auto-swipe demo configuration for swipe steps
+  // When enabled, disables user input and performs a slow swipe animation
+  autoSwipe?: {
+    // Direction to swipe ("left" reveals right actions, "right" reveals left actions)
+    direction: "left" | "right";
+    // Duration of the animation in ms (default: 1500)
+    duration?: number;
+    // Delay before starting the animation in ms (default: 500)
+    delay?: number;
+  };
 }
 
 export interface TourDefinition {


### PR DESCRIPTION
## Summary

- Add auto-swipe demonstration for guided tour swipe steps
- Disable user inputs during the demo animation
- Show a slow swipe animation to teach the gesture
- Leave drawer open after demo to show action buttons
- Enable for all swipe steps in assignments, compensations, and exchange tours

## Test Plan

- [ ] Start the assignments tour and verify auto-swipe demo plays on "swipe-validate" step
- [ ] Verify user cannot interact with the card during the animation
- [ ] Verify the drawer stays open after the animation completes
- [ ] Test compensations and exchange tour swipe steps