### PR TITLE
feat(help-site): add i18n support to all help pages

### DIFF
--- a/help-site/src/i18n/de.ts
+++ b/help-site/src/i18n/de.ts
@@ -171,4 +171,669 @@ export const de: TranslationKeys = {
     tip: 'Tipp',
     warning: 'Warnung',
   },
+
+  gettingStarted: {
+    heading: 'Erste Schritte mit VolleyKit',
+    lead: 'VolleyKit ist eine progressive Web-Anwendung, die eine verbesserte Oberfläche zur Verwaltung Ihrer Volleyball-Schiedsrichtereinsätze über das volleymanager-System des Schweizerischen Volleyball-Verbandes bietet.',
+    whatIs: {
+      title: 'Was ist VolleyKit?',
+      description: 'VolleyKit verbindet sich mit der offiziellen volleymanager.volleyball.ch-Plattform und bietet Schiedsrichtern eine moderne, mobilfreundliche Oberfläche für:',
+      features: {
+        viewAssignments: 'Anstehende Spieleinsätze anzeigen',
+        manageExchanges: 'Spieltausche mit anderen Schiedsrichtern anfordern und verwalten',
+        trackCompensations: 'Vergütungszahlungen verfolgen',
+        offlineAccess: 'Offline auf Einsätze zugreifen',
+        travelTime: 'Reisezeiten mit dem Schweizer ÖV berechnen',
+      },
+      infoBox: 'VolleyKit ist eine inoffizielle App, die zur Verbesserung der Schiedsrichtererfahrung erstellt wurde. Alle Daten stammen aus dem offiziellen volleymanager-System.',
+    },
+    howToLogin: {
+      title: 'So melden Sie sich an',
+      description: 'VolleyKit bietet zwei Möglichkeiten, auf Ihre Einsätze zuzugreifen:',
+      calendarMode: {
+        title: 'Option 1: Kalendermodus (Empfohlen)',
+        description: 'Für einen schnellen Zugriff auf Ihren Spielplan ohne Passwort können Sie den Kalendermodus mit Ihrer eindeutigen Kalender-URL oder Ihrem Code aus volleymanager nutzen.',
+        steps: {
+          findUrl: {
+            title: 'Kalender-URL finden',
+            description: 'Gehen Sie in volleymanager zu "Meine Einsätze" und kopieren Sie Ihre Kalender-Abonnement-URL.',
+          },
+          selectMode: {
+            title: 'Kalendermodus auswählen',
+            description: 'Tippen Sie auf der VolleyKit-Anmeldeseite auf den Tab "Kalendermodus".',
+          },
+          pasteUrl: {
+            title: 'URL oder Code einfügen',
+            description: 'Geben Sie Ihre Kalender-URL oder nur den Code-Teil ein, um auf Ihren Spielplan zuzugreifen.',
+          },
+        },
+        infoBox: 'Der Kalendermodus bietet nur Lesezugriff – Sie können Einsätze anzeigen, aber keine Spiele bestätigen, Tausche anfordern oder auf Vergütungen zugreifen. Weitere Details finden Sie im Kalendermodus-Leitfaden.',
+      },
+      fullLogin: {
+        title: 'Option 2: Vollständige Anmeldung',
+        description: 'Verwenden Sie Ihre volleymanager.volleyball.ch-Anmeldedaten für vollen Zugriff auf alle Funktionen.',
+        steps: {
+          openApp: {
+            title: 'VolleyKit öffnen',
+            description: 'Navigieren Sie zur VolleyKit-App in Ihrem Browser oder öffnen Sie die installierte App.',
+          },
+          enterCredentials: {
+            title: 'Anmeldedaten eingeben',
+            description: 'Verwenden Sie Ihren volleymanager-Benutzernamen und Ihr Passwort zur Anmeldung.',
+          },
+          stayLoggedIn: {
+            title: 'Angemeldet bleiben',
+            description: 'Aktivieren Sie "Angemeldet bleiben", um zwischen Sitzungen angemeldet zu bleiben.',
+          },
+        },
+        screenshotAlt: 'VolleyKit-Anmeldeseite mit Benutzernamen- und Passwortfeldern',
+        screenshotCaption: 'Die VolleyKit-Anmeldeseite',
+        tipTitle: 'Passwort vergessen?',
+        tipContent: 'VolleyKit verwendet dieselben Anmeldedaten wie volleymanager.volleyball.ch. Nutzen Sie die Passwort-Zurücksetzen-Funktion auf der offiziellen Seite, wenn Sie Ihr Passwort vergessen haben.',
+      },
+    },
+    quickTour: {
+      title: 'Schnellübersicht',
+      description: 'Nach der Anmeldung sehen Sie das Haupt-Dashboard mit Ihren anstehenden Einsätzen. Hier ist ein kurzer Überblick über die Hauptbereiche:',
+      assignments: {
+        title: 'Einsätze',
+        description: 'Alle Ihre anstehenden Schiedsrichterspiele anzeigen. Jeder Einsatz zeigt Datum, Uhrzeit, Teams, Spielort und Ihre Rolle (1. Schiedsrichter, 2. Schiedsrichter oder Linienrichter).',
+      },
+      exchanges: {
+        title: 'Tauschbörse',
+        description: 'Verfügbare Spieltausche von anderen Schiedsrichtern durchsuchen oder einen Tausch für einen Ihrer eigenen Einsätze anfordern.',
+      },
+      compensations: {
+        title: 'Vergütungen',
+        description: 'Ihre Schiedsrichterzahlungen und Vergütungshistorie verfolgen. Nach Datum filtern und Daten exportieren.',
+      },
+      settings: {
+        title: 'Einstellungen',
+        description: 'Passen Sie Ihre Erfahrung an, einschliesslich Sprache, Heimatstandort für Reisezeitberechnungen und Benachrichtigungseinstellungen.',
+      },
+    },
+    nextSteps: {
+      title: 'Nächste Schritte',
+      description: 'Nachdem Sie nun mit den Grundlagen vertraut sind, erkunden Sie die detaillierten Anleitungen für jede Funktion:',
+      links: {
+        assignments: 'Ihre Einsätze verwalten',
+        exchanges: 'Tausche anfordern und annehmen',
+        compensations: 'Ihre Vergütungen verfolgen',
+      },
+    },
+  },
+
+  assignments: {
+    heading: 'Ihre Einsätze verwalten',
+    lead: 'Der Einsätze-Bereich ist Ihre zentrale Anlaufstelle für alle anstehenden Volleyball-Schiedsrichterspiele und die Verwaltung Ihres Spielplans.',
+    whatAre: {
+      title: 'Was sind Einsätze?',
+      description: 'Einsätze sind die Spiele, für die Sie als Schiedsrichter eingeteilt wurden. Jeder Einsatz enthält:',
+      details: {
+        dateTime: 'Datum und Uhrzeit – Wann das Spiel stattfindet',
+        teams: 'Teams – Heim- und Gastmannschaftsnamen',
+        venue: 'Spielort – Ort des Spiels mit Adresse',
+        role: 'Ihre Rolle – 1. Schiedsrichter, 2. Schiedsrichter oder Linienrichter',
+        league: 'Liga – Die Wettbewerbsstufe (z.B. NLA, NLB, 1. Liga)',
+      },
+    },
+    viewing: {
+      title: 'Ihre Einsätze anzeigen',
+      description: 'Die Einsatzliste zeigt alle Ihre anstehenden Spiele in chronologischer Reihenfolge. Spiele sind nach Datum gruppiert, damit Sie leicht sehen können, was ansteht.',
+      screenshotAlt: 'Einsatzliste mit mehreren anstehenden Spielen, nach Datum gruppiert',
+      screenshotCaption: 'Die Einsatzlistenansicht mit anstehenden Spielen',
+    },
+    details: {
+      title: 'Einsatzdetails',
+      description: 'Tippen Sie auf einen Einsatz, um alle Details zu sehen. Die Detailansicht enthält:',
+      items: {
+        gameInfo: 'Vollständige Spielinformationen',
+        venueAddress: 'Spielortadresse mit Kartenlink',
+        travelTime: 'Reisezeit von Ihrem Heimatstandort',
+        otherReferees: 'Andere Schiedsrichter, die demselben Spiel zugewiesen sind',
+        swipeActions: 'Verfügbare Aktionen über Wischgesten',
+      },
+      screenshotAlt: 'Einsatzdetailansicht mit allen Spielinformationen',
+      screenshotCaption: 'Detaillierte Ansicht eines einzelnen Einsatzes',
+    },
+    actions: {
+      title: 'Aktionen durchführen',
+      description: 'VolleyKit verwendet Wischgesten für schnellen Zugriff auf Aktionen bei Ihren Einsatzkarten. Je nach Spielstatus stehen Ihnen verschiedene Aktionen zur Verfügung.',
+      swipeRight: {
+        title: 'Nach rechts wischen – Zur Tauschbörse hinzufügen',
+        description: 'Wischen Sie eine Einsatzkarte nach rechts, um die Tauschaktion anzuzeigen. Wenn Sie ein Spiel nicht wahrnehmen können, können Sie es zur Tauschbörse für andere Schiedsrichter hinzufügen.',
+        screenshotAlt: 'Einsatzkarte nach rechts gewischt mit Tauschaktion',
+        screenshotCaption: 'Nach rechts wischen, um einen Einsatz zur Tauschbörse hinzuzufügen',
+        warning: 'Fordern Sie einen Tausch rechtzeitig an. Last-Minute-Anfragen finden möglicherweise keinen Ersatz rechtzeitig.',
+      },
+      swipeLeft: {
+        title: 'Nach links wischen – Validieren & Bearbeiten',
+        description: 'Wischen Sie eine Einsatzkarte nach links, um zusätzliche Aktionen anzuzeigen:',
+        validate: 'Validieren – Spielergebnisse einreichen und das Spiel validieren (für Erstschiedsrichter nach dem Spiel verfügbar)',
+        edit: 'Bearbeiten – Ihre Vergütungsdetails für diesen Einsatz bearbeiten',
+        screenshotAlt: 'Einsatzkarte nach links gewischt mit Validieren- und Bearbeiten-Aktionen',
+        screenshotCaption: 'Nach links wischen, um Validieren- und Bearbeiten-Aktionen anzuzeigen',
+        tip: 'Sie können auch einen vollständigen Wisch durchführen, um die primäre Aktion sofort auszulösen, ohne auf die Schaltfläche zu tippen.',
+      },
+      directions: {
+        title: 'Wegbeschreibung abrufen',
+        description: 'Tippen Sie auf eine Einsatzkarte, um sie zu erweitern, und verwenden Sie dann die Wegbeschreibungsschaltfläche, um Ihre bevorzugte Kartenanwendung mit der Route zum Spielort zu öffnen.',
+      },
+    },
+    upcomingPast: {
+      title: 'Anstehende und vergangene Spiele',
+      description: 'Verwenden Sie die Tabs oben, um zwischen folgenden Ansichten zu wechseln:',
+      upcoming: 'Anstehend – Spiele, die noch nicht stattgefunden haben',
+      validationClosed: 'Validierung abgeschlossen – Vergangene Spiele, deren Validierung abgeschlossen ist',
+      tip: 'Legen Sie Ihren Heimatstandort in den Einstellungen fest, um Reisezeitschätzungen auf jeder Einsatzkarte zu sehen.',
+    },
+  },
+
+  exchanges: {
+    heading: 'Spieltausche',
+    lead: 'Das Tauschsystem ermöglicht es Schiedsrichtern, Spiele zu tauschen, wenn sie ihre geplanten Einsätze nicht wahrnehmen können. Sie können Tausche für Ihre Spiele anfordern oder Spiele von anderen Schiedsrichtern übernehmen.',
+    whatAre: {
+      title: 'Was sind Tausche?',
+      description: 'Ein Tausch ist eine Anfrage von einem Schiedsrichter, der sein geplantes Spiel nicht wahrnehmen kann und einen Ersatz sucht. Das volleymanager-System pflegt eine Tauschbörse, wo Schiedsrichter:',
+      features: {
+        postGames: 'Ihre Spiele zum Tausch anbieten können',
+        browseGames: 'Verfügbare Spiele von anderen Schiedsrichtern durchsuchen können',
+        acceptGames: 'Spiele annehmen können, die in ihren Zeitplan passen',
+      },
+      infoBox: 'Tausche werden über das offizielle volleymanager-System verwaltet. VolleyKit bietet eine benutzerfreundlichere Oberfläche für dieselbe Tauschbörse.',
+    },
+    requesting: {
+      title: 'Einen Tausch anfordern',
+      description: 'Wenn Sie eines Ihrer geplanten Spiele nicht wahrnehmen können, können Sie einen Tausch anfordern, um einen Ersatzschiedsrichter zu finden.',
+      steps: {
+        findAssignment: {
+          title: 'Den Einsatz finden',
+          description: 'Gehen Sie zu Ihrem Einsätze-Tab und suchen Sie das Spiel, das Sie tauschen möchten.',
+        },
+        swipeRight: {
+          title: 'Nach rechts auf die Karte wischen',
+          description: 'Wischen Sie die Einsatzkarte nach rechts, um die Tauschaktion anzuzeigen, und tippen Sie darauf. Das Spiel wird in der Tauschbörse veröffentlicht.',
+        },
+      },
+      screenshotAlt: 'Einsatzkarte mit angezeigter Tausch-Wischaktion',
+      screenshotCaption: 'Einen Tausch für ein Spiel anfordern',
+      warningTitle: 'Frühzeitig anfragen',
+      warningContent: 'Je früher Sie einen Tausch anfordern, desto wahrscheinlicher finden Sie einen Ersatz. Last-Minute-Anfragen bleiben oft unbesetzt.',
+    },
+    viewing: {
+      title: 'Verfügbare Tausche anzeigen',
+      description: 'Der Tauschbörse-Tab zeigt alle derzeit zum Tausch verfügbaren Spiele. Dies sind Spiele, die andere Schiedsrichter angeboten haben und für die sie Ersatz suchen.',
+      screenshotAlt: 'Liste der verfügbaren Tauschspiele von anderen Schiedsrichtern',
+      screenshotCaption: 'Verfügbare Spiele in der Tauschbörse',
+      filtering: {
+        title: 'Tausche filtern',
+        description: 'Filtern Sie die Tauschliste, um Spiele zu finden, die für Sie passen. Filter werden verfügbar, nachdem Sie die erforderlichen Einstellungen konfiguriert haben:',
+        distance: 'Entfernung – Nach maximaler Entfernung von Ihrem Heimatstandort filtern. Erfordert das Festlegen Ihres Heimatstandorts in den Einstellungen.',
+        travelTime: 'Reisezeit – Nach maximaler Reisezeit mit öffentlichen Verkehrsmitteln filtern. Erfordert sowohl einen Heimatstandort als auch die Aktivierung der ÖV-API in den Einstellungen.',
+        usage: 'Sobald Filter verfügbar sind, erscheinen sie als Umschalt-Chips neben dem Einstellungszahnrad-Symbol. Tippen Sie auf das Zahnrad, um die Maximalwerte für jeden Filter zu konfigurieren.',
+        tip: 'Legen Sie Ihren Heimatstandort in den Einstellungen fest, um die Entfernungsfilterung freizuschalten. Aktivieren Sie die ÖV-API, um auch nach Reisezeit zu filtern.',
+      },
+    },
+    accepting: {
+      title: 'Einen Tausch annehmen',
+      description: 'Wenn Sie ein Spiel finden, das Sie übernehmen möchten, können Sie den Tausch annehmen:',
+      steps: {
+        review: {
+          title: 'Spieldetails prüfen',
+          description: 'Überprüfen Sie Datum, Uhrzeit, Spielort und Reiseanforderungen.',
+        },
+        swipeLeft: {
+          title: 'Nach links auf die Karte wischen',
+          description: 'Wischen Sie die Tauschkarte nach links, um die Übernahmeaktion anzuzeigen, und tippen Sie darauf.',
+        },
+        confirm: {
+          title: 'Ihre Annahme bestätigen',
+          description: 'Überprüfen Sie die Details und bestätigen Sie Ihre Annahme.',
+        },
+        gameAdded: {
+          title: 'Spiel zu Ihrem Spielplan hinzugefügt',
+          description: 'Das Spiel erscheint nun in Ihren Einsätzen.',
+        },
+      },
+      tip: 'Stellen Sie sicher, dass Sie das Spiel tatsächlich wahrnehmen können, bevor Sie annehmen. Nach der Annahme wird der ursprüngliche Schiedsrichter vom Einsatz entbunden.',
+    },
+    managing: {
+      title: 'Ihre Tauschanfragen verwalten',
+      description: 'Sie können Ihre aktiven Tauschanfragen über den Tauschbörse-Tab anzeigen und verwalten. Wenn Sie keinen Tausch mehr benötigen (z.B. Ihr Zeitplan hat sich geändert), können Sie die Anfrage stornieren, bevor jemand sie annimmt.',
+      canceling: {
+        title: 'Eine Anfrage stornieren',
+        description: 'Um eine von Ihnen gestellte Tauschanfrage zu stornieren:',
+        steps: {
+          goToExchanges: 'Gehen Sie zum Tauschbörse-Tab',
+          selectAddedByMe: 'Wählen Sie den Tab "Von mir hinzugefügt", um Ihre ausstehenden Anfragen zu sehen',
+          swipeRight: 'Wischen Sie nach rechts auf die Anfragekarte, um die Entfernen-Aktion anzuzeigen, und tippen Sie darauf',
+          confirmCancellation: 'Bestätigen Sie die Stornierung',
+        },
+        infoBox: 'Sie können eine Tauschanfrage nur stornieren, wenn sie noch niemand angenommen hat. Nach der Annahme ist der Tausch endgültig.',
+      },
+    },
+  },
+
+  compensations: {
+    heading: 'Ihre Vergütungen verfolgen',
+    lead: 'Der Vergütungsbereich hilft Ihnen, Ihre Schiedsrichtereinnahmen und Zahlungshistorie zu verfolgen. Vergangene Zahlungen anzeigen, nach Datum filtern und Daten für Ihre Unterlagen exportieren.',
+    whatAre: {
+      title: 'Was sind Vergütungen?',
+      description: 'Vergütungen sind die Zahlungen, die Sie für das Leiten von Volleyballspielen erhalten. Jeder Vergütungseintrag enthält typischerweise:',
+      details: {
+        gameDetails: 'Spieldetails – Das Spiel, das Sie geleitet haben',
+        date: 'Datum – Wann das Spiel stattfand',
+        amount: 'Betrag – Der Vergütungsbetrag in CHF',
+        paymentStatus: 'Zahlungsstatus – Ausstehend, bezahlt oder verarbeitet',
+        role: 'Rolle – Ihre Funktion im Spiel',
+      },
+      infoBox: 'Vergütungsbeträge werden von Swiss Volley festgelegt und variieren je nach Ligastufe und Ihrer Rolle im Spiel.',
+    },
+    viewing: {
+      title: 'Ihre Vergütungen anzeigen',
+      description: 'Die Vergütungsliste zeigt alle Ihre erfassten Zahlungen in chronologischer Reihenfolge. Jeder Eintrag zeigt die wichtigsten Informationen auf einen Blick.',
+      screenshotAlt: 'Vergütungsliste mit Zahlungshistorie mit Beträgen und Daten',
+      screenshotCaption: 'Ihre Vergütungshistorie',
+      paymentStatus: {
+        title: 'Zahlungsstatus verstehen',
+        pending: 'Ausstehend – Spiel abgeschlossen, Zahlung noch nicht verarbeitet',
+        processing: 'In Bearbeitung – Zahlung wird verarbeitet',
+        paid: 'Bezahlt – Zahlung wurde auf Ihr Konto überwiesen',
+      },
+    },
+    filtering: {
+      title: 'Nach Status filtern',
+      description: 'Verwenden Sie die Tabs oben, um Vergütungen nach Status zu filtern:',
+      tabs: {
+        pendingPast: 'Ausstehend (Vergangenheit) – Vergangene Spiele, die auf Zahlung warten',
+        pendingFuture: 'Ausstehend (Zukunft) – Kommende Spiele, die noch nicht gespielt wurden',
+        closed: 'Abgeschlossen – Abgeschlossene und bezahlte Vergütungen',
+      },
+      screenshotAlt: 'Vergütungs-Tabs mit Ausstehend- und Abgeschlossen-Optionen',
+      screenshotCaption: 'Vergütungen nach Status filtern',
+      tip: 'Vergütungen werden automatisch auf die aktuelle Saison (September bis Mai) gefiltert, damit Sie sich auf aktuelle Spiele konzentrieren können.',
+    },
+    exportPdf: {
+      title: 'Als PDF exportieren',
+      description: 'Sie können einzelne Vergütungsdatensätze als PDF-Dokumente exportieren. Wischen Sie nach links auf einer Vergütungskarte, um die PDF-Export-Aktion anzuzeigen.',
+      usage: 'Das exportierte PDF enthält die Spieldetails und Vergütungsinformationen in einem formatierten Dokument. Dies ist nützlich für Teams, die den Schiedsrichter direkt bezahlen müssen.',
+      infoBox: 'Der PDF-Export erstellt ein offiziell aussehendes Dokument mit allen Spiel- und Vergütungsdetails, die Teams für ihre Unterlagen benötigen könnten.',
+    },
+    paymentSchedule: {
+      title: 'Zahlungsplan',
+      description: 'Vergütungszahlungen werden typischerweise monatlich von Swiss Volley verarbeitet. Der genaue Zahlungsplan kann variieren, aber generell:',
+      details: {
+        processing: 'Spiele des Vormonats werden zu Beginn jedes Monats verarbeitet',
+        bankTransfer: 'Zahlungen erfolgen per Banküberweisung auf Ihr registriertes Konto',
+        timing: 'Die Verarbeitung kann 2-4 Wochen nach Monatsende dauern',
+      },
+      warning: 'Stellen Sie sicher, dass Ihre Bankdaten im volleymanager-System aktuell sind, um Zahlungsverzögerungen zu vermeiden.',
+    },
+  },
+
+  calendarMode: {
+    heading: 'Kalendermodus',
+    lead: 'Der Kalendermodus bietet Lesezugriff auf Schiedsrichtereinsätze ohne vollständige Anmeldung. Perfekt für schnelle Spielplanprüfungen oder zum Teilen mit Familienmitgliedern.',
+    whatIs: {
+      title: 'Was ist der Kalendermodus?',
+      description: 'Der Kalendermodus ist eine leichtgewichtige Nur-Lese-Zugriffsmethode, mit der Sie Ihre anstehenden Einsätze sehen können, ohne Ihr Passwort einzugeben. Er verwendet einen eindeutigen Kalendercode, der mit Ihrem Schiedsrichterkonto verknüpft ist.',
+      features: {
+        viewAssignments: 'Ihre anstehenden Spieleinsätze anzeigen',
+        seeDetails: 'Spieldetails einschliesslich Datum, Uhrzeit, Teams und Spielort sehen',
+        noPassword: 'Kein Passwort erforderlich – nur Ihr Kalendercode',
+        safeToShare: 'Sicher zum Teilen mit Familie oder Hinzufügen zu gemeinsamen Kalendern',
+      },
+    },
+    whoIsFor: {
+      title: 'Für wen ist der Kalendermodus?',
+      description: 'Der Kalendermodus ist ideal für:',
+      useCases: {
+        quickChecks: 'Schnelle Spielplanprüfungen – Ihre Spiele ohne Anmeldung anzeigen',
+        familyMembers: 'Familienmitglieder – Ihren Spielplan mit Partnern oder Familie teilen',
+        calendarIntegration: 'Kalenderintegration – Spiele zu externen Kalender-Apps hinzufügen',
+        publicDevices: 'Öffentliche Geräte – Ihren Spielplan auf gemeinsamen Computern prüfen',
+      },
+      tip: 'Der Kalendermodus ist perfekt, um Ihrer Familie mitzuteilen, wann Sie Spiele haben, ohne ihnen Zugriff auf Ihr vollständiges Konto zu geben.',
+    },
+    howToAccess: {
+      title: 'So greifen Sie auf den Kalendermodus zu',
+      description: 'Um den Kalendermodus zu nutzen, benötigen Sie Ihren eindeutigen Kalendercode aus dem volleymanager-System.',
+      steps: {
+        findCode: {
+          title: 'Ihren Kalendercode finden',
+          description: 'Melden Sie sich bei volleymanager.volleyball.ch an und finden Sie Ihren Kalendercode in Ihren Profileinstellungen.',
+        },
+        openApp: {
+          title: 'VolleyKit öffnen',
+          description: 'Navigieren Sie zur VolleyKit-App.',
+        },
+        selectMode: {
+          title: '"Kalendermodus" auswählen',
+          description: 'Tippen Sie auf der Anmeldeseite auf die Option "Kalendermodus".',
+        },
+        enterCode: {
+          title: 'Ihren Code eingeben',
+          description: 'Geben Sie Ihren Kalendercode ein, um auf Ihren Nur-Lese-Spielplan zuzugreifen.',
+        },
+      },
+      screenshotAlt: 'Kalendermodus-Eingabebildschirm mit Code-Eingabefeld',
+      screenshotCaption: 'Kalendermodus mit Ihrem Code aufrufen',
+    },
+    viewingSchedule: {
+      title: 'Ihren Spielplan anzeigen',
+      description: 'Im Kalendermodus sehen Sie Ihre anstehenden Einsätze in einer vereinfachten Ansicht. Die Oberfläche zeigt die wesentlichen Informationen für jedes Spiel.',
+      screenshotAlt: 'Kalendermodus mit anstehenden Einsätzen in Nur-Lese-Ansicht',
+      screenshotCaption: 'Kalendermodus-Einsatzansicht',
+    },
+    limitations: {
+      title: 'Einschränkungen vs. vollständige Anmeldung',
+      description: 'Der Kalendermodus ist schreibgeschützt, was bedeutet, dass einige Funktionen nicht verfügbar sind:',
+      table: {
+        feature: 'Funktion',
+        fullLogin: 'Vollständige Anmeldung',
+        calendarMode: 'Kalendermodus',
+        viewAssignments: 'Einsätze anzeigen',
+        viewDetails: 'Spieldetails anzeigen',
+        travelTime: 'Reisezeitinfo',
+        confirmAssignments: 'Einsätze bestätigen',
+        requestExchanges: 'Tausche anfordern',
+        viewCompensations: 'Vergütungen anzeigen',
+        acceptExchanges: 'Tausche annehmen',
+      },
+      infoBox: 'Für Aktionen wie das Bestätigen von Einsätzen oder das Anfordern von Tauschen müssen Sie sich mit Ihren vollständigen Anmeldedaten anmelden.',
+    },
+    security: {
+      title: 'Ihren Code sicher aufbewahren',
+      description: 'Obwohl der Kalendermodus schreibgeschützt ist, sollten Sie Ihren Kalendercode mit Vorsicht behandeln:',
+      tips: {
+        shareWithTrust: 'Nur mit vertrauenswürdigen Personen teilen',
+        dontPostPublicly: 'Ihren Code nicht öffentlich online veröffentlichen',
+        ifCompromised: 'Bei Verdacht auf Kompromittierung Ihres Codes Swiss Volley kontaktieren',
+      },
+      warning: 'Ihr Kalendercode offenbart Ihren vollständigen Spielplan. Teilen Sie ihn nur mit Personen, denen Sie Ihren Aufenthaltsort anvertrauen möchten.',
+    },
+  },
+
+  travelTime: {
+    heading: 'Reisezeit-Funktion',
+    lead: 'VolleyKit integriert Schweizer ÖV-Daten, um Ihnen zu zeigen, wie lange Sie brauchen, um jeden Spielort zu erreichen. Planen Sie Ihre Reisen besser und kommen Sie nie zu spät zu einem Spiel.',
+    howItWorks: {
+      title: 'So funktioniert es',
+      description: 'Die Reisezeit-Funktion verwendet die Schweizer ÖV-API (SBB/öV), um Reisezeiten von Ihrem Heimatstandort zu jedem Spielort zu berechnen. Sie berücksichtigt:',
+      considerations: {
+        schedules: 'Echtzeit-Zug-, Bus- und Tram-Fahrpläne',
+        walkingTime: 'Gehzeit zu/von Stationen',
+        transferTimes: 'Umsteigezeiten zwischen Verbindungen',
+        gameStartTime: 'Die tatsächliche Spielstartzeit',
+      },
+      infoBox: 'Reisezeiten werden mit öffentlichen Verkehrsmitteln berechnet. Wenn Sie normalerweise fahren, nutzen Sie die Zeiten als grobe Schätzung oder zur Planung alternativer Transportmöglichkeiten.',
+    },
+    settingHome: {
+      title: 'Ihren Heimatstandort festlegen',
+      description: 'Um genaue Reisezeiten zu erhalten, müssen Sie Ihren Heimatstandort in den App-Einstellungen festlegen.',
+      steps: {
+        openSettings: {
+          title: 'Einstellungen öffnen',
+          description: 'Navigieren Sie zur Einstellungsseite in VolleyKit.',
+        },
+        findHomeLocation: {
+          title: '"Heimatstandort" finden',
+          description: 'Scrollen Sie zum Reiseeinstellungen-Bereich.',
+        },
+        enterAddress: {
+          title: 'Ihre Adresse eingeben',
+          description: 'Geben Sie Ihre Heimadresse oder die Station ein, von der Sie normalerweise reisen.',
+        },
+        saveSettings: {
+          title: 'Ihre Einstellungen speichern',
+          description: 'Bestätigen Sie Ihren Standort, um Reisezeiten zu sehen.',
+        },
+      },
+      screenshotAlt: 'Einstellungsseite mit Heimatstandort-Eingabefeld',
+      screenshotCaption: 'Ihren Heimatstandort festlegen',
+      tip: 'Verwenden Sie Ihren nächsten Bahnhof als Heimatstandort, wenn Sie normalerweise zu Fuss oder mit dem Fahrrad zum Bahnhof kommen – dies gibt genauere ÖV-Zeiten.',
+    },
+    viewingTimes: {
+      title: 'Reisezeiten anzeigen',
+      description: 'Sobald Ihr Heimatstandort festgelegt ist, erscheinen Reisezeiten auf Ihren Einsatzkarten und in der Einsatzdetailansicht.',
+      screenshotAlt: 'Einsatzkarte mit Reisezeitinformationen',
+      screenshotCaption: 'Reisezeit auf einem Einsatz angezeigt',
+      whatsShown: {
+        title: 'Was angezeigt wird',
+        duration: 'Dauer – Gesamtreisezeit von zu Hause zum Spielort',
+        departureTime: 'Abfahrtszeit – Wann Sie losfahren sollten, um pünktlich anzukommen',
+        transportType: 'Transportart – Zug-, Bus- oder gemischtes Transportsymbol',
+      },
+    },
+    journeyDetails: {
+      title: 'Reisedetails',
+      description: 'Tippen Sie auf die Reisezeit, um vollständige Reisedetails zu sehen:',
+      features: {
+        stepByStep: 'Schritt-für-Schritt-Anleitung',
+        connectionDetails: 'Verbindungsdetails (Zugnummern, Gleise)',
+        walkingSegments: 'Fusswegabschnitte',
+        transferTimes: 'Umsteigezeiten',
+      },
+      sbbLink: 'Sie können die Reise auch direkt in der SBB-App oder Website öffnen für Echtzeit-Updates und Ticketkauf.',
+      screenshotAlt: 'Detaillierte Reiseinformationen mit Verbindungen und Zeiten',
+      screenshotCaption: 'Vollständige Reisedetails für die Reiseplanung',
+    },
+    arrivalBuffer: {
+      title: 'Ankunftspuffer',
+      description: 'Die vorgeschlagene Abfahrtszeit enthält einen Puffer, um sicherzustellen, dass Sie vor Spielbeginn ankommen:',
+      details: {
+        standardBuffer: 'Standardpuffer: 15-30 Minuten vor Spielbeginn',
+        timeFor: 'Zeit zum Finden des Spielorts, Umziehen und Aufwärmen',
+        accountForDelays: 'Berücksichtigung möglicher kleiner Verspätungen',
+      },
+      warning: 'Planen Sie immer zusätzliche Zeit für wichtige Spiele oder unbekannte Spielorte ein. Öffentliche Verkehrsmittel können unerwartete Verspätungen haben.',
+    },
+    offlineAvailability: {
+      title: 'Offline-Verfügbarkeit',
+      description: 'Reisezeiten werden zwischengespeichert, wenn Sie sie online anzeigen. Wenn Sie offline sind:',
+      details: {
+        cachedAvailable: 'Zuvor angesehene Reisezeiten bleiben verfügbar',
+        requiresConnection: 'Neue Berechnungen erfordern eine Internetverbindung',
+        outdatedIndicator: 'Die App zeigt an, wenn Daten möglicherweise veraltet sind',
+      },
+      tip: 'Prüfen Sie Ihre Reisezeiten online, bevor Sie in ein Gebiet mit schlechter Verbindung gehen. Die zwischengespeicherten Daten sind offline verfügbar.',
+    },
+  },
+
+  offlinePwa: {
+    heading: 'Offline & PWA-Funktionen',
+    lead: 'VolleyKit ist eine Progressive Web App (PWA), die Sie auf Ihrem Gerät installieren und offline nutzen können. Greifen Sie auf Ihre Einsätze zu, auch ohne Internetverbindung.',
+    whatIsPwa: {
+      title: 'Was ist eine PWA?',
+      description: 'Eine Progressive Web App ist eine Website, die wie eine native App funktioniert. Wenn Sie VolleyKit installieren:',
+      benefits: {
+        homeScreen: 'Erscheint auf Ihrem Startbildschirm wie eine reguläre App',
+        ownWindow: 'Öffnet sich in einem eigenen Fenster ohne Browser-Oberfläche',
+        worksOffline: 'Funktioniert offline für zuvor angesehene Inhalte',
+        autoUpdates: 'Erhält automatisch Updates',
+        minimalStorage: 'Verwendet minimalen Speicher im Vergleich zu nativen Apps',
+      },
+      tip: 'PWAs kombinieren das Beste aus Web- und nativen Apps – einfache Installation, automatische Updates und Offline-Fähigkeit ohne App-Store-Downloads.',
+    },
+    installing: {
+      title: 'Die App installieren',
+      description: 'Sie können VolleyKit auf jedem modernen Gerät installieren – Handys, Tablets oder Computer.',
+      ios: {
+        title: 'Auf iOS (iPhone/iPad)',
+        steps: {
+          openSafari: {
+            title: 'VolleyKit in Safari öffnen',
+            description: 'Die Installationsfunktion funktioniert nur in Safari auf iOS.',
+          },
+          tapShare: {
+            title: 'Auf den Teilen-Button tippen',
+            description: 'Finden Sie das Teilen-Symbol am unteren Bildschirmrand.',
+          },
+          selectAddHome: {
+            title: '"Zum Home-Bildschirm" auswählen',
+            description: 'Scrollen Sie im Teilen-Menü nach unten, um diese Option zu finden.',
+          },
+          confirmInstall: {
+            title: 'Installation bestätigen',
+            description: 'Tippen Sie auf "Hinzufügen", um VolleyKit auf Ihrem Startbildschirm zu installieren.',
+          },
+        },
+      },
+      android: {
+        title: 'Auf Android',
+        steps: {
+          openChrome: {
+            title: 'VolleyKit in Chrome öffnen',
+            description: 'Andere Browser wie Firefox unterstützen ebenfalls PWA-Installation.',
+          },
+          lookForPrompt: {
+            title: 'Nach der Installationsaufforderung suchen',
+            description: 'Ein Banner oder eine Aufforderung sollte erscheinen, um die App zu installieren.',
+          },
+          tapInstall: {
+            title: 'Auf "Installieren" oder "Zum Startbildschirm hinzufügen" tippen',
+            description: 'Bestätigen Sie, um die App zu Ihrem Gerät hinzuzufügen.',
+          },
+        },
+      },
+      screenshotAlt: 'PWA-Installationsaufforderung mit "Zum Startbildschirm hinzufügen"-Option',
+      screenshotCaption: 'VolleyKit auf Ihrem Gerät installieren',
+      desktop: {
+        title: 'Auf Desktop (Chrome/Edge)',
+        description: 'Suchen Sie nach dem Installationssymbol in der Adressleiste (normalerweise ein + oder Computersymbol) oder verwenden Sie das Browsermenü, um "VolleyKit installieren" zu finden.',
+      },
+    },
+    whatWorksOffline: {
+      title: 'Was offline funktioniert',
+      description: 'Wenn Sie offline sind, können Sie weiterhin auf zuvor angesehene Inhalte zugreifen:',
+      table: {
+        feature: 'Funktion',
+        offline: 'Offline',
+        notes: 'Hinweise',
+        viewAssignments: 'Einsätze anzeigen',
+        viewAssignmentsNote: 'Zuvor geladene Einsätze',
+        viewDetails: 'Spieldetails anzeigen',
+        viewDetailsNote: 'Wenn zuvor angesehen',
+        travelTimes: 'Reisezeiten',
+        travelTimesNote: 'Zwischengespeicherte Reisedaten',
+        confirmAssignments: 'Einsätze bestätigen',
+        confirmAssignmentsNote: 'Erfordert Verbindung',
+        requestExchanges: 'Tausche anfordern',
+        requestExchangesNote: 'Erfordert Verbindung',
+        viewCompensations: 'Vergütungen anzeigen',
+        viewCompensationsNote: 'Wenn zuvor geladen',
+      },
+      infoBox: 'Die App synchronisiert automatisch, wenn Sie wieder online sind. Alle Datenänderungen werden abgerufen und angezeigt.',
+    },
+    offlineIndicator: {
+      title: 'Offline-Anzeige',
+      description: 'Wenn Sie offline sind, zeigt VolleyKit eine visuelle Anzeige, damit Sie wissen, dass Sie zwischengespeicherte Daten sehen. Achten Sie auf das Offline-Abzeichen im Header oder ein Banner am oberen Bildschirmrand.',
+      screenshotAlt: 'Offline-Anzeige, die zeigt, dass die App ohne Internet läuft',
+      screenshotCaption: 'Offline-Modus-Anzeige',
+    },
+    updating: {
+      title: 'Die App aktualisieren',
+      description: 'VolleyKit aktualisiert sich automatisch im Hintergrund. Wenn eine neue Version verfügbar ist:',
+      steps: {
+        backgroundDownload: 'Die App lädt das Update im Hintergrund herunter',
+        notificationAppears: 'Eine Benachrichtigung erscheint, wenn das Update bereit ist',
+        tapReload: 'Tippen Sie auf "Neu laden", um die neue Version zu aktivieren',
+      },
+      screenshotAlt: 'App-Update-Benachrichtigung mit Aufforderung zum Neu laden',
+      screenshotCaption: 'Update verfügbar-Benachrichtigung',
+      tip: 'Wenn Sie die Update-Benachrichtigung ablehnen, wird die neue Version beim nächsten Schliessen und erneuten Öffnen der App aktiviert.',
+    },
+    storage: {
+      title: 'Speichernutzung',
+      description: 'VolleyKit verwendet minimalen Speicher auf Ihrem Gerät – typischerweise weniger als 5MB für die App selbst plus zwischengespeicherte Daten. Sie können den Cache bei Bedarf in Ihren Browsereinstellungen löschen.',
+      warning: 'Das Löschen von Browserdaten oder "Cache leeren" entfernt Ihre Offline-Daten. Sie müssen möglicherweise Einsätze beim nächsten Öffnen der App neu laden.',
+    },
+  },
+
+  settings: {
+    heading: 'App-Einstellungen',
+    lead: 'Passen Sie VolleyKit an Ihre Präferenzen an. Konfigurieren Sie Sprache, Heimatstandort und Datenschutzoptionen.',
+    accessing: {
+      title: 'Auf Einstellungen zugreifen',
+      description: 'Öffnen Sie die Einstellungen durch Tippen auf das Zahnradsymbol in der Navigationsleiste oder durch Auswählen von "Einstellungen" im Hauptmenü.',
+      screenshotAlt: 'Einstellungsseite mit allen verfügbaren Optionen',
+      screenshotCaption: 'VolleyKit-Einstellungsseite',
+    },
+    profile: {
+      title: 'Profilbereich',
+      description: 'Der Profilbereich zeigt Ihre Kontoinformationen:',
+      fields: {
+        name: 'Name – Ihr registrierter Schiedsrichtername',
+        licenseNumber: 'Lizenznummer – Ihre Swiss Volley Schiedsrichterlizenz',
+        email: 'E-Mail – Ihre registrierte E-Mail-Adresse',
+        sessionStatus: 'Sitzungsstatus – Ihr aktueller Anmeldestatus',
+      },
+      infoBox: 'Profilinformationen stammen aus volleymanager und können nur auf der offiziellen Website geändert werden, nicht in VolleyKit.',
+      loggingOut: {
+        title: 'Abmelden',
+        description: 'Tippen Sie auf "Abmelden", um sich von Ihrem Konto abzumelden. Dies löscht Ihre Sitzung und alle lokal gespeicherten Daten.',
+      },
+    },
+    language: {
+      title: 'Spracheinstellungen',
+      description: 'VolleyKit unterstützt mehrere Sprachen entsprechend Ihrer Präferenz:',
+      options: {
+        deutsch: 'Deutsch – Deutsch',
+        english: 'English – Englisch',
+        francais: 'Français – Französisch',
+        italiano: 'Italiano – Italienisch',
+      },
+      autoDetect: 'Die App verwendet automatisch die Sprache Ihres Browsers, wenn sie unterstützt wird, aber Sie können dies in den Einstellungen überschreiben.',
+      screenshotAlt: 'Sprachauswahl mit verfügbaren Optionen',
+      screenshotCaption: 'Die App-Sprache ändern',
+    },
+    homeLocation: {
+      title: 'Heimatstandort',
+      description: 'Legen Sie Ihren Heimatstandort fest, um Reisezeitberechnungen zu aktivieren. Dies wird verwendet, um zu zeigen, wie lange Sie brauchen, um jeden Spielort zu erreichen.',
+      instructions: {
+        enterAddress: 'Ihre Adresse oder den nächsten Bahnhof eingeben',
+        useAutocomplete: 'Die Autovervollständigungs-Vorschläge für Genauigkeit verwenden',
+        travelTimesAppear: 'Reisezeiten erscheinen auf Ihren Einsatzkarten',
+      },
+      screenshotAlt: 'Heimatstandort-Eingabe mit Adresssuche',
+      screenshotCaption: 'Ihren Heimatstandort festlegen',
+      tip: 'Wenn Sie normalerweise öffentliche Verkehrsmittel nehmen, verwenden Sie Ihren nächsten Bahnhof als Heimatstandort für genauere Reisezeiten.',
+      seeGuide: 'Weitere Details zu dieser Funktion finden Sie im Reisezeit-Leitfaden.',
+    },
+    dataPrivacy: {
+      title: 'Daten & Datenschutz',
+      description: 'Kontrollieren Sie, wie Ihre Daten behandelt werden:',
+      localStorage: {
+        title: 'Lokaler Speicher',
+        description: 'VolleyKit speichert Daten lokal, um Offline-Zugriff zu ermöglichen und die Leistung zu verbessern:',
+        items: {
+          assignmentCache: 'Einsatz-Cache – Ihre letzten Einsätze',
+          preferences: 'Einstellungen – Ihre Einstellungen und Präferenzen',
+          travelData: 'Reisedaten – Zwischengespeicherte Reiseinformationen',
+        },
+      },
+      clearData: {
+        title: 'Lokale Daten löschen',
+        description: 'Sie können alle lokal gespeicherten Daten von der Einstellungsseite löschen. Dies wird:',
+        effects: {
+          removeCached: 'Zwischengespeicherte Einsätze und Reisedaten entfernen',
+          resetPreferences: 'Alle Einstellungen auf Standardwerte zurücksetzen',
+          requireLogin: 'Erfordert erneute Anmeldung',
+        },
+        warning: 'Das Löschen lokaler Daten kann nicht rückgängig gemacht werden. Sie müssen Ihre Einsätze beim nächsten Öffnen der App neu laden.',
+      },
+      screenshotAlt: 'Daten- und Datenschutzeinstellungen mit Daten-löschen-Schaltfläche',
+      screenshotCaption: 'Daten- und Datenschutzoptionen',
+    },
+    about: {
+      title: 'Über VolleyKit',
+      description: 'Der Über-Bereich zeigt:',
+      items: {
+        versionNumber: 'Versionsnummer – Aktuelle App-Version',
+        lastUpdated: 'Zuletzt aktualisiert – Wann die App zuletzt aktualisiert wurde',
+        links: 'Links – GitHub-Repository, Issue-Tracker, Hilfeseite',
+      },
+      infoBox: 'Überprüfen Sie die Versionsnummer beim Melden von Problemen – dies hilft uns, Probleme schneller zu identifizieren und zu beheben.',
+    },
+  },
 };

