### PR TITLE
fix(test): stabilize flaky progress bar and fix timer issues

### DIFF
--- a/web-app/src/features/validation/components/panels.test.tsx
+++ b/web-app/src/features/validation/components/panels.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HomeRosterPanel } from "./HomeRosterPanel";
 import { AwayRosterPanel } from "./AwayRosterPanel";
@@ -434,7 +434,7 @@ describe("ScoresheetPanel", () => {
   });
 
   describe("Accessibility", () => {
-    it("has proper ARIA attributes on progress bar during upload", async () => {
+    it("has proper ARIA attributes on progress bar during upload", () => {
       render(<ScoresheetPanel />, { wrapper: createWrapper() });
       selectFile(getFileInput());
 
@@ -444,7 +444,11 @@ describe("ScoresheetPanel", () => {
       expect(progressBar).toHaveAttribute("aria-valuenow");
       expect(progressBar).toHaveAttribute("aria-label", "Uploading...");
 
-      await vi.runAllTimersAsync();
+      // Use act() to ensure React processes all state updates from timer callbacks
+      // This matches the pattern used in ScoresheetPanel.test.tsx for reliable timer handling
+      act(() => {
+        vi.advanceTimersByTime(2000); // > SIMULATED_UPLOAD_DURATION_MS (1500ms)
+      });
       expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary
- Fixed flaky "has proper ARIA attributes on progress bar" test that intermittently failed in CI
- Replaced all `vi.runAllTimersAsync()` calls with `act(() => vi.advanceTimersByTime(2000))` pattern
- Changed `uploadTestFile` helper from async to sync with proper `act()` wrapping
- Eliminated multiple `act()` warnings during test runs

## Test Plan
- [x] All 40 tests in panels.test.tsx pass
- [x] All 3034 tests in the suite pass
- [x] Lint passes with 0 warnings
- [x] Build succeeds