### PR TITLE
fix(tour): show assignment card in calendar mode during tour

### DIFF
--- a/web-app/src/features/assignments/AssignmentsPage.tsx
+++ b/web-app/src/features/assignments/AssignmentsPage.tsx
@@ -198,12 +198,14 @@ export function AssignmentsPage() {
   const groupedData = useMemo(() => {
     if (!data || data.length === 0) return [];
     // For calendar mode, CalendarAssignment has startTime, regular Assignment has refereeGame?.game?.startingDateTime
-    const getDate = isCalendarMode
-      ? (a: { startTime?: string }) => a.startTime
-      : (a: { refereeGame?: { game?: { startingDateTime?: string } } }) =>
-          a.refereeGame?.game?.startingDateTime;
+    // When showDummyData is true, always use regular Assignment extractor since tour dummy is an Assignment
+    const getDate =
+      isCalendarMode && !showDummyData
+        ? (a: { startTime?: string }) => a.startTime
+        : (a: { refereeGame?: { game?: { startingDateTime?: string } } }) =>
+            a.refereeGame?.game?.startingDateTime;
     return groupByWeek(data, getDate as (item: unknown) => string | undefined);
-  }, [data, isCalendarMode]);
+  }, [data, isCalendarMode, showDummyData]);
 
   const getSwipeConfig = useCallback(
     (assignment: Assignment) => {


### PR DESCRIPTION
## Summary
- Fixed an issue where the assignment tour did not display the dummy assignment card when in calendar mode
- The `groupedData` calculation was using the wrong date extractor for the tour dummy assignment
- Added a check for `showDummyData` to ensure the correct date extractor is used

## Test Plan
- [ ] Enable calendar mode in settings
- [ ] Clear tour completion (localStorage) to trigger the tour
- [ ] Verify the tour starts and shows the dummy assignment card
- [ ] Complete the tour steps (auto-advance, swipe left, swipe right, tap)
- [ ] Verify tour also works correctly in regular (non-calendar) mode