### PR TITLE
fix(help-site): add i18n support to StepList component

### DIFF
--- a/help-site/src/components/StepList.astro
+++ b/help-site/src/components/StepList.astro
@@ -33,14 +33,14 @@ const { steps } = Astro.props;
         <div class="pt-0.5">
           <h4
             class="mb-1 font-semibold text-text-primary dark:text-text-primary-dark"
-            data-i18n={step.titleKey}
+            {...(step.titleKey ? { 'data-i18n': step.titleKey } : {})}
           >
             {step.title}
           </h4>
           {step.description && (
             <p
               class="text-sm text-text-secondary dark:text-text-secondary-dark"
-              data-i18n={step.descriptionKey}
+              {...(step.descriptionKey ? { 'data-i18n': step.descriptionKey } : {})}
             >
               {step.description}
             </p>

--- a/help-site/src/components/StepList.astro
+++ b/help-site/src/components/StepList.astro
@@ -7,6 +7,10 @@
 interface Step {
   title: string;
   description?: string;
+  /** i18n key for client-side language switching */
+  titleKey?: string;
+  /** i18n key for client-side language switching */
+  descriptionKey?: string;
 }
 
 interface Props {
@@ -27,11 +31,17 @@ const { steps } = Astro.props;
 
         {/* Step content */}
         <div class="pt-0.5">
-          <h4 class="mb-1 font-semibold text-text-primary dark:text-text-primary-dark">
+          <h4
+            class="mb-1 font-semibold text-text-primary dark:text-text-primary-dark"
+            data-i18n={step.titleKey}
+          >
             {step.title}
           </h4>
           {step.description && (
-            <p class="text-sm text-text-secondary dark:text-text-secondary-dark">
+            <p
+              class="text-sm text-text-secondary dark:text-text-secondary-dark"
+              data-i18n={step.descriptionKey}
+            >
               {step.description}
             </p>
           )}


### PR DESCRIPTION
## Summary
- Added `titleKey` and `descriptionKey` props to the StepList component interface
- Renders these as `data-i18n` attributes for client-side language switching
- Fixes translations not updating in step lists on the exchanges help page

## Test Plan
- [ ] Build help-site successfully
- [ ] Verify step lists on the exchanges page now have data-i18n attributes
- [ ] Test language switching on the exchanges help page