### PR TITLE
fix(test): resolve flaky aria-live region test in ScoresheetPanel

### DIFF
--- a/web-app/src/features/validation/components/panels.test.tsx
+++ b/web-app/src/features/validation/components/panels.test.tsx
@@ -450,8 +450,12 @@ describe("ScoresheetPanel", () => {
 
     it("announces upload completion via aria-live region", async () => {
       render(<ScoresheetPanel />, { wrapper: createWrapper() });
-      await uploadTestFile(getFileInput());
+      selectFile(getFileInput());
 
+      // Run all timers to complete the simulated upload
+      await vi.runAllTimersAsync();
+
+      // The status element should now be present with complete state
       const statusElement = screen.getByRole("status");
       expect(statusElement).toHaveAttribute("aria-live", "polite");
       expect(statusElement).toHaveTextContent("Upload complete");


### PR DESCRIPTION
## Summary
- Fixed flaky test "announces upload completion via aria-live region" in `panels.test.tsx` that was failing in CI
- Changed test to use inline `vi.runAllTimersAsync()` pattern matching other passing tests in the file

## Test plan
- [x] All 3052 unit tests pass locally
- [x] Lint passes with 0 warnings
- [x] Knip (dead code detection) passes
- [x] Production build succeeds
- [ ] CI pipeline passes (verifies the fix works in CI environment)