### PR TITLE
fix(settings): show transport settings pane in calendar mode

### DIFF
--- a/web-app/src/features/auth/hooks/useActiveAssociation.test.ts
+++ b/web-app/src/features/auth/hooks/useActiveAssociation.test.ts
@@ -196,7 +196,7 @@ describe("useActiveAssociationCode", () => {
     });
 
     it("returns CALENDAR_ASSOCIATION regardless of user occupations in calendar mode", () => {
-      // Even with multiple occupations, calendar mode should use dummy association
+      // Even with multiple occupations, calendar mode should use global association
       const occupations: Occupation[] = [
         createOccupation({ id: "occ-1", associationCode: "SV" }),
         createOccupation({ id: "occ-2", associationCode: "SVRBA" }),

--- a/web-app/src/features/auth/hooks/useActiveAssociation.ts
+++ b/web-app/src/features/auth/hooks/useActiveAssociation.ts
@@ -9,8 +9,8 @@ import { useAuthStore, CALENDAR_ASSOCIATION } from "@/shared/stores/auth";
  * Returns the association code of the currently active occupation.
  * Falls back to the first occupation if no active occupation is set.
  *
- * In calendar mode, returns a dummy association code (CALENDAR_ASSOCIATION)
- * to keep transport settings separate from real API login settings.
+ * In calendar mode, returns CALENDAR_ASSOCIATION for global transport settings
+ * that apply across all assignments regardless of their association.
  *
  * @returns The association code (e.g., "SV", "SVRBA", "CAL") or undefined if not available
  */
@@ -24,8 +24,7 @@ export function useActiveAssociationCode(): string | undefined {
     })),
   );
 
-  // In calendar mode, use a dummy association so settings don't interfere
-  // with real API association settings if the user logs in later
+  // In calendar mode, use a global association for transport settings
   if (dataSource === "calendar") {
     return CALENDAR_ASSOCIATION;
   }

--- a/web-app/src/features/settings/components/TravelSettingsSection.tsx
+++ b/web-app/src/features/settings/components/TravelSettingsSection.tsx
@@ -1,6 +1,5 @@
 import { memo } from "react";
 import { useTranslation } from "@/shared/hooks/useTranslation";
-import { CALENDAR_ASSOCIATION } from "@/shared/stores/auth";
 import { Card, CardContent, CardHeader } from "@/shared/components/Card";
 import { ToggleSwitch } from "@/shared/components/ToggleSwitch";
 import { TrainFront, MapPin, Clock, Info } from "@/shared/components/icons";
@@ -20,7 +19,7 @@ function TravelSettingsSectionComponent() {
   const transport = useTransportSettings();
 
   // Don't show if no association selected
-  if (!transport.associationCode || transport.associationCode === CALENDAR_ASSOCIATION) {
+  if (!transport.associationCode) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Remove the `CALENDAR_ASSOCIATION` guard from `TravelSettingsSection` that was preventing the transport settings from being displayed in calendar mode
- Calendar mode now uses a global "CAL" association for transport settings, which applies to all assignments regardless of their original association

## Test Plan

- [ ] Login with calendar code
- [ ] Navigate to Settings page
- [ ] Verify the Transport Settings section is now visible
- [ ] Enable public transport and verify settings persist