--- a/help-site/src/i18n/en.ts
+++ b/help-site/src/i18n/en.ts
@@ -170,4 +170,669 @@ export const en: TranslationKeys = {
     tip: 'Tip',
     warning: 'Warning',
   },
+
+  gettingStarted: {
+    heading: 'Getting Started with VolleyKit',
+    lead: 'VolleyKit is a progressive web application that provides an improved interface for managing your volleyball referee assignments through the Swiss Volleyball Federation\'s volleymanager system.',
+    whatIs: {
+      title: 'What is VolleyKit?',
+      description: 'VolleyKit connects to the official volleymanager.volleyball.ch platform and provides a modern, mobile-friendly interface for referees to:',
+      features: {
+        viewAssignments: 'View upcoming game assignments',
+        manageExchanges: 'Request and manage game exchanges with other referees',
+        trackCompensations: 'Track compensation payments',
+        offlineAccess: 'Access assignments offline',
+        travelTime: 'Calculate travel times using Swiss public transport',
+      },
+      infoBox: 'VolleyKit is an unofficial app created to improve the referee experience. All data comes from the official volleymanager system.',
+    },
+    howToLogin: {
+      title: 'How to Login',
+      description: 'VolleyKit offers two ways to access your assignments:',
+      calendarMode: {
+        title: 'Option 1: Calendar Mode (Recommended)',
+        description: 'For quick access to view your schedule without entering your password, you can use Calendar Mode with your unique calendar URL or code from volleymanager.',
+        steps: {
+          findUrl: {
+            title: 'Find your calendar URL',
+            description: 'In volleymanager, go to "My Assignments" and copy your calendar subscription URL.',
+          },
+          selectMode: {
+            title: 'Select Calendar Mode',
+            description: 'On the VolleyKit login page, tap the "Calendar Mode" tab.',
+          },
+          pasteUrl: {
+            title: 'Paste your URL or code',
+            description: 'Enter your calendar URL or just the code portion to access your schedule.',
+          },
+        },
+        infoBox: 'Calendar Mode provides read-only access – you can view assignments but cannot confirm games, request exchanges, or access compensations. See the Calendar Mode guide for more details.',
+      },
+      fullLogin: {
+        title: 'Option 2: Full Login',
+        description: 'Use your volleymanager.volleyball.ch credentials for full access to all features.',
+        steps: {
+          openApp: {
+            title: 'Open VolleyKit',
+            description: 'Navigate to the VolleyKit app in your browser or open the installed app.',
+          },
+          enterCredentials: {
+            title: 'Enter your credentials',
+            description: 'Use your volleymanager username and password to log in.',
+          },
+          stayLoggedIn: {
+            title: 'Stay logged in',
+            description: 'Enable "Remember me" to stay logged in between sessions.',
+          },
+        },
+        screenshotAlt: 'VolleyKit login page showing username and password fields',
+        screenshotCaption: 'The VolleyKit login page',
+        tipTitle: 'Can\'t remember your password?',
+        tipContent: 'VolleyKit uses the same credentials as volleymanager.volleyball.ch. Use the password reset function on the official site if you\'ve forgotten your password.',
+      },
+    },
+    quickTour: {
+      title: 'Quick Tour',
+      description: 'After logging in, you\'ll see the main dashboard with your upcoming assignments. Here\'s a quick overview of the main sections:',
+      assignments: {
+        title: 'Assignments',
+        description: 'View all your upcoming referee games. Each assignment shows the date, time, teams, venue, and your role (1st referee, 2nd referee, or line judge).',
+      },
+      exchanges: {
+        title: 'Exchanges',
+        description: 'Browse available game exchanges from other referees or request an exchange for one of your own assignments.',
+      },
+      compensations: {
+        title: 'Compensations',
+        description: 'Track your referee payments and compensation history. Filter by date range and export your data.',
+      },
+      settings: {
+        title: 'Settings',
+        description: 'Customize your experience including language, home location for travel calculations, and notification preferences.',
+      },
+    },
+    nextSteps: {
+      title: 'Next Steps',
+      description: 'Now that you\'re familiar with the basics, explore the detailed guides for each feature:',
+      links: {
+        assignments: 'Managing your assignments',
+        exchanges: 'Requesting and accepting exchanges',
+        compensations: 'Tracking your compensations',
+      },
+    },
+  },
+
+  assignments: {
+    heading: 'Managing Your Assignments',
+    lead: 'The Assignments section is your central hub for viewing all your upcoming volleyball referee games and managing your schedule.',
+    whatAre: {
+      title: 'What Are Assignments?',
+      description: 'Assignments are the games you\'ve been scheduled to referee. Each assignment includes:',
+      details: {
+        dateTime: 'Date and time – When the game takes place',
+        teams: 'Teams – Home and away team names',
+        venue: 'Venue – Location of the game with address',
+        role: 'Your role – 1st referee, 2nd referee, or line judge',
+        league: 'League – The competition level (e.g., NLA, NLB, 1. Liga)',
+      },
+    },
+    viewing: {
+      title: 'Viewing Your Assignments',
+      description: 'The assignment list shows all your upcoming games in chronological order. Games are grouped by date, making it easy to see what\'s coming up.',
+      screenshotAlt: 'Assignment list showing multiple upcoming games grouped by date',
+      screenshotCaption: 'The assignment list view with upcoming games',
+    },
+    details: {
+      title: 'Assignment Details',
+      description: 'Tap on any assignment to see the full details. The detail view includes:',
+      items: {
+        gameInfo: 'Complete game information',
+        venueAddress: 'Venue address with map link',
+        travelTime: 'Travel time from your home location',
+        otherReferees: 'Other referees assigned to the same game',
+        swipeActions: 'Available actions via swipe gestures',
+      },
+      screenshotAlt: 'Assignment detail view showing all game information',
+      screenshotCaption: 'Detailed view of a single assignment',
+    },
+    actions: {
+      title: 'Taking Actions',
+      description: 'VolleyKit uses swipe gestures to quickly access actions on your assignment cards. Depending on the game status, you may have different actions available.',
+      swipeRight: {
+        title: 'Swipe Right – Add to Exchange',
+        description: 'Swipe an assignment card to the right to reveal the exchange action. If you can\'t attend a game, you can add it to the exchange board for other referees to pick up.',
+        screenshotAlt: 'Assignment card swiped right showing exchange action',
+        screenshotCaption: 'Swipe right to add an assignment to the exchange board',
+        warning: 'Make sure to request an exchange well in advance. Last-minute requests may not find a replacement in time.',
+      },
+      swipeLeft: {
+        title: 'Swipe Left – Validate & Edit',
+        description: 'Swipe an assignment card to the left to reveal additional actions:',
+        validate: 'Validate – Submit game results and validate the match (available for first referees after the game)',
+        edit: 'Edit – Edit your compensation details for this assignment',
+        screenshotAlt: 'Assignment card swiped left showing validate and edit actions',
+        screenshotCaption: 'Swipe left to reveal validate and edit actions',
+        tip: 'You can also perform a full swipe to immediately trigger the primary action without tapping the button.',
+      },
+      directions: {
+        title: 'Get Directions',
+        description: 'Tap on an assignment card to expand it, then use the directions button to open your preferred maps application with directions to the venue.',
+      },
+    },
+    upcomingPast: {
+      title: 'Upcoming and Past Games',
+      description: 'Use the tabs at the top to switch between:',
+      upcoming: 'Upcoming – Games that haven\'t happened yet',
+      validationClosed: 'Validation Closed – Past games where validation is complete',
+      tip: 'Set your home location in Settings to see travel time estimates on each assignment card.',
+    },
+  },
+
+  exchanges: {
+    heading: 'Game Exchanges',
+    lead: 'The exchange system allows referees to swap games when they can\'t attend their scheduled assignments. You can request exchanges for your games or pick up games from other referees.',
+    whatAre: {
+      title: 'What Are Exchanges?',
+      description: 'An exchange is a request from a referee who can\'t attend their scheduled game and is looking for a replacement. The volleymanager system maintains an exchange board where referees can:',
+      features: {
+        postGames: 'Post their games for exchange',
+        browseGames: 'Browse available games from other referees',
+        acceptGames: 'Accept games that fit their schedule',
+      },
+      infoBox: 'Exchanges are managed through the official volleymanager system. VolleyKit provides a more user-friendly interface to the same exchange board.',
+    },
+    requesting: {
+      title: 'Requesting an Exchange',
+      description: 'When you can\'t attend one of your scheduled games, you can request an exchange to find a replacement referee.',
+      steps: {
+        findAssignment: {
+          title: 'Find the assignment',
+          description: 'Go to your Assignments tab and locate the game you want to exchange.',
+        },
+        swipeRight: {
+          title: 'Swipe right on the card',
+          description: 'Swipe the assignment card to the right to reveal the exchange action, then tap it. The game will be posted to the exchange board.',
+        },
+      },
+      screenshotAlt: 'Assignment card with exchange swipe action revealed',
+      screenshotCaption: 'Requesting an exchange for a game',
+      warningTitle: 'Request early',
+      warningContent: 'The earlier you request an exchange, the more likely you\'ll find a replacement. Last-minute requests often go unfilled.',
+    },
+    viewing: {
+      title: 'Viewing Available Exchanges',
+      description: 'The Exchanges tab shows all games currently available for exchange. These are games that other referees have posted and are looking for replacements.',
+      screenshotAlt: 'List of available exchange games from other referees',
+      screenshotCaption: 'Available games on the exchange board',
+      filtering: {
+        title: 'Filtering Exchanges',
+        description: 'Filter the exchange list to find games that work for you. Filters become available after you configure the required settings:',
+        distance: 'Distance – Filter by maximum distance from your home location. Requires setting your home location in Settings.',
+        travelTime: 'Travel time – Filter by maximum travel time using public transport. Requires both a home location and enabling the public transport API in Settings.',
+        usage: 'Once filters are available, they appear as toggle chips next to the settings gear icon. Tap the gear to configure the maximum values for each filter.',
+        tip: 'Set your home location in Settings to unlock distance filtering. Enable the public transport API to also filter by travel time.',
+      },
+    },
+    accepting: {
+      title: 'Accepting an Exchange',
+      description: 'When you find a game you\'d like to take over, you can accept the exchange:',
+      steps: {
+        review: {
+          title: 'Review the game details',
+          description: 'Check the date, time, venue, and travel requirements.',
+        },
+        swipeLeft: {
+          title: 'Swipe left on the card',
+          description: 'Swipe the exchange card to the left to reveal the take over action, then tap it.',
+        },
+        confirm: {
+          title: 'Confirm your acceptance',
+          description: 'Review the details and confirm your acceptance.',
+        },
+        gameAdded: {
+          title: 'Game added to your schedule',
+          description: 'The game now appears in your assignments.',
+        },
+      },
+      tip: 'Make sure you can actually attend the game before accepting. Once accepted, the original referee is released from the assignment.',
+    },
+    managing: {
+      title: 'Managing Your Exchange Requests',
+      description: 'You can view and manage your active exchange requests from the Exchanges tab. If you no longer need an exchange (e.g., your schedule changed), you can cancel the request before someone accepts it.',
+      canceling: {
+        title: 'Canceling a Request',
+        description: 'To cancel an exchange request you\'ve made:',
+        steps: {
+          goToExchanges: 'Go to the Exchanges tab',
+          selectAddedByMe: 'Select the "Added by Me" tab to see your pending requests',
+          swipeRight: 'Swipe right on the request card to reveal the remove action, then tap it',
+          confirmCancellation: 'Confirm the cancellation',
+        },
+        infoBox: 'You can only cancel an exchange request if no one has accepted it yet. Once accepted, the exchange is final.',
+      },
+    },
+  },
+
+  compensations: {
+    heading: 'Tracking Your Compensations',
+    lead: 'The Compensations section helps you track your referee earnings and payment history. View past payments, filter by date range, and export your data for record-keeping.',
+    whatAre: {
+      title: 'What Are Compensations?',
+      description: 'Compensations are the payments you receive for officiating volleyball games. Each compensation entry typically includes:',
+      details: {
+        gameDetails: 'Game details – The match you officiated',
+        date: 'Date – When the game took place',
+        amount: 'Amount – The compensation amount in CHF',
+        paymentStatus: 'Payment status – Pending, paid, or processed',
+        role: 'Role – Your function in the game',
+      },
+      infoBox: 'Compensation amounts are set by Swiss Volley and vary based on the league level and your role in the game.',
+    },
+    viewing: {
+      title: 'Viewing Your Compensations',
+      description: 'The compensation list shows all your recorded payments in chronological order. Each entry displays the key information at a glance.',
+      screenshotAlt: 'Compensation list showing payment history with amounts and dates',
+      screenshotCaption: 'Your compensation history',
+      paymentStatus: {
+        title: 'Understanding Payment Status',
+        pending: 'Pending – Game completed, payment not yet processed',
+        processing: 'Processing – Payment is being processed',
+        paid: 'Paid – Payment has been made to your account',
+      },
+    },
+    filtering: {
+      title: 'Filtering by Status',
+      description: 'Use the tabs at the top to filter compensations by their status:',
+      tabs: {
+        pendingPast: 'Pending (Past) – Past games awaiting payment',
+        pendingFuture: 'Pending (Future) – Upcoming games not yet played',
+        closed: 'Closed – Completed and paid compensations',
+      },
+      screenshotAlt: 'Compensation tabs showing pending and closed options',
+      screenshotCaption: 'Filtering compensations by status',
+      tip: 'Compensations are automatically filtered to the current season (September to May) so you can focus on recent games.',
+    },
+    exportPdf: {
+      title: 'Export to PDF',
+      description: 'You can export individual compensation records as PDF documents. Swipe left on any compensation card to reveal the PDF export action.',
+      usage: 'The exported PDF includes the game details and compensation information in a formatted document. This is useful for providing to teams that need to pay the referee directly.',
+      infoBox: 'The PDF export creates an official-looking document with all the game and compensation details that teams may require for their records.',
+    },
+    paymentSchedule: {
+      title: 'Payment Schedule',
+      description: 'Compensation payments are typically processed monthly by Swiss Volley. The exact payment schedule may vary, but generally:',
+      details: {
+        processing: 'Games from the previous month are processed at the start of each month',
+        bankTransfer: 'Payments are made via bank transfer to your registered account',
+        timing: 'Processing may take 2-4 weeks after the month ends',
+      },
+      warning: 'Make sure your bank details are up to date in the volleymanager system to avoid payment delays.',
+    },
+  },
+
+  calendarMode: {
+    heading: 'Calendar Mode',
+    lead: 'Calendar mode provides read-only access to view referee assignments without requiring a full login. It\'s perfect for quickly checking your schedule or sharing with family members.',
+    whatIs: {
+      title: 'What Is Calendar Mode?',
+      description: 'Calendar mode is a lightweight view-only access method that lets you see your upcoming assignments without entering your password. It uses a unique calendar code that\'s linked to your referee account.',
+      features: {
+        viewAssignments: 'View your upcoming game assignments',
+        seeDetails: 'See game details including date, time, teams, and venue',
+        noPassword: 'No password required – just your calendar code',
+        safeToShare: 'Safe to share with family or add to shared calendars',
+      },
+    },
+    whoIsFor: {
+      title: 'Who Is Calendar Mode For?',
+      description: 'Calendar mode is ideal for:',
+      useCases: {
+        quickChecks: 'Quick schedule checks – View your games without logging in',
+        familyMembers: 'Family members – Share your schedule with partners or family',
+        calendarIntegration: 'Calendar integration – Add games to external calendar apps',
+        publicDevices: 'Public devices – Check your schedule on shared computers',
+      },
+      tip: 'Calendar mode is perfect for letting your family know when you have games without giving them access to your full account.',
+    },
+    howToAccess: {
+      title: 'How to Access Calendar Mode',
+      description: 'To use calendar mode, you need your unique calendar code from the volleymanager system.',
+      steps: {
+        findCode: {
+          title: 'Find your calendar code',
+          description: 'Log in to volleymanager.volleyball.ch and find your calendar code in your profile settings.',
+        },
+        openApp: {
+          title: 'Open VolleyKit',
+          description: 'Navigate to the VolleyKit app.',
+        },
+        selectMode: {
+          title: 'Select "Calendar Mode"',
+          description: 'On the login page, tap the "Calendar Mode" option.',
+        },
+        enterCode: {
+          title: 'Enter your code',
+          description: 'Input your calendar code to access your read-only schedule.',
+        },
+      },
+      screenshotAlt: 'Calendar mode entry screen with code input field',
+      screenshotCaption: 'Entering calendar mode with your code',
+    },
+    viewingSchedule: {
+      title: 'Viewing Your Schedule',
+      description: 'Once in calendar mode, you\'ll see your upcoming assignments in a simplified view. The interface shows the essential information for each game.',
+      screenshotAlt: 'Calendar mode showing upcoming assignments in read-only view',
+      screenshotCaption: 'Calendar mode assignment view',
+    },
+    limitations: {
+      title: 'Limitations vs Full Login',
+      description: 'Calendar mode is read-only, which means some features are not available:',
+      table: {
+        feature: 'Feature',
+        fullLogin: 'Full Login',
+        calendarMode: 'Calendar Mode',
+        viewAssignments: 'View assignments',
+        viewDetails: 'View game details',
+        travelTime: 'Travel time info',
+        confirmAssignments: 'Confirm assignments',
+        requestExchanges: 'Request exchanges',
+        viewCompensations: 'View compensations',
+        acceptExchanges: 'Accept exchanges',
+      },
+      infoBox: 'For any actions like confirming assignments or requesting exchanges, you\'ll need to log in with your full credentials.',
+    },
+    security: {
+      title: 'Keeping Your Code Secure',
+      description: 'While calendar mode is read-only, your calendar code should still be treated with care:',
+      tips: {
+        shareWithTrust: 'Only share with people you trust',
+        dontPostPublicly: 'Don\'t post your code publicly online',
+        ifCompromised: 'If you suspect your code has been compromised, contact Swiss Volley',
+      },
+      warning: 'Your calendar code reveals your full game schedule. Only share it with people you\'re comfortable knowing your whereabouts.',
+    },
+  },
+
+  travelTime: {
+    heading: 'Travel Time Feature',
+    lead: 'VolleyKit integrates with Swiss public transport data to show you how long it takes to reach each game venue. Plan your trips better and never be late to a game.',
+    howItWorks: {
+      title: 'How It Works',
+      description: 'The travel time feature uses the Swiss public transport API (SBB/öV) to calculate journey times from your home location to each game venue. It considers:',
+      considerations: {
+        schedules: 'Real-time train, bus, and tram schedules',
+        walkingTime: 'Walking time to/from stations',
+        transferTimes: 'Transfer times between connections',
+        gameStartTime: 'The actual game start time',
+      },
+      infoBox: 'Travel times are calculated using public transport. If you typically drive, use the times as a rough estimate or for planning alternative transport options.',
+    },
+    settingHome: {
+      title: 'Setting Your Home Location',
+      description: 'To get accurate travel times, you need to set your home location in the app settings.',
+      steps: {
+        openSettings: {
+          title: 'Open Settings',
+          description: 'Navigate to the Settings page in VolleyKit.',
+        },
+        findHomeLocation: {
+          title: 'Find "Home Location"',
+          description: 'Scroll to the travel settings section.',
+        },
+        enterAddress: {
+          title: 'Enter your address',
+          description: 'Type your home address or the station you typically travel from.',
+        },
+        saveSettings: {
+          title: 'Save your settings',
+          description: 'Confirm your location to start seeing travel times.',
+        },
+      },
+      screenshotAlt: 'Settings page showing home location input field',
+      screenshotCaption: 'Setting your home location',
+      tip: 'Use your nearest train station as your home location if you typically walk or cycle to the station – this gives more accurate public transport times.',
+    },
+    viewingTimes: {
+      title: 'Viewing Travel Times',
+      description: 'Once your home location is set, travel times appear on your assignment cards and in the assignment detail view.',
+      screenshotAlt: 'Assignment card showing travel time information',
+      screenshotCaption: 'Travel time displayed on an assignment',
+      whatsShown: {
+        title: 'What\'s Shown',
+        duration: 'Duration – Total travel time from home to venue',
+        departureTime: 'Departure time – When you should leave to arrive on time',
+        transportType: 'Transport type – Train, bus, or mixed transport icon',
+      },
+    },
+    journeyDetails: {
+      title: 'Journey Details',
+      description: 'Tap on the travel time to see full journey details:',
+      features: {
+        stepByStep: 'Step-by-step directions',
+        connectionDetails: 'Connection details (train numbers, platforms)',
+        walkingSegments: 'Walking segments',
+        transferTimes: 'Transfer times',
+      },
+      sbbLink: 'You can also open the journey directly in the SBB app or website for real-time updates and ticket purchase.',
+      screenshotAlt: 'Detailed journey information with connections and times',
+      screenshotCaption: 'Full journey details for travel planning',
+    },
+    arrivalBuffer: {
+      title: 'Arrival Buffer',
+      description: 'The suggested departure time includes a buffer to ensure you arrive before the game starts:',
+      details: {
+        standardBuffer: 'Standard buffer: 15-30 minutes before game time',
+        timeFor: 'Time for finding the venue, changing, and warmup',
+        accountForDelays: 'Account for potential minor delays',
+      },
+      warning: 'Always allow extra time for important games or unfamiliar venues. Public transport can experience unexpected delays.',
+    },
+    offlineAvailability: {
+      title: 'Offline Availability',
+      description: 'Travel times are cached when you view them online. If you\'re offline:',
+      details: {
+        cachedAvailable: 'Previously viewed travel times remain available',
+        requiresConnection: 'New calculations require an internet connection',
+        outdatedIndicator: 'The app indicates when data might be outdated',
+      },
+      tip: 'Check your travel times while online before heading to an area with poor connectivity. The cached data will be available offline.',
+    },
+  },
+
+  offlinePwa: {
+    heading: 'Offline & PWA Features',
+    lead: 'VolleyKit is a Progressive Web App (PWA) that you can install on your device and use offline. Access your assignments even without an internet connection.',
+    whatIsPwa: {
+      title: 'What Is a PWA?',
+      description: 'A Progressive Web App is a website that works like a native app. When you install VolleyKit:',
+      benefits: {
+        homeScreen: 'It appears on your home screen like a regular app',
+        ownWindow: 'Opens in its own window without browser UI',
+        worksOffline: 'Works offline for previously viewed content',
+        autoUpdates: 'Receives updates automatically',
+        minimalStorage: 'Uses minimal storage compared to native apps',
+      },
+      tip: 'PWAs combine the best of web and native apps – easy installation, automatic updates, and offline capability without app store downloads.',
+    },
+    installing: {
+      title: 'Installing the App',
+      description: 'You can install VolleyKit on any modern device – phones, tablets, or computers.',
+      ios: {
+        title: 'On iOS (iPhone/iPad)',
+        steps: {
+          openSafari: {
+            title: 'Open VolleyKit in Safari',
+            description: 'The install feature only works in Safari on iOS.',
+          },
+          tapShare: {
+            title: 'Tap the Share button',
+            description: 'Find the share icon at the bottom of the screen.',
+          },
+          selectAddHome: {
+            title: 'Select "Add to Home Screen"',
+            description: 'Scroll down in the share menu to find this option.',
+          },
+          confirmInstall: {
+            title: 'Confirm the installation',
+            description: 'Tap "Add" to install VolleyKit on your home screen.',
+          },
+        },
+      },
+      android: {
+        title: 'On Android',
+        steps: {
+          openChrome: {
+            title: 'Open VolleyKit in Chrome',
+            description: 'Other browsers like Firefox also support PWA installation.',
+          },
+          lookForPrompt: {
+            title: 'Look for the install prompt',
+            description: 'A banner or prompt should appear asking to install the app.',
+          },
+          tapInstall: {
+            title: 'Tap "Install" or "Add to Home Screen"',
+            description: 'Confirm to add the app to your device.',
+          },
+        },
+      },
+      screenshotAlt: 'PWA install prompt showing Add to Home Screen option',
+      screenshotCaption: 'Installing VolleyKit on your device',
+      desktop: {
+        title: 'On Desktop (Chrome/Edge)',
+        description: 'Look for the install icon in the address bar (usually a + or computer icon), or use the browser menu to find "Install VolleyKit".',
+      },
+    },
+    whatWorksOffline: {
+      title: 'What Works Offline',
+      description: 'When you\'re offline, you can still access content you\'ve previously viewed:',
+      table: {
+        feature: 'Feature',
+        offline: 'Offline',
+        notes: 'Notes',
+        viewAssignments: 'View assignments',
+        viewAssignmentsNote: 'Previously loaded assignments',
+        viewDetails: 'View game details',
+        viewDetailsNote: 'If previously viewed',
+        travelTimes: 'Travel times',
+        travelTimesNote: 'Cached journey data',
+        confirmAssignments: 'Confirm assignments',
+        confirmAssignmentsNote: 'Requires connection',
+        requestExchanges: 'Request exchanges',
+        requestExchangesNote: 'Requires connection',
+        viewCompensations: 'View compensations',
+        viewCompensationsNote: 'If previously loaded',
+      },
+      infoBox: 'The app automatically syncs when you\'re back online. Any data changes will be fetched and displayed.',
+    },
+    offlineIndicator: {
+      title: 'Offline Indicator',
+      description: 'When you\'re offline, VolleyKit shows a visual indicator so you know you\'re viewing cached data. Look for the offline badge in the header or a banner at the top of the screen.',
+      screenshotAlt: 'Offline indicator showing the app is running without internet',
+      screenshotCaption: 'Offline mode indicator',
+    },
+    updating: {
+      title: 'Updating the App',
+      description: 'VolleyKit updates automatically in the background. When a new version is available:',
+      steps: {
+        backgroundDownload: 'The app downloads the update in the background',
+        notificationAppears: 'A notification appears when the update is ready',
+        tapReload: 'Tap "Reload" to activate the new version',
+      },
+      screenshotAlt: 'App update notification prompting to reload',
+      screenshotCaption: 'Update available notification',
+      tip: 'If you dismiss the update notification, the new version will activate the next time you close and reopen the app.',
+    },
+    storage: {
+      title: 'Storage Usage',
+      description: 'VolleyKit uses minimal storage on your device – typically less than 5MB for the app itself plus cached data. You can clear the cache from your browser settings if needed.',
+      warning: 'Clearing browser data or "Clear Cache" will remove your offline data. You may need to reload assignments the next time you open the app.',
+    },
+  },
+
+  settings: {
+    heading: 'App Settings',
+    lead: 'Customize VolleyKit to match your preferences. Configure language, home location, and privacy options.',
+    accessing: {
+      title: 'Accessing Settings',
+      description: 'Open settings by tapping the gear icon in the navigation bar, or by selecting "Settings" from the main menu.',
+      screenshotAlt: 'Settings page showing all available options',
+      screenshotCaption: 'VolleyKit settings page',
+    },
+    profile: {
+      title: 'Profile Section',
+      description: 'The profile section shows your account information:',
+      fields: {
+        name: 'Name – Your registered referee name',
+        licenseNumber: 'License number – Your Swiss Volley referee license',
+        email: 'Email – Your registered email address',
+        sessionStatus: 'Session status – Your current login status',
+      },
+      infoBox: 'Profile information comes from volleymanager and can only be changed on the official website, not in VolleyKit.',
+      loggingOut: {
+        title: 'Logging Out',
+        description: 'Tap "Log Out" to sign out of your account. This clears your session and any locally stored data.',
+      },
+    },
+    language: {
+      title: 'Language Settings',
+      description: 'VolleyKit supports multiple languages to match your preference:',
+      options: {
+        deutsch: 'Deutsch – German',
+        english: 'English – English',
+        francais: 'Français – French',
+        italiano: 'Italiano – Italian',
+      },
+      autoDetect: 'The app will automatically use your browser\'s language if it\'s supported, but you can override this in settings.',
+      screenshotAlt: 'Language selection showing available options',
+      screenshotCaption: 'Changing the app language',
+    },
+    homeLocation: {
+      title: 'Home Location',
+      description: 'Set your home location to enable travel time calculations. This is used to show how long it takes to reach each game venue.',
+      instructions: {
+        enterAddress: 'Enter your address or nearest train station',
+        useAutocomplete: 'Use the autocomplete suggestions for accuracy',
+        travelTimesAppear: 'Travel times will appear on your assignment cards',
+      },
+      screenshotAlt: 'Home location input with address search',
+      screenshotCaption: 'Setting your home location',
+      tip: 'If you typically take public transport, use your nearest station as your home location for more accurate journey times.',
+      seeGuide: 'See the Travel Time guide for more details on this feature.',
+    },
+    dataPrivacy: {
+      title: 'Data & Privacy',
+      description: 'Control how your data is handled:',
+      localStorage: {
+        title: 'Local Storage',
+        description: 'VolleyKit stores data locally to enable offline access and improve performance:',
+        items: {
+          assignmentCache: 'Assignment cache – Your recent assignments',
+          preferences: 'Preferences – Your settings and preferences',
+          travelData: 'Travel data – Cached journey information',
+        },
+      },
+      clearData: {
+        title: 'Clear Local Data',
+        description: 'You can clear all locally stored data from the settings page. This will:',
+        effects: {
+          removeCached: 'Remove cached assignments and travel data',
+          resetPreferences: 'Reset all preferences to defaults',
+          requireLogin: 'Require you to log in again',
+        },
+        warning: 'Clearing local data cannot be undone. You\'ll need to reload your assignments the next time you open the app.',
+      },
+      screenshotAlt: 'Data and privacy settings section with clear data button',
+      screenshotCaption: 'Data and privacy options',
+    },
+    about: {
+      title: 'About VolleyKit',
+      description: 'The About section shows:',
+      items: {
+        versionNumber: 'Version number – Current app version',
+        lastUpdated: 'Last updated – When the app was last updated',
+        links: 'Links – GitHub repository, issue tracker, help site',
+      },
+      infoBox: 'Check the version number when reporting issues – it helps us identify and fix problems faster.',
+    },
+  },
 };

