### PR TITLE
fix(settings): hide safe mode toggles in calendar mode

### DIFF
--- a/web-app/src/features/settings/SettingsPage.test.tsx
+++ b/web-app/src/features/settings/SettingsPage.test.tsx
@@ -47,11 +47,13 @@ const mockUser = {
 const mockLogout = vi.fn();
 const mockSetSafeMode = vi.fn();
 
-function mockAuthStore(overrides = {}) {
+function mockAuthStore(overrides: Record<string, unknown> = {}) {
+  const dataSource = (overrides.dataSource ?? "api") as "api" | "demo" | "calendar";
   const state = {
     user: mockUser,
     logout: mockLogout,
-    dataSource: "api" as const,
+    dataSource,
+    isCalendarMode: () => dataSource === "calendar",
     ...overrides,
   };
   vi.mocked(authStore.useAuthStore).mockImplementation((selector?: unknown) => {
@@ -131,7 +133,13 @@ describe("SettingsPage", () => {
       expect(screen.queryByText("settings.safeMode")).not.toBeInTheDocument();
     });
 
-    it("shows safe mode section when not in demo mode", () => {
+    it("hides safe mode section in calendar mode", () => {
+      mockAuthStore({ dataSource: "calendar" });
+      render(<SettingsPage />, { wrapper: createWrapper() });
+      expect(screen.queryByText("settings.safeMode")).not.toBeInTheDocument();
+    });
+
+    it("shows safe mode section when not in demo or calendar mode", () => {
       render(<SettingsPage />, { wrapper: createWrapper() });
       expect(screen.getByText("settings.safeMode")).toBeInTheDocument();
     });

--- a/web-app/src/features/settings/SettingsPage.tsx
+++ b/web-app/src/features/settings/SettingsPage.tsx
@@ -18,11 +18,12 @@ import {
 } from "./components";
 
 export function SettingsPage() {
-  const { user, logout, dataSource } = useAuthStore(
+  const { user, logout, dataSource, isCalendarMode } = useAuthStore(
     useShallow((state) => ({
       user: state.user,
       logout: state.logout,
       dataSource: state.dataSource,
+      isCalendarMode: state.isCalendarMode(),
     })),
   );
   const isDemoMode = dataSource === "demo";
@@ -82,7 +83,7 @@ export function SettingsPage() {
         />
       )}
 
-      {!isDemoMode && (
+      {!isDemoMode && !isCalendarMode && (
         <DataProtectionSection
           isSafeModeEnabled={isSafeModeEnabled}
           onSetSafeMode={setSafeMode}


### PR DESCRIPTION
## Summary
- Hide the DataProtectionSection (safe mode toggles) in calendar mode since calendar mode is read-only and safe mode settings are irrelevant
- Added test coverage for the new calendar mode behavior

## Test Plan
- [x] Verify safe mode section is hidden in calendar mode
- [x] Verify safe mode section is still hidden in demo mode
- [x] Verify safe mode section is visible in normal API mode
- [x] All existing tests pass