### PR TITLE
fix(tour): use regular assignment rendering for tour dummy in calendar mode

### DIFF
--- a/web-app/src/features/assignments/AssignmentsPage.tsx
+++ b/web-app/src/features/assignments/AssignmentsPage.tsx
@@ -375,7 +375,7 @@ export function AssignmentsPage() {
                   {groupedData.length > 1 && (
                     <WeekSeparator week={group.week} />
                   )}
-                  {isCalendarMode
+                  {isCalendarMode && !showDummyData
                     ? // Calendar mode: same card component, no swipe actions
                       (group.items as CalendarAssignment[]).map(
                         (calendarAssignment, itemIndex) => {
@@ -400,7 +400,7 @@ export function AssignmentsPage() {
                           );
                         },
                       )
-                    : // Regular mode: render full cards with swipe actions
+                    : // Regular mode (or tour dummy): render full cards with swipe actions
                       (group.items as Assignment[]).map(
                         (assignment, itemIndex) => (
                           <SwipeableCard


### PR DESCRIPTION
## Summary
- Fix tour dummy assignment not rendering correctly in calendar mode
- The tour dummy is an Assignment type, not CalendarAssignment, so it shouldn't go through the mapCalendarAssignmentToAssignment conversion

## Test Plan
- All existing tests pass (3052 tests)
- Lint passes with 0 warnings
- Build succeeds