--- a/help-site/src/i18n/fr.ts
+++ b/help-site/src/i18n/fr.ts
@@ -171,4 +171,669 @@ export const fr: TranslationKeys = {
     tip: 'Astuce',
     warning: 'Avertissement',
   },
+
+  gettingStarted: {
+    heading: 'Premiers pas avec VolleyKit',
+    lead: "VolleyKit est une application web progressive qui offre une interface améliorée pour gérer vos désignations d'arbitrage de volleyball via le système volleymanager de la Fédération Suisse de Volleyball.",
+    whatIs: {
+      title: "Qu'est-ce que VolleyKit ?",
+      description: "VolleyKit se connecte à la plateforme officielle volleymanager.volleyball.ch et offre aux arbitres une interface moderne et adaptée aux mobiles pour :",
+      features: {
+        viewAssignments: 'Voir les prochaines désignations',
+        manageExchanges: "Demander et gérer les échanges avec d'autres arbitres",
+        trackCompensations: 'Suivre les paiements d\'indemnités',
+        offlineAccess: 'Accéder aux désignations hors ligne',
+        travelTime: 'Calculer les temps de trajet avec les transports publics suisses',
+      },
+      infoBox: "VolleyKit est une application non officielle créée pour améliorer l'expérience des arbitres. Toutes les données proviennent du système volleymanager officiel.",
+    },
+    howToLogin: {
+      title: 'Comment se connecter',
+      description: "VolleyKit offre deux façons d'accéder à vos désignations :",
+      calendarMode: {
+        title: 'Option 1 : Mode calendrier (Recommandé)',
+        description: 'Pour un accès rapide à votre planning sans entrer votre mot de passe, vous pouvez utiliser le mode calendrier avec votre URL ou code de calendrier unique de volleymanager.',
+        steps: {
+          findUrl: {
+            title: 'Trouver votre URL de calendrier',
+            description: 'Dans volleymanager, allez dans "Mes désignations" et copiez votre URL d\'abonnement au calendrier.',
+          },
+          selectMode: {
+            title: 'Sélectionner le mode calendrier',
+            description: 'Sur la page de connexion VolleyKit, appuyez sur l\'onglet "Mode calendrier".',
+          },
+          pasteUrl: {
+            title: 'Coller votre URL ou code',
+            description: 'Entrez votre URL de calendrier ou juste le code pour accéder à votre planning.',
+          },
+        },
+        infoBox: "Le mode calendrier offre un accès en lecture seule – vous pouvez voir les désignations mais ne pouvez pas confirmer les matchs, demander des échanges ou accéder aux indemnités. Voir le guide du mode calendrier pour plus de détails.",
+      },
+      fullLogin: {
+        title: 'Option 2 : Connexion complète',
+        description: 'Utilisez vos identifiants volleymanager.volleyball.ch pour un accès complet à toutes les fonctionnalités.',
+        steps: {
+          openApp: {
+            title: 'Ouvrir VolleyKit',
+            description: "Naviguez vers l'application VolleyKit dans votre navigateur ou ouvrez l'application installée.",
+          },
+          enterCredentials: {
+            title: 'Entrer vos identifiants',
+            description: 'Utilisez votre nom d\'utilisateur et mot de passe volleymanager pour vous connecter.',
+          },
+          stayLoggedIn: {
+            title: 'Rester connecté',
+            description: 'Activez "Se souvenir de moi" pour rester connecté entre les sessions.',
+          },
+        },
+        screenshotAlt: "Page de connexion VolleyKit montrant les champs nom d'utilisateur et mot de passe",
+        screenshotCaption: 'La page de connexion VolleyKit',
+        tipTitle: 'Mot de passe oublié ?',
+        tipContent: "VolleyKit utilise les mêmes identifiants que volleymanager.volleyball.ch. Utilisez la fonction de réinitialisation du mot de passe sur le site officiel si vous avez oublié votre mot de passe.",
+      },
+    },
+    quickTour: {
+      title: 'Visite rapide',
+      description: "Après la connexion, vous verrez le tableau de bord principal avec vos prochaines désignations. Voici un aperçu rapide des sections principales :",
+      assignments: {
+        title: 'Désignations',
+        description: "Voir tous vos prochains matchs d'arbitrage. Chaque désignation affiche la date, l'heure, les équipes, le lieu et votre rôle (1er arbitre, 2e arbitre ou juge de ligne).",
+      },
+      exchanges: {
+        title: 'Échanges',
+        description: "Parcourir les échanges disponibles d'autres arbitres ou demander un échange pour l'une de vos désignations.",
+      },
+      compensations: {
+        title: 'Indemnités',
+        description: "Suivre vos paiements d'arbitrage et l'historique des indemnités. Filtrer par période et exporter vos données.",
+      },
+      settings: {
+        title: 'Paramètres',
+        description: 'Personnaliser votre expérience incluant la langue, le lieu de domicile pour les calculs de trajet et les préférences de notification.',
+      },
+    },
+    nextSteps: {
+      title: 'Prochaines étapes',
+      description: 'Maintenant que vous êtes familier avec les bases, explorez les guides détaillés pour chaque fonctionnalité :',
+      links: {
+        assignments: 'Gérer vos désignations',
+        exchanges: 'Demander et accepter des échanges',
+        compensations: 'Suivre vos indemnités',
+      },
+    },
+  },
+
+  assignments: {
+    heading: 'Gérer vos désignations',
+    lead: "La section Désignations est votre centre principal pour voir tous vos prochains matchs d'arbitrage de volleyball et gérer votre planning.",
+    whatAre: {
+      title: 'Que sont les désignations ?',
+      description: 'Les désignations sont les matchs pour lesquels vous avez été programmé comme arbitre. Chaque désignation comprend :',
+      details: {
+        dateTime: 'Date et heure – Quand le match a lieu',
+        teams: 'Équipes – Noms des équipes à domicile et visiteuses',
+        venue: 'Lieu – Emplacement du match avec adresse',
+        role: 'Votre rôle – 1er arbitre, 2e arbitre ou juge de ligne',
+        league: 'Ligue – Le niveau de compétition (ex: LNA, LNB, 1ère Ligue)',
+      },
+    },
+    viewing: {
+      title: 'Voir vos désignations',
+      description: 'La liste des désignations affiche tous vos prochains matchs dans l\'ordre chronologique. Les matchs sont groupés par date pour voir facilement ce qui arrive.',
+      screenshotAlt: 'Liste de désignations montrant plusieurs matchs à venir groupés par date',
+      screenshotCaption: 'La vue liste des désignations avec les prochains matchs',
+    },
+    details: {
+      title: 'Détails de désignation',
+      description: 'Appuyez sur une désignation pour voir tous les détails. La vue détaillée comprend :',
+      items: {
+        gameInfo: 'Informations complètes du match',
+        venueAddress: 'Adresse du lieu avec lien carte',
+        travelTime: 'Temps de trajet depuis votre domicile',
+        otherReferees: 'Autres arbitres assignés au même match',
+        swipeActions: 'Actions disponibles via gestes de balayage',
+      },
+      screenshotAlt: 'Vue détaillée de désignation montrant toutes les informations du match',
+      screenshotCaption: 'Vue détaillée d\'une désignation unique',
+    },
+    actions: {
+      title: 'Effectuer des actions',
+      description: 'VolleyKit utilise des gestes de balayage pour accéder rapidement aux actions sur vos cartes de désignation. Selon le statut du match, différentes actions peuvent être disponibles.',
+      swipeRight: {
+        title: 'Balayer à droite – Ajouter à l\'échange',
+        description: 'Balayez une carte de désignation vers la droite pour révéler l\'action d\'échange. Si vous ne pouvez pas assister à un match, vous pouvez l\'ajouter au tableau d\'échange pour d\'autres arbitres.',
+        screenshotAlt: 'Carte de désignation balayée à droite montrant l\'action d\'échange',
+        screenshotCaption: 'Balayer à droite pour ajouter une désignation au tableau d\'échange',
+        warning: 'Assurez-vous de demander un échange bien à l\'avance. Les demandes de dernière minute peuvent ne pas trouver de remplaçant à temps.',
+      },
+      swipeLeft: {
+        title: 'Balayer à gauche – Valider & Modifier',
+        description: 'Balayez une carte de désignation vers la gauche pour révéler des actions supplémentaires :',
+        validate: 'Valider – Soumettre les résultats du match et valider (disponible pour les premiers arbitres après le match)',
+        edit: 'Modifier – Modifier vos détails d\'indemnité pour cette désignation',
+        screenshotAlt: 'Carte de désignation balayée à gauche montrant les actions valider et modifier',
+        screenshotCaption: 'Balayer à gauche pour révéler les actions valider et modifier',
+        tip: 'Vous pouvez aussi effectuer un balayage complet pour déclencher immédiatement l\'action principale sans appuyer sur le bouton.',
+      },
+      directions: {
+        title: 'Obtenir l\'itinéraire',
+        description: 'Appuyez sur une carte de désignation pour l\'agrandir, puis utilisez le bouton d\'itinéraire pour ouvrir votre application de cartes préférée avec les directions vers le lieu.',
+      },
+    },
+    upcomingPast: {
+      title: 'Matchs à venir et passés',
+      description: 'Utilisez les onglets en haut pour basculer entre :',
+      upcoming: 'À venir – Matchs qui n\'ont pas encore eu lieu',
+      validationClosed: 'Validation terminée – Matchs passés où la validation est complète',
+      tip: 'Définissez votre domicile dans les Paramètres pour voir les estimations de temps de trajet sur chaque carte de désignation.',
+    },
+  },
+
+  exchanges: {
+    heading: 'Échanges de matchs',
+    lead: "Le système d'échange permet aux arbitres d'échanger des matchs quand ils ne peuvent pas assister à leurs désignations programmées. Vous pouvez demander des échanges pour vos matchs ou prendre des matchs d'autres arbitres.",
+    whatAre: {
+      title: 'Que sont les échanges ?',
+      description: "Un échange est une demande d'un arbitre qui ne peut pas assister à son match programmé et cherche un remplaçant. Le système volleymanager maintient un tableau d'échange où les arbitres peuvent :",
+      features: {
+        postGames: 'Publier leurs matchs pour échange',
+        browseGames: "Parcourir les matchs disponibles d'autres arbitres",
+        acceptGames: 'Accepter des matchs qui correspondent à leur planning',
+      },
+      infoBox: "Les échanges sont gérés via le système volleymanager officiel. VolleyKit offre une interface plus conviviale au même tableau d'échange.",
+    },
+    requesting: {
+      title: 'Demander un échange',
+      description: 'Quand vous ne pouvez pas assister à l\'un de vos matchs programmés, vous pouvez demander un échange pour trouver un arbitre remplaçant.',
+      steps: {
+        findAssignment: {
+          title: 'Trouver la désignation',
+          description: 'Allez dans l\'onglet Désignations et localisez le match que vous voulez échanger.',
+        },
+        swipeRight: {
+          title: 'Balayer à droite sur la carte',
+          description: "Balayez la carte de désignation vers la droite pour révéler l'action d'échange, puis appuyez dessus. Le match sera publié sur le tableau d'échange.",
+        },
+      },
+      screenshotAlt: "Carte de désignation avec action de balayage d'échange révélée",
+      screenshotCaption: 'Demander un échange pour un match',
+      warningTitle: 'Demandez tôt',
+      warningContent: 'Plus vous demandez un échange tôt, plus vous avez de chances de trouver un remplaçant. Les demandes de dernière minute restent souvent sans réponse.',
+    },
+    viewing: {
+      title: 'Voir les échanges disponibles',
+      description: "L'onglet Échanges affiche tous les matchs actuellement disponibles pour échange. Ce sont des matchs que d'autres arbitres ont publiés et pour lesquels ils cherchent des remplaçants.",
+      screenshotAlt: "Liste des matchs d'échange disponibles d'autres arbitres",
+      screenshotCaption: "Matchs disponibles sur le tableau d'échange",
+      filtering: {
+        title: 'Filtrer les échanges',
+        description: 'Filtrez la liste d\'échanges pour trouver des matchs qui vous conviennent. Les filtres deviennent disponibles après avoir configuré les paramètres requis :',
+        distance: 'Distance – Filtrer par distance maximale depuis votre domicile. Nécessite de définir votre domicile dans les Paramètres.',
+        travelTime: "Temps de trajet – Filtrer par temps de trajet maximum en transports publics. Nécessite à la fois un domicile et l'activation de l'API des transports publics dans les Paramètres.",
+        usage: "Une fois les filtres disponibles, ils apparaissent comme des puces à bascule à côté de l'icône d'engrenage. Appuyez sur l'engrenage pour configurer les valeurs maximales pour chaque filtre.",
+        tip: "Définissez votre domicile dans les Paramètres pour débloquer le filtrage par distance. Activez l'API des transports publics pour aussi filtrer par temps de trajet.",
+      },
+    },
+    accepting: {
+      title: 'Accepter un échange',
+      description: 'Quand vous trouvez un match que vous aimeriez prendre, vous pouvez accepter l\'échange :',
+      steps: {
+        review: {
+          title: 'Vérifier les détails du match',
+          description: 'Vérifiez la date, l\'heure, le lieu et les exigences de trajet.',
+        },
+        swipeLeft: {
+          title: 'Balayer à gauche sur la carte',
+          description: "Balayez la carte d'échange vers la gauche pour révéler l'action de reprise, puis appuyez dessus.",
+        },
+        confirm: {
+          title: 'Confirmer votre acceptation',
+          description: 'Vérifiez les détails et confirmez votre acceptation.',
+        },
+        gameAdded: {
+          title: 'Match ajouté à votre planning',
+          description: 'Le match apparaît maintenant dans vos désignations.',
+        },
+      },
+      tip: "Assurez-vous de pouvoir vraiment assister au match avant d'accepter. Une fois accepté, l'arbitre original est libéré de la désignation.",
+    },
+    managing: {
+      title: 'Gérer vos demandes d\'échange',
+      description: "Vous pouvez voir et gérer vos demandes d'échange actives depuis l'onglet Échanges. Si vous n'avez plus besoin d'un échange (ex: votre planning a changé), vous pouvez annuler la demande avant que quelqu'un l'accepte.",
+      canceling: {
+        title: 'Annuler une demande',
+        description: 'Pour annuler une demande d\'échange que vous avez faite :',
+        steps: {
+          goToExchanges: 'Allez dans l\'onglet Échanges',
+          selectAddedByMe: 'Sélectionnez l\'onglet "Ajoutés par moi" pour voir vos demandes en attente',
+          swipeRight: "Balayez à droite sur la carte de demande pour révéler l'action de suppression, puis appuyez dessus",
+          confirmCancellation: 'Confirmez l\'annulation',
+        },
+        infoBox: "Vous ne pouvez annuler une demande d'échange que si personne ne l'a encore acceptée. Une fois accepté, l'échange est définitif.",
+      },
+    },
+  },
+
+  compensations: {
+    heading: 'Suivre vos indemnités',
+    lead: "La section Indemnités vous aide à suivre vos gains d'arbitrage et l'historique des paiements. Voir les paiements passés, filtrer par période et exporter vos données pour vos archives.",
+    whatAre: {
+      title: 'Que sont les indemnités ?',
+      description: "Les indemnités sont les paiements que vous recevez pour arbitrer des matchs de volleyball. Chaque entrée d'indemnité comprend généralement :",
+      details: {
+        gameDetails: 'Détails du match – Le match que vous avez arbitré',
+        date: 'Date – Quand le match a eu lieu',
+        amount: 'Montant – Le montant de l\'indemnité en CHF',
+        paymentStatus: 'Statut de paiement – En attente, payé ou traité',
+        role: 'Rôle – Votre fonction dans le match',
+      },
+      infoBox: "Les montants d'indemnité sont fixés par Swiss Volley et varient selon le niveau de ligue et votre rôle dans le match.",
+    },
+    viewing: {
+      title: 'Voir vos indemnités',
+      description: "La liste des indemnités affiche tous vos paiements enregistrés dans l'ordre chronologique. Chaque entrée affiche les informations clés d'un coup d'œil.",
+      screenshotAlt: "Liste d'indemnités montrant l'historique des paiements avec montants et dates",
+      screenshotCaption: 'Votre historique d\'indemnités',
+      paymentStatus: {
+        title: 'Comprendre le statut de paiement',
+        pending: 'En attente – Match terminé, paiement pas encore traité',
+        processing: 'En traitement – Le paiement est en cours de traitement',
+        paid: 'Payé – Le paiement a été effectué sur votre compte',
+      },
+    },
+    filtering: {
+      title: 'Filtrer par statut',
+      description: 'Utilisez les onglets en haut pour filtrer les indemnités par leur statut :',
+      tabs: {
+        pendingPast: 'En attente (Passé) – Matchs passés en attente de paiement',
+        pendingFuture: 'En attente (Futur) – Matchs à venir pas encore joués',
+        closed: 'Fermé – Indemnités complétées et payées',
+      },
+      screenshotAlt: "Onglets d'indemnités montrant les options en attente et fermé",
+      screenshotCaption: 'Filtrer les indemnités par statut',
+      tip: 'Les indemnités sont automatiquement filtrées sur la saison actuelle (septembre à mai) pour vous concentrer sur les matchs récents.',
+    },
+    exportPdf: {
+      title: 'Exporter en PDF',
+      description: "Vous pouvez exporter des enregistrements d'indemnités individuels en documents PDF. Balayez à gauche sur une carte d'indemnité pour révéler l'action d'export PDF.",
+      usage: "Le PDF exporté inclut les détails du match et les informations d'indemnité dans un document formaté. C'est utile pour les équipes qui doivent payer l'arbitre directement.",
+      infoBox: "L'export PDF crée un document d'aspect officiel avec tous les détails du match et de l'indemnité que les équipes peuvent requérir pour leurs archives.",
+    },
+    paymentSchedule: {
+      title: 'Calendrier de paiement',
+      description: 'Les paiements d\'indemnités sont généralement traités mensuellement par Swiss Volley. Le calendrier exact peut varier, mais généralement :',
+      details: {
+        processing: 'Les matchs du mois précédent sont traités au début de chaque mois',
+        bankTransfer: 'Les paiements sont effectués par virement bancaire sur votre compte enregistré',
+        timing: 'Le traitement peut prendre 2-4 semaines après la fin du mois',
+      },
+      warning: 'Assurez-vous que vos coordonnées bancaires sont à jour dans le système volleymanager pour éviter les retards de paiement.',
+    },
+  },
+
+  calendarMode: {
+    heading: 'Mode calendrier',
+    lead: "Le mode calendrier offre un accès en lecture seule pour voir les désignations d'arbitrage sans connexion complète. Parfait pour vérifier rapidement votre planning ou le partager avec des membres de la famille.",
+    whatIs: {
+      title: 'Qu\'est-ce que le mode calendrier ?',
+      description: "Le mode calendrier est une méthode d'accès légère en lecture seule qui vous permet de voir vos prochaines désignations sans entrer votre mot de passe. Il utilise un code de calendrier unique lié à votre compte d'arbitre.",
+      features: {
+        viewAssignments: 'Voir vos prochaines désignations de matchs',
+        seeDetails: 'Voir les détails des matchs incluant date, heure, équipes et lieu',
+        noPassword: 'Pas de mot de passe requis – juste votre code de calendrier',
+        safeToShare: 'Sûr à partager avec la famille ou à ajouter aux calendriers partagés',
+      },
+    },
+    whoIsFor: {
+      title: 'Pour qui est le mode calendrier ?',
+      description: 'Le mode calendrier est idéal pour :',
+      useCases: {
+        quickChecks: 'Vérifications rapides de planning – Voir vos matchs sans vous connecter',
+        familyMembers: 'Membres de la famille – Partager votre planning avec partenaires ou famille',
+        calendarIntegration: 'Intégration calendrier – Ajouter des matchs à des applications de calendrier externes',
+        publicDevices: 'Appareils publics – Vérifier votre planning sur des ordinateurs partagés',
+      },
+      tip: "Le mode calendrier est parfait pour informer votre famille de vos matchs sans leur donner accès à votre compte complet.",
+    },
+    howToAccess: {
+      title: 'Comment accéder au mode calendrier',
+      description: 'Pour utiliser le mode calendrier, vous avez besoin de votre code de calendrier unique du système volleymanager.',
+      steps: {
+        findCode: {
+          title: 'Trouver votre code de calendrier',
+          description: 'Connectez-vous à volleymanager.volleyball.ch et trouvez votre code de calendrier dans les paramètres de votre profil.',
+        },
+        openApp: {
+          title: 'Ouvrir VolleyKit',
+          description: "Naviguez vers l'application VolleyKit.",
+        },
+        selectMode: {
+          title: 'Sélectionner "Mode calendrier"',
+          description: 'Sur la page de connexion, appuyez sur l\'option "Mode calendrier".',
+        },
+        enterCode: {
+          title: 'Entrer votre code',
+          description: 'Entrez votre code de calendrier pour accéder à votre planning en lecture seule.',
+        },
+      },
+      screenshotAlt: "Écran d'entrée du mode calendrier avec champ de saisie de code",
+      screenshotCaption: 'Entrer en mode calendrier avec votre code',
+    },
+    viewingSchedule: {
+      title: 'Voir votre planning',
+      description: 'En mode calendrier, vous verrez vos prochaines désignations dans une vue simplifiée. L\'interface affiche les informations essentielles pour chaque match.',
+      screenshotAlt: 'Mode calendrier montrant les prochaines désignations en vue lecture seule',
+      screenshotCaption: 'Vue désignation en mode calendrier',
+    },
+    limitations: {
+      title: 'Limitations vs connexion complète',
+      description: 'Le mode calendrier est en lecture seule, ce qui signifie que certaines fonctionnalités ne sont pas disponibles :',
+      table: {
+        feature: 'Fonctionnalité',
+        fullLogin: 'Connexion complète',
+        calendarMode: 'Mode calendrier',
+        viewAssignments: 'Voir les désignations',
+        viewDetails: 'Voir les détails des matchs',
+        travelTime: 'Info temps de trajet',
+        confirmAssignments: 'Confirmer les désignations',
+        requestExchanges: 'Demander des échanges',
+        viewCompensations: 'Voir les indemnités',
+        acceptExchanges: 'Accepter des échanges',
+      },
+      infoBox: "Pour des actions comme confirmer des désignations ou demander des échanges, vous devrez vous connecter avec vos identifiants complets.",
+    },
+    security: {
+      title: 'Garder votre code sécurisé',
+      description: 'Bien que le mode calendrier soit en lecture seule, votre code de calendrier doit quand même être traité avec soin :',
+      tips: {
+        shareWithTrust: 'Ne partagez qu\'avec des personnes de confiance',
+        dontPostPublicly: 'Ne publiez pas votre code publiquement en ligne',
+        ifCompromised: 'Si vous suspectez que votre code a été compromis, contactez Swiss Volley',
+      },
+      warning: "Votre code de calendrier révèle votre planning de matchs complet. Ne le partagez qu'avec des personnes à qui vous faites confiance pour connaître vos déplacements.",
+    },
+  },
+
+  travelTime: {
+    heading: 'Fonctionnalité temps de trajet',
+    lead: 'VolleyKit intègre les données des transports publics suisses pour vous montrer combien de temps il faut pour atteindre chaque lieu de match. Planifiez mieux vos déplacements et n\'arrivez jamais en retard à un match.',
+    howItWorks: {
+      title: 'Comment ça fonctionne',
+      description: "La fonctionnalité temps de trajet utilise l'API des transports publics suisses (CFF/öV) pour calculer les temps de trajet depuis votre domicile vers chaque lieu de match. Elle prend en compte :",
+      considerations: {
+        schedules: 'Horaires en temps réel des trains, bus et trams',
+        walkingTime: 'Temps de marche vers/depuis les gares',
+        transferTimes: 'Temps de correspondance entre connexions',
+        gameStartTime: 'L\'heure réelle de début du match',
+      },
+      infoBox: 'Les temps de trajet sont calculés avec les transports publics. Si vous conduisez habituellement, utilisez les temps comme estimation approximative ou pour planifier des options de transport alternatives.',
+    },
+    settingHome: {
+      title: 'Définir votre domicile',
+      description: "Pour obtenir des temps de trajet précis, vous devez définir votre domicile dans les paramètres de l'application.",
+      steps: {
+        openSettings: {
+          title: 'Ouvrir les Paramètres',
+          description: 'Naviguez vers la page Paramètres dans VolleyKit.',
+        },
+        findHomeLocation: {
+          title: 'Trouver "Domicile"',
+          description: 'Faites défiler jusqu\'à la section paramètres de trajet.',
+        },
+        enterAddress: {
+          title: 'Entrer votre adresse',
+          description: 'Tapez votre adresse ou la gare depuis laquelle vous voyagez habituellement.',
+        },
+        saveSettings: {
+          title: 'Sauvegarder vos paramètres',
+          description: 'Confirmez votre emplacement pour commencer à voir les temps de trajet.',
+        },
+      },
+      screenshotAlt: 'Page paramètres montrant le champ de saisie du domicile',
+      screenshotCaption: 'Définir votre domicile',
+      tip: "Utilisez votre gare la plus proche comme domicile si vous marchez ou faites du vélo habituellement jusqu'à la gare – cela donne des temps de transport public plus précis.",
+    },
+    viewingTimes: {
+      title: 'Voir les temps de trajet',
+      description: 'Une fois votre domicile défini, les temps de trajet apparaissent sur vos cartes de désignation et dans la vue détaillée de désignation.',
+      screenshotAlt: 'Carte de désignation montrant les informations de temps de trajet',
+      screenshotCaption: 'Temps de trajet affiché sur une désignation',
+      whatsShown: {
+        title: 'Ce qui est affiché',
+        duration: 'Durée – Temps de trajet total du domicile au lieu',
+        departureTime: 'Heure de départ – Quand vous devriez partir pour arriver à temps',
+        transportType: 'Type de transport – Icône train, bus ou transport mixte',
+      },
+    },
+    journeyDetails: {
+      title: 'Détails du trajet',
+      description: 'Appuyez sur le temps de trajet pour voir les détails complets du trajet :',
+      features: {
+        stepByStep: 'Instructions étape par étape',
+        connectionDetails: 'Détails des connexions (numéros de train, quais)',
+        walkingSegments: 'Segments de marche',
+        transferTimes: 'Temps de correspondance',
+      },
+      sbbLink: "Vous pouvez aussi ouvrir le trajet directement dans l'application ou le site CFF pour des mises à jour en temps réel et l'achat de billets.",
+      screenshotAlt: 'Informations détaillées du trajet avec connexions et horaires',
+      screenshotCaption: 'Détails complets du trajet pour la planification',
+    },
+    arrivalBuffer: {
+      title: "Marge d'arrivée",
+      description: "L'heure de départ suggérée inclut une marge pour s'assurer que vous arrivez avant le début du match :",
+      details: {
+        standardBuffer: 'Marge standard : 15-30 minutes avant l\'heure du match',
+        timeFor: 'Temps pour trouver le lieu, se changer et s\'échauffer',
+        accountForDelays: 'Tenir compte des petits retards potentiels',
+      },
+      warning: 'Prévoyez toujours du temps supplémentaire pour les matchs importants ou les lieux inconnus. Les transports publics peuvent subir des retards inattendus.',
+    },
+    offlineAvailability: {
+      title: 'Disponibilité hors ligne',
+      description: 'Les temps de trajet sont mis en cache quand vous les consultez en ligne. Si vous êtes hors ligne :',
+      details: {
+        cachedAvailable: 'Les temps de trajet consultés précédemment restent disponibles',
+        requiresConnection: 'Les nouveaux calculs nécessitent une connexion internet',
+        outdatedIndicator: "L'application indique quand les données peuvent être obsolètes",
+      },
+      tip: 'Vérifiez vos temps de trajet en ligne avant de vous rendre dans une zone avec une mauvaise connectivité. Les données en cache seront disponibles hors ligne.',
+    },
+  },
+
+  offlinePwa: {
+    heading: 'Fonctionnalités hors ligne & PWA',
+    lead: "VolleyKit est une Progressive Web App (PWA) que vous pouvez installer sur votre appareil et utiliser hors ligne. Accédez à vos désignations même sans connexion internet.",
+    whatIsPwa: {
+      title: "Qu'est-ce qu'une PWA ?",
+      description: 'Une Progressive Web App est un site web qui fonctionne comme une application native. Quand vous installez VolleyKit :',
+      benefits: {
+        homeScreen: "Elle apparaît sur votre écran d'accueil comme une application normale",
+        ownWindow: "S'ouvre dans sa propre fenêtre sans interface de navigateur",
+        worksOffline: 'Fonctionne hors ligne pour le contenu précédemment consulté',
+        autoUpdates: 'Reçoit automatiquement les mises à jour',
+        minimalStorage: 'Utilise un stockage minimal comparé aux applications natives',
+      },
+      tip: "Les PWA combinent le meilleur du web et des applications natives – installation facile, mises à jour automatiques et capacité hors ligne sans téléchargement d'app store.",
+    },
+    installing: {
+      title: "Installer l'application",
+      description: 'Vous pouvez installer VolleyKit sur n\'importe quel appareil moderne – téléphones, tablettes ou ordinateurs.',
+      ios: {
+        title: 'Sur iOS (iPhone/iPad)',
+        steps: {
+          openSafari: {
+            title: 'Ouvrir VolleyKit dans Safari',
+            description: 'La fonctionnalité d\'installation ne fonctionne que dans Safari sur iOS.',
+          },
+          tapShare: {
+            title: 'Appuyer sur le bouton Partager',
+            description: 'Trouvez l\'icône de partage en bas de l\'écran.',
+          },
+          selectAddHome: {
+            title: 'Sélectionner "Ajouter à l\'écran d\'accueil"',
+            description: 'Faites défiler dans le menu de partage pour trouver cette option.',
+          },
+          confirmInstall: {
+            title: 'Confirmer l\'installation',
+            description: 'Appuyez sur "Ajouter" pour installer VolleyKit sur votre écran d\'accueil.',
+          },
+        },
+      },
+      android: {
+        title: 'Sur Android',
+        steps: {
+          openChrome: {
+            title: 'Ouvrir VolleyKit dans Chrome',
+            description: "D'autres navigateurs comme Firefox supportent aussi l'installation PWA.",
+          },
+          lookForPrompt: {
+            title: "Chercher l'invite d'installation",
+            description: "Une bannière ou invite devrait apparaître demandant d'installer l'application.",
+          },
+          tapInstall: {
+            title: 'Appuyer sur "Installer" ou "Ajouter à l\'écran d\'accueil"',
+            description: 'Confirmez pour ajouter l\'application à votre appareil.',
+          },
+        },
+      },
+      screenshotAlt: "Invite d'installation PWA montrant l'option Ajouter à l'écran d'accueil",
+      screenshotCaption: 'Installer VolleyKit sur votre appareil',
+      desktop: {
+        title: 'Sur ordinateur (Chrome/Edge)',
+        description: "Cherchez l'icône d'installation dans la barre d'adresse (généralement un + ou icône d'ordinateur), ou utilisez le menu du navigateur pour trouver \"Installer VolleyKit\".",
+      },
+    },
+    whatWorksOffline: {
+      title: 'Ce qui fonctionne hors ligne',
+      description: 'Quand vous êtes hors ligne, vous pouvez toujours accéder au contenu que vous avez consulté précédemment :',
+      table: {
+        feature: 'Fonctionnalité',
+        offline: 'Hors ligne',
+        notes: 'Notes',
+        viewAssignments: 'Voir les désignations',
+        viewAssignmentsNote: 'Désignations chargées précédemment',
+        viewDetails: 'Voir les détails des matchs',
+        viewDetailsNote: 'Si consultés précédemment',
+        travelTimes: 'Temps de trajet',
+        travelTimesNote: 'Données de trajet en cache',
+        confirmAssignments: 'Confirmer les désignations',
+        confirmAssignmentsNote: 'Nécessite une connexion',
+        requestExchanges: 'Demander des échanges',
+        requestExchangesNote: 'Nécessite une connexion',
+        viewCompensations: 'Voir les indemnités',
+        viewCompensationsNote: 'Si chargées précédemment',
+      },
+      infoBox: "L'application se synchronise automatiquement quand vous êtes de retour en ligne. Tous les changements de données seront récupérés et affichés.",
+    },
+    offlineIndicator: {
+      title: 'Indicateur hors ligne',
+      description: "Quand vous êtes hors ligne, VolleyKit affiche un indicateur visuel pour que vous sachiez que vous consultez des données en cache. Cherchez le badge hors ligne dans l'en-tête ou une bannière en haut de l'écran.",
+      screenshotAlt: "Indicateur hors ligne montrant que l'application fonctionne sans internet",
+      screenshotCaption: 'Indicateur mode hors ligne',
+    },
+    updating: {
+      title: "Mettre à jour l'application",
+      description: 'VolleyKit se met à jour automatiquement en arrière-plan. Quand une nouvelle version est disponible :',
+      steps: {
+        backgroundDownload: "L'application télécharge la mise à jour en arrière-plan",
+        notificationAppears: 'Une notification apparaît quand la mise à jour est prête',
+        tapReload: 'Appuyez sur "Recharger" pour activer la nouvelle version',
+      },
+      screenshotAlt: 'Notification de mise à jour invitant à recharger',
+      screenshotCaption: 'Notification mise à jour disponible',
+      tip: "Si vous ignorez la notification de mise à jour, la nouvelle version s'activera la prochaine fois que vous fermerez et rouvrirez l'application.",
+    },
+    storage: {
+      title: 'Utilisation du stockage',
+      description: "VolleyKit utilise un stockage minimal sur votre appareil – généralement moins de 5Mo pour l'application elle-même plus les données en cache. Vous pouvez vider le cache depuis les paramètres de votre navigateur si nécessaire.",
+      warning: 'Vider les données du navigateur ou "Vider le cache" supprimera vos données hors ligne. Vous devrez peut-être recharger les désignations la prochaine fois que vous ouvrirez l\'application.',
+    },
+  },
+
+  settings: {
+    heading: "Paramètres de l'application",
+    lead: 'Personnalisez VolleyKit selon vos préférences. Configurez la langue, le domicile et les options de confidentialité.',
+    accessing: {
+      title: 'Accéder aux paramètres',
+      description: 'Ouvrez les paramètres en appuyant sur l\'icône d\'engrenage dans la barre de navigation, ou en sélectionnant "Paramètres" dans le menu principal.',
+      screenshotAlt: 'Page paramètres montrant toutes les options disponibles',
+      screenshotCaption: 'Page paramètres VolleyKit',
+    },
+    profile: {
+      title: 'Section profil',
+      description: 'La section profil affiche les informations de votre compte :',
+      fields: {
+        name: 'Nom – Votre nom d\'arbitre enregistré',
+        licenseNumber: 'Numéro de licence – Votre licence d\'arbitre Swiss Volley',
+        email: 'Email – Votre adresse email enregistrée',
+        sessionStatus: 'Statut de session – Votre statut de connexion actuel',
+      },
+      infoBox: 'Les informations de profil proviennent de volleymanager et ne peuvent être modifiées que sur le site officiel, pas dans VolleyKit.',
+      loggingOut: {
+        title: 'Déconnexion',
+        description: 'Appuyez sur "Déconnexion" pour vous déconnecter de votre compte. Cela efface votre session et toutes les données stockées localement.',
+      },
+    },
+    language: {
+      title: 'Paramètres de langue',
+      description: 'VolleyKit supporte plusieurs langues selon votre préférence :',
+      options: {
+        deutsch: 'Deutsch – Allemand',
+        english: 'English – Anglais',
+        francais: 'Français – Français',
+        italiano: 'Italiano – Italien',
+      },
+      autoDetect: "L'application utilisera automatiquement la langue de votre navigateur si elle est supportée, mais vous pouvez la modifier dans les paramètres.",
+      screenshotAlt: 'Sélection de langue montrant les options disponibles',
+      screenshotCaption: "Changer la langue de l'application",
+    },
+    homeLocation: {
+      title: 'Domicile',
+      description: 'Définissez votre domicile pour activer les calculs de temps de trajet. Ceci est utilisé pour montrer combien de temps il faut pour atteindre chaque lieu de match.',
+      instructions: {
+        enterAddress: 'Entrez votre adresse ou la gare la plus proche',
+        useAutocomplete: 'Utilisez les suggestions d\'autocomplétion pour la précision',
+        travelTimesAppear: 'Les temps de trajet apparaîtront sur vos cartes de désignation',
+      },
+      screenshotAlt: "Saisie du domicile avec recherche d'adresse",
+      screenshotCaption: 'Définir votre domicile',
+      tip: 'Si vous prenez habituellement les transports publics, utilisez votre gare la plus proche comme domicile pour des temps de trajet plus précis.',
+      seeGuide: 'Voir le guide Temps de trajet pour plus de détails sur cette fonctionnalité.',
+    },
+    dataPrivacy: {
+      title: 'Données & Confidentialité',
+      description: 'Contrôlez comment vos données sont gérées :',
+      localStorage: {
+        title: 'Stockage local',
+        description: "VolleyKit stocke des données localement pour permettre l'accès hors ligne et améliorer les performances :",
+        items: {
+          assignmentCache: 'Cache de désignations – Vos désignations récentes',
+          preferences: 'Préférences – Vos paramètres et préférences',
+          travelData: 'Données de trajet – Informations de trajet en cache',
+        },
+      },
+      clearData: {
+        title: 'Effacer les données locales',
+        description: 'Vous pouvez effacer toutes les données stockées localement depuis la page paramètres. Cela va :',
+        effects: {
+          removeCached: 'Supprimer les désignations en cache et les données de trajet',
+          resetPreferences: 'Réinitialiser toutes les préférences aux valeurs par défaut',
+          requireLogin: 'Nécessiter une nouvelle connexion',
+        },
+        warning: "L'effacement des données locales ne peut pas être annulé. Vous devrez recharger vos désignations la prochaine fois que vous ouvrirez l'application.",
+      },
+      screenshotAlt: 'Section paramètres données et confidentialité avec bouton effacer données',
+      screenshotCaption: 'Options données et confidentialité',
+    },
+    about: {
+      title: 'À propos de VolleyKit',
+      description: 'La section À propos affiche :',
+      items: {
+        versionNumber: "Numéro de version – Version actuelle de l'application",
+        lastUpdated: "Dernière mise à jour – Quand l'application a été mise à jour pour la dernière fois",
+        links: 'Liens – Dépôt GitHub, suivi des problèmes, site d\'aide',
+      },
+      infoBox: 'Vérifiez le numéro de version lors de la signalisation de problèmes – cela nous aide à identifier et corriger les problèmes plus rapidement.',
+    },
+  },
 };

