### PR TITLE
fix(help-site): sync language between main app and help site

### DIFF
--- a/help-site/src/components/FeatureCard.astro
+++ b/help-site/src/components/FeatureCard.astro
@@ -2,6 +2,7 @@
 /**
  * FeatureCard component
  * Card with icon, title, description for feature grids
+ * Supports i18n via data-i18n attributes
  */
 
 interface Props {
@@ -9,9 +10,11 @@ interface Props {
   description: string;
   href: string;
   icon: string;
+  titleKey?: string;
+  descriptionKey?: string;
 }
 
-const { title, description, href, icon } = Astro.props;
+const { title, description, href, icon, titleKey, descriptionKey } = Astro.props;
 
 // Icon SVGs mapped by name
 const icons: Record<string, string> = {
@@ -50,18 +53,24 @@ const iconSvg = icons[icon] || icons['help-circle'];
   </div>
 
   <!-- Title -->
-  <h3 class="mb-2 font-semibold text-text-primary group-hover:text-primary-600 dark:text-text-primary-dark dark:group-hover:text-primary-400">
+  <h3
+    class="mb-2 font-semibold text-text-primary group-hover:text-primary-600 dark:text-text-primary-dark dark:group-hover:text-primary-400"
+    data-i18n={titleKey}
+  >
     {title}
   </h3>
 
   <!-- Description -->
-  <p class="text-sm text-text-secondary dark:text-text-secondary-dark">
+  <p
+    class="text-sm text-text-secondary dark:text-text-secondary-dark"
+    data-i18n={descriptionKey}
+  >
     {description}
   </p>
 
   <!-- Arrow indicator -->
   <div class="mt-4 flex items-center text-sm font-medium text-primary-600 dark:text-primary-400">
-    <span>Learn more</span>
+    <span data-i18n="common.learnMore">Learn more</span>
     <svg
       class="ml-1 h-4 w-4 transition-transform group-hover:translate-x-1"
       fill="none"

--- a/help-site/src/i18n/de.ts
+++ b/help-site/src/i18n/de.ts
@@ -23,6 +23,7 @@ export const de: TranslationKeys = {
     close: 'Schliessen',
     menu: 'Menü',
     search: 'Suchen',
+    viewOnGithub: 'Auf GitHub ansehen',
   },
 
   home: {
@@ -32,37 +33,48 @@ export const de: TranslationKeys = {
       'Erfahren Sie, wie Sie VolleyKit nutzen können, um Ihre Volleyball-Schiedsrichtereinsätze, Tauschbörse und Vergütungen zu verwalten.',
     ctaOpenApp: 'App öffnen',
     ctaGetStarted: 'Jetzt starten',
-    featuresTitle: 'Funktionen',
+    featuresTitle: 'Dokumentation erkunden',
+    readyToStart: 'Bereit loszulegen?',
     features: {
+      gettingStarted: {
+        title: 'Erste Schritte',
+        description:
+          'Schnellstartanleitung zur Einrichtung und Nutzung von VolleyKit.',
+      },
       assignments: {
         title: 'Einsätze',
         description:
-          'Sehen und verwalten Sie Ihre anstehenden Schiedsrichtereinsätze mit allen benötigten Details.',
+          'Sehen und verwalten Sie Ihre anstehenden Volleyball-Schiedsrichterspiele.',
       },
       exchanges: {
         title: 'Tauschbörse',
         description:
-          'Fordern Sie einfach Einsatztausche mit anderen Schiedsrichtern an und akzeptieren Sie diese.',
+          'Fordern Sie Spieltausche an und bieten Sie Ihre Einsätze anderen Schiedsrichtern an.',
       },
       compensations: {
         title: 'Vergütungen',
         description:
-          'Verfolgen Sie Ihre Schiedsrichtervergütungen und deren Verlauf an einem Ort.',
+          'Verfolgen Sie Ihre Schiedsrichtervergütungen und deren Verlauf.',
       },
       calendarMode: {
         title: 'Kalendermodus',
         description:
-          'Schneller Nur-Lese-Zugriff auf Ihren Zeitplan ohne vollständige Anmeldung.',
+          'Nur-Lese-Zugriff auf Einsätze ohne Anmeldung.',
       },
       travelTime: {
         title: 'Reisezeit',
         description:
-          'Sehen Sie, wie lange Sie mit dem öffentlichen Verkehr in der Schweiz zu jedem Spielort benötigen.',
+          'Reisezeiten mit Schweizer ÖV-Integration berechnen.',
       },
       offlinePwa: {
         title: 'Offline & PWA',
         description:
-          'Greifen Sie auch ohne Internet auf Ihre Einsätze zu. Als App installierbar.',
+          'App installieren und offline auf Ihrem Gerät nutzen.',
+      },
+      settings: {
+        title: 'Einstellungen',
+        description:
+          'Sprache, Design und Benachrichtigungen anpassen.',
       },
     },
   },

--- a/help-site/src/i18n/en.ts
+++ b/help-site/src/i18n/en.ts
@@ -23,6 +23,7 @@ export const en: TranslationKeys = {
     close: 'Close',
     menu: 'Menu',
     search: 'Search',
+    viewOnGithub: 'View on GitHub',
   },
 
   home: {
@@ -32,37 +33,48 @@ export const en: TranslationKeys = {
       'Learn how to use VolleyKit to manage your volleyball referee assignments, exchanges, and compensations.',
     ctaOpenApp: 'Open App',
     ctaGetStarted: 'Get Started',
-    featuresTitle: 'Features',
+    featuresTitle: 'Explore the Documentation',
+    readyToStart: 'Ready to get started?',
     features: {
+      gettingStarted: {
+        title: 'Getting Started',
+        description:
+          'Quick start guide to set up and use VolleyKit for the first time.',
+      },
       assignments: {
         title: 'Assignments',
         description:
-          'View and manage your upcoming referee assignments with all the details you need.',
+          'View and manage your upcoming volleyball referee games.',
       },
       exchanges: {
         title: 'Exchanges',
         description:
-          'Request and accept assignment exchanges with other referees easily.',
+          'Request game swaps and offer your assignments to other referees.',
       },
       compensations: {
         title: 'Compensations',
         description:
-          'Track your referee compensation payments and history in one place.',
+          'Track your referee earnings and compensation history.',
       },
       calendarMode: {
         title: 'Calendar Mode',
         description:
-          'Quick read-only access to your schedule without full login.',
+          'Read-only access to view assignments without logging in.',
       },
       travelTime: {
         title: 'Travel Time',
         description:
-          'See how long it takes to reach each venue using Swiss public transport.',
+          'Calculate travel times using Swiss public transport integration.',
       },
       offlinePwa: {
         title: 'Offline & PWA',
         description:
-          'Access your assignments even without internet. Install as an app.',
+          'Install the app and use it offline on your device.',
+      },
+      settings: {
+        title: 'Settings',
+        description:
+          'Customize your language, theme, and notification preferences.',
       },
     },
   },

--- a/help-site/src/i18n/fr.ts
+++ b/help-site/src/i18n/fr.ts
@@ -23,6 +23,7 @@ export const fr: TranslationKeys = {
     close: 'Fermer',
     menu: 'Menu',
     search: 'Rechercher',
+    viewOnGithub: 'Voir sur GitHub',
   },
 
   home: {
@@ -32,37 +33,48 @@ export const fr: TranslationKeys = {
       "Apprenez à utiliser VolleyKit pour gérer vos désignations d'arbitrage, échanges et indemnités.",
     ctaOpenApp: "Ouvrir l'app",
     ctaGetStarted: 'Commencer',
-    featuresTitle: 'Fonctionnalités',
+    featuresTitle: 'Explorer la documentation',
+    readyToStart: 'Prêt à commencer ?',
     features: {
+      gettingStarted: {
+        title: 'Premiers pas',
+        description:
+          'Guide de démarrage rapide pour configurer et utiliser VolleyKit.',
+      },
       assignments: {
         title: 'Désignations',
         description:
-          "Consultez et gérez vos prochaines désignations d'arbitrage avec tous les détails nécessaires.",
+          "Consultez et gérez vos prochains matchs d'arbitrage de volleyball.",
       },
       exchanges: {
         title: 'Échanges',
         description:
-          "Demandez et acceptez facilement des échanges de désignations avec d'autres arbitres.",
+          "Demandez des échanges et proposez vos désignations à d'autres arbitres.",
       },
       compensations: {
         title: 'Indemnités',
         description:
-          "Suivez vos paiements et l'historique de vos indemnités d'arbitrage en un seul endroit.",
+          "Suivez vos gains d'arbitrage et l'historique de vos indemnités.",
       },
       calendarMode: {
         title: 'Mode calendrier',
         description:
-          'Accès rapide en lecture seule à votre emploi du temps sans connexion complète.',
+          'Accès en lecture seule aux désignations sans connexion.',
       },
       travelTime: {
         title: 'Temps de trajet',
         description:
-          "Voyez combien de temps il faut pour rejoindre chaque salle en utilisant les transports publics suisses.",
+          'Calculez les temps de trajet avec les transports publics suisses.',
       },
       offlinePwa: {
         title: 'Hors ligne & PWA',
         description:
-          "Accédez à vos désignations même sans internet. Installez l'application.",
+          "Installez l'app et utilisez-la hors ligne sur votre appareil.",
+      },
+      settings: {
+        title: 'Paramètres',
+        description:
+          'Personnalisez la langue, le thème et les préférences de notification.',
       },
     },
   },

--- a/help-site/src/i18n/index.ts
+++ b/help-site/src/i18n/index.ts
@@ -31,7 +31,8 @@ function getNestedValue(obj: unknown, path: string): string | undefined {
 }
 
 /**
- * Get the current language from localStorage or browser settings
+ * Get the current language from URL parameter, localStorage, or browser settings
+ * Priority: URL param > localStorage > browser language > default
  * Falls back to default language if not found
  */
 export function getLanguage(): Language {
@@ -39,7 +40,16 @@ export function getLanguage(): Language {
     return defaultLanguage;
   }
 
-  // Check localStorage first
+  // Check URL parameter first (allows main app to pass language)
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlLang = urlParams.get('lang');
+  if (urlLang && isValidLanguage(urlLang)) {
+    // Persist the URL language to localStorage for subsequent page loads
+    localStorage.setItem('help-site-language', urlLang);
+    return urlLang;
+  }
+
+  // Check localStorage second
   const stored = localStorage.getItem('help-site-language');
   if (stored && isValidLanguage(stored)) {
     return stored;

--- a/help-site/src/i18n/it.ts
+++ b/help-site/src/i18n/it.ts
@@ -23,6 +23,7 @@ export const it: TranslationKeys = {
     close: 'Chiudi',
     menu: 'Menu',
     search: 'Cerca',
+    viewOnGithub: 'Vedi su GitHub',
   },
 
   home: {
@@ -32,37 +33,48 @@ export const it: TranslationKeys = {
       'Scopri come utilizzare VolleyKit per gestire le tue designazioni arbitrali, gli scambi e i compensi.',
     ctaOpenApp: 'Apri App',
     ctaGetStarted: 'Inizia',
-    featuresTitle: 'Funzionalità',
+    featuresTitle: 'Esplora la documentazione',
+    readyToStart: 'Pronto per iniziare?',
     features: {
+      gettingStarted: {
+        title: 'Primi passi',
+        description:
+          'Guida rapida per configurare e utilizzare VolleyKit per la prima volta.',
+      },
       assignments: {
         title: 'Designazioni',
         description:
-          'Visualizza e gestisci le tue prossime designazioni arbitrali con tutti i dettagli necessari.',
+          'Visualizza e gestisci le tue prossime partite arbitrali di pallavolo.',
       },
       exchanges: {
         title: 'Scambi',
         description:
-          'Richiedi e accetta scambi di designazioni con altri arbitri in modo semplice.',
+          'Richiedi scambi di partite e offri le tue designazioni ad altri arbitri.',
       },
       compensations: {
         title: 'Compensi',
         description:
-          'Tieni traccia dei tuoi compensi arbitrali e dello storico in un unico posto.',
+          'Monitora i tuoi guadagni arbitrali e lo storico dei compensi.',
       },
       calendarMode: {
         title: 'Modalità calendario',
         description:
-          'Accesso rapido in sola lettura al tuo programma senza login completo.',
+          'Accesso in sola lettura alle designazioni senza effettuare il login.',
       },
       travelTime: {
         title: 'Tempo di viaggio',
         description:
-          'Scopri quanto tempo ci vuole per raggiungere ogni sede con i trasporti pubblici svizzeri.',
+          'Calcola i tempi di viaggio con i trasporti pubblici svizzeri.',
       },
       offlinePwa: {
         title: 'Offline & PWA',
         description:
-          'Accedi alle tue designazioni anche senza internet. Installabile come app.',
+          'Installa l\'app e usala offline sul tuo dispositivo.',
+      },
+      settings: {
+        title: 'Impostazioni',
+        description:
+          'Personalizza lingua, tema e preferenze di notifica.',
       },
     },
   },

--- a/help-site/src/i18n/types.ts
+++ b/help-site/src/i18n/types.ts
@@ -28,6 +28,7 @@ export interface TranslationKeys {
     close: string;
     menu: string;
     search: string;
+    viewOnGithub: string;
   };
 
   // Landing page
@@ -38,7 +39,12 @@ export interface TranslationKeys {
     ctaOpenApp: string;
     ctaGetStarted: string;
     featuresTitle: string;
+    readyToStart: string;
     features: {
+      gettingStarted: {
+        title: string;
+        description: string;
+      };
       assignments: {
         title: string;
         description: string;
@@ -60,6 +66,10 @@ export interface TranslationKeys {
         description: string;
       };
       offlinePwa: {
+        title: string;
+        description: string;
+      };
+      settings: {
         title: string;
         description: string;
       };

--- a/help-site/src/pages/index.astro
+++ b/help-site/src/pages/index.astro
@@ -5,53 +5,70 @@ import MobileNav from '../components/MobileNav.astro';
 import Footer from '../components/Footer.astro';
 import FeatureCard from '../components/FeatureCard.astro';
 import { BASE_PATH } from '../constants';
+import { t } from '../i18n';
 
 const features = [
   {
-    title: 'Getting Started',
-    description: 'Quick start guide to set up and use VolleyKit for the first time.',
+    title: t('home.features.gettingStarted.title'),
+    description: t('home.features.gettingStarted.description'),
+    titleKey: 'home.features.gettingStarted.title',
+    descriptionKey: 'home.features.gettingStarted.description',
     href: `${BASE_PATH}/getting-started/`,
     icon: 'rocket',
   },
   {
-    title: 'Assignments',
-    description: 'View and manage your upcoming volleyball referee games.',
+    title: t('home.features.assignments.title'),
+    description: t('home.features.assignments.description'),
+    titleKey: 'home.features.assignments.title',
+    descriptionKey: 'home.features.assignments.description',
     href: `${BASE_PATH}/assignments/`,
     icon: 'calendar-check',
   },
   {
-    title: 'Exchanges',
-    description: 'Request game swaps and offer your assignments to other referees.',
+    title: t('home.features.exchanges.title'),
+    description: t('home.features.exchanges.description'),
+    titleKey: 'home.features.exchanges.title',
+    descriptionKey: 'home.features.exchanges.description',
     href: `${BASE_PATH}/exchanges/`,
     icon: 'arrow-left-right',
   },
   {
-    title: 'Compensations',
-    description: 'Track your referee earnings and compensation history.',
+    title: t('home.features.compensations.title'),
+    description: t('home.features.compensations.description'),
+    titleKey: 'home.features.compensations.title',
+    descriptionKey: 'home.features.compensations.description',
     href: `${BASE_PATH}/compensations/`,
     icon: 'wallet',
   },
   {
-    title: 'Calendar Mode',
-    description: 'Read-only access to view assignments without logging in.',
+    title: t('home.features.calendarMode.title'),
+    description: t('home.features.calendarMode.description'),
+    titleKey: 'home.features.calendarMode.title',
+    descriptionKey: 'home.features.calendarMode.description',
     href: `${BASE_PATH}/calendar-mode/`,
     icon: 'calendar',
   },
   {
-    title: 'Travel Time',
-    description: 'Calculate travel times using Swiss public transport integration.',
+    title: t('home.features.travelTime.title'),
+    description: t('home.features.travelTime.description'),
+    titleKey: 'home.features.travelTime.title',
+    descriptionKey: 'home.features.travelTime.description',
     href: `${BASE_PATH}/travel-time/`,
     icon: 'train',
   },
   {
-    title: 'Offline & PWA',
-    description: 'Install the app and use it offline on your device.',
+    title: t('home.features.offlinePwa.title'),
+    description: t('home.features.offlinePwa.description'),
+    titleKey: 'home.features.offlinePwa.title',
+    descriptionKey: 'home.features.offlinePwa.description',
     href: `${BASE_PATH}/offline-pwa/`,
     icon: 'wifi-off',
   },
   {
-    title: 'Settings',
-    description: 'Customize your language, theme, and notification preferences.',
+    title: t('home.features.settings.title'),
+    description: t('home.features.settings.description'),
+    titleKey: 'home.features.settings.title',
+    descriptionKey: 'home.features.settings.description',
     href: `${BASE_PATH}/settings/`,
     icon: 'settings',
   },
@@ -82,13 +99,19 @@ const features = [
           </div>
 
           <!-- Heading -->
-          <h1 class="mb-4 text-4xl font-bold text-text-primary dark:text-text-primary-dark md:text-5xl">
-            VolleyKit Documentation
+          <h1
+            class="mb-4 text-4xl font-bold text-text-primary dark:text-text-primary-dark md:text-5xl"
+            data-i18n="home.title"
+          >
+            {t('home.title')}
           </h1>
 
           <!-- Subtitle -->
-          <p class="mx-auto mb-8 max-w-2xl text-lg text-text-secondary dark:text-text-secondary-dark md:text-xl">
-            Learn how to use VolleyKit to manage your volleyball referee assignments
+          <p
+            class="mx-auto mb-8 max-w-2xl text-lg text-text-secondary dark:text-text-secondary-dark md:text-xl"
+            data-i18n="home.description"
+          >
+            {t('home.description')}
           </p>
 
           <!-- CTA Button -->
@@ -96,7 +119,7 @@ const features = [
             href={`${BASE_PATH}/getting-started/`}
             class="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-6 py-3 text-lg font-medium text-primary-950 transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
           >
-            Get Started
+            <span data-i18n="home.ctaGetStarted">{t('home.ctaGetStarted')}</span>
             <svg
               class="h-5 w-5"
               fill="none"
@@ -116,8 +139,11 @@ const features = [
 
       <!-- Feature Grid -->
       <section class="container mx-auto px-4 py-16">
-        <h2 class="mb-8 text-center text-2xl font-bold text-text-primary dark:text-text-primary-dark md:text-3xl">
-          Explore the Documentation
+        <h2
+          class="mb-8 text-center text-2xl font-bold text-text-primary dark:text-text-primary-dark md:text-3xl"
+          data-i18n="home.featuresTitle"
+        >
+          {t('home.featuresTitle')}
         </h2>
 
         <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
@@ -127,6 +153,8 @@ const features = [
               description={feature.description}
               href={feature.href}
               icon={feature.icon}
+              titleKey={feature.titleKey}
+              descriptionKey={feature.descriptionKey}
             />
           ))}
         </div>
@@ -135,8 +163,11 @@ const features = [
       <!-- Quick Links Section -->
       <section class="border-t border-border-default bg-surface-subtle py-12 dark:border-border-default-dark dark:bg-surface-subtle-dark">
         <div class="container mx-auto px-4 text-center">
-          <h2 class="mb-6 text-xl font-bold text-text-primary dark:text-text-primary-dark">
-            Ready to get started?
+          <h2
+            class="mb-6 text-xl font-bold text-text-primary dark:text-text-primary-dark"
+            data-i18n="home.readyToStart"
+          >
+            {t('home.readyToStart')}
           </h2>
           <div class="flex flex-wrap justify-center gap-4">
             <a
@@ -145,7 +176,7 @@ const features = [
               rel="noopener noreferrer"
               class="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-5 py-2.5 font-medium text-primary-950 transition-colors hover:bg-primary-600"
             >
-              Open VolleyKit App
+              <span data-i18n="common.openApp">{t('common.openApp')}</span>
               <svg
                 class="h-4 w-4"
                 fill="none"
@@ -173,7 +204,7 @@ const features = [
                   d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
                   clip-rule="evenodd"></path>
               </svg>
-              View on GitHub
+              <span data-i18n="common.viewOnGithub">{t('common.viewOnGithub')}</span>
             </a>
           </div>
         </div>

--- a/web-app/src/shared/utils/constants.test.ts
+++ b/web-app/src/shared/utils/constants.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { getHelpSiteUrl } from "./constants";
+import { useLanguageStore } from "@/shared/stores/language";
 
 describe("getHelpSiteUrl", () => {
+  beforeEach(() => {
+    // Reset the language store to default locale before each test
+    useLanguageStore.setState({ locale: "en" });
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -15,7 +21,7 @@ describe("getHelpSiteUrl", () => {
 
     const url = getHelpSiteUrl();
 
-    expect(url).toBe("https://takishima.github.io/volleykit/help/");
+    expect(url).toBe("https://takishima.github.io/volleykit/help/?lang=en");
   });
 
   it("returns help URL with correct base path for PR preview", () => {
@@ -27,7 +33,7 @@ describe("getHelpSiteUrl", () => {
 
     const url = getHelpSiteUrl();
 
-    expect(url).toBe("https://takishima.github.io/volleykit/pr-123/help/");
+    expect(url).toBe("https://takishima.github.io/volleykit/pr-123/help/?lang=en");
   });
 
   it("returns help URL for local development", () => {
@@ -41,7 +47,7 @@ describe("getHelpSiteUrl", () => {
 
     const url = getHelpSiteUrl();
 
-    expect(url).toBe("http://localhost:5173/help/");
+    expect(url).toBe("http://localhost:5173/help/?lang=en");
   });
 
   it("handles missing window (SSR) gracefully", () => {
@@ -51,6 +57,33 @@ describe("getHelpSiteUrl", () => {
 
     const url = getHelpSiteUrl();
 
-    expect(url).toBe("/volleykit/help/");
+    expect(url).toBe("/volleykit/help/?lang=en");
+  });
+
+  it("includes the current language in the URL", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://takishima.github.io" },
+    });
+    vi.stubEnv("BASE_URL", "/volleykit/");
+
+    // Set German as the current language
+    useLanguageStore.setState({ locale: "de" });
+
+    const url = getHelpSiteUrl();
+
+    expect(url).toBe("https://takishima.github.io/volleykit/help/?lang=de");
+  });
+
+  it("includes French language when selected", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://takishima.github.io" },
+    });
+    vi.stubEnv("BASE_URL", "/volleykit/");
+
+    useLanguageStore.setState({ locale: "fr" });
+
+    const url = getHelpSiteUrl();
+
+    expect(url).toBe("https://takishima.github.io/volleykit/help/?lang=fr");
   });
 });

--- a/web-app/src/shared/utils/constants.ts
+++ b/web-app/src/shared/utils/constants.ts
@@ -2,6 +2,8 @@
  * Application-wide constants.
  */
 
+import { useLanguageStore } from "@/shared/stores/language";
+
 /**
  * Returns the absolute URL to the VolleyKit help documentation site.
  * Must be absolute (not relative) to bypass the service worker which would
@@ -11,8 +13,16 @@
  * - Production: https://takishima.github.io/volleykit/help/
  * - PR previews: https://takishima.github.io/volleykit/pr-123/help/
  * - Local dev: http://localhost:5173/help/
+ *
+ * Includes the current app language as a query parameter so the help site
+ * opens in the same language as the main app.
  */
 export function getHelpSiteUrl(): string {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
-  return `${origin}${import.meta.env.BASE_URL}help/`;
+  const baseUrl = `${origin}${import.meta.env.BASE_URL}help/`;
+
+  // Get current language from store (works outside React components)
+  const currentLang = useLanguageStore.getState().locale;
+
+  return `${baseUrl}?lang=${currentLang}`;
 }

--- a/web-app/src/shared/utils/constants.ts
+++ b/web-app/src/shared/utils/constants.ts
@@ -24,5 +24,7 @@ export function getHelpSiteUrl(): string {
   // Get current language from store (works outside React components)
   const currentLang = useLanguageStore.getState().locale;
 
-  return `${baseUrl}?lang=${currentLang}`;
+  // Use URLSearchParams for safe query parameter construction
+  const params = new URLSearchParams({ lang: currentLang });
+  return `${baseUrl}?${params.toString()}`;
 }


### PR DESCRIPTION
## Summary

- Add URL parameter support (`?lang=XX`) to help site's `getLanguage()` function
- Update main app's `getHelpSiteUrl()` to include the current language as a query parameter
- Help site now opens with the same language as the main app

## Changes

### Help Site (`help-site/src/i18n/index.ts`)
- Modified `getLanguage()` to check URL parameters first
- Priority: URL param > localStorage > browser language > default
- Persists URL language to localStorage for subsequent page navigation

### Main App (`web-app/src/shared/utils/constants.ts`)
- Updated `getHelpSiteUrl()` to append `?lang=XX` query parameter
- Reads current language from zustand store using `getState()`

### Tests (`web-app/src/shared/utils/constants.test.ts`)
- Updated existing tests to expect `?lang=XX` in URLs
- Added new tests for German and French language scenarios

## Test plan

- [x] All existing tests pass
- [x] Build succeeds
- [x] Lint passes with no warnings
- [ ] Manual test: Open help site from main app with different languages selected
- [ ] Manual test: Switch language within help site and verify it persists