### PR TITLE
fix(help-site): remove duplicate list numbers in StepList component

### DIFF
--- a/help-site/src/components/StepList.astro
+++ b/help-site/src/components/StepList.astro
@@ -16,7 +16,7 @@ interface Props {
 const { steps } = Astro.props;
 ---
 
-<ol class="relative my-8 space-y-8 border-l-2 border-border-default pl-8 dark:border-border-default-dark">
+<ol class="relative my-8 list-none space-y-8 border-l-2 border-border-default pl-8 dark:border-border-default-dark">
   {
     steps.map((step, index) => (
       <li class="relative">


### PR DESCRIPTION
## Summary
- Add `list-none` class to the `<ol>` element in StepList component to hide default ordered list markers that were showing alongside custom styled circled step numbers

## Test Plan
- Build the help-site and verify step lists no longer show duplicate numbers
- Check pages using StepList (getting-started, calendar-mode, etc.)