### PR TITLE
fix(tour): improve tour interaction blocking and drawer reveal

### DIFF
--- a/web-app/src/features/assignments/assignments.ts
+++ b/web-app/src/features/assignments/assignments.ts
@@ -53,6 +53,8 @@ function getUpcomingDate(): string {
 }
 
 // Configured to pass all eligibility checks so all action buttons are visible during the tour
+// - refereePosition: "head-one" = 1st referee (enables validate game action)
+// - leagueCategory: "NLA" = top league (enables hall report generation)
 export const TOUR_DUMMY_ASSIGNMENT: TourDummyAssignment = {
   __identity: "tour-dummy-assignment",
   refereePosition: "head-one",

--- a/web-app/src/features/assignments/assignments.ts
+++ b/web-app/src/features/assignments/assignments.ts
@@ -13,7 +13,6 @@ export const assignmentsTour: TourDefinition = {
       titleKey: "tour.assignments.welcome.title",
       descriptionKey: "tour.assignments.welcome.description",
       placement: "bottom",
-      completionEvent: { type: "auto", delay: 3000 },
     },
     {
       id: "swipe-validate",
@@ -21,7 +20,6 @@ export const assignmentsTour: TourDefinition = {
       titleKey: "tour.assignments.swipeValidate.title",
       descriptionKey: "tour.assignments.swipeValidate.description",
       placement: "bottom",
-      completionEvent: { type: "swipe" },
       autoSwipe: { direction: "left" },
     },
     {
@@ -30,7 +28,6 @@ export const assignmentsTour: TourDefinition = {
       titleKey: "tour.assignments.swipeExchange.title",
       descriptionKey: "tour.assignments.swipeExchange.description",
       placement: "bottom",
-      completionEvent: { type: "swipe" },
       autoSwipe: { direction: "right" },
     },
     {
@@ -39,7 +36,6 @@ export const assignmentsTour: TourDefinition = {
       titleKey: "tour.assignments.tapDetails.title",
       descriptionKey: "tour.assignments.tapDetails.description",
       placement: "bottom",
-      completionEvent: { type: "click" },
     },
   ],
 };

--- a/web-app/src/shared/components/SwipeableCard.tsx
+++ b/web-app/src/shared/components/SwipeableCard.tsx
@@ -273,6 +273,23 @@ export function SwipeableCard({
     return () => document.removeEventListener("keydown", handleEscape);
   }, [showActions, resetPosition]);
 
+  // Listen for tour auto-swipe events to update state and render action buttons
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !hasAnyAction) return;
+
+    const handleTourSwipe = (e: Event) => {
+      const { translateX: targetTranslate } = (e as CustomEvent).detail;
+      // Update React state so action buttons render
+      setTranslateX(targetTranslate);
+      currentTranslateRef.current = targetTranslate;
+      setIsDrawerOpen(true);
+    };
+
+    container.addEventListener("tour-swipe-start", handleTourSwipe);
+    return () => container.removeEventListener("tour-swipe-start", handleTourSwipe);
+  }, [containerRef, hasAnyAction, setTranslateX]);
+
   // Capture phase click handler prevents card expansion when drawer is open
   const handleClickCapture = useCallback(
     (e: React.MouseEvent) => {

--- a/web-app/src/shared/components/SwipeableCard.tsx
+++ b/web-app/src/shared/components/SwipeableCard.tsx
@@ -9,17 +9,18 @@ import {
 import {
   type SwipeConfig,
   type SwipeAction,
+  type TourSwipeStartEvent,
   DRAWER_OPEN_RATIO,
   FULL_SWIPE_RATIO,
   MINIMUM_SWIPE_RATIO,
+  ACTION_BUTTON_WIDTH,
+  ACTION_BUTTON_GAP,
+  DRAWER_PADDING,
 } from "../../types/swipe";
 import { useTranslation } from "@/shared/hooks/useTranslation";
 import { useSwipeGesture } from "@/shared/hooks/useSwipeGesture";
 
-// Layout constants for action buttons
-const ACTION_BUTTON_WIDTH = 72;
-const ACTION_BUTTON_GAP = 8;
-const DRAWER_PADDING = 16;
+// Layout constants for action buttons (others imported from types/swipe.ts)
 const MAX_DRAWER_WIDTH_RATIO = 0.8;
 const SWIPE_OVERSHOOT_MULTIPLIER = 1.2;
 const OPACITY_FADE_MULTIPLIER = 1.5;
@@ -273,13 +274,15 @@ export function SwipeableCard({
     return () => document.removeEventListener("keydown", handleEscape);
   }, [showActions, resetPosition]);
 
-  // Listen for tour auto-swipe events to update state and render action buttons
+  // Listen for tour auto-swipe events to update state and render action buttons.
+  // TourAutoSwipe dispatches 'tour-swipe-start' during guided tour demonstrations
+  // so SwipeableCard can update its React state and render the action buttons.
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !hasAnyAction) return;
 
     const handleTourSwipe = (e: Event) => {
-      const { translateX: targetTranslate } = (e as CustomEvent).detail;
+      const { translateX: targetTranslate } = (e as TourSwipeStartEvent).detail;
       // Update React state so action buttons render
       setTranslateX(targetTranslate);
       currentTranslateRef.current = targetTranslate;

--- a/web-app/src/shared/components/tour/TourAutoSwipe.tsx
+++ b/web-app/src/shared/components/tour/TourAutoSwipe.tsx
@@ -13,8 +13,12 @@ interface TourAutoSwipeProps {
 // Default timing values
 const DEFAULT_DURATION_MS = 1500;
 const DEFAULT_DELAY_MS = 800;
-// Swipe distance as percentage of container width
-const SWIPE_DISTANCE_RATIO = 0.35;
+// Action button layout constants (must match SwipeableCard.tsx)
+const ACTION_BUTTON_WIDTH = 72;
+const ACTION_BUTTON_GAP = 8;
+const DRAWER_PADDING = 16;
+// Default number of actions to assume if we can't detect them
+const DEFAULT_ACTION_COUNT = 3;
 
 export function TourAutoSwipe({
   targetSelector,
@@ -56,10 +60,22 @@ export function TourAutoSwipe({
 
     hasAnimatedRef.current = true;
 
-    // Calculate swipe distance
-    const containerWidth = container.getBoundingClientRect().width;
-    const swipeDistance = containerWidth * SWIPE_DISTANCE_RATIO;
-    const targetTranslate = direction === "left" ? -swipeDistance : swipeDistance;
+    // Calculate drawer width based on number of actions
+    // Using default count since we can't detect the actual swipe config
+    const actionCount = DEFAULT_ACTION_COUNT;
+    const drawerWidth = actionCount * ACTION_BUTTON_WIDTH +
+      (actionCount - 1) * ACTION_BUTTON_GAP +
+      DRAWER_PADDING;
+    const targetTranslate = direction === "left" ? -drawerWidth : drawerWidth;
+
+    // Dispatch event to notify SwipeableCard to update its state
+    // This allows the action buttons to render properly
+    container.dispatchEvent(
+      new CustomEvent("tour-swipe-start", {
+        bubbles: true,
+        detail: { translateX: targetTranslate },
+      }),
+    );
 
     // Store original styles for cleanup
     const originalTransition = swipeableContent.style.transition;

--- a/web-app/src/shared/components/tour/TourAutoSwipe.tsx
+++ b/web-app/src/shared/components/tour/TourAutoSwipe.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "@/shared/hooks/useTranslation";
+import { ACTION_BUTTON_WIDTH, ACTION_BUTTON_GAP, DRAWER_PADDING } from "@/types/swipe";
 
 interface TourAutoSwipeProps {
   targetSelector: string;
@@ -13,10 +14,6 @@ interface TourAutoSwipeProps {
 // Default timing values
 const DEFAULT_DURATION_MS = 1500;
 const DEFAULT_DELAY_MS = 800;
-// Action button layout constants (must match SwipeableCard.tsx)
-const ACTION_BUTTON_WIDTH = 72;
-const ACTION_BUTTON_GAP = 8;
-const DRAWER_PADDING = 16;
 // Default number of actions to assume if we can't detect them
 const DEFAULT_ACTION_COUNT = 3;
 

--- a/web-app/src/shared/components/tour/TourProvider.tsx
+++ b/web-app/src/shared/components/tour/TourProvider.tsx
@@ -155,6 +155,7 @@ export function TourProvider({ children }: TourProviderProps) {
         freezePosition={isSwipeStep}
         disableBlur={isSwipeStep}
         blockInteraction={isAutoSwipeActive}
+        blockAllInteraction
       >
         <TourTooltip
           titleKey={currentStepData.titleKey}

--- a/web-app/src/shared/components/tour/TourProvider.tsx
+++ b/web-app/src/shared/components/tour/TourProvider.tsx
@@ -38,13 +38,14 @@ export function TourProvider({ children }: TourProviderProps) {
   const isFirstStep = currentStep === 0;
 
   // Freeze spotlight position during swipe steps to keep drawer visible
-  const isSwipeStep = currentStepData?.completionEvent?.type === "swipe";
+  // A step is a "swipe step" if it has autoSwipe config (regardless of completionEvent)
   const hasAutoSwipe = Boolean(currentStepData?.autoSwipe);
+  const isSwipeStep = hasAutoSwipe;
   // Auto-swipe is completed only if it was completed for the current tour and step
   const isAutoSwipeCompleted =
     autoSwipeCompletedFor?.tour === activeTour &&
     autoSwipeCompletedFor?.step === currentStep;
-  const isAutoSwipeActive = isSwipeStep && hasAutoSwipe && !isAutoSwipeCompleted;
+  const isAutoSwipeActive = hasAutoSwipe && !isAutoSwipeCompleted;
 
   // Handle step completion
   const handleStepComplete = useCallback(() => {

--- a/web-app/src/shared/components/tour/TourProvider.tsx
+++ b/web-app/src/shared/components/tour/TourProvider.tsx
@@ -148,13 +148,21 @@ export function TourProvider({ children }: TourProviderProps) {
   return (
     <>
       {children}
+      {/* blockAllInteraction is always enabled during the tour to prevent users from
+          accidentally navigating away, clicking buttons, or interacting with the page
+          in ways that could break the tour flow. Users can still interact with the
+          tour tooltip (next/previous/skip) and exit the tour at any time.
+
+          blockInteraction covers the target element during swipe steps so users can
+          see the drawer buttons but cannot click them - this demonstrates the feature
+          without triggering actual actions. */}
       <TourSpotlight
         targetSelector={currentStepData.targetSelector}
         placement={currentStepData.placement}
         onDismiss={handleDismiss}
         freezePosition={isSwipeStep}
         disableBlur={isSwipeStep}
-        blockInteraction={isAutoSwipeActive}
+        blockInteraction={isSwipeStep}
         blockAllInteraction
       >
         <TourTooltip

--- a/web-app/src/shared/components/tour/TourSpotlight.tsx
+++ b/web-app/src/shared/components/tour/TourSpotlight.tsx
@@ -22,6 +22,8 @@ interface TourSpotlightProps {
   disableBlur?: boolean;
   /** When true, blocks all interaction with the target element (during auto-swipe demo) */
   blockInteraction?: boolean;
+  /** When true, blocks interaction with the entire page except for the tour tooltip */
+  blockAllInteraction?: boolean;
 }
 
 const SPOTLIGHT_PADDING = 8;
@@ -90,6 +92,7 @@ export function TourSpotlight({
   freezePosition = false,
   disableBlur = false,
   blockInteraction = false,
+  blockAllInteraction = false,
 }: TourSpotlightProps) {
   // Start with null - position will be set after mount when element is ready
   const [targetRect, setTargetRect] = useState<TargetRect | null>(null);
@@ -301,6 +304,14 @@ export function TourSpotlight({
       aria-modal="true"
       aria-label="Guided tour"
     >
+      {/* Full-screen interaction blocker - blocks all page interaction during tour */}
+      {blockAllInteraction && (
+        <div
+          className="fixed inset-0 z-40 pointer-events-auto"
+          aria-hidden="true"
+        />
+      )}
+
       {/* Backdrop overlay with blur and cutout - pointer-events-none to let clicks through */}
       <div
         className={`fixed inset-0 z-40 bg-black/70 transition-opacity ${disableBlur ? "" : "backdrop-blur-sm"}`}

--- a/web-app/src/types/swipe.ts
+++ b/web-app/src/types/swipe.ts
@@ -42,3 +42,19 @@ export const MINIMUM_SWIPE_RATIO = 0.03;
  * Used consistently across all swipe action configurations.
  */
 export const SWIPE_ACTION_ICON_SIZE = 20;
+
+/**
+ * Layout constants for swipe action drawer buttons.
+ * Used by SwipeableCard and TourAutoSwipe for consistent drawer sizing.
+ */
+export const ACTION_BUTTON_WIDTH = 72;
+export const ACTION_BUTTON_GAP = 8;
+export const DRAWER_PADDING = 16;
+
+/**
+ * Custom event interface for tour auto-swipe coordination.
+ * Dispatched by TourAutoSwipe, listened to by SwipeableCard.
+ */
+export interface TourSwipeStartEvent extends CustomEvent {
+  detail: { translateX: number };
+}


### PR DESCRIPTION
## Summary
- Block all user interaction during tour except tooltip and exit button (via full-screen transparent overlay)
- Fix auto-swipe to properly reveal drawer action buttons by calculating proper drawer width and dispatching events to update SwipeableCard React state
- Keep drawer buttons visible but not clickable during swipe steps (transparent overlay over target element)
- Extract duplicated swipe constants (`ACTION_BUTTON_WIDTH`, `ACTION_BUTTON_GAP`, `DRAWER_PADDING`) to shared `types/swipe.ts`
- Add `TourSwipeStartEvent` interface for type-safe event handling between TourAutoSwipe and SwipeableCard
- Remove automatic advancing - users must click "Next" to proceed through tour steps

## Test Plan
- Start the guided tour on the assignments page
- Verify that user cannot interact with the page except for tour tooltip buttons (next/previous/skip)
- Verify that auto-swipe reveals all drawer action buttons properly
- Verify drawer buttons are visible but clicking them does nothing
- Verify tour does NOT auto-advance - user must click Next
- Test tour navigation works correctly
- Verify Escape key still dismisses the tour