### PR TITLE
fix(a11y): translate hardcoded aria-label in TourSpotlight

### DIFF
--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -112,6 +112,7 @@ const de: Translations = {
     },
     accessibility: {
       swipeDemoInProgress: "Wischgeste wird demonstriert",
+      spotlightLabel: "Geführte Tour",
     },
   },
   common: {

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -112,6 +112,7 @@ const en: Translations = {
     },
     accessibility: {
       swipeDemoInProgress: "Demonstrating swipe gesture",
+      spotlightLabel: "Guided tour",
     },
   },
   common: {

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -112,6 +112,7 @@ const fr: Translations = {
     },
     accessibility: {
       swipeDemoInProgress: "Démonstration du geste de glissement",
+      spotlightLabel: "Visite guidée",
     },
   },
   common: {

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -112,6 +112,7 @@ const it: Translations = {
     },
     accessibility: {
       swipeDemoInProgress: "Dimostrazione del gesto di scorrimento",
+      spotlightLabel: "Visita guidata",
     },
   },
   common: {

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -606,6 +606,7 @@ export interface Translations {
     };
     accessibility: {
       swipeDemoInProgress: string;
+      spotlightLabel: string;
     };
   };
 }

--- a/web-app/src/shared/components/tour/TourSpotlight.tsx
+++ b/web-app/src/shared/components/tour/TourSpotlight.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useRef, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
 import type { TooltipPlacement } from "./definitions/types";
+import { useTranslation } from "@/shared/hooks/useTranslation";
 
 interface TargetRect {
   top: number;
@@ -99,6 +100,7 @@ export function TourSpotlight({
   const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
   const [isPositioned, setIsPositioned] = useState(false);
   const tooltipRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation();
 
   // Find target element and calculate positions
   const updatePositions = useCallback(
@@ -302,7 +304,7 @@ export function TourSpotlight({
       className="tour-spotlight pointer-events-none"
       role="dialog"
       aria-modal="true"
-      aria-label="Guided tour"
+      aria-label={t("tour.accessibility.spotlightLabel")}
     >
       {/* Full-screen interaction blocker - blocks all page interaction during tour */}
       {blockAllInteraction && (


### PR DESCRIPTION
## Summary
- Replace hardcoded English "Guided tour" aria-label in TourSpotlight component with translated string
- Add `spotlightLabel` translation key to tour.accessibility section in i18n types
- Add translations for all 4 supported languages (German, English, French, Italian)

## Test Plan
- [x] All linting passes (`npm run lint`)
- [x] Dead code detection passes (`npm run knip`)
- [x] All tests pass (`npm test`)
- [x] Production build succeeds (`npm run build`)