--- a/help-site/src/i18n/it.ts
+++ b/help-site/src/i18n/it.ts
@@ -171,4 +171,669 @@ export const it: TranslationKeys = {
     tip: 'Suggerimento',
     warning: 'Avviso',
   },
+
+  gettingStarted: {
+    heading: 'Primi passi con VolleyKit',
+    lead: "VolleyKit è un'applicazione web progressiva che offre un'interfaccia migliorata per gestire le tue designazioni arbitrali di pallavolo tramite il sistema volleymanager della Federazione Svizzera di Pallavolo.",
+    whatIs: {
+      title: "Cos'è VolleyKit?",
+      description: "VolleyKit si connette alla piattaforma ufficiale volleymanager.volleyball.ch e offre agli arbitri un'interfaccia moderna e ottimizzata per dispositivi mobili per:",
+      features: {
+        viewAssignments: 'Visualizzare le prossime designazioni',
+        manageExchanges: 'Richiedere e gestire scambi con altri arbitri',
+        trackCompensations: 'Monitorare i pagamenti dei compensi',
+        offlineAccess: 'Accedere alle designazioni offline',
+        travelTime: 'Calcolare i tempi di viaggio con i trasporti pubblici svizzeri',
+      },
+      infoBox: "VolleyKit è un'app non ufficiale creata per migliorare l'esperienza degli arbitri. Tutti i dati provengono dal sistema volleymanager ufficiale.",
+    },
+    howToLogin: {
+      title: 'Come accedere',
+      description: 'VolleyKit offre due modi per accedere alle tue designazioni:',
+      calendarMode: {
+        title: 'Opzione 1: Modalità calendario (Consigliata)',
+        description: "Per un accesso rapido al tuo calendario senza inserire la password, puoi usare la modalità calendario con il tuo URL o codice calendario univoco da volleymanager.",
+        steps: {
+          findUrl: {
+            title: 'Trova il tuo URL calendario',
+            description: 'In volleymanager, vai su "Le mie designazioni" e copia il tuo URL di abbonamento al calendario.',
+          },
+          selectMode: {
+            title: 'Seleziona Modalità calendario',
+            description: 'Nella pagina di login di VolleyKit, tocca la scheda "Modalità calendario".',
+          },
+          pasteUrl: {
+            title: 'Incolla il tuo URL o codice',
+            description: 'Inserisci il tuo URL calendario o solo il codice per accedere al tuo programma.',
+          },
+        },
+        infoBox: "La modalità calendario offre accesso in sola lettura – puoi vedere le designazioni ma non puoi confermare partite, richiedere scambi o accedere ai compensi. Vedi la guida alla modalità calendario per maggiori dettagli.",
+      },
+      fullLogin: {
+        title: 'Opzione 2: Login completo',
+        description: "Usa le tue credenziali volleymanager.volleyball.ch per l'accesso completo a tutte le funzionalità.",
+        steps: {
+          openApp: {
+            title: 'Apri VolleyKit',
+            description: "Naviga all'app VolleyKit nel tuo browser o apri l'app installata.",
+          },
+          enterCredentials: {
+            title: 'Inserisci le tue credenziali',
+            description: 'Usa il tuo nome utente e password volleymanager per accedere.',
+          },
+          stayLoggedIn: {
+            title: 'Resta connesso',
+            description: 'Attiva "Ricordami" per restare connesso tra le sessioni.',
+          },
+        },
+        screenshotAlt: 'Pagina di login VolleyKit con campi nome utente e password',
+        screenshotCaption: 'La pagina di login VolleyKit',
+        tipTitle: 'Password dimenticata?',
+        tipContent: 'VolleyKit usa le stesse credenziali di volleymanager.volleyball.ch. Usa la funzione di recupero password sul sito ufficiale se hai dimenticato la password.',
+      },
+    },
+    quickTour: {
+      title: 'Tour rapido',
+      description: 'Dopo il login, vedrai la dashboard principale con le tue prossime designazioni. Ecco una panoramica rapida delle sezioni principali:',
+      assignments: {
+        title: 'Designazioni',
+        description: 'Visualizza tutte le tue prossime partite arbitrali. Ogni designazione mostra data, ora, squadre, sede e il tuo ruolo (1° arbitro, 2° arbitro o giudice di linea).',
+      },
+      exchanges: {
+        title: 'Scambi',
+        description: 'Sfoglia gli scambi disponibili da altri arbitri o richiedi uno scambio per una delle tue designazioni.',
+      },
+      compensations: {
+        title: 'Compensi',
+        description: "Monitora i tuoi pagamenti arbitrali e lo storico dei compensi. Filtra per periodo ed esporta i tuoi dati.",
+      },
+      settings: {
+        title: 'Impostazioni',
+        description: 'Personalizza la tua esperienza includendo lingua, posizione di casa per i calcoli di viaggio e preferenze di notifica.',
+      },
+    },
+    nextSteps: {
+      title: 'Prossimi passi',
+      description: 'Ora che hai familiarità con le basi, esplora le guide dettagliate per ogni funzionalità:',
+      links: {
+        assignments: 'Gestire le tue designazioni',
+        exchanges: 'Richiedere e accettare scambi',
+        compensations: 'Monitorare i tuoi compensi',
+      },
+    },
+  },
+
+  assignments: {
+    heading: 'Gestire le tue designazioni',
+    lead: 'La sezione Designazioni è il tuo centro principale per visualizzare tutte le tue prossime partite arbitrali di pallavolo e gestire il tuo programma.',
+    whatAre: {
+      title: 'Cosa sono le designazioni?',
+      description: 'Le designazioni sono le partite per cui sei stato programmato come arbitro. Ogni designazione include:',
+      details: {
+        dateTime: 'Data e ora – Quando si svolge la partita',
+        teams: 'Squadre – Nomi delle squadre di casa e ospite',
+        venue: 'Sede – Luogo della partita con indirizzo',
+        role: 'Il tuo ruolo – 1° arbitro, 2° arbitro o giudice di linea',
+        league: 'Lega – Il livello di competizione (es. NLA, NLB, 1ª Lega)',
+      },
+    },
+    viewing: {
+      title: 'Visualizzare le tue designazioni',
+      description: "La lista delle designazioni mostra tutte le tue prossime partite in ordine cronologico. Le partite sono raggruppate per data per vedere facilmente cosa c'è in arrivo.",
+      screenshotAlt: 'Lista designazioni con più partite in arrivo raggruppate per data',
+      screenshotCaption: 'La vista lista designazioni con le prossime partite',
+    },
+    details: {
+      title: 'Dettagli designazione',
+      description: 'Tocca una designazione per vedere tutti i dettagli. La vista dettagliata include:',
+      items: {
+        gameInfo: 'Informazioni complete della partita',
+        venueAddress: 'Indirizzo sede con link mappa',
+        travelTime: 'Tempo di viaggio dalla tua posizione di casa',
+        otherReferees: 'Altri arbitri assegnati alla stessa partita',
+        swipeActions: 'Azioni disponibili tramite gesti di scorrimento',
+      },
+      screenshotAlt: 'Vista dettagliata designazione con tutte le informazioni della partita',
+      screenshotCaption: 'Vista dettagliata di una singola designazione',
+    },
+    actions: {
+      title: 'Eseguire azioni',
+      description: 'VolleyKit usa gesti di scorrimento per accedere rapidamente alle azioni sulle tue schede designazione. A seconda dello stato della partita, potrebbero essere disponibili azioni diverse.',
+      swipeRight: {
+        title: 'Scorri a destra – Aggiungi allo scambio',
+        description: 'Scorri una scheda designazione verso destra per rivelare l\'azione di scambio. Se non puoi partecipare a una partita, puoi aggiungerla alla bacheca scambi per altri arbitri.',
+        screenshotAlt: 'Scheda designazione scorsa a destra che mostra azione di scambio',
+        screenshotCaption: 'Scorri a destra per aggiungere una designazione alla bacheca scambi',
+        warning: 'Assicurati di richiedere uno scambio con largo anticipo. Le richieste dell\'ultimo minuto potrebbero non trovare un sostituto in tempo.',
+      },
+      swipeLeft: {
+        title: 'Scorri a sinistra – Valida & Modifica',
+        description: 'Scorri una scheda designazione verso sinistra per rivelare azioni aggiuntive:',
+        validate: 'Valida – Invia i risultati della partita e valida (disponibile per i primi arbitri dopo la partita)',
+        edit: 'Modifica – Modifica i dettagli del tuo compenso per questa designazione',
+        screenshotAlt: 'Scheda designazione scorsa a sinistra che mostra azioni valida e modifica',
+        screenshotCaption: 'Scorri a sinistra per rivelare le azioni valida e modifica',
+        tip: "Puoi anche eseguire uno scorrimento completo per attivare immediatamente l'azione principale senza toccare il pulsante.",
+      },
+      directions: {
+        title: 'Ottieni indicazioni',
+        description: 'Tocca una scheda designazione per espanderla, poi usa il pulsante indicazioni per aprire la tua app mappe preferita con le indicazioni per la sede.',
+      },
+    },
+    upcomingPast: {
+      title: 'Partite future e passate',
+      description: 'Usa le schede in alto per passare tra:',
+      upcoming: 'In arrivo – Partite che non si sono ancora svolte',
+      validationClosed: 'Validazione chiusa – Partite passate dove la validazione è completa',
+      tip: 'Imposta la tua posizione di casa nelle Impostazioni per vedere le stime dei tempi di viaggio su ogni scheda designazione.',
+    },
+  },
+
+  exchanges: {
+    heading: 'Scambi di partite',
+    lead: 'Il sistema di scambio permette agli arbitri di scambiare partite quando non possono partecipare alle loro designazioni programmate. Puoi richiedere scambi per le tue partite o prendere partite da altri arbitri.',
+    whatAre: {
+      title: 'Cosa sono gli scambi?',
+      description: 'Uno scambio è una richiesta da un arbitro che non può partecipare alla sua partita programmata e cerca un sostituto. Il sistema volleymanager mantiene una bacheca scambi dove gli arbitri possono:',
+      features: {
+        postGames: 'Pubblicare le loro partite per lo scambio',
+        browseGames: 'Sfogliare le partite disponibili da altri arbitri',
+        acceptGames: 'Accettare partite che si adattano al loro programma',
+      },
+      infoBox: 'Gli scambi sono gestiti tramite il sistema volleymanager ufficiale. VolleyKit offre un\'interfaccia più user-friendly alla stessa bacheca scambi.',
+    },
+    requesting: {
+      title: 'Richiedere uno scambio',
+      description: 'Quando non puoi partecipare a una delle tue partite programmate, puoi richiedere uno scambio per trovare un arbitro sostituto.',
+      steps: {
+        findAssignment: {
+          title: 'Trova la designazione',
+          description: 'Vai alla scheda Designazioni e trova la partita che vuoi scambiare.',
+        },
+        swipeRight: {
+          title: 'Scorri a destra sulla scheda',
+          description: "Scorri la scheda designazione verso destra per rivelare l'azione di scambio, poi toccala. La partita verrà pubblicata sulla bacheca scambi.",
+        },
+      },
+      screenshotAlt: 'Scheda designazione con azione di scorrimento scambio rivelata',
+      screenshotCaption: 'Richiedere uno scambio per una partita',
+      warningTitle: 'Richiedi presto',
+      warningContent: 'Prima richiedi uno scambio, più probabilità hai di trovare un sostituto. Le richieste dell\'ultimo minuto spesso restano senza risposta.',
+    },
+    viewing: {
+      title: 'Visualizzare gli scambi disponibili',
+      description: 'La scheda Scambi mostra tutte le partite attualmente disponibili per lo scambio. Queste sono partite che altri arbitri hanno pubblicato e per cui cercano sostituti.',
+      screenshotAlt: 'Lista delle partite di scambio disponibili da altri arbitri',
+      screenshotCaption: 'Partite disponibili sulla bacheca scambi',
+      filtering: {
+        title: 'Filtrare gli scambi',
+        description: 'Filtra la lista scambi per trovare partite che ti convengono. I filtri diventano disponibili dopo aver configurato le impostazioni richieste:',
+        distance: 'Distanza – Filtra per distanza massima dalla tua posizione di casa. Richiede di impostare la posizione di casa nelle Impostazioni.',
+        travelTime: "Tempo di viaggio – Filtra per tempo di viaggio massimo con i trasporti pubblici. Richiede sia una posizione di casa che l'attivazione dell'API dei trasporti pubblici nelle Impostazioni.",
+        usage: "Una volta disponibili, i filtri appaiono come chip toggle accanto all'icona ingranaggio. Tocca l'ingranaggio per configurare i valori massimi per ogni filtro.",
+        tip: "Imposta la tua posizione di casa nelle Impostazioni per sbloccare il filtraggio per distanza. Attiva l'API dei trasporti pubblici per filtrare anche per tempo di viaggio.",
+      },
+    },
+    accepting: {
+      title: 'Accettare uno scambio',
+      description: 'Quando trovi una partita che vorresti prendere, puoi accettare lo scambio:',
+      steps: {
+        review: {
+          title: 'Verifica i dettagli della partita',
+          description: 'Controlla data, ora, sede e requisiti di viaggio.',
+        },
+        swipeLeft: {
+          title: 'Scorri a sinistra sulla scheda',
+          description: "Scorri la scheda scambio verso sinistra per rivelare l'azione di presa in carico, poi toccala.",
+        },
+        confirm: {
+          title: 'Conferma la tua accettazione',
+          description: 'Verifica i dettagli e conferma la tua accettazione.',
+        },
+        gameAdded: {
+          title: 'Partita aggiunta al tuo programma',
+          description: 'La partita ora appare nelle tue designazioni.',
+        },
+      },
+      tip: "Assicurati di poter effettivamente partecipare alla partita prima di accettare. Una volta accettato, l'arbitro originale viene liberato dalla designazione.",
+    },
+    managing: {
+      title: 'Gestire le tue richieste di scambio',
+      description: "Puoi visualizzare e gestire le tue richieste di scambio attive dalla scheda Scambi. Se non hai più bisogno di uno scambio (es. il tuo programma è cambiato), puoi annullare la richiesta prima che qualcuno la accetti.",
+      canceling: {
+        title: 'Annullare una richiesta',
+        description: 'Per annullare una richiesta di scambio che hai fatto:',
+        steps: {
+          goToExchanges: 'Vai alla scheda Scambi',
+          selectAddedByMe: 'Seleziona la scheda "Aggiunti da me" per vedere le tue richieste in sospeso',
+          swipeRight: "Scorri a destra sulla scheda richiesta per rivelare l'azione di rimozione, poi toccala",
+          confirmCancellation: "Conferma l'annullamento",
+        },
+        infoBox: "Puoi annullare una richiesta di scambio solo se nessuno l'ha ancora accettata. Una volta accettato, lo scambio è definitivo.",
+      },
+    },
+  },
+
+  compensations: {
+    heading: 'Monitorare i tuoi compensi',
+    lead: 'La sezione Compensi ti aiuta a monitorare i tuoi guadagni arbitrali e lo storico dei pagamenti. Visualizza i pagamenti passati, filtra per periodo ed esporta i tuoi dati per i tuoi archivi.',
+    whatAre: {
+      title: 'Cosa sono i compensi?',
+      description: 'I compensi sono i pagamenti che ricevi per arbitrare partite di pallavolo. Ogni voce di compenso include tipicamente:',
+      details: {
+        gameDetails: 'Dettagli partita – La partita che hai arbitrato',
+        date: 'Data – Quando si è svolta la partita',
+        amount: 'Importo – L\'importo del compenso in CHF',
+        paymentStatus: 'Stato pagamento – In sospeso, pagato o elaborato',
+        role: 'Ruolo – La tua funzione nella partita',
+      },
+      infoBox: 'Gli importi dei compensi sono stabiliti da Swiss Volley e variano in base al livello di lega e al tuo ruolo nella partita.',
+    },
+    viewing: {
+      title: 'Visualizzare i tuoi compensi',
+      description: "La lista compensi mostra tutti i tuoi pagamenti registrati in ordine cronologico. Ogni voce mostra le informazioni chiave a colpo d'occhio.",
+      screenshotAlt: 'Lista compensi che mostra lo storico pagamenti con importi e date',
+      screenshotCaption: 'Il tuo storico compensi',
+      paymentStatus: {
+        title: 'Capire lo stato del pagamento',
+        pending: 'In sospeso – Partita completata, pagamento non ancora elaborato',
+        processing: 'In elaborazione – Il pagamento è in corso di elaborazione',
+        paid: 'Pagato – Il pagamento è stato effettuato sul tuo conto',
+      },
+    },
+    filtering: {
+      title: 'Filtrare per stato',
+      description: 'Usa le schede in alto per filtrare i compensi per stato:',
+      tabs: {
+        pendingPast: 'In sospeso (Passato) – Partite passate in attesa di pagamento',
+        pendingFuture: 'In sospeso (Futuro) – Partite future non ancora giocate',
+        closed: 'Chiuso – Compensi completati e pagati',
+      },
+      screenshotAlt: 'Schede compensi che mostrano le opzioni in sospeso e chiuso',
+      screenshotCaption: 'Filtrare i compensi per stato',
+      tip: 'I compensi sono automaticamente filtrati sulla stagione corrente (settembre a maggio) per concentrarti sulle partite recenti.',
+    },
+    exportPdf: {
+      title: 'Esporta in PDF',
+      description: "Puoi esportare singoli record di compenso come documenti PDF. Scorri a sinistra su una scheda compenso per rivelare l'azione di esportazione PDF.",
+      usage: "Il PDF esportato include i dettagli della partita e le informazioni sul compenso in un documento formattato. Questo è utile per le squadre che devono pagare l'arbitro direttamente.",
+      infoBox: "L'esportazione PDF crea un documento dall'aspetto ufficiale con tutti i dettagli della partita e del compenso che le squadre potrebbero richiedere per i loro archivi.",
+    },
+    paymentSchedule: {
+      title: 'Calendario pagamenti',
+      description: 'I pagamenti dei compensi sono tipicamente elaborati mensilmente da Swiss Volley. Il calendario esatto può variare, ma generalmente:',
+      details: {
+        processing: "Le partite del mese precedente vengono elaborate all'inizio di ogni mese",
+        bankTransfer: 'I pagamenti vengono effettuati tramite bonifico bancario sul tuo conto registrato',
+        timing: "L'elaborazione può richiedere 2-4 settimane dopo la fine del mese",
+      },
+      warning: 'Assicurati che i tuoi dati bancari siano aggiornati nel sistema volleymanager per evitare ritardi nei pagamenti.',
+    },
+  },
+
+  calendarMode: {
+    heading: 'Modalità calendario',
+    lead: 'La modalità calendario offre accesso in sola lettura per visualizzare le designazioni arbitrali senza un login completo. Perfetta per controllare rapidamente il tuo programma o condividerlo con i familiari.',
+    whatIs: {
+      title: "Cos'è la modalità calendario?",
+      description: "La modalità calendario è un metodo di accesso leggero in sola lettura che ti permette di vedere le tue prossime designazioni senza inserire la password. Usa un codice calendario univoco collegato al tuo account arbitro.",
+      features: {
+        viewAssignments: 'Visualizzare le tue prossime designazioni di partite',
+        seeDetails: 'Vedere i dettagli delle partite inclusi data, ora, squadre e sede',
+        noPassword: 'Nessuna password richiesta – solo il tuo codice calendario',
+        safeToShare: 'Sicuro da condividere con la famiglia o aggiungere ai calendari condivisi',
+      },
+    },
+    whoIsFor: {
+      title: 'Per chi è la modalità calendario?',
+      description: 'La modalità calendario è ideale per:',
+      useCases: {
+        quickChecks: 'Controlli rapidi del programma – Visualizza le tue partite senza accedere',
+        familyMembers: 'Membri della famiglia – Condividi il tuo programma con partner o famiglia',
+        calendarIntegration: 'Integrazione calendario – Aggiungi partite ad app calendario esterne',
+        publicDevices: 'Dispositivi pubblici – Controlla il tuo programma su computer condivisi',
+      },
+      tip: 'La modalità calendario è perfetta per far sapere alla tua famiglia quando hai partite senza dare loro accesso al tuo account completo.',
+    },
+    howToAccess: {
+      title: 'Come accedere alla modalità calendario',
+      description: 'Per usare la modalità calendario, hai bisogno del tuo codice calendario univoco dal sistema volleymanager.',
+      steps: {
+        findCode: {
+          title: 'Trova il tuo codice calendario',
+          description: 'Accedi a volleymanager.volleyball.ch e trova il tuo codice calendario nelle impostazioni del profilo.',
+        },
+        openApp: {
+          title: 'Apri VolleyKit',
+          description: "Naviga all'app VolleyKit.",
+        },
+        selectMode: {
+          title: 'Seleziona "Modalità calendario"',
+          description: 'Nella pagina di login, tocca l\'opzione "Modalità calendario".',
+        },
+        enterCode: {
+          title: 'Inserisci il tuo codice',
+          description: 'Inserisci il tuo codice calendario per accedere al tuo programma in sola lettura.',
+        },
+      },
+      screenshotAlt: "Schermata di ingresso modalità calendario con campo inserimento codice",
+      screenshotCaption: 'Entrare in modalità calendario con il tuo codice',
+    },
+    viewingSchedule: {
+      title: 'Visualizzare il tuo programma',
+      description: 'In modalità calendario, vedrai le tue prossime designazioni in una vista semplificata. L\'interfaccia mostra le informazioni essenziali per ogni partita.',
+      screenshotAlt: 'Modalità calendario che mostra le prossime designazioni in vista sola lettura',
+      screenshotCaption: 'Vista designazioni in modalità calendario',
+    },
+    limitations: {
+      title: 'Limitazioni vs login completo',
+      description: 'La modalità calendario è in sola lettura, il che significa che alcune funzionalità non sono disponibili:',
+      table: {
+        feature: 'Funzionalità',
+        fullLogin: 'Login completo',
+        calendarMode: 'Modalità calendario',
+        viewAssignments: 'Visualizza designazioni',
+        viewDetails: 'Visualizza dettagli partita',
+        travelTime: 'Info tempo di viaggio',
+        confirmAssignments: 'Conferma designazioni',
+        requestExchanges: 'Richiedi scambi',
+        viewCompensations: 'Visualizza compensi',
+        acceptExchanges: 'Accetta scambi',
+      },
+      infoBox: 'Per azioni come confermare designazioni o richiedere scambi, dovrai accedere con le tue credenziali complete.',
+    },
+    security: {
+      title: 'Mantenere il tuo codice sicuro',
+      description: 'Anche se la modalità calendario è in sola lettura, il tuo codice calendario dovrebbe comunque essere trattato con cura:',
+      tips: {
+        shareWithTrust: 'Condividi solo con persone di fiducia',
+        dontPostPublicly: 'Non pubblicare il tuo codice pubblicamente online',
+        ifCompromised: 'Se sospetti che il tuo codice sia stato compromesso, contatta Swiss Volley',
+      },
+      warning: 'Il tuo codice calendario rivela il tuo programma completo di partite. Condividilo solo con persone con cui ti fidi di condividere i tuoi spostamenti.',
+    },
+  },
+
+  travelTime: {
+    heading: 'Funzionalità tempo di viaggio',
+    lead: 'VolleyKit integra i dati dei trasporti pubblici svizzeri per mostrarti quanto tempo ci vuole per raggiungere ogni sede di partita. Pianifica meglio i tuoi viaggi e non arrivare mai in ritardo a una partita.',
+    howItWorks: {
+      title: 'Come funziona',
+      description: "La funzionalità tempo di viaggio usa l'API dei trasporti pubblici svizzeri (FFS/öV) per calcolare i tempi di viaggio dalla tua posizione di casa a ogni sede di partita. Considera:",
+      considerations: {
+        schedules: 'Orari in tempo reale di treni, bus e tram',
+        walkingTime: 'Tempo di cammino da/per le stazioni',
+        transferTimes: 'Tempi di cambio tra connessioni',
+        gameStartTime: "L'ora effettiva di inizio partita",
+      },
+      infoBox: 'I tempi di viaggio sono calcolati usando i trasporti pubblici. Se guidi abitualmente, usa i tempi come stima approssimativa o per pianificare opzioni di trasporto alternative.',
+    },
+    settingHome: {
+      title: 'Impostare la tua posizione di casa',
+      description: "Per ottenere tempi di viaggio accurati, devi impostare la tua posizione di casa nelle impostazioni dell'app.",
+      steps: {
+        openSettings: {
+          title: 'Apri Impostazioni',
+          description: 'Naviga alla pagina Impostazioni in VolleyKit.',
+        },
+        findHomeLocation: {
+          title: 'Trova "Posizione casa"',
+          description: 'Scorri fino alla sezione impostazioni di viaggio.',
+        },
+        enterAddress: {
+          title: 'Inserisci il tuo indirizzo',
+          description: 'Digita il tuo indirizzo di casa o la stazione da cui viaggi abitualmente.',
+        },
+        saveSettings: {
+          title: 'Salva le tue impostazioni',
+          description: 'Conferma la tua posizione per iniziare a vedere i tempi di viaggio.',
+        },
+      },
+      screenshotAlt: 'Pagina impostazioni che mostra il campo di inserimento posizione casa',
+      screenshotCaption: 'Impostare la tua posizione di casa',
+      tip: 'Usa la stazione ferroviaria più vicina come posizione di casa se cammini o vai in bici abitualmente alla stazione – questo dà tempi di trasporto pubblico più accurati.',
+    },
+    viewingTimes: {
+      title: 'Visualizzare i tempi di viaggio',
+      description: 'Una volta impostata la posizione di casa, i tempi di viaggio appaiono sulle tue schede designazione e nella vista dettagliata della designazione.',
+      screenshotAlt: 'Scheda designazione che mostra informazioni sul tempo di viaggio',
+      screenshotCaption: 'Tempo di viaggio visualizzato su una designazione',
+      whatsShown: {
+        title: 'Cosa viene mostrato',
+        duration: 'Durata – Tempo di viaggio totale da casa alla sede',
+        departureTime: 'Ora di partenza – Quando dovresti partire per arrivare in tempo',
+        transportType: 'Tipo di trasporto – Icona treno, bus o trasporto misto',
+      },
+    },
+    journeyDetails: {
+      title: 'Dettagli del viaggio',
+      description: 'Tocca il tempo di viaggio per vedere i dettagli completi del viaggio:',
+      features: {
+        stepByStep: 'Indicazioni passo passo',
+        connectionDetails: 'Dettagli connessioni (numeri treno, binari)',
+        walkingSegments: 'Segmenti a piedi',
+        transferTimes: 'Tempi di cambio',
+      },
+      sbbLink: "Puoi anche aprire il viaggio direttamente nell'app o sito FFS per aggiornamenti in tempo reale e acquisto biglietti.",
+      screenshotAlt: 'Informazioni dettagliate del viaggio con connessioni e orari',
+      screenshotCaption: 'Dettagli completi del viaggio per la pianificazione',
+    },
+    arrivalBuffer: {
+      title: "Margine d'arrivo",
+      description: "L'ora di partenza suggerita include un margine per assicurarsi di arrivare prima dell'inizio della partita:",
+      details: {
+        standardBuffer: "Margine standard: 15-30 minuti prima dell'ora della partita",
+        timeFor: 'Tempo per trovare la sede, cambiarsi e riscaldarsi',
+        accountForDelays: 'Tenere conto di potenziali piccoli ritardi',
+      },
+      warning: 'Prevedi sempre tempo extra per partite importanti o sedi sconosciute. I trasporti pubblici possono subire ritardi imprevisti.',
+    },
+    offlineAvailability: {
+      title: 'Disponibilità offline',
+      description: 'I tempi di viaggio vengono memorizzati nella cache quando li visualizzi online. Se sei offline:',
+      details: {
+        cachedAvailable: 'I tempi di viaggio visualizzati in precedenza restano disponibili',
+        requiresConnection: 'I nuovi calcoli richiedono una connessione internet',
+        outdatedIndicator: "L'app indica quando i dati potrebbero essere obsoleti",
+      },
+      tip: 'Controlla i tuoi tempi di viaggio online prima di andare in una zona con scarsa connettività. I dati in cache saranno disponibili offline.',
+    },
+  },
+
+  offlinePwa: {
+    heading: 'Funzionalità offline & PWA',
+    lead: "VolleyKit è una Progressive Web App (PWA) che puoi installare sul tuo dispositivo e usare offline. Accedi alle tue designazioni anche senza connessione internet.",
+    whatIsPwa: {
+      title: "Cos'è una PWA?",
+      description: "Una Progressive Web App è un sito web che funziona come un'app nativa. Quando installi VolleyKit:",
+      benefits: {
+        homeScreen: "Appare sulla tua schermata home come un'app normale",
+        ownWindow: 'Si apre in una propria finestra senza interfaccia browser',
+        worksOffline: 'Funziona offline per contenuti visualizzati in precedenza',
+        autoUpdates: 'Riceve aggiornamenti automaticamente',
+        minimalStorage: 'Usa spazio di archiviazione minimo rispetto alle app native',
+      },
+      tip: "Le PWA combinano il meglio del web e delle app native – installazione facile, aggiornamenti automatici e capacità offline senza download dall'app store.",
+    },
+    installing: {
+      title: "Installare l'app",
+      description: 'Puoi installare VolleyKit su qualsiasi dispositivo moderno – telefoni, tablet o computer.',
+      ios: {
+        title: 'Su iOS (iPhone/iPad)',
+        steps: {
+          openSafari: {
+            title: 'Apri VolleyKit in Safari',
+            description: 'La funzione di installazione funziona solo in Safari su iOS.',
+          },
+          tapShare: {
+            title: 'Tocca il pulsante Condividi',
+            description: "Trova l'icona di condivisione in fondo allo schermo.",
+          },
+          selectAddHome: {
+            title: 'Seleziona "Aggiungi a Home"',
+            description: 'Scorri nel menu di condivisione per trovare questa opzione.',
+          },
+          confirmInstall: {
+            title: "Conferma l'installazione",
+            description: 'Tocca "Aggiungi" per installare VolleyKit sulla tua schermata home.',
+          },
+        },
+      },
+      android: {
+        title: 'Su Android',
+        steps: {
+          openChrome: {
+            title: 'Apri VolleyKit in Chrome',
+            description: "Altri browser come Firefox supportano anche l'installazione PWA.",
+          },
+          lookForPrompt: {
+            title: "Cerca il prompt di installazione",
+            description: "Dovrebbe apparire un banner o prompt che chiede di installare l'app.",
+          },
+          tapInstall: {
+            title: 'Tocca "Installa" o "Aggiungi a schermata Home"',
+            description: "Conferma per aggiungere l'app al tuo dispositivo.",
+          },
+        },
+      },
+      screenshotAlt: "Prompt di installazione PWA che mostra l'opzione Aggiungi a schermata Home",
+      screenshotCaption: 'Installare VolleyKit sul tuo dispositivo',
+      desktop: {
+        title: 'Su Desktop (Chrome/Edge)',
+        description: "Cerca l'icona di installazione nella barra degli indirizzi (di solito un + o icona computer), o usa il menu del browser per trovare \"Installa VolleyKit\".",
+      },
+    },
+    whatWorksOffline: {
+      title: 'Cosa funziona offline',
+      description: 'Quando sei offline, puoi ancora accedere ai contenuti che hai visualizzato in precedenza:',
+      table: {
+        feature: 'Funzionalità',
+        offline: 'Offline',
+        notes: 'Note',
+        viewAssignments: 'Visualizza designazioni',
+        viewAssignmentsNote: 'Designazioni caricate in precedenza',
+        viewDetails: 'Visualizza dettagli partita',
+        viewDetailsNote: 'Se visualizzati in precedenza',
+        travelTimes: 'Tempi di viaggio',
+        travelTimesNote: 'Dati di viaggio in cache',
+        confirmAssignments: 'Conferma designazioni',
+        confirmAssignmentsNote: 'Richiede connessione',
+        requestExchanges: 'Richiedi scambi',
+        requestExchangesNote: 'Richiede connessione',
+        viewCompensations: 'Visualizza compensi',
+        viewCompensationsNote: 'Se caricati in precedenza',
+      },
+      infoBox: "L'app si sincronizza automaticamente quando torni online. Qualsiasi modifica ai dati verrà recuperata e visualizzata.",
+    },
+    offlineIndicator: {
+      title: 'Indicatore offline',
+      description: "Quando sei offline, VolleyKit mostra un indicatore visivo per farti sapere che stai visualizzando dati in cache. Cerca il badge offline nell'intestazione o un banner in cima allo schermo.",
+      screenshotAlt: "Indicatore offline che mostra che l'app funziona senza internet",
+      screenshotCaption: 'Indicatore modalità offline',
+    },
+    updating: {
+      title: "Aggiornare l'app",
+      description: 'VolleyKit si aggiorna automaticamente in background. Quando una nuova versione è disponibile:',
+      steps: {
+        backgroundDownload: "L'app scarica l'aggiornamento in background",
+        notificationAppears: "Appare una notifica quando l'aggiornamento è pronto",
+        tapReload: 'Tocca "Ricarica" per attivare la nuova versione',
+      },
+      screenshotAlt: 'Notifica di aggiornamento app che invita a ricaricare',
+      screenshotCaption: 'Notifica aggiornamento disponibile',
+      tip: "Se ignori la notifica di aggiornamento, la nuova versione si attiverà la prossima volta che chiudi e riapri l'app.",
+    },
+    storage: {
+      title: 'Utilizzo dello spazio',
+      description: "VolleyKit usa spazio di archiviazione minimo sul tuo dispositivo – tipicamente meno di 5MB per l'app stessa più i dati in cache. Puoi svuotare la cache dalle impostazioni del browser se necessario.",
+      warning: 'Svuotare i dati del browser o "Svuota cache" rimuoverà i tuoi dati offline. Potresti dover ricaricare le designazioni la prossima volta che apri l\'app.',
+    },
+  },
+
+  settings: {
+    heading: "Impostazioni dell'app",
+    lead: 'Personalizza VolleyKit secondo le tue preferenze. Configura lingua, posizione di casa e opzioni di privacy.',
+    accessing: {
+      title: 'Accedere alle impostazioni',
+      description: 'Apri le impostazioni toccando l\'icona ingranaggio nella barra di navigazione, o selezionando "Impostazioni" dal menu principale.',
+      screenshotAlt: 'Pagina impostazioni che mostra tutte le opzioni disponibili',
+      screenshotCaption: 'Pagina impostazioni VolleyKit',
+    },
+    profile: {
+      title: 'Sezione profilo',
+      description: 'La sezione profilo mostra le informazioni del tuo account:',
+      fields: {
+        name: 'Nome – Il tuo nome arbitro registrato',
+        licenseNumber: 'Numero licenza – La tua licenza arbitro Swiss Volley',
+        email: 'Email – Il tuo indirizzo email registrato',
+        sessionStatus: 'Stato sessione – Il tuo stato di login attuale',
+      },
+      infoBox: 'Le informazioni del profilo provengono da volleymanager e possono essere modificate solo sul sito ufficiale, non in VolleyKit.',
+      loggingOut: {
+        title: 'Disconnessione',
+        description: 'Tocca "Disconnetti" per uscire dal tuo account. Questo cancella la tua sessione e tutti i dati memorizzati localmente.',
+      },
+    },
+    language: {
+      title: 'Impostazioni lingua',
+      description: 'VolleyKit supporta più lingue secondo la tua preferenza:',
+      options: {
+        deutsch: 'Deutsch – Tedesco',
+        english: 'English – Inglese',
+        francais: 'Français – Francese',
+        italiano: 'Italiano – Italiano',
+      },
+      autoDetect: "L'app userà automaticamente la lingua del tuo browser se supportata, ma puoi cambiarla nelle impostazioni.",
+      screenshotAlt: 'Selezione lingua che mostra le opzioni disponibili',
+      screenshotCaption: "Cambiare la lingua dell'app",
+    },
+    homeLocation: {
+      title: 'Posizione casa',
+      description: 'Imposta la tua posizione di casa per abilitare i calcoli dei tempi di viaggio. Questo viene usato per mostrare quanto tempo ci vuole per raggiungere ogni sede di partita.',
+      instructions: {
+        enterAddress: 'Inserisci il tuo indirizzo o la stazione più vicina',
+        useAutocomplete: "Usa i suggerimenti di autocompletamento per l'accuratezza",
+        travelTimesAppear: 'I tempi di viaggio appariranno sulle tue schede designazione',
+      },
+      screenshotAlt: 'Inserimento posizione casa con ricerca indirizzo',
+      screenshotCaption: 'Impostare la tua posizione di casa',
+      tip: 'Se prendi abitualmente i trasporti pubblici, usa la stazione più vicina come posizione di casa per tempi di viaggio più accurati.',
+      seeGuide: 'Vedi la guida Tempo di viaggio per maggiori dettagli su questa funzionalità.',
+    },
+    dataPrivacy: {
+      title: 'Dati & Privacy',
+      description: 'Controlla come vengono gestiti i tuoi dati:',
+      localStorage: {
+        title: 'Archiviazione locale',
+        description: "VolleyKit memorizza dati localmente per abilitare l'accesso offline e migliorare le prestazioni:",
+        items: {
+          assignmentCache: 'Cache designazioni – Le tue designazioni recenti',
+          preferences: 'Preferenze – Le tue impostazioni e preferenze',
+          travelData: 'Dati viaggio – Informazioni di viaggio in cache',
+        },
+      },
+      clearData: {
+        title: 'Cancella dati locali',
+        description: 'Puoi cancellare tutti i dati memorizzati localmente dalla pagina impostazioni. Questo:',
+        effects: {
+          removeCached: 'Rimuoverà designazioni in cache e dati di viaggio',
+          resetPreferences: 'Ripristinerà tutte le preferenze ai valori predefiniti',
+          requireLogin: 'Richiederà un nuovo login',
+        },
+        warning: "La cancellazione dei dati locali non può essere annullata. Dovrai ricaricare le tue designazioni la prossima volta che apri l'app.",
+      },
+      screenshotAlt: 'Sezione impostazioni dati e privacy con pulsante cancella dati',
+      screenshotCaption: 'Opzioni dati e privacy',
+    },
+    about: {
+      title: 'Info su VolleyKit',
+      description: 'La sezione Info mostra:',
+      items: {
+        versionNumber: "Numero versione – Versione attuale dell'app",
+        lastUpdated: "Ultimo aggiornamento – Quando l'app è stata aggiornata l'ultima volta",
+        links: 'Link – Repository GitHub, tracker problemi, sito aiuto',
+      },
+      infoBox: 'Controlla il numero di versione quando segnali problemi – ci aiuta a identificare e risolvere i problemi più velocemente.',
+    },
+  },
 };

--- a/help-site/src/i18n/types.ts
+++ b/help-site/src/i18n/types.ts
@@ -165,6 +165,586 @@ export interface TranslationKeys {
     tip: string;
     warning: string;
   };
+
+  // Getting Started page content
+  gettingStarted: {
+    heading: string;
+    lead: string;
+    whatIs: {
+      title: string;
+      description: string;
+      features: {
+        viewAssignments: string;
+        manageExchanges: string;
+        trackCompensations: string;
+        offlineAccess: string;
+        travelTime: string;
+      };
+      infoBox: string;
+    };
+    howToLogin: {
+      title: string;
+      description: string;
+      calendarMode: {
+        title: string;
+        description: string;
+        steps: {
+          findUrl: { title: string; description: string };
+          selectMode: { title: string; description: string };
+          pasteUrl: { title: string; description: string };
+        };
+        infoBox: string;
+      };
+      fullLogin: {
+        title: string;
+        description: string;
+        steps: {
+          openApp: { title: string; description: string };
+          enterCredentials: { title: string; description: string };
+          stayLoggedIn: { title: string; description: string };
+        };
+        screenshotAlt: string;
+        screenshotCaption: string;
+        tipTitle: string;
+        tipContent: string;
+      };
+    };
+    quickTour: {
+      title: string;
+      description: string;
+      assignments: { title: string; description: string };
+      exchanges: { title: string; description: string };
+      compensations: { title: string; description: string };
+      settings: { title: string; description: string };
+    };
+    nextSteps: {
+      title: string;
+      description: string;
+      links: {
+        assignments: string;
+        exchanges: string;
+        compensations: string;
+      };
+    };
+  };
+
+  // Assignments page content
+  assignments: {
+    heading: string;
+    lead: string;
+    whatAre: {
+      title: string;
+      description: string;
+      details: {
+        dateTime: string;
+        teams: string;
+        venue: string;
+        role: string;
+        league: string;
+      };
+    };
+    viewing: {
+      title: string;
+      description: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    details: {
+      title: string;
+      description: string;
+      items: {
+        gameInfo: string;
+        venueAddress: string;
+        travelTime: string;
+        otherReferees: string;
+        swipeActions: string;
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    actions: {
+      title: string;
+      description: string;
+      swipeRight: {
+        title: string;
+        description: string;
+        screenshotAlt: string;
+        screenshotCaption: string;
+        warning: string;
+      };
+      swipeLeft: {
+        title: string;
+        description: string;
+        validate: string;
+        edit: string;
+        screenshotAlt: string;
+        screenshotCaption: string;
+        tip: string;
+      };
+      directions: {
+        title: string;
+        description: string;
+      };
+    };
+    upcomingPast: {
+      title: string;
+      description: string;
+      upcoming: string;
+      validationClosed: string;
+      tip: string;
+    };
+  };
+
+  // Exchanges page content
+  exchanges: {
+    heading: string;
+    lead: string;
+    whatAre: {
+      title: string;
+      description: string;
+      features: {
+        postGames: string;
+        browseGames: string;
+        acceptGames: string;
+      };
+      infoBox: string;
+    };
+    requesting: {
+      title: string;
+      description: string;
+      steps: {
+        findAssignment: { title: string; description: string };
+        swipeRight: { title: string; description: string };
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+      warningTitle: string;
+      warningContent: string;
+    };
+    viewing: {
+      title: string;
+      description: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+      filtering: {
+        title: string;
+        description: string;
+        distance: string;
+        travelTime: string;
+        usage: string;
+        tip: string;
+      };
+    };
+    accepting: {
+      title: string;
+      description: string;
+      steps: {
+        review: { title: string; description: string };
+        swipeLeft: { title: string; description: string };
+        confirm: { title: string; description: string };
+        gameAdded: { title: string; description: string };
+      };
+      tip: string;
+    };
+    managing: {
+      title: string;
+      description: string;
+      canceling: {
+        title: string;
+        description: string;
+        steps: {
+          goToExchanges: string;
+          selectAddedByMe: string;
+          swipeRight: string;
+          confirmCancellation: string;
+        };
+        infoBox: string;
+      };
+    };
+  };
+
+  // Compensations page content
+  compensations: {
+    heading: string;
+    lead: string;
+    whatAre: {
+      title: string;
+      description: string;
+      details: {
+        gameDetails: string;
+        date: string;
+        amount: string;
+        paymentStatus: string;
+        role: string;
+      };
+      infoBox: string;
+    };
+    viewing: {
+      title: string;
+      description: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+      paymentStatus: {
+        title: string;
+        pending: string;
+        processing: string;
+        paid: string;
+      };
+    };
+    filtering: {
+      title: string;
+      description: string;
+      tabs: {
+        pendingPast: string;
+        pendingFuture: string;
+        closed: string;
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+      tip: string;
+    };
+    exportPdf: {
+      title: string;
+      description: string;
+      usage: string;
+      infoBox: string;
+    };
+    paymentSchedule: {
+      title: string;
+      description: string;
+      details: {
+        processing: string;
+        bankTransfer: string;
+        timing: string;
+      };
+      warning: string;
+    };
+  };
+
+  // Calendar Mode page content
+  calendarMode: {
+    heading: string;
+    lead: string;
+    whatIs: {
+      title: string;
+      description: string;
+      features: {
+        viewAssignments: string;
+        seeDetails: string;
+        noPassword: string;
+        safeToShare: string;
+      };
+    };
+    whoIsFor: {
+      title: string;
+      description: string;
+      useCases: {
+        quickChecks: string;
+        familyMembers: string;
+        calendarIntegration: string;
+        publicDevices: string;
+      };
+      tip: string;
+    };
+    howToAccess: {
+      title: string;
+      description: string;
+      steps: {
+        findCode: { title: string; description: string };
+        openApp: { title: string; description: string };
+        selectMode: { title: string; description: string };
+        enterCode: { title: string; description: string };
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    viewingSchedule: {
+      title: string;
+      description: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    limitations: {
+      title: string;
+      description: string;
+      table: {
+        feature: string;
+        fullLogin: string;
+        calendarMode: string;
+        viewAssignments: string;
+        viewDetails: string;
+        travelTime: string;
+        confirmAssignments: string;
+        requestExchanges: string;
+        viewCompensations: string;
+        acceptExchanges: string;
+      };
+      infoBox: string;
+    };
+    security: {
+      title: string;
+      description: string;
+      tips: {
+        shareWithTrust: string;
+        dontPostPublicly: string;
+        ifCompromised: string;
+      };
+      warning: string;
+    };
+  };
+
+  // Travel Time page content
+  travelTime: {
+    heading: string;
+    lead: string;
+    howItWorks: {
+      title: string;
+      description: string;
+      considerations: {
+        schedules: string;
+        walkingTime: string;
+        transferTimes: string;
+        gameStartTime: string;
+      };
+      infoBox: string;
+    };
+    settingHome: {
+      title: string;
+      description: string;
+      steps: {
+        openSettings: { title: string; description: string };
+        findHomeLocation: { title: string; description: string };
+        enterAddress: { title: string; description: string };
+        saveSettings: { title: string; description: string };
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+      tip: string;
+    };
+    viewingTimes: {
+      title: string;
+      description: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+      whatsShown: {
+        title: string;
+        duration: string;
+        departureTime: string;
+        transportType: string;
+      };
+    };
+    journeyDetails: {
+      title: string;
+      description: string;
+      features: {
+        stepByStep: string;
+        connectionDetails: string;
+        walkingSegments: string;
+        transferTimes: string;
+      };
+      sbbLink: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    arrivalBuffer: {
+      title: string;
+      description: string;
+      details: {
+        standardBuffer: string;
+        timeFor: string;
+        accountForDelays: string;
+      };
+      warning: string;
+    };
+    offlineAvailability: {
+      title: string;
+      description: string;
+      details: {
+        cachedAvailable: string;
+        requiresConnection: string;
+        outdatedIndicator: string;
+      };
+      tip: string;
+    };
+  };
+
+  // Offline & PWA page content
+  offlinePwa: {
+    heading: string;
+    lead: string;
+    whatIsPwa: {
+      title: string;
+      description: string;
+      benefits: {
+        homeScreen: string;
+        ownWindow: string;
+        worksOffline: string;
+        autoUpdates: string;
+        minimalStorage: string;
+      };
+      tip: string;
+    };
+    installing: {
+      title: string;
+      description: string;
+      ios: {
+        title: string;
+        steps: {
+          openSafari: { title: string; description: string };
+          tapShare: { title: string; description: string };
+          selectAddHome: { title: string; description: string };
+          confirmInstall: { title: string; description: string };
+        };
+      };
+      android: {
+        title: string;
+        steps: {
+          openChrome: { title: string; description: string };
+          lookForPrompt: { title: string; description: string };
+          tapInstall: { title: string; description: string };
+        };
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+      desktop: {
+        title: string;
+        description: string;
+      };
+    };
+    whatWorksOffline: {
+      title: string;
+      description: string;
+      table: {
+        feature: string;
+        offline: string;
+        notes: string;
+        viewAssignments: string;
+        viewAssignmentsNote: string;
+        viewDetails: string;
+        viewDetailsNote: string;
+        travelTimes: string;
+        travelTimesNote: string;
+        confirmAssignments: string;
+        confirmAssignmentsNote: string;
+        requestExchanges: string;
+        requestExchangesNote: string;
+        viewCompensations: string;
+        viewCompensationsNote: string;
+      };
+      infoBox: string;
+    };
+    offlineIndicator: {
+      title: string;
+      description: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    updating: {
+      title: string;
+      description: string;
+      steps: {
+        backgroundDownload: string;
+        notificationAppears: string;
+        tapReload: string;
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+      tip: string;
+    };
+    storage: {
+      title: string;
+      description: string;
+      warning: string;
+    };
+  };
+
+  // Settings page content
+  settings: {
+    heading: string;
+    lead: string;
+    accessing: {
+      title: string;
+      description: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    profile: {
+      title: string;
+      description: string;
+      fields: {
+        name: string;
+        licenseNumber: string;
+        email: string;
+        sessionStatus: string;
+      };
+      infoBox: string;
+      loggingOut: {
+        title: string;
+        description: string;
+      };
+    };
+    language: {
+      title: string;
+      description: string;
+      options: {
+        deutsch: string;
+        english: string;
+        francais: string;
+        italiano: string;
+      };
+      autoDetect: string;
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    homeLocation: {
+      title: string;
+      description: string;
+      instructions: {
+        enterAddress: string;
+        useAutocomplete: string;
+        travelTimesAppear: string;
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+      tip: string;
+      seeGuide: string;
+    };
+    dataPrivacy: {
+      title: string;
+      description: string;
+      localStorage: {
+        title: string;
+        description: string;
+        items: {
+          assignmentCache: string;
+          preferences: string;
+          travelData: string;
+        };
+      };
+      clearData: {
+        title: string;
+        description: string;
+        effects: {
+          removeCached: string;
+          resetPreferences: string;
+          requireLogin: string;
+        };
+        warning: string;
+      };
+      screenshotAlt: string;
+      screenshotCaption: string;
+    };
+    about: {
+      title: string;
+      description: string;
+      items: {
+        versionNumber: string;
+        lastUpdated: string;
+        links: string;
+      };
+      infoBox: string;
+    };
+  };
 }
 
 export type Language = 'en' | 'de' | 'fr' | 'it';

--- a/help-site/src/pages/assignments.astro
+++ b/help-site/src/pages/assignments.astro
@@ -2,143 +2,127 @@
 import DocLayout from '../layouts/DocLayout.astro';
 import DeviceScreenshot from '../components/DeviceScreenshot.astro';
 import InfoBox from '../components/InfoBox.astro';
+import { t } from '../i18n';
 ---
 
 <DocLayout
-  title="Assignments"
-  description="Learn how to view and manage your volleyball referee assignments in VolleyKit. See game details, directions, and take actions on your games."
+  title={t('pages.assignments.title')}
+  description={t('pages.assignments.description')}
 >
-  <h1>Managing Your Assignments</h1>
+  <h1 data-i18n="assignments.heading">{t('assignments.heading')}</h1>
 
-  <p class="lead text-text-secondary dark:text-text-secondary-dark">
-    The Assignments section is your central hub for viewing all your upcoming volleyball
-    referee games and managing your schedule.
+  <p class="lead text-text-secondary dark:text-text-secondary-dark" data-i18n="assignments.lead">
+    {t('assignments.lead')}
   </p>
 
-  <h2>What Are Assignments?</h2>
+  <h2 data-i18n="assignments.whatAre.title">{t('assignments.whatAre.title')}</h2>
 
-  <p>
-    Assignments are the games you've been scheduled to referee. Each assignment includes:
-  </p>
+  <p data-i18n="assignments.whatAre.description">{t('assignments.whatAre.description')}</p>
 
   <ul>
-    <li><strong>Date and time</strong> – When the game takes place</li>
-    <li><strong>Teams</strong> – Home and away team names</li>
-    <li><strong>Venue</strong> – Location of the game with address</li>
-    <li><strong>Your role</strong> – 1st referee, 2nd referee, or line judge</li>
-    <li><strong>League</strong> – The competition level (e.g., NLA, NLB, 1. Liga)</li>
+    <li data-i18n="assignments.whatAre.details.dateTime">{t('assignments.whatAre.details.dateTime')}</li>
+    <li data-i18n="assignments.whatAre.details.teams">{t('assignments.whatAre.details.teams')}</li>
+    <li data-i18n="assignments.whatAre.details.venue">{t('assignments.whatAre.details.venue')}</li>
+    <li data-i18n="assignments.whatAre.details.role">{t('assignments.whatAre.details.role')}</li>
+    <li data-i18n="assignments.whatAre.details.league">{t('assignments.whatAre.details.league')}</li>
   </ul>
 
-  <h2>Viewing Your Assignments</h2>
+  <h2 data-i18n="assignments.viewing.title">{t('assignments.viewing.title')}</h2>
 
-  <p>
-    The assignment list shows all your upcoming games in chronological order.
-    Games are grouped by date, making it easy to see what's coming up.
-  </p>
+  <p data-i18n="assignments.viewing.description">{t('assignments.viewing.description')}</p>
 
   <DeviceScreenshot
     id="assignments-list"
-    alt="Assignment list showing multiple upcoming games grouped by date"
-    caption="The assignment list view with upcoming games"
+    alt={t('assignments.viewing.screenshotAlt')}
+    caption={t('assignments.viewing.screenshotCaption')}
+    altKey="assignments.viewing.screenshotAlt"
+    captionKey="assignments.viewing.screenshotCaption"
     instructions="Take a screenshot of the assignments page showing at least 3-4 games. Show the date grouping, team names, times, and venue info."
   />
 
-  <h2>Assignment Details</h2>
+  <h2 data-i18n="assignments.details.title">{t('assignments.details.title')}</h2>
 
-  <p>
-    Tap on any assignment to see the full details. The detail view includes:
-  </p>
+  <p data-i18n="assignments.details.description">{t('assignments.details.description')}</p>
 
   <ul>
-    <li>Complete game information</li>
-    <li>Venue address with map link</li>
-    <li>Travel time from your home location</li>
-    <li>Other referees assigned to the same game</li>
-    <li>Available actions via swipe gestures</li>
+    <li data-i18n="assignments.details.items.gameInfo">{t('assignments.details.items.gameInfo')}</li>
+    <li data-i18n="assignments.details.items.venueAddress">{t('assignments.details.items.venueAddress')}</li>
+    <li data-i18n="assignments.details.items.travelTime">{t('assignments.details.items.travelTime')}</li>
+    <li data-i18n="assignments.details.items.otherReferees">{t('assignments.details.items.otherReferees')}</li>
+    <li data-i18n="assignments.details.items.swipeActions">{t('assignments.details.items.swipeActions')}</li>
   </ul>
 
   <DeviceScreenshot
     id="assignment-detail"
-    alt="Assignment detail view showing all game information"
-    caption="Detailed view of a single assignment"
+    alt={t('assignments.details.screenshotAlt')}
+    caption={t('assignments.details.screenshotCaption')}
+    altKey="assignments.details.screenshotAlt"
+    captionKey="assignments.details.screenshotCaption"
     instructions="Take a screenshot of an assignment detail page. Show the game header, venue info, travel time, other referees section, and action buttons at the bottom."
   />
 
-  <h2>Taking Actions</h2>
+  <h2 data-i18n="assignments.actions.title">{t('assignments.actions.title')}</h2>
 
-  <p>
-    VolleyKit uses swipe gestures to quickly access actions on your assignment cards.
-    Depending on the game status, you may have different actions available.
-  </p>
+  <p data-i18n="assignments.actions.description">{t('assignments.actions.description')}</p>
 
-  <h3>Swipe Right – Add to Exchange</h3>
+  <h3 data-i18n="assignments.actions.swipeRight.title">{t('assignments.actions.swipeRight.title')}</h3>
 
-  <p>
-    Swipe an assignment card to the <strong>right</strong> to reveal the exchange action.
-    If you can't attend a game, you can add it to the exchange board for other
-    referees to pick up.
-  </p>
+  <p data-i18n="assignments.actions.swipeRight.description">{t('assignments.actions.swipeRight.description')}</p>
 
   <DeviceScreenshot
     id="swipe-right-exchange"
-    alt="Assignment card swiped right showing exchange action"
-    caption="Swipe right to add an assignment to the exchange board"
+    alt={t('assignments.actions.swipeRight.screenshotAlt')}
+    caption={t('assignments.actions.swipeRight.screenshotCaption')}
+    altKey="assignments.actions.swipeRight.screenshotAlt"
+    captionKey="assignments.actions.swipeRight.screenshotCaption"
     instructions="Take a screenshot showing an assignment card swiped to the right, revealing the green Exchange button on the left side of the card."
   />
 
   <InfoBox type="warning">
-    <p>
-      Make sure to request an exchange well in advance. Last-minute requests
-      may not find a replacement in time.
+    <p data-i18n="assignments.actions.swipeRight.warning">
+      {t('assignments.actions.swipeRight.warning')}
     </p>
   </InfoBox>
 
-  <h3>Swipe Left – Validate &amp; Edit</h3>
+  <h3 data-i18n="assignments.actions.swipeLeft.title">{t('assignments.actions.swipeLeft.title')}</h3>
 
-  <p>
-    Swipe an assignment card to the <strong>left</strong> to reveal additional actions:
-  </p>
+  <p data-i18n="assignments.actions.swipeLeft.description">{t('assignments.actions.swipeLeft.description')}</p>
 
   <ul>
-    <li><strong>Validate</strong> – Submit game results and validate the match (available for first referees after the game)</li>
-    <li><strong>Edit</strong> – Edit your compensation details for this assignment</li>
+    <li data-i18n="assignments.actions.swipeLeft.validate">{t('assignments.actions.swipeLeft.validate')}</li>
+    <li data-i18n="assignments.actions.swipeLeft.edit">{t('assignments.actions.swipeLeft.edit')}</li>
   </ul>
 
   <DeviceScreenshot
     id="assignment-actions"
-    alt="Assignment card swiped left showing validate and edit actions"
-    caption="Swipe left to reveal validate and edit actions"
+    alt={t('assignments.actions.swipeLeft.screenshotAlt')}
+    caption={t('assignments.actions.swipeLeft.screenshotCaption')}
+    altKey="assignments.actions.swipeLeft.screenshotAlt"
+    captionKey="assignments.actions.swipeLeft.screenshotCaption"
     instructions="Take a screenshot showing an assignment card swiped to the left, revealing the Validate and Edit buttons on the right side of the card."
   />
 
   <InfoBox type="tip">
-    <p>
-      You can also perform a full swipe to immediately trigger the primary action
-      without tapping the button.
+    <p data-i18n="assignments.actions.swipeLeft.tip">
+      {t('assignments.actions.swipeLeft.tip')}
     </p>
   </InfoBox>
 
-  <h3>Get Directions</h3>
-  <p>
-    Tap on an assignment card to expand it, then use the directions button to open
-    your preferred maps application with directions to the venue.
-  </p>
+  <h3 data-i18n="assignments.actions.directions.title">{t('assignments.actions.directions.title')}</h3>
+  <p data-i18n="assignments.actions.directions.description">{t('assignments.actions.directions.description')}</p>
 
-  <h2>Upcoming and Past Games</h2>
+  <h2 data-i18n="assignments.upcomingPast.title">{t('assignments.upcomingPast.title')}</h2>
 
-  <p>
-    Use the tabs at the top to switch between:
-  </p>
+  <p data-i18n="assignments.upcomingPast.description">{t('assignments.upcomingPast.description')}</p>
 
   <ul>
-    <li><strong>Upcoming</strong> – Games that haven't happened yet</li>
-    <li><strong>Validation Closed</strong> – Past games where validation is complete</li>
+    <li data-i18n="assignments.upcomingPast.upcoming">{t('assignments.upcomingPast.upcoming')}</li>
+    <li data-i18n="assignments.upcomingPast.validationClosed">{t('assignments.upcomingPast.validationClosed')}</li>
   </ul>
 
   <InfoBox type="tip">
-    <p>
-      Set your home location in Settings to see travel time estimates on each
-      assignment card.
+    <p data-i18n="assignments.upcomingPast.tip">
+      {t('assignments.upcomingPast.tip')}
     </p>
   </InfoBox>
 </DocLayout>

--- a/help-site/src/pages/calendar-mode.astro
+++ b/help-site/src/pages/calendar-mode.astro
@@ -3,153 +3,149 @@ import DocLayout from '../layouts/DocLayout.astro';
 import Screenshot from '../components/Screenshot.astro';
 import InfoBox from '../components/InfoBox.astro';
 import StepList from '../components/StepList.astro';
+import { t } from '../i18n';
 ---
 
 <DocLayout
-  title="Calendar Mode"
-  description="Learn about VolleyKit's calendar mode for read-only access to referee assignments without a full login."
+  title={t('pages.calendarMode.title')}
+  description={t('pages.calendarMode.description')}
 >
-  <h1>Calendar Mode</h1>
+  <h1 data-i18n="calendarMode.heading">{t('calendarMode.heading')}</h1>
 
-  <p class="lead text-text-secondary dark:text-text-secondary-dark">
-    Calendar mode provides read-only access to view referee assignments without
-    requiring a full login. It's perfect for quickly checking your schedule or
-    sharing with family members.
+  <p class="lead text-text-secondary dark:text-text-secondary-dark" data-i18n="calendarMode.lead">
+    {t('calendarMode.lead')}
   </p>
 
-  <h2>What Is Calendar Mode?</h2>
+  <h2 data-i18n="calendarMode.whatIs.title">{t('calendarMode.whatIs.title')}</h2>
 
-  <p>
-    Calendar mode is a lightweight view-only access method that lets you see
-    your upcoming assignments without entering your password. It uses a unique
-    calendar code that's linked to your referee account.
-  </p>
+  <p data-i18n="calendarMode.whatIs.description">{t('calendarMode.whatIs.description')}</p>
 
-  <h3>Key Features</h3>
+  <h3 data-i18n="calendarMode.whatIs.features.viewAssignments">{t('calendarMode.whatIs.features.viewAssignments')}</h3>
 
   <ul>
-    <li>View your upcoming game assignments</li>
-    <li>See game details including date, time, teams, and venue</li>
-    <li>No password required – just your calendar code</li>
-    <li>Safe to share with family or add to shared calendars</li>
+    <li data-i18n="calendarMode.whatIs.features.viewAssignments">{t('calendarMode.whatIs.features.viewAssignments')}</li>
+    <li data-i18n="calendarMode.whatIs.features.seeDetails">{t('calendarMode.whatIs.features.seeDetails')}</li>
+    <li data-i18n="calendarMode.whatIs.features.noPassword">{t('calendarMode.whatIs.features.noPassword')}</li>
+    <li data-i18n="calendarMode.whatIs.features.safeToShare">{t('calendarMode.whatIs.features.safeToShare')}</li>
   </ul>
 
-  <h2>Who Is Calendar Mode For?</h2>
+  <h2 data-i18n="calendarMode.whoIsFor.title">{t('calendarMode.whoIsFor.title')}</h2>
 
-  <p>
-    Calendar mode is ideal for:
-  </p>
+  <p data-i18n="calendarMode.whoIsFor.description">{t('calendarMode.whoIsFor.description')}</p>
 
   <ul>
-    <li><strong>Quick schedule checks</strong> – View your games without logging in</li>
-    <li><strong>Family members</strong> – Share your schedule with partners or family</li>
-    <li><strong>Calendar integration</strong> – Add games to external calendar apps</li>
-    <li><strong>Public devices</strong> – Check your schedule on shared computers</li>
+    <li data-i18n="calendarMode.whoIsFor.useCases.quickChecks">{t('calendarMode.whoIsFor.useCases.quickChecks')}</li>
+    <li data-i18n="calendarMode.whoIsFor.useCases.familyMembers">{t('calendarMode.whoIsFor.useCases.familyMembers')}</li>
+    <li data-i18n="calendarMode.whoIsFor.useCases.calendarIntegration">{t('calendarMode.whoIsFor.useCases.calendarIntegration')}</li>
+    <li data-i18n="calendarMode.whoIsFor.useCases.publicDevices">{t('calendarMode.whoIsFor.useCases.publicDevices')}</li>
   </ul>
 
   <InfoBox type="tip">
-    <p>
-      Calendar mode is perfect for letting your family know when you have games
-      without giving them access to your full account.
+    <p data-i18n="calendarMode.whoIsFor.tip">
+      {t('calendarMode.whoIsFor.tip')}
     </p>
   </InfoBox>
 
-  <h2>How to Access Calendar Mode</h2>
+  <h2 data-i18n="calendarMode.howToAccess.title">{t('calendarMode.howToAccess.title')}</h2>
 
-  <p>
-    To use calendar mode, you need your unique calendar code from the volleymanager
-    system.
-  </p>
+  <p data-i18n="calendarMode.howToAccess.description">{t('calendarMode.howToAccess.description')}</p>
 
   <StepList
     steps={[
       {
-        title: 'Find your calendar code',
-        description: 'Log in to volleymanager.volleyball.ch and find your calendar code in your profile settings.',
+        title: t('calendarMode.howToAccess.steps.findCode.title'),
+        description: t('calendarMode.howToAccess.steps.findCode.description'),
+        titleKey: 'calendarMode.howToAccess.steps.findCode.title',
+        descriptionKey: 'calendarMode.howToAccess.steps.findCode.description',
       },
       {
-        title: 'Open VolleyKit',
-        description: 'Navigate to the VolleyKit app.',
+        title: t('calendarMode.howToAccess.steps.openApp.title'),
+        description: t('calendarMode.howToAccess.steps.openApp.description'),
+        titleKey: 'calendarMode.howToAccess.steps.openApp.title',
+        descriptionKey: 'calendarMode.howToAccess.steps.openApp.description',
       },
       {
-        title: 'Select "Calendar Mode"',
-        description: 'On the login page, tap the "Calendar Mode" option.',
+        title: t('calendarMode.howToAccess.steps.selectMode.title'),
+        description: t('calendarMode.howToAccess.steps.selectMode.description'),
+        titleKey: 'calendarMode.howToAccess.steps.selectMode.title',
+        descriptionKey: 'calendarMode.howToAccess.steps.selectMode.description',
       },
       {
-        title: 'Enter your code',
-        description: 'Input your calendar code to access your read-only schedule.',
+        title: t('calendarMode.howToAccess.steps.enterCode.title'),
+        description: t('calendarMode.howToAccess.steps.enterCode.description'),
+        titleKey: 'calendarMode.howToAccess.steps.enterCode.title',
+        descriptionKey: 'calendarMode.howToAccess.steps.enterCode.description',
       },
     ]}
   />
 
   <Screenshot
     id="calendar-mode-login"
-    alt="Calendar mode entry screen with code input field"
-    caption="Entering calendar mode with your code"
+    alt={t('calendarMode.howToAccess.screenshotAlt')}
+    caption={t('calendarMode.howToAccess.screenshotCaption')}
+    altKey="calendarMode.howToAccess.screenshotAlt"
+    captionKey="calendarMode.howToAccess.screenshotCaption"
     instructions="Take a screenshot of the calendar mode login/entry screen. Show the calendar code input field and any explanatory text about what calendar mode provides."
   />
 
-  <h2>Viewing Your Schedule</h2>
+  <h2 data-i18n="calendarMode.viewingSchedule.title">{t('calendarMode.viewingSchedule.title')}</h2>
 
-  <p>
-    Once in calendar mode, you'll see your upcoming assignments in a simplified
-    view. The interface shows the essential information for each game.
-  </p>
+  <p data-i18n="calendarMode.viewingSchedule.description">{t('calendarMode.viewingSchedule.description')}</p>
 
   <Screenshot
     id="calendar-mode-view"
-    alt="Calendar mode showing upcoming assignments in read-only view"
-    caption="Calendar mode assignment view"
+    alt={t('calendarMode.viewingSchedule.screenshotAlt')}
+    caption={t('calendarMode.viewingSchedule.screenshotCaption')}
+    altKey="calendarMode.viewingSchedule.screenshotAlt"
+    captionKey="calendarMode.viewingSchedule.screenshotCaption"
     instructions="Take a screenshot of the calendar mode view showing several upcoming games. Show the read-only indicator and the simplified game cards with date, teams, and venue."
   />
 
-  <h2>Limitations vs Full Login</h2>
+  <h2 data-i18n="calendarMode.limitations.title">{t('calendarMode.limitations.title')}</h2>
 
-  <p>
-    Calendar mode is read-only, which means some features are not available:
-  </p>
+  <p data-i18n="calendarMode.limitations.description">{t('calendarMode.limitations.description')}</p>
 
   <table class="w-full text-sm">
     <thead>
       <tr class="border-b border-border-default dark:border-border-default-dark">
-        <th class="py-2 text-left">Feature</th>
-        <th class="py-2 text-center">Full Login</th>
-        <th class="py-2 text-center">Calendar Mode</th>
+        <th class="py-2 text-left" data-i18n="calendarMode.limitations.table.feature">{t('calendarMode.limitations.table.feature')}</th>
+        <th class="py-2 text-center" data-i18n="calendarMode.limitations.table.fullLogin">{t('calendarMode.limitations.table.fullLogin')}</th>
+        <th class="py-2 text-center" data-i18n="calendarMode.limitations.table.calendarMode">{t('calendarMode.limitations.table.calendarMode')}</th>
       </tr>
     </thead>
     <tbody>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">View assignments</td>
+        <td class="py-2" data-i18n="calendarMode.limitations.table.viewAssignments">{t('calendarMode.limitations.table.viewAssignments')}</td>
         <td class="py-2 text-center">✓</td>
         <td class="py-2 text-center">✓</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">View game details</td>
+        <td class="py-2" data-i18n="calendarMode.limitations.table.viewDetails">{t('calendarMode.limitations.table.viewDetails')}</td>
         <td class="py-2 text-center">✓</td>
         <td class="py-2 text-center">✓</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">Travel time info</td>
+        <td class="py-2" data-i18n="calendarMode.limitations.table.travelTime">{t('calendarMode.limitations.table.travelTime')}</td>
         <td class="py-2 text-center">✓</td>
         <td class="py-2 text-center">✓</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">Confirm assignments</td>
+        <td class="py-2" data-i18n="calendarMode.limitations.table.confirmAssignments">{t('calendarMode.limitations.table.confirmAssignments')}</td>
         <td class="py-2 text-center">✓</td>
         <td class="py-2 text-center">✗</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">Request exchanges</td>
+        <td class="py-2" data-i18n="calendarMode.limitations.table.requestExchanges">{t('calendarMode.limitations.table.requestExchanges')}</td>
         <td class="py-2 text-center">✓</td>
         <td class="py-2 text-center">✗</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">View compensations</td>
+        <td class="py-2" data-i18n="calendarMode.limitations.table.viewCompensations">{t('calendarMode.limitations.table.viewCompensations')}</td>
         <td class="py-2 text-center">✓</td>
         <td class="py-2 text-center">✗</td>
       </tr>
       <tr>
-        <td class="py-2">Accept exchanges</td>
+        <td class="py-2" data-i18n="calendarMode.limitations.table.acceptExchanges">{t('calendarMode.limitations.table.acceptExchanges')}</td>
         <td class="py-2 text-center">✓</td>
         <td class="py-2 text-center">✗</td>
       </tr>
@@ -157,29 +153,24 @@ import StepList from '../components/StepList.astro';
   </table>
 
   <InfoBox type="info">
-    <p>
-      For any actions like confirming assignments or requesting exchanges,
-      you'll need to log in with your full credentials.
+    <p data-i18n="calendarMode.limitations.infoBox">
+      {t('calendarMode.limitations.infoBox')}
     </p>
   </InfoBox>
 
-  <h2>Keeping Your Code Secure</h2>
+  <h2 data-i18n="calendarMode.security.title">{t('calendarMode.security.title')}</h2>
 
-  <p>
-    While calendar mode is read-only, your calendar code should still be treated
-    with care:
-  </p>
+  <p data-i18n="calendarMode.security.description">{t('calendarMode.security.description')}</p>
 
   <ul>
-    <li>Only share with people you trust</li>
-    <li>Don't post your code publicly online</li>
-    <li>If you suspect your code has been compromised, contact Swiss Volley</li>
+    <li data-i18n="calendarMode.security.tips.shareWithTrust">{t('calendarMode.security.tips.shareWithTrust')}</li>
+    <li data-i18n="calendarMode.security.tips.dontPostPublicly">{t('calendarMode.security.tips.dontPostPublicly')}</li>
+    <li data-i18n="calendarMode.security.tips.ifCompromised">{t('calendarMode.security.tips.ifCompromised')}</li>
   </ul>
 
   <InfoBox type="warning">
-    <p>
-      Your calendar code reveals your full game schedule. Only share it with
-      people you're comfortable knowing your whereabouts.
+    <p data-i18n="calendarMode.security.warning">
+      {t('calendarMode.security.warning')}
     </p>
   </InfoBox>
 </DocLayout>

--- a/help-site/src/pages/compensations.astro
+++ b/help-site/src/pages/compensations.astro
@@ -3,131 +3,110 @@ import DocLayout from '../layouts/DocLayout.astro';
 import Screenshot from '../components/Screenshot.astro';
 import DeviceScreenshot from '../components/DeviceScreenshot.astro';
 import InfoBox from '../components/InfoBox.astro';
+import { t } from '../i18n';
 ---
 
 <DocLayout
-  title="Compensations"
-  description="Track your volleyball referee earnings and compensation history in VolleyKit. View payments, filter by date, and export your data."
+  title={t('pages.compensations.title')}
+  description={t('pages.compensations.description')}
 >
-  <h1>Tracking Your Compensations</h1>
+  <h1 data-i18n="compensations.heading">{t('compensations.heading')}</h1>
 
-  <p class="lead text-text-secondary dark:text-text-secondary-dark">
-    The Compensations section helps you track your referee earnings and payment
-    history. View past payments, filter by date range, and export your data
-    for record-keeping.
+  <p class="lead text-text-secondary dark:text-text-secondary-dark" data-i18n="compensations.lead">
+    {t('compensations.lead')}
   </p>
 
-  <h2>What Are Compensations?</h2>
+  <h2 data-i18n="compensations.whatAre.title">{t('compensations.whatAre.title')}</h2>
 
-  <p>
-    Compensations are the payments you receive for officiating volleyball games.
-    Each compensation entry typically includes:
-  </p>
+  <p data-i18n="compensations.whatAre.description">{t('compensations.whatAre.description')}</p>
 
   <ul>
-    <li><strong>Game details</strong> – The match you officiated</li>
-    <li><strong>Date</strong> – When the game took place</li>
-    <li><strong>Amount</strong> – The compensation amount in CHF</li>
-    <li><strong>Payment status</strong> – Pending, paid, or processed</li>
-    <li><strong>Role</strong> – Your function in the game</li>
+    <li data-i18n="compensations.whatAre.details.gameDetails">{t('compensations.whatAre.details.gameDetails')}</li>
+    <li data-i18n="compensations.whatAre.details.date">{t('compensations.whatAre.details.date')}</li>
+    <li data-i18n="compensations.whatAre.details.amount">{t('compensations.whatAre.details.amount')}</li>
+    <li data-i18n="compensations.whatAre.details.paymentStatus">{t('compensations.whatAre.details.paymentStatus')}</li>
+    <li data-i18n="compensations.whatAre.details.role">{t('compensations.whatAre.details.role')}</li>
   </ul>
 
   <InfoBox type="info">
-    <p>
-      Compensation amounts are set by Swiss Volley and vary based on the league
-      level and your role in the game.
+    <p data-i18n="compensations.whatAre.infoBox">
+      {t('compensations.whatAre.infoBox')}
     </p>
   </InfoBox>
 
-  <h2>Viewing Your Compensations</h2>
+  <h2 data-i18n="compensations.viewing.title">{t('compensations.viewing.title')}</h2>
 
-  <p>
-    The compensation list shows all your recorded payments in chronological order.
-    Each entry displays the key information at a glance.
-  </p>
+  <p data-i18n="compensations.viewing.description">{t('compensations.viewing.description')}</p>
 
   <DeviceScreenshot
     id="compensations-list"
-    alt="Compensation list showing payment history with amounts and dates"
-    caption="Your compensation history"
+    alt={t('compensations.viewing.screenshotAlt')}
+    caption={t('compensations.viewing.screenshotCaption')}
+    altKey="compensations.viewing.screenshotAlt"
+    captionKey="compensations.viewing.screenshotCaption"
     instructions="Take a screenshot of the compensations page showing several payment entries. Show game info, dates, amounts in CHF, and payment status indicators."
   />
 
-  <h3>Understanding Payment Status</h3>
+  <h3 data-i18n="compensations.viewing.paymentStatus.title">{t('compensations.viewing.paymentStatus.title')}</h3>
 
-  <p>
-    Compensations can have different statuses:
-  </p>
+  <p data-i18n="compensations.viewing.description">{t('compensations.viewing.description')}</p>
 
   <ul>
-    <li><strong>Pending</strong> – Game completed, payment not yet processed</li>
-    <li><strong>Processing</strong> – Payment is being processed</li>
-    <li><strong>Paid</strong> – Payment has been made to your account</li>
+    <li data-i18n="compensations.viewing.paymentStatus.pending">{t('compensations.viewing.paymentStatus.pending')}</li>
+    <li data-i18n="compensations.viewing.paymentStatus.processing">{t('compensations.viewing.paymentStatus.processing')}</li>
+    <li data-i18n="compensations.viewing.paymentStatus.paid">{t('compensations.viewing.paymentStatus.paid')}</li>
   </ul>
 
-  <h2>Filtering by Status</h2>
+  <h2 data-i18n="compensations.filtering.title">{t('compensations.filtering.title')}</h2>
 
-  <p>
-    Use the tabs at the top to filter compensations by their status:
-  </p>
+  <p data-i18n="compensations.filtering.description">{t('compensations.filtering.description')}</p>
 
   <ul>
-    <li><strong>Pending (Past)</strong> – Past games awaiting payment</li>
-    <li><strong>Pending (Future)</strong> – Upcoming games not yet played</li>
-    <li><strong>Closed</strong> – Completed and paid compensations</li>
+    <li data-i18n="compensations.filtering.tabs.pendingPast">{t('compensations.filtering.tabs.pendingPast')}</li>
+    <li data-i18n="compensations.filtering.tabs.pendingFuture">{t('compensations.filtering.tabs.pendingFuture')}</li>
+    <li data-i18n="compensations.filtering.tabs.closed">{t('compensations.filtering.tabs.closed')}</li>
   </ul>
 
   <Screenshot
     id="compensations-filters"
-    alt="Compensation tabs showing pending and closed options"
-    caption="Filtering compensations by status"
+    alt={t('compensations.filtering.screenshotAlt')}
+    caption={t('compensations.filtering.screenshotCaption')}
+    altKey="compensations.filtering.screenshotAlt"
+    captionKey="compensations.filtering.screenshotCaption"
     instructions="Take a screenshot showing the compensation page tabs. Include the pending past, pending future, and closed tabs."
   />
 
   <InfoBox type="tip">
-    <p>
-      Compensations are automatically filtered to the current season (September
-      to May) so you can focus on recent games.
+    <p data-i18n="compensations.filtering.tip">
+      {t('compensations.filtering.tip')}
     </p>
   </InfoBox>
 
-  <h2>Export to PDF</h2>
+  <h2 data-i18n="compensations.exportPdf.title">{t('compensations.exportPdf.title')}</h2>
 
-  <p>
-    You can export individual compensation records as PDF documents. Swipe left
-    on any compensation card to reveal the PDF export action.
-  </p>
+  <p data-i18n="compensations.exportPdf.description">{t('compensations.exportPdf.description')}</p>
 
-  <p>
-    The exported PDF includes the game details and compensation information
-    in a formatted document. This is useful for providing to teams that need
-    to pay the referee directly.
-  </p>
+  <p data-i18n="compensations.exportPdf.usage">{t('compensations.exportPdf.usage')}</p>
 
   <InfoBox type="info">
-    <p>
-      The PDF export creates an official-looking document with all the game
-      and compensation details that teams may require for their records.
+    <p data-i18n="compensations.exportPdf.infoBox">
+      {t('compensations.exportPdf.infoBox')}
     </p>
   </InfoBox>
 
-  <h2>Payment Schedule</h2>
+  <h2 data-i18n="compensations.paymentSchedule.title">{t('compensations.paymentSchedule.title')}</h2>
 
-  <p>
-    Compensation payments are typically processed monthly by Swiss Volley.
-    The exact payment schedule may vary, but generally:
-  </p>
+  <p data-i18n="compensations.paymentSchedule.description">{t('compensations.paymentSchedule.description')}</p>
 
   <ul>
-    <li>Games from the previous month are processed at the start of each month</li>
-    <li>Payments are made via bank transfer to your registered account</li>
-    <li>Processing may take 2-4 weeks after the month ends</li>
+    <li data-i18n="compensations.paymentSchedule.details.processing">{t('compensations.paymentSchedule.details.processing')}</li>
+    <li data-i18n="compensations.paymentSchedule.details.bankTransfer">{t('compensations.paymentSchedule.details.bankTransfer')}</li>
+    <li data-i18n="compensations.paymentSchedule.details.timing">{t('compensations.paymentSchedule.details.timing')}</li>
   </ul>
 
   <InfoBox type="warning">
-    <p>
-      Make sure your bank details are up to date in the volleymanager system
-      to avoid payment delays.
+    <p data-i18n="compensations.paymentSchedule.warning">
+      {t('compensations.paymentSchedule.warning')}
     </p>
   </InfoBox>
 </DocLayout>

--- a/help-site/src/pages/exchanges.astro
+++ b/help-site/src/pages/exchanges.astro
@@ -3,172 +3,158 @@ import DocLayout from '../layouts/DocLayout.astro';
 import DeviceScreenshot from '../components/DeviceScreenshot.astro';
 import InfoBox from '../components/InfoBox.astro';
 import StepList from '../components/StepList.astro';
+import { t } from '../i18n';
 ---
 
 <DocLayout
-  title="Exchanges"
-  description="Learn how to request game exchanges and pick up available games from other referees in VolleyKit."
+  title={t('pages.exchanges.title')}
+  description={t('pages.exchanges.description')}
 >
-  <h1>Game Exchanges</h1>
+  <h1 data-i18n="exchanges.heading">{t('exchanges.heading')}</h1>
 
-  <p class="lead text-text-secondary dark:text-text-secondary-dark">
-    The exchange system allows referees to swap games when they can't attend their
-    scheduled assignments. You can request exchanges for your games or pick up
-    games from other referees.
+  <p class="lead text-text-secondary dark:text-text-secondary-dark" data-i18n="exchanges.lead">
+    {t('exchanges.lead')}
   </p>
 
-  <h2>What Are Exchanges?</h2>
+  <h2 data-i18n="exchanges.whatAre.title">{t('exchanges.whatAre.title')}</h2>
 
-  <p>
-    An exchange is a request from a referee who can't attend their scheduled game
-    and is looking for a replacement. The volleymanager system maintains an exchange
-    board where referees can:
-  </p>
+  <p data-i18n="exchanges.whatAre.description">{t('exchanges.whatAre.description')}</p>
 
   <ul>
-    <li>Post their games for exchange</li>
-    <li>Browse available games from other referees</li>
-    <li>Accept games that fit their schedule</li>
+    <li data-i18n="exchanges.whatAre.features.postGames">{t('exchanges.whatAre.features.postGames')}</li>
+    <li data-i18n="exchanges.whatAre.features.browseGames">{t('exchanges.whatAre.features.browseGames')}</li>
+    <li data-i18n="exchanges.whatAre.features.acceptGames">{t('exchanges.whatAre.features.acceptGames')}</li>
   </ul>
 
   <InfoBox type="info">
-    <p>
-      Exchanges are managed through the official volleymanager system. VolleyKit
-      provides a more user-friendly interface to the same exchange board.
+    <p data-i18n="exchanges.whatAre.infoBox">
+      {t('exchanges.whatAre.infoBox')}
     </p>
   </InfoBox>
 
-  <h2>Requesting an Exchange</h2>
+  <h2 data-i18n="exchanges.requesting.title">{t('exchanges.requesting.title')}</h2>
 
-  <p>
-    When you can't attend one of your scheduled games, you can request an exchange
-    to find a replacement referee.
-  </p>
+  <p data-i18n="exchanges.requesting.description">{t('exchanges.requesting.description')}</p>
 
   <StepList
     steps={[
       {
-        title: 'Find the assignment',
-        description: 'Go to your Assignments tab and locate the game you want to exchange.',
+        title: t('exchanges.requesting.steps.findAssignment.title'),
+        description: t('exchanges.requesting.steps.findAssignment.description'),
+        titleKey: 'exchanges.requesting.steps.findAssignment.title',
+        descriptionKey: 'exchanges.requesting.steps.findAssignment.description',
       },
       {
-        title: 'Swipe right on the card',
-        description: 'Swipe the assignment card to the right to reveal the exchange action, then tap it. The game will be posted to the exchange board.',
+        title: t('exchanges.requesting.steps.swipeRight.title'),
+        description: t('exchanges.requesting.steps.swipeRight.description'),
+        titleKey: 'exchanges.requesting.steps.swipeRight.title',
+        descriptionKey: 'exchanges.requesting.steps.swipeRight.description',
       },
     ]}
   />
 
   <DeviceScreenshot
     id="exchange-request"
-    alt="Assignment card with exchange swipe action revealed"
-    caption="Requesting an exchange for a game"
+    alt={t('exchanges.requesting.screenshotAlt')}
+    caption={t('exchanges.requesting.screenshotCaption')}
+    altKey="exchanges.requesting.screenshotAlt"
+    captionKey="exchanges.requesting.screenshotCaption"
     instructions="Take a screenshot showing an assignment card with the exchange swipe action revealed on the right side."
   />
 
-  <InfoBox type="warning" title="Request early">
-    <p>
-      The earlier you request an exchange, the more likely you'll find a replacement.
-      Last-minute requests often go unfilled.
+  <InfoBox type="warning" title={t('exchanges.requesting.warningTitle')} titleKey="exchanges.requesting.warningTitle">
+    <p data-i18n="exchanges.requesting.warningContent">
+      {t('exchanges.requesting.warningContent')}
     </p>
   </InfoBox>
 
-  <h2>Viewing Available Exchanges</h2>
+  <h2 data-i18n="exchanges.viewing.title">{t('exchanges.viewing.title')}</h2>
 
-  <p>
-    The Exchanges tab shows all games currently available for exchange. These are
-    games that other referees have posted and are looking for replacements.
-  </p>
+  <p data-i18n="exchanges.viewing.description">{t('exchanges.viewing.description')}</p>
 
   <DeviceScreenshot
     id="exchange-list"
-    alt="List of available exchange games from other referees"
-    caption="Available games on the exchange board"
+    alt={t('exchanges.viewing.screenshotAlt')}
+    caption={t('exchanges.viewing.screenshotCaption')}
+    altKey="exchanges.viewing.screenshotAlt"
+    captionKey="exchanges.viewing.screenshotCaption"
     instructions="Take a screenshot of the exchanges page showing several available games. Show game details including date, teams, venue, and the requesting referee's info."
   />
 
-  <h3>Filtering Exchanges</h3>
+  <h3 data-i18n="exchanges.viewing.filtering.title">{t('exchanges.viewing.filtering.title')}</h3>
 
-  <p>
-    Filter the exchange list to find games that work for you. Filters become
-    available after you configure the required settings:
-  </p>
+  <p data-i18n="exchanges.viewing.filtering.description">{t('exchanges.viewing.filtering.description')}</p>
 
   <ul>
-    <li><strong>Distance</strong> – Filter by maximum distance from your home location. Requires setting your home location in Settings.</li>
-    <li><strong>Travel time</strong> – Filter by maximum travel time using public transport. Requires both a home location and enabling the public transport API in Settings.</li>
+    <li data-i18n="exchanges.viewing.filtering.distance">{t('exchanges.viewing.filtering.distance')}</li>
+    <li data-i18n="exchanges.viewing.filtering.travelTime">{t('exchanges.viewing.filtering.travelTime')}</li>
   </ul>
 
-  <p>
-    Once filters are available, they appear as toggle chips next to the settings
-    gear icon. Tap the gear to configure the maximum values for each filter.
-  </p>
+  <p data-i18n="exchanges.viewing.filtering.usage">{t('exchanges.viewing.filtering.usage')}</p>
 
   <InfoBox type="tip">
-    <p>
-      Set your home location in Settings to unlock distance filtering. Enable the
-      public transport API to also filter by travel time.
+    <p data-i18n="exchanges.viewing.filtering.tip">
+      {t('exchanges.viewing.filtering.tip')}
     </p>
   </InfoBox>
 
-  <h2>Accepting an Exchange</h2>
+  <h2 data-i18n="exchanges.accepting.title">{t('exchanges.accepting.title')}</h2>
 
-  <p>
-    When you find a game you'd like to take over, you can accept the exchange:
-  </p>
+  <p data-i18n="exchanges.accepting.description">{t('exchanges.accepting.description')}</p>
 
   <StepList
     steps={[
       {
-        title: 'Review the game details',
-        description: 'Check the date, time, venue, and travel requirements.',
+        title: t('exchanges.accepting.steps.review.title'),
+        description: t('exchanges.accepting.steps.review.description'),
+        titleKey: 'exchanges.accepting.steps.review.title',
+        descriptionKey: 'exchanges.accepting.steps.review.description',
       },
       {
-        title: 'Swipe left on the card',
-        description: 'Swipe the exchange card to the left to reveal the take over action, then tap it.',
+        title: t('exchanges.accepting.steps.swipeLeft.title'),
+        description: t('exchanges.accepting.steps.swipeLeft.description'),
+        titleKey: 'exchanges.accepting.steps.swipeLeft.title',
+        descriptionKey: 'exchanges.accepting.steps.swipeLeft.description',
       },
       {
-        title: 'Confirm your acceptance',
-        description: 'Review the details and confirm your acceptance.',
+        title: t('exchanges.accepting.steps.confirm.title'),
+        description: t('exchanges.accepting.steps.confirm.description'),
+        titleKey: 'exchanges.accepting.steps.confirm.title',
+        descriptionKey: 'exchanges.accepting.steps.confirm.description',
       },
       {
-        title: 'Game added to your schedule',
-        description: 'The game now appears in your assignments.',
+        title: t('exchanges.accepting.steps.gameAdded.title'),
+        description: t('exchanges.accepting.steps.gameAdded.description'),
+        titleKey: 'exchanges.accepting.steps.gameAdded.title',
+        descriptionKey: 'exchanges.accepting.steps.gameAdded.description',
       },
     ]}
   />
 
   <InfoBox type="tip">
-    <p>
-      Make sure you can actually attend the game before accepting. Once accepted,
-      the original referee is released from the assignment.
+    <p data-i18n="exchanges.accepting.tip">
+      {t('exchanges.accepting.tip')}
     </p>
   </InfoBox>
 
-  <h2>Managing Your Exchange Requests</h2>
+  <h2 data-i18n="exchanges.managing.title">{t('exchanges.managing.title')}</h2>
 
-  <p>
-    You can view and manage your active exchange requests from the Exchanges tab.
-    If you no longer need an exchange (e.g., your schedule changed), you can
-    cancel the request before someone accepts it.
-  </p>
+  <p data-i18n="exchanges.managing.description">{t('exchanges.managing.description')}</p>
 
-  <h3>Canceling a Request</h3>
+  <h3 data-i18n="exchanges.managing.canceling.title">{t('exchanges.managing.canceling.title')}</h3>
 
-  <p>
-    To cancel an exchange request you've made:
-  </p>
+  <p data-i18n="exchanges.managing.canceling.description">{t('exchanges.managing.canceling.description')}</p>
 
   <ol>
-    <li>Go to the Exchanges tab</li>
-    <li>Select the "Added by Me" tab to see your pending requests</li>
-    <li>Swipe right on the request card to reveal the remove action, then tap it</li>
-    <li>Confirm the cancellation</li>
+    <li data-i18n="exchanges.managing.canceling.steps.goToExchanges">{t('exchanges.managing.canceling.steps.goToExchanges')}</li>
+    <li data-i18n="exchanges.managing.canceling.steps.selectAddedByMe">{t('exchanges.managing.canceling.steps.selectAddedByMe')}</li>
+    <li data-i18n="exchanges.managing.canceling.steps.swipeRight">{t('exchanges.managing.canceling.steps.swipeRight')}</li>
+    <li data-i18n="exchanges.managing.canceling.steps.confirmCancellation">{t('exchanges.managing.canceling.steps.confirmCancellation')}</li>
   </ol>
 
   <InfoBox type="info">
-    <p>
-      You can only cancel an exchange request if no one has accepted it yet.
-      Once accepted, the exchange is final.
+    <p data-i18n="exchanges.managing.canceling.infoBox">
+      {t('exchanges.managing.canceling.infoBox')}
     </p>
   </InfoBox>
 </DocLayout>

--- a/help-site/src/pages/getting-started.astro
+++ b/help-site/src/pages/getting-started.astro
@@ -5,156 +5,140 @@ import DeviceScreenshot from '../components/DeviceScreenshot.astro';
 import InfoBox from '../components/InfoBox.astro';
 import StepList from '../components/StepList.astro';
 import { BASE_PATH } from '../constants';
+import { t } from '../i18n';
 ---
 
 <DocLayout
-  title="Getting Started"
-  description="Quick start guide to set up and use VolleyKit for the first time. Learn how to login, navigate the app, and manage your referee assignments."
+  title={t('pages.gettingStarted.title')}
+  description={t('pages.gettingStarted.description')}
 >
-  <h1>Getting Started with VolleyKit</h1>
+  <h1 data-i18n="gettingStarted.heading">{t('gettingStarted.heading')}</h1>
 
-  <p class="lead text-text-secondary dark:text-text-secondary-dark">
-    VolleyKit is a progressive web application that provides an improved interface for managing
-    your volleyball referee assignments through the Swiss Volleyball Federation's volleymanager system.
+  <p class="lead text-text-secondary dark:text-text-secondary-dark" data-i18n="gettingStarted.lead">
+    {t('gettingStarted.lead')}
   </p>
 
-  <h2>What is VolleyKit?</h2>
+  <h2 data-i18n="gettingStarted.whatIs.title">{t('gettingStarted.whatIs.title')}</h2>
 
-  <p>
-    VolleyKit connects to the official volleymanager.volleyball.ch platform and provides a modern,
-    mobile-friendly interface for referees to:
-  </p>
+  <p data-i18n="gettingStarted.whatIs.description">{t('gettingStarted.whatIs.description')}</p>
 
   <ul>
-    <li>View upcoming game assignments</li>
-    <li>Request and manage game exchanges with other referees</li>
-    <li>Track compensation payments</li>
-    <li>Access assignments offline</li>
-    <li>Calculate travel times using Swiss public transport</li>
+    <li data-i18n="gettingStarted.whatIs.features.viewAssignments">{t('gettingStarted.whatIs.features.viewAssignments')}</li>
+    <li data-i18n="gettingStarted.whatIs.features.manageExchanges">{t('gettingStarted.whatIs.features.manageExchanges')}</li>
+    <li data-i18n="gettingStarted.whatIs.features.trackCompensations">{t('gettingStarted.whatIs.features.trackCompensations')}</li>
+    <li data-i18n="gettingStarted.whatIs.features.offlineAccess">{t('gettingStarted.whatIs.features.offlineAccess')}</li>
+    <li data-i18n="gettingStarted.whatIs.features.travelTime">{t('gettingStarted.whatIs.features.travelTime')}</li>
   </ul>
 
   <InfoBox type="info">
-    <p>
-      VolleyKit is an unofficial app created to improve the referee experience. All data comes
-      from the official volleymanager system.
+    <p data-i18n="gettingStarted.whatIs.infoBox">
+      {t('gettingStarted.whatIs.infoBox')}
     </p>
   </InfoBox>
 
-  <h2>How to Login</h2>
+  <h2 data-i18n="gettingStarted.howToLogin.title">{t('gettingStarted.howToLogin.title')}</h2>
 
-  <p>
-    VolleyKit offers two ways to access your assignments:
-  </p>
+  <p data-i18n="gettingStarted.howToLogin.description">{t('gettingStarted.howToLogin.description')}</p>
 
-  <h3>Option 1: Calendar Mode (Recommended)</h3>
+  <h3 data-i18n="gettingStarted.howToLogin.calendarMode.title">{t('gettingStarted.howToLogin.calendarMode.title')}</h3>
 
-  <p>
-    For quick access to view your schedule without entering your password, you can use
-    Calendar Mode with your unique calendar URL or code from volleymanager.
-  </p>
+  <p data-i18n="gettingStarted.howToLogin.calendarMode.description">{t('gettingStarted.howToLogin.calendarMode.description')}</p>
 
   <StepList
     steps={[
       {
-        title: 'Find your calendar URL',
-        description: 'In volleymanager, go to "My Assignments" and copy your calendar subscription URL.',
+        title: t('gettingStarted.howToLogin.calendarMode.steps.findUrl.title'),
+        description: t('gettingStarted.howToLogin.calendarMode.steps.findUrl.description'),
+        titleKey: 'gettingStarted.howToLogin.calendarMode.steps.findUrl.title',
+        descriptionKey: 'gettingStarted.howToLogin.calendarMode.steps.findUrl.description',
       },
       {
-        title: 'Select Calendar Mode',
-        description: 'On the VolleyKit login page, tap the "Calendar Mode" tab.',
+        title: t('gettingStarted.howToLogin.calendarMode.steps.selectMode.title'),
+        description: t('gettingStarted.howToLogin.calendarMode.steps.selectMode.description'),
+        titleKey: 'gettingStarted.howToLogin.calendarMode.steps.selectMode.title',
+        descriptionKey: 'gettingStarted.howToLogin.calendarMode.steps.selectMode.description',
       },
       {
-        title: 'Paste your URL or code',
-        description: 'Enter your calendar URL or just the code portion to access your schedule.',
+        title: t('gettingStarted.howToLogin.calendarMode.steps.pasteUrl.title'),
+        description: t('gettingStarted.howToLogin.calendarMode.steps.pasteUrl.description'),
+        titleKey: 'gettingStarted.howToLogin.calendarMode.steps.pasteUrl.title',
+        descriptionKey: 'gettingStarted.howToLogin.calendarMode.steps.pasteUrl.description',
       },
     ]}
   />
 
   <InfoBox type="info">
-    <p>
-      Calendar Mode provides read-only access – you can view assignments but cannot
-      confirm games, request exchanges, or access compensations. See the
-      <a href={`${BASE_PATH}/calendar-mode/`}>Calendar Mode guide</a> for more details.
+    <p data-i18n="gettingStarted.howToLogin.calendarMode.infoBox">
+      {t('gettingStarted.howToLogin.calendarMode.infoBox')}
+      <a href={`${BASE_PATH}/calendar-mode/`} data-i18n-skip="true">{t('nav.calendarMode')}</a>
     </p>
   </InfoBox>
 
-  <h3>Option 2: Full Login</h3>
+  <h3 data-i18n="gettingStarted.howToLogin.fullLogin.title">{t('gettingStarted.howToLogin.fullLogin.title')}</h3>
 
-  <p>
-    Use your volleymanager.volleyball.ch credentials for full access to all features.
-  </p>
+  <p data-i18n="gettingStarted.howToLogin.fullLogin.description">{t('gettingStarted.howToLogin.fullLogin.description')}</p>
 
   <StepList
     steps={[
       {
-        title: 'Open VolleyKit',
-        description: 'Navigate to the VolleyKit app in your browser or open the installed app.',
+        title: t('gettingStarted.howToLogin.fullLogin.steps.openApp.title'),
+        description: t('gettingStarted.howToLogin.fullLogin.steps.openApp.description'),
+        titleKey: 'gettingStarted.howToLogin.fullLogin.steps.openApp.title',
+        descriptionKey: 'gettingStarted.howToLogin.fullLogin.steps.openApp.description',
       },
       {
-        title: 'Enter your credentials',
-        description: 'Use your volleymanager username and password to log in.',
+        title: t('gettingStarted.howToLogin.fullLogin.steps.enterCredentials.title'),
+        description: t('gettingStarted.howToLogin.fullLogin.steps.enterCredentials.description'),
+        titleKey: 'gettingStarted.howToLogin.fullLogin.steps.enterCredentials.title',
+        descriptionKey: 'gettingStarted.howToLogin.fullLogin.steps.enterCredentials.description',
       },
       {
-        title: 'Stay logged in',
-        description: 'Enable "Remember me" to stay logged in between sessions.',
+        title: t('gettingStarted.howToLogin.fullLogin.steps.stayLoggedIn.title'),
+        description: t('gettingStarted.howToLogin.fullLogin.steps.stayLoggedIn.description'),
+        titleKey: 'gettingStarted.howToLogin.fullLogin.steps.stayLoggedIn.title',
+        descriptionKey: 'gettingStarted.howToLogin.fullLogin.steps.stayLoggedIn.description',
       },
     ]}
   />
 
   <DeviceScreenshot
     id="login-page"
-    alt="VolleyKit login page showing username and password fields"
-    caption="The VolleyKit login page"
+    alt={t('gettingStarted.howToLogin.fullLogin.screenshotAlt')}
+    caption={t('gettingStarted.howToLogin.fullLogin.screenshotCaption')}
+    altKey="gettingStarted.howToLogin.fullLogin.screenshotAlt"
+    captionKey="gettingStarted.howToLogin.fullLogin.screenshotCaption"
     instructions="Take a screenshot of the login page with empty form fields. Show the VolleyKit branding, username/password inputs, and login button."
   />
 
-  <InfoBox type="tip" title="Can't remember your password?">
-    <p>
-      VolleyKit uses the same credentials as volleymanager.volleyball.ch. Use the password
-      reset function on the official site if you've forgotten your password.
+  <InfoBox type="tip" title={t('gettingStarted.howToLogin.fullLogin.tipTitle')} titleKey="gettingStarted.howToLogin.fullLogin.tipTitle">
+    <p data-i18n="gettingStarted.howToLogin.fullLogin.tipContent">
+      {t('gettingStarted.howToLogin.fullLogin.tipContent')}
     </p>
   </InfoBox>
 
-  <h2>Quick Tour</h2>
+  <h2 data-i18n="gettingStarted.quickTour.title">{t('gettingStarted.quickTour.title')}</h2>
 
-  <p>
-    After logging in, you'll see the main dashboard with your upcoming assignments.
-    Here's a quick overview of the main sections:
-  </p>
+  <p data-i18n="gettingStarted.quickTour.description">{t('gettingStarted.quickTour.description')}</p>
 
-  <h3>Assignments</h3>
-  <p>
-    View all your upcoming referee games. Each assignment shows the date, time, teams,
-    venue, and your role (1st referee, 2nd referee, or line judge).
-  </p>
+  <h3 data-i18n="gettingStarted.quickTour.assignments.title">{t('gettingStarted.quickTour.assignments.title')}</h3>
+  <p data-i18n="gettingStarted.quickTour.assignments.description">{t('gettingStarted.quickTour.assignments.description')}</p>
 
-  <h3>Exchanges</h3>
-  <p>
-    Browse available game exchanges from other referees or request an exchange for
-    one of your own assignments.
-  </p>
+  <h3 data-i18n="gettingStarted.quickTour.exchanges.title">{t('gettingStarted.quickTour.exchanges.title')}</h3>
+  <p data-i18n="gettingStarted.quickTour.exchanges.description">{t('gettingStarted.quickTour.exchanges.description')}</p>
 
-  <h3>Compensations</h3>
-  <p>
-    Track your referee payments and compensation history. Filter by date range
-    and export your data.
-  </p>
+  <h3 data-i18n="gettingStarted.quickTour.compensations.title">{t('gettingStarted.quickTour.compensations.title')}</h3>
+  <p data-i18n="gettingStarted.quickTour.compensations.description">{t('gettingStarted.quickTour.compensations.description')}</p>
 
-  <h3>Settings</h3>
-  <p>
-    Customize your experience including language, home location for travel calculations,
-    and notification preferences.
-  </p>
+  <h3 data-i18n="gettingStarted.quickTour.settings.title">{t('gettingStarted.quickTour.settings.title')}</h3>
+  <p data-i18n="gettingStarted.quickTour.settings.description">{t('gettingStarted.quickTour.settings.description')}</p>
 
-  <h2>Next Steps</h2>
+  <h2 data-i18n="gettingStarted.nextSteps.title">{t('gettingStarted.nextSteps.title')}</h2>
 
-  <p>
-    Now that you're familiar with the basics, explore the detailed guides for each feature:
-  </p>
+  <p data-i18n="gettingStarted.nextSteps.description">{t('gettingStarted.nextSteps.description')}</p>
 
   <ul>
-    <li><a href={`${BASE_PATH}/assignments/`}>Managing your assignments</a></li>
-    <li><a href={`${BASE_PATH}/exchanges/`}>Requesting and accepting exchanges</a></li>
-    <li><a href={`${BASE_PATH}/compensations/`}>Tracking your compensations</a></li>
+    <li><a href={`${BASE_PATH}/assignments/`} data-i18n="gettingStarted.nextSteps.links.assignments">{t('gettingStarted.nextSteps.links.assignments')}</a></li>
+    <li><a href={`${BASE_PATH}/exchanges/`} data-i18n="gettingStarted.nextSteps.links.exchanges">{t('gettingStarted.nextSteps.links.exchanges')}</a></li>
+    <li><a href={`${BASE_PATH}/compensations/`} data-i18n="gettingStarted.nextSteps.links.compensations">{t('gettingStarted.nextSteps.links.compensations')}</a></li>
   </ul>
 </DocLayout>

--- a/help-site/src/pages/offline-pwa.astro
+++ b/help-site/src/pages/offline-pwa.astro
@@ -3,212 +3,207 @@ import DocLayout from '../layouts/DocLayout.astro';
 import Screenshot from '../components/Screenshot.astro';
 import InfoBox from '../components/InfoBox.astro';
 import StepList from '../components/StepList.astro';
+import { t } from '../i18n';
 ---
 
 <DocLayout
-  title="Offline & PWA"
-  description="Learn how to install VolleyKit as a Progressive Web App and use it offline on your device."
+  title={t('pages.offlinePwa.title')}
+  description={t('pages.offlinePwa.description')}
 >
-  <h1>Offline & PWA Features</h1>
+  <h1 data-i18n="offlinePwa.heading">{t('offlinePwa.heading')}</h1>
 
-  <p class="lead text-text-secondary dark:text-text-secondary-dark">
-    VolleyKit is a Progressive Web App (PWA) that you can install on your device
-    and use offline. Access your assignments even without an internet connection.
+  <p class="lead text-text-secondary dark:text-text-secondary-dark" data-i18n="offlinePwa.lead">
+    {t('offlinePwa.lead')}
   </p>
 
-  <h2>What Is a PWA?</h2>
+  <h2 data-i18n="offlinePwa.whatIsPwa.title">{t('offlinePwa.whatIsPwa.title')}</h2>
 
-  <p>
-    A Progressive Web App is a website that works like a native app. When you
-    install VolleyKit:
-  </p>
+  <p data-i18n="offlinePwa.whatIsPwa.description">{t('offlinePwa.whatIsPwa.description')}</p>
 
   <ul>
-    <li>It appears on your home screen like a regular app</li>
-    <li>Opens in its own window without browser UI</li>
-    <li>Works offline for previously viewed content</li>
-    <li>Receives updates automatically</li>
-    <li>Uses minimal storage compared to native apps</li>
+    <li data-i18n="offlinePwa.whatIsPwa.benefits.homeScreen">{t('offlinePwa.whatIsPwa.benefits.homeScreen')}</li>
+    <li data-i18n="offlinePwa.whatIsPwa.benefits.ownWindow">{t('offlinePwa.whatIsPwa.benefits.ownWindow')}</li>
+    <li data-i18n="offlinePwa.whatIsPwa.benefits.worksOffline">{t('offlinePwa.whatIsPwa.benefits.worksOffline')}</li>
+    <li data-i18n="offlinePwa.whatIsPwa.benefits.autoUpdates">{t('offlinePwa.whatIsPwa.benefits.autoUpdates')}</li>
+    <li data-i18n="offlinePwa.whatIsPwa.benefits.minimalStorage">{t('offlinePwa.whatIsPwa.benefits.minimalStorage')}</li>
   </ul>
 
   <InfoBox type="tip">
-    <p>
-      PWAs combine the best of web and native apps – easy installation, automatic
-      updates, and offline capability without app store downloads.
+    <p data-i18n="offlinePwa.whatIsPwa.tip">
+      {t('offlinePwa.whatIsPwa.tip')}
     </p>
   </InfoBox>
 
-  <h2>Installing the App</h2>
+  <h2 data-i18n="offlinePwa.installing.title">{t('offlinePwa.installing.title')}</h2>
 
-  <p>
-    You can install VolleyKit on any modern device – phones, tablets, or computers.
-  </p>
+  <p data-i18n="offlinePwa.installing.description">{t('offlinePwa.installing.description')}</p>
 
-  <h3>On iOS (iPhone/iPad)</h3>
+  <h3 data-i18n="offlinePwa.installing.ios.title">{t('offlinePwa.installing.ios.title')}</h3>
 
   <StepList
     steps={[
       {
-        title: 'Open VolleyKit in Safari',
-        description: 'The install feature only works in Safari on iOS.',
+        title: t('offlinePwa.installing.ios.steps.openSafari.title'),
+        description: t('offlinePwa.installing.ios.steps.openSafari.description'),
+        titleKey: 'offlinePwa.installing.ios.steps.openSafari.title',
+        descriptionKey: 'offlinePwa.installing.ios.steps.openSafari.description',
       },
       {
-        title: 'Tap the Share button',
-        description: 'Find the share icon at the bottom of the screen.',
+        title: t('offlinePwa.installing.ios.steps.tapShare.title'),
+        description: t('offlinePwa.installing.ios.steps.tapShare.description'),
+        titleKey: 'offlinePwa.installing.ios.steps.tapShare.title',
+        descriptionKey: 'offlinePwa.installing.ios.steps.tapShare.description',
       },
       {
-        title: 'Select "Add to Home Screen"',
-        description: 'Scroll down in the share menu to find this option.',
+        title: t('offlinePwa.installing.ios.steps.selectAddHome.title'),
+        description: t('offlinePwa.installing.ios.steps.selectAddHome.description'),
+        titleKey: 'offlinePwa.installing.ios.steps.selectAddHome.title',
+        descriptionKey: 'offlinePwa.installing.ios.steps.selectAddHome.description',
       },
       {
-        title: 'Confirm the installation',
-        description: 'Tap "Add" to install VolleyKit on your home screen.',
+        title: t('offlinePwa.installing.ios.steps.confirmInstall.title'),
+        description: t('offlinePwa.installing.ios.steps.confirmInstall.description'),
+        titleKey: 'offlinePwa.installing.ios.steps.confirmInstall.title',
+        descriptionKey: 'offlinePwa.installing.ios.steps.confirmInstall.description',
       },
     ]}
   />
 
-  <h3>On Android</h3>
+  <h3 data-i18n="offlinePwa.installing.android.title">{t('offlinePwa.installing.android.title')}</h3>
 
   <StepList
     steps={[
       {
-        title: 'Open VolleyKit in Chrome',
-        description: 'Other browsers like Firefox also support PWA installation.',
+        title: t('offlinePwa.installing.android.steps.openChrome.title'),
+        description: t('offlinePwa.installing.android.steps.openChrome.description'),
+        titleKey: 'offlinePwa.installing.android.steps.openChrome.title',
+        descriptionKey: 'offlinePwa.installing.android.steps.openChrome.description',
       },
       {
-        title: 'Look for the install prompt',
-        description: 'A banner or prompt should appear asking to install the app.',
+        title: t('offlinePwa.installing.android.steps.lookForPrompt.title'),
+        description: t('offlinePwa.installing.android.steps.lookForPrompt.description'),
+        titleKey: 'offlinePwa.installing.android.steps.lookForPrompt.title',
+        descriptionKey: 'offlinePwa.installing.android.steps.lookForPrompt.description',
       },
       {
-        title: 'Tap "Install" or "Add to Home Screen"',
-        description: 'Confirm to add the app to your device.',
+        title: t('offlinePwa.installing.android.steps.tapInstall.title'),
+        description: t('offlinePwa.installing.android.steps.tapInstall.description'),
+        titleKey: 'offlinePwa.installing.android.steps.tapInstall.title',
+        descriptionKey: 'offlinePwa.installing.android.steps.tapInstall.description',
       },
     ]}
   />
 
   <Screenshot
     id="install-prompt"
-    alt="PWA install prompt showing Add to Home Screen option"
-    caption="Installing VolleyKit on your device"
+    alt={t('offlinePwa.installing.screenshotAlt')}
+    caption={t('offlinePwa.installing.screenshotCaption')}
+    altKey="offlinePwa.installing.screenshotAlt"
+    captionKey="offlinePwa.installing.screenshotCaption"
     instructions="Take a screenshot of the PWA install prompt or banner. Show the VolleyKit icon, name, and install button. If possible, show both iOS and Android versions."
   />
 
-  <h3>On Desktop (Chrome/Edge)</h3>
+  <h3 data-i18n="offlinePwa.installing.desktop.title">{t('offlinePwa.installing.desktop.title')}</h3>
 
-  <p>
-    Look for the install icon in the address bar (usually a + or computer icon),
-    or use the browser menu to find "Install VolleyKit".
-  </p>
+  <p data-i18n="offlinePwa.installing.desktop.description">{t('offlinePwa.installing.desktop.description')}</p>
 
-  <h2>What Works Offline</h2>
+  <h2 data-i18n="offlinePwa.whatWorksOffline.title">{t('offlinePwa.whatWorksOffline.title')}</h2>
 
-  <p>
-    When you're offline, you can still access content you've previously viewed:
-  </p>
+  <p data-i18n="offlinePwa.whatWorksOffline.description">{t('offlinePwa.whatWorksOffline.description')}</p>
 
   <table class="w-full text-sm">
     <thead>
       <tr class="border-b border-border-default dark:border-border-default-dark">
-        <th class="py-2 text-left">Feature</th>
-        <th class="py-2 text-center">Offline</th>
-        <th class="py-2 text-left">Notes</th>
+        <th class="py-2 text-left" data-i18n="offlinePwa.whatWorksOffline.table.feature">{t('offlinePwa.whatWorksOffline.table.feature')}</th>
+        <th class="py-2 text-center" data-i18n="offlinePwa.whatWorksOffline.table.offline">{t('offlinePwa.whatWorksOffline.table.offline')}</th>
+        <th class="py-2 text-left" data-i18n="offlinePwa.whatWorksOffline.table.notes">{t('offlinePwa.whatWorksOffline.table.notes')}</th>
       </tr>
     </thead>
     <tbody>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">View assignments</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.viewAssignments">{t('offlinePwa.whatWorksOffline.table.viewAssignments')}</td>
         <td class="py-2 text-center">✓</td>
-        <td class="py-2">Previously loaded assignments</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.viewAssignmentsNote">{t('offlinePwa.whatWorksOffline.table.viewAssignmentsNote')}</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">View game details</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.viewDetails">{t('offlinePwa.whatWorksOffline.table.viewDetails')}</td>
         <td class="py-2 text-center">✓</td>
-        <td class="py-2">If previously viewed</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.viewDetailsNote">{t('offlinePwa.whatWorksOffline.table.viewDetailsNote')}</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">Travel times</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.travelTimes">{t('offlinePwa.whatWorksOffline.table.travelTimes')}</td>
         <td class="py-2 text-center">✓</td>
-        <td class="py-2">Cached journey data</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.travelTimesNote">{t('offlinePwa.whatWorksOffline.table.travelTimesNote')}</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">Confirm assignments</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.confirmAssignments">{t('offlinePwa.whatWorksOffline.table.confirmAssignments')}</td>
         <td class="py-2 text-center">✗</td>
-        <td class="py-2">Requires connection</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.confirmAssignmentsNote">{t('offlinePwa.whatWorksOffline.table.confirmAssignmentsNote')}</td>
       </tr>
       <tr class="border-b border-border-subtle dark:border-border-subtle-dark">
-        <td class="py-2">Request exchanges</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.requestExchanges">{t('offlinePwa.whatWorksOffline.table.requestExchanges')}</td>
         <td class="py-2 text-center">✗</td>
-        <td class="py-2">Requires connection</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.requestExchangesNote">{t('offlinePwa.whatWorksOffline.table.requestExchangesNote')}</td>
       </tr>
       <tr>
-        <td class="py-2">View compensations</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.viewCompensations">{t('offlinePwa.whatWorksOffline.table.viewCompensations')}</td>
         <td class="py-2 text-center">✓</td>
-        <td class="py-2">If previously loaded</td>
+        <td class="py-2" data-i18n="offlinePwa.whatWorksOffline.table.viewCompensationsNote">{t('offlinePwa.whatWorksOffline.table.viewCompensationsNote')}</td>
       </tr>
     </tbody>
   </table>
 
   <InfoBox type="info">
-    <p>
-      The app automatically syncs when you're back online. Any data changes
-      will be fetched and displayed.
+    <p data-i18n="offlinePwa.whatWorksOffline.infoBox">
+      {t('offlinePwa.whatWorksOffline.infoBox')}
     </p>
   </InfoBox>
 
-  <h2>Offline Indicator</h2>
+  <h2 data-i18n="offlinePwa.offlineIndicator.title">{t('offlinePwa.offlineIndicator.title')}</h2>
 
-  <p>
-    When you're offline, VolleyKit shows a visual indicator so you know you're
-    viewing cached data. Look for the offline badge in the header or a banner
-    at the top of the screen.
-  </p>
+  <p data-i18n="offlinePwa.offlineIndicator.description">{t('offlinePwa.offlineIndicator.description')}</p>
 
   <Screenshot
     id="offline-indicator"
-    alt="Offline indicator showing the app is running without internet"
-    caption="Offline mode indicator"
+    alt={t('offlinePwa.offlineIndicator.screenshotAlt')}
+    caption={t('offlinePwa.offlineIndicator.screenshotCaption')}
+    altKey="offlinePwa.offlineIndicator.screenshotAlt"
+    captionKey="offlinePwa.offlineIndicator.screenshotCaption"
     instructions="Take a screenshot showing the offline indicator. This could be a banner at the top, an icon in the header, or a toast message indicating offline status."
   />
 
-  <h2>Updating the App</h2>
+  <h2 data-i18n="offlinePwa.updating.title">{t('offlinePwa.updating.title')}</h2>
 
-  <p>
-    VolleyKit updates automatically in the background. When a new version is
-    available:
-  </p>
+  <p data-i18n="offlinePwa.updating.description">{t('offlinePwa.updating.description')}</p>
 
   <ol>
-    <li>The app downloads the update in the background</li>
-    <li>A notification appears when the update is ready</li>
-    <li>Tap "Reload" to activate the new version</li>
+    <li data-i18n="offlinePwa.updating.steps.backgroundDownload">{t('offlinePwa.updating.steps.backgroundDownload')}</li>
+    <li data-i18n="offlinePwa.updating.steps.notificationAppears">{t('offlinePwa.updating.steps.notificationAppears')}</li>
+    <li data-i18n="offlinePwa.updating.steps.tapReload">{t('offlinePwa.updating.steps.tapReload')}</li>
   </ol>
 
   <Screenshot
     id="update-prompt"
-    alt="App update notification prompting to reload"
-    caption="Update available notification"
+    alt={t('offlinePwa.updating.screenshotAlt')}
+    caption={t('offlinePwa.updating.screenshotCaption')}
+    altKey="offlinePwa.updating.screenshotAlt"
+    captionKey="offlinePwa.updating.screenshotCaption"
     instructions="Take a screenshot of the update available prompt/toast. Show the reload button and any message about the new version being ready."
   />
 
   <InfoBox type="tip">
-    <p>
-      If you dismiss the update notification, the new version will activate
-      the next time you close and reopen the app.
+    <p data-i18n="offlinePwa.updating.tip">
+      {t('offlinePwa.updating.tip')}
     </p>
   </InfoBox>
 
-  <h2>Storage Usage</h2>
+  <h2 data-i18n="offlinePwa.storage.title">{t('offlinePwa.storage.title')}</h2>
 
-  <p>
-    VolleyKit uses minimal storage on your device – typically less than 5MB
-    for the app itself plus cached data. You can clear the cache from your
-    browser settings if needed.
-  </p>
+  <p data-i18n="offlinePwa.storage.description">{t('offlinePwa.storage.description')}</p>
 
   <InfoBox type="warning">
-    <p>
-      Clearing browser data or "Clear Cache" will remove your offline data.
-      You may need to reload assignments the next time you open the app.
+    <p data-i18n="offlinePwa.storage.warning">
+      {t('offlinePwa.storage.warning')}
     </p>
   </InfoBox>
 </DocLayout>

--- a/help-site/src/pages/settings.astro
+++ b/help-site/src/pages/settings.astro
@@ -3,177 +3,157 @@ import DocLayout from '../layouts/DocLayout.astro';
 import DeviceScreenshot from '../components/DeviceScreenshot.astro';
 import InfoBox from '../components/InfoBox.astro';
 import { BASE_PATH } from '../constants';
+import { t } from '../i18n';
 ---
 
 <DocLayout
-  title="Settings"
-  description="Customize your VolleyKit experience with language, location, and privacy settings."
+  title={t('pages.settings.title')}
+  description={t('pages.settings.description')}
 >
-  <h1>App Settings</h1>
+  <h1 data-i18n="settings.heading">{t('settings.heading')}</h1>
 
-  <p class="lead text-text-secondary dark:text-text-secondary-dark">
-    Customize VolleyKit to match your preferences. Configure language, home
-    location, and privacy options.
+  <p class="lead text-text-secondary dark:text-text-secondary-dark" data-i18n="settings.lead">
+    {t('settings.lead')}
   </p>
 
-  <h2>Accessing Settings</h2>
+  <h2 data-i18n="settings.accessing.title">{t('settings.accessing.title')}</h2>
 
-  <p>
-    Open settings by tapping the gear icon in the navigation bar, or by selecting
-    "Settings" from the main menu.
-  </p>
+  <p data-i18n="settings.accessing.description">{t('settings.accessing.description')}</p>
 
   <DeviceScreenshot
     id="settings-overview"
-    alt="Settings page showing all available options"
-    caption="VolleyKit settings page"
+    alt={t('settings.accessing.screenshotAlt')}
+    caption={t('settings.accessing.screenshotCaption')}
+    altKey="settings.accessing.screenshotAlt"
+    captionKey="settings.accessing.screenshotCaption"
     instructions="Take a screenshot of the full settings page showing all sections: profile, language, location, and data settings. Show the organized layout with clear section headers."
   />
 
-  <h2>Profile Section</h2>
+  <h2 data-i18n="settings.profile.title">{t('settings.profile.title')}</h2>
 
-  <p>
-    The profile section shows your account information:
-  </p>
+  <p data-i18n="settings.profile.description">{t('settings.profile.description')}</p>
 
   <ul>
-    <li><strong>Name</strong> – Your registered referee name</li>
-    <li><strong>License number</strong> – Your Swiss Volley referee license</li>
-    <li><strong>Email</strong> – Your registered email address</li>
-    <li><strong>Session status</strong> – Your current login status</li>
+    <li data-i18n="settings.profile.fields.name">{t('settings.profile.fields.name')}</li>
+    <li data-i18n="settings.profile.fields.licenseNumber">{t('settings.profile.fields.licenseNumber')}</li>
+    <li data-i18n="settings.profile.fields.email">{t('settings.profile.fields.email')}</li>
+    <li data-i18n="settings.profile.fields.sessionStatus">{t('settings.profile.fields.sessionStatus')}</li>
   </ul>
 
   <InfoBox type="info">
-    <p>
-      Profile information comes from volleymanager and can only be changed
-      on the official website, not in VolleyKit.
+    <p data-i18n="settings.profile.infoBox">
+      {t('settings.profile.infoBox')}
     </p>
   </InfoBox>
 
-  <h3>Logging Out</h3>
+  <h3 data-i18n="settings.profile.loggingOut.title">{t('settings.profile.loggingOut.title')}</h3>
 
-  <p>
-    Tap "Log Out" to sign out of your account. This clears your session and
-    any locally stored data.
-  </p>
+  <p data-i18n="settings.profile.loggingOut.description">{t('settings.profile.loggingOut.description')}</p>
 
-  <h2>Language Settings</h2>
+  <h2 data-i18n="settings.language.title">{t('settings.language.title')}</h2>
 
-  <p>
-    VolleyKit supports multiple languages to match your preference:
-  </p>
+  <p data-i18n="settings.language.description">{t('settings.language.description')}</p>
 
   <ul>
-    <li><strong>Deutsch</strong> – German</li>
-    <li><strong>English</strong> – English</li>
-    <li><strong>Français</strong> – French</li>
-    <li><strong>Italiano</strong> – Italian</li>
+    <li data-i18n="settings.language.options.deutsch">{t('settings.language.options.deutsch')}</li>
+    <li data-i18n="settings.language.options.english">{t('settings.language.options.english')}</li>
+    <li data-i18n="settings.language.options.francais">{t('settings.language.options.francais')}</li>
+    <li data-i18n="settings.language.options.italiano">{t('settings.language.options.italiano')}</li>
   </ul>
 
-  <p>
-    The app will automatically use your browser's language if it's supported,
-    but you can override this in settings.
-  </p>
+  <p data-i18n="settings.language.autoDetect">{t('settings.language.autoDetect')}</p>
 
   <DeviceScreenshot
     id="language-settings"
-    alt="Language selection showing available options"
-    caption="Changing the app language"
+    alt={t('settings.language.screenshotAlt')}
+    caption={t('settings.language.screenshotCaption')}
+    altKey="settings.language.screenshotAlt"
+    captionKey="settings.language.screenshotCaption"
     instructions="Take a screenshot of the language setting section or dropdown. Show the available language options with the current selection highlighted."
   />
 
-  <h2>Home Location</h2>
+  <h2 data-i18n="settings.homeLocation.title">{t('settings.homeLocation.title')}</h2>
 
-  <p>
-    Set your home location to enable travel time calculations. This is used
-    to show how long it takes to reach each game venue.
-  </p>
+  <p data-i18n="settings.homeLocation.description">{t('settings.homeLocation.description')}</p>
 
   <ul>
-    <li>Enter your address or nearest train station</li>
-    <li>Use the autocomplete suggestions for accuracy</li>
-    <li>Travel times will appear on your assignment cards</li>
+    <li data-i18n="settings.homeLocation.instructions.enterAddress">{t('settings.homeLocation.instructions.enterAddress')}</li>
+    <li data-i18n="settings.homeLocation.instructions.useAutocomplete">{t('settings.homeLocation.instructions.useAutocomplete')}</li>
+    <li data-i18n="settings.homeLocation.instructions.travelTimesAppear">{t('settings.homeLocation.instructions.travelTimesAppear')}</li>
   </ul>
 
   <DeviceScreenshot
     id="home-location-setting"
-    alt="Home location input with address search"
-    caption="Setting your home location"
+    alt={t('settings.homeLocation.screenshotAlt')}
+    caption={t('settings.homeLocation.screenshotCaption')}
+    altKey="settings.homeLocation.screenshotAlt"
+    captionKey="settings.homeLocation.screenshotCaption"
     instructions="Take a screenshot of the home location input showing the address search field and any autocomplete suggestions."
   />
 
   <InfoBox type="tip">
-    <p>
-      If you typically take public transport, use your nearest station as
-      your home location for more accurate journey times.
+    <p data-i18n="settings.homeLocation.tip">
+      {t('settings.homeLocation.tip')}
     </p>
   </InfoBox>
 
-  <p>
-    See the <a href={`${BASE_PATH}/travel-time/`}>Travel Time guide</a> for more
-    details on this feature.
+  <p data-i18n="settings.homeLocation.seeGuide">
+    {t('settings.homeLocation.seeGuide')}
+    <a href={`${BASE_PATH}/travel-time/`} data-i18n-skip="true">{t('nav.travelTime')}</a>
   </p>
 
-  <h2>Data & Privacy</h2>
+  <h2 data-i18n="settings.dataPrivacy.title">{t('settings.dataPrivacy.title')}</h2>
 
-  <p>
-    Control how your data is handled:
-  </p>
+  <p data-i18n="settings.dataPrivacy.description">{t('settings.dataPrivacy.description')}</p>
 
-  <h3>Local Storage</h3>
+  <h3 data-i18n="settings.dataPrivacy.localStorage.title">{t('settings.dataPrivacy.localStorage.title')}</h3>
 
-  <p>
-    VolleyKit stores data locally to enable offline access and improve performance:
-  </p>
+  <p data-i18n="settings.dataPrivacy.localStorage.description">{t('settings.dataPrivacy.localStorage.description')}</p>
 
   <ul>
-    <li><strong>Assignment cache</strong> – Your recent assignments</li>
-    <li><strong>Preferences</strong> – Your settings and preferences</li>
-    <li><strong>Travel data</strong> – Cached journey information</li>
+    <li data-i18n="settings.dataPrivacy.localStorage.items.assignmentCache">{t('settings.dataPrivacy.localStorage.items.assignmentCache')}</li>
+    <li data-i18n="settings.dataPrivacy.localStorage.items.preferences">{t('settings.dataPrivacy.localStorage.items.preferences')}</li>
+    <li data-i18n="settings.dataPrivacy.localStorage.items.travelData">{t('settings.dataPrivacy.localStorage.items.travelData')}</li>
   </ul>
 
-  <h3>Clear Local Data</h3>
+  <h3 data-i18n="settings.dataPrivacy.clearData.title">{t('settings.dataPrivacy.clearData.title')}</h3>
 
-  <p>
-    You can clear all locally stored data from the settings page. This will:
-  </p>
+  <p data-i18n="settings.dataPrivacy.clearData.description">{t('settings.dataPrivacy.clearData.description')}</p>
 
   <ul>
-    <li>Remove cached assignments and travel data</li>
-    <li>Reset all preferences to defaults</li>
-    <li>Require you to log in again</li>
+    <li data-i18n="settings.dataPrivacy.clearData.effects.removeCached">{t('settings.dataPrivacy.clearData.effects.removeCached')}</li>
+    <li data-i18n="settings.dataPrivacy.clearData.effects.resetPreferences">{t('settings.dataPrivacy.clearData.effects.resetPreferences')}</li>
+    <li data-i18n="settings.dataPrivacy.clearData.effects.requireLogin">{t('settings.dataPrivacy.clearData.effects.requireLogin')}</li>
   </ul>
 
   <InfoBox type="warning">
-    <p>
-      Clearing local data cannot be undone. You'll need to reload your
-      assignments the next time you open the app.
+    <p data-i18n="settings.dataPrivacy.clearData.warning">
+      {t('settings.dataPrivacy.clearData.warning')}
     </p>
   </InfoBox>
 
   <DeviceScreenshot
     id="data-privacy-settings"
-    alt="Data and privacy settings section with clear data button"
-    caption="Data and privacy options"
+    alt={t('settings.dataPrivacy.screenshotAlt')}
+    caption={t('settings.dataPrivacy.screenshotCaption')}
+    altKey="settings.dataPrivacy.screenshotAlt"
+    captionKey="settings.dataPrivacy.screenshotCaption"
     instructions="Take a screenshot of the data/privacy section showing the clear data button and any explanatory text about what data is stored."
   />
 
-  <h2>About VolleyKit</h2>
+  <h2 data-i18n="settings.about.title">{t('settings.about.title')}</h2>
 
-  <p>
-    The About section shows:
-  </p>
+  <p data-i18n="settings.about.description">{t('settings.about.description')}</p>
 
   <ul>
-    <li><strong>Version number</strong> – Current app version</li>
-    <li><strong>Last updated</strong> – When the app was last updated</li>
-    <li><strong>Links</strong> – GitHub repository, issue tracker, help site</li>
+    <li data-i18n="settings.about.items.versionNumber">{t('settings.about.items.versionNumber')}</li>
+    <li data-i18n="settings.about.items.lastUpdated">{t('settings.about.items.lastUpdated')}</li>
+    <li data-i18n="settings.about.items.links">{t('settings.about.items.links')}</li>
   </ul>
 
   <InfoBox type="info">
-    <p>
-      Check the version number when reporting issues – it helps us identify
-      and fix problems faster.
+    <p data-i18n="settings.about.infoBox">
+      {t('settings.about.infoBox')}
     </p>
   </InfoBox>
 </DocLayout>

--- a/help-site/src/pages/travel-time.astro
+++ b/help-site/src/pages/travel-time.astro
@@ -3,168 +3,156 @@ import DocLayout from '../layouts/DocLayout.astro';
 import Screenshot from '../components/Screenshot.astro';
 import InfoBox from '../components/InfoBox.astro';
 import StepList from '../components/StepList.astro';
+import { t } from '../i18n';
 ---
 
 <DocLayout
-  title="Travel Time"
-  description="Learn how VolleyKit calculates travel times to game venues using Swiss public transport data."
+  title={t('pages.travelTime.title')}
+  description={t('pages.travelTime.description')}
 >
-  <h1>Travel Time Feature</h1>
+  <h1 data-i18n="travelTime.heading">{t('travelTime.heading')}</h1>
 
-  <p class="lead text-text-secondary dark:text-text-secondary-dark">
-    VolleyKit integrates with Swiss public transport data to show you how long
-    it takes to reach each game venue. Plan your trips better and never be late
-    to a game.
+  <p class="lead text-text-secondary dark:text-text-secondary-dark" data-i18n="travelTime.lead">
+    {t('travelTime.lead')}
   </p>
 
-  <h2>How It Works</h2>
+  <h2 data-i18n="travelTime.howItWorks.title">{t('travelTime.howItWorks.title')}</h2>
 
-  <p>
-    The travel time feature uses the Swiss public transport API (SBB/öV) to
-    calculate journey times from your home location to each game venue. It
-    considers:
-  </p>
+  <p data-i18n="travelTime.howItWorks.description">{t('travelTime.howItWorks.description')}</p>
 
   <ul>
-    <li>Real-time train, bus, and tram schedules</li>
-    <li>Walking time to/from stations</li>
-    <li>Transfer times between connections</li>
-    <li>The actual game start time</li>
+    <li data-i18n="travelTime.howItWorks.considerations.schedules">{t('travelTime.howItWorks.considerations.schedules')}</li>
+    <li data-i18n="travelTime.howItWorks.considerations.walkingTime">{t('travelTime.howItWorks.considerations.walkingTime')}</li>
+    <li data-i18n="travelTime.howItWorks.considerations.transferTimes">{t('travelTime.howItWorks.considerations.transferTimes')}</li>
+    <li data-i18n="travelTime.howItWorks.considerations.gameStartTime">{t('travelTime.howItWorks.considerations.gameStartTime')}</li>
   </ul>
 
   <InfoBox type="info">
-    <p>
-      Travel times are calculated using public transport. If you typically
-      drive, use the times as a rough estimate or for planning alternative
-      transport options.
+    <p data-i18n="travelTime.howItWorks.infoBox">
+      {t('travelTime.howItWorks.infoBox')}
     </p>
   </InfoBox>
 
-  <h2>Setting Your Home Location</h2>
+  <h2 data-i18n="travelTime.settingHome.title">{t('travelTime.settingHome.title')}</h2>
 
-  <p>
-    To get accurate travel times, you need to set your home location in the
-    app settings.
-  </p>
+  <p data-i18n="travelTime.settingHome.description">{t('travelTime.settingHome.description')}</p>
 
   <StepList
     steps={[
       {
-        title: 'Open Settings',
-        description: 'Navigate to the Settings page in VolleyKit.',
+        title: t('travelTime.settingHome.steps.openSettings.title'),
+        description: t('travelTime.settingHome.steps.openSettings.description'),
+        titleKey: 'travelTime.settingHome.steps.openSettings.title',
+        descriptionKey: 'travelTime.settingHome.steps.openSettings.description',
       },
       {
-        title: 'Find "Home Location"',
-        description: 'Scroll to the travel settings section.',
+        title: t('travelTime.settingHome.steps.findHomeLocation.title'),
+        description: t('travelTime.settingHome.steps.findHomeLocation.description'),
+        titleKey: 'travelTime.settingHome.steps.findHomeLocation.title',
+        descriptionKey: 'travelTime.settingHome.steps.findHomeLocation.description',
       },
       {
-        title: 'Enter your address',
-        description: 'Type your home address or the station you typically travel from.',
+        title: t('travelTime.settingHome.steps.enterAddress.title'),
+        description: t('travelTime.settingHome.steps.enterAddress.description'),
+        titleKey: 'travelTime.settingHome.steps.enterAddress.title',
+        descriptionKey: 'travelTime.settingHome.steps.enterAddress.description',
       },
       {
-        title: 'Save your settings',
-        description: 'Confirm your location to start seeing travel times.',
+        title: t('travelTime.settingHome.steps.saveSettings.title'),
+        description: t('travelTime.settingHome.steps.saveSettings.description'),
+        titleKey: 'travelTime.settingHome.steps.saveSettings.title',
+        descriptionKey: 'travelTime.settingHome.steps.saveSettings.description',
       },
     ]}
   />
 
   <Screenshot
     id="home-location-setting"
-    alt="Settings page showing home location input field"
-    caption="Setting your home location"
+    alt={t('travelTime.settingHome.screenshotAlt')}
+    caption={t('travelTime.settingHome.screenshotCaption')}
+    altKey="travelTime.settingHome.screenshotAlt"
+    captionKey="travelTime.settingHome.screenshotCaption"
     instructions="Take a screenshot of the settings page focused on the home location section. Show the address input field with autocomplete suggestions if possible."
   />
 
   <InfoBox type="tip">
-    <p>
-      Use your nearest train station as your home location if you typically
-      walk or cycle to the station – this gives more accurate public transport times.
+    <p data-i18n="travelTime.settingHome.tip">
+      {t('travelTime.settingHome.tip')}
     </p>
   </InfoBox>
 
-  <h2>Viewing Travel Times</h2>
+  <h2 data-i18n="travelTime.viewingTimes.title">{t('travelTime.viewingTimes.title')}</h2>
 
-  <p>
-    Once your home location is set, travel times appear on your assignment cards
-    and in the assignment detail view.
-  </p>
+  <p data-i18n="travelTime.viewingTimes.description">{t('travelTime.viewingTimes.description')}</p>
 
   <Screenshot
     id="travel-time-display"
-    alt="Assignment card showing travel time information"
-    caption="Travel time displayed on an assignment"
+    alt={t('travelTime.viewingTimes.screenshotAlt')}
+    caption={t('travelTime.viewingTimes.screenshotCaption')}
+    altKey="travelTime.viewingTimes.screenshotAlt"
+    captionKey="travelTime.viewingTimes.screenshotCaption"
     instructions="Take a screenshot of an assignment card or detail view showing the travel time prominently. Include the duration in minutes/hours and any public transport icon."
   />
 
-  <h3>What's Shown</h3>
+  <h3 data-i18n="travelTime.viewingTimes.whatsShown.title">{t('travelTime.viewingTimes.whatsShown.title')}</h3>
 
   <ul>
-    <li><strong>Duration</strong> – Total travel time from home to venue</li>
-    <li><strong>Departure time</strong> – When you should leave to arrive on time</li>
-    <li><strong>Transport type</strong> – Train, bus, or mixed transport icon</li>
+    <li data-i18n="travelTime.viewingTimes.whatsShown.duration">{t('travelTime.viewingTimes.whatsShown.duration')}</li>
+    <li data-i18n="travelTime.viewingTimes.whatsShown.departureTime">{t('travelTime.viewingTimes.whatsShown.departureTime')}</li>
+    <li data-i18n="travelTime.viewingTimes.whatsShown.transportType">{t('travelTime.viewingTimes.whatsShown.transportType')}</li>
   </ul>
 
-  <h2>Journey Details</h2>
+  <h2 data-i18n="travelTime.journeyDetails.title">{t('travelTime.journeyDetails.title')}</h2>
 
-  <p>
-    Tap on the travel time to see full journey details:
-  </p>
+  <p data-i18n="travelTime.journeyDetails.description">{t('travelTime.journeyDetails.description')}</p>
 
   <ul>
-    <li>Step-by-step directions</li>
-    <li>Connection details (train numbers, platforms)</li>
-    <li>Walking segments</li>
-    <li>Transfer times</li>
+    <li data-i18n="travelTime.journeyDetails.features.stepByStep">{t('travelTime.journeyDetails.features.stepByStep')}</li>
+    <li data-i18n="travelTime.journeyDetails.features.connectionDetails">{t('travelTime.journeyDetails.features.connectionDetails')}</li>
+    <li data-i18n="travelTime.journeyDetails.features.walkingSegments">{t('travelTime.journeyDetails.features.walkingSegments')}</li>
+    <li data-i18n="travelTime.journeyDetails.features.transferTimes">{t('travelTime.journeyDetails.features.transferTimes')}</li>
   </ul>
 
-  <p>
-    You can also open the journey directly in the SBB app or website for
-    real-time updates and ticket purchase.
-  </p>
+  <p data-i18n="travelTime.journeyDetails.sbbLink">{t('travelTime.journeyDetails.sbbLink')}</p>
 
   <Screenshot
     id="journey-details"
-    alt="Detailed journey information with connections and times"
-    caption="Full journey details for travel planning"
+    alt={t('travelTime.journeyDetails.screenshotAlt')}
+    caption={t('travelTime.journeyDetails.screenshotCaption')}
+    altKey="travelTime.journeyDetails.screenshotAlt"
+    captionKey="travelTime.journeyDetails.screenshotCaption"
     instructions="Take a screenshot showing the expanded journey details or a modal with the full route. Include departure/arrival times, train/bus details, and any transfer information."
   />
 
-  <h2>Arrival Buffer</h2>
+  <h2 data-i18n="travelTime.arrivalBuffer.title">{t('travelTime.arrivalBuffer.title')}</h2>
 
-  <p>
-    The suggested departure time includes a buffer to ensure you arrive before
-    the game starts:
-  </p>
+  <p data-i18n="travelTime.arrivalBuffer.description">{t('travelTime.arrivalBuffer.description')}</p>
 
   <ul>
-    <li><strong>Standard buffer:</strong> 15-30 minutes before game time</li>
-    <li>Time for finding the venue, changing, and warmup</li>
-    <li>Account for potential minor delays</li>
+    <li data-i18n="travelTime.arrivalBuffer.details.standardBuffer">{t('travelTime.arrivalBuffer.details.standardBuffer')}</li>
+    <li data-i18n="travelTime.arrivalBuffer.details.timeFor">{t('travelTime.arrivalBuffer.details.timeFor')}</li>
+    <li data-i18n="travelTime.arrivalBuffer.details.accountForDelays">{t('travelTime.arrivalBuffer.details.accountForDelays')}</li>
   </ul>
 
   <InfoBox type="warning">
-    <p>
-      Always allow extra time for important games or unfamiliar venues.
-      Public transport can experience unexpected delays.
+    <p data-i18n="travelTime.arrivalBuffer.warning">
+      {t('travelTime.arrivalBuffer.warning')}
     </p>
   </InfoBox>
 
-  <h2>Offline Availability</h2>
+  <h2 data-i18n="travelTime.offlineAvailability.title">{t('travelTime.offlineAvailability.title')}</h2>
 
-  <p>
-    Travel times are cached when you view them online. If you're offline:
-  </p>
+  <p data-i18n="travelTime.offlineAvailability.description">{t('travelTime.offlineAvailability.description')}</p>
 
   <ul>
-    <li>Previously viewed travel times remain available</li>
-    <li>New calculations require an internet connection</li>
-    <li>The app indicates when data might be outdated</li>
+    <li data-i18n="travelTime.offlineAvailability.details.cachedAvailable">{t('travelTime.offlineAvailability.details.cachedAvailable')}</li>
+    <li data-i18n="travelTime.offlineAvailability.details.requiresConnection">{t('travelTime.offlineAvailability.details.requiresConnection')}</li>
+    <li data-i18n="travelTime.offlineAvailability.details.outdatedIndicator">{t('travelTime.offlineAvailability.details.outdatedIndicator')}</li>
   </ul>
 
   <InfoBox type="tip">
-    <p>
-      Check your travel times while online before heading to an area with
-      poor connectivity. The cached data will be available offline.
+    <p data-i18n="travelTime.offlineAvailability.tip">
+      {t('travelTime.offlineAvailability.tip')}
     </p>
   </InfoBox>
 </DocLayout>


### PR DESCRIPTION
## Summary

- Add data-i18n attributes to 8 help pages for dynamic language switching
- Updated pages: getting-started, assignments, exchanges, compensations, calendar-mode, travel-time, offline-pwa, settings
- Added translation keys to types.ts and all 4 locale files (en, de, fr, it)

## Test Plan

- [ ] Build help-site and verify all pages render correctly
- [ ] Switch language and verify content updates on all 8 pages
- [ ] Verify translations display correctly in all 4 languages