### PR TITLE
perf(ci): add per-branch caching for CI and PR preview builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,17 @@ jobs:
         with:
           node-version: '20'
 
+      # Cache node_modules per branch with fallback to main
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
         with:
           path: web-app/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -57,12 +62,17 @@ jobs:
         with:
           node-version: '20'
 
+      # Cache node_modules per branch with fallback to main
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
         with:
           path: web-app/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -79,8 +89,18 @@ jobs:
         if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
 
+      # Cache ESLint results per branch
+      - name: Cache ESLint
+        uses: actions/cache@v5
+        with:
+          path: web-app/.eslintcache
+          key: eslint-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/src/**/*.ts', 'web-app/src/**/*.tsx') }}
+          restore-keys: |
+            eslint-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            eslint-${{ runner.os }}-
+
       - name: Lint
-        run: npm run lint
+        run: npm run lint -- --cache --cache-location .eslintcache
 
   # Dead code detection - needs API types
   knip:
@@ -98,12 +118,17 @@ jobs:
         with:
           node-version: '20'
 
+      # Cache node_modules per branch with fallback to main
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
         with:
           path: web-app/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -139,12 +164,17 @@ jobs:
         with:
           node-version: '20'
 
+      # Cache node_modules per branch with fallback to main
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
         with:
           path: web-app/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -160,6 +190,16 @@ jobs:
       - name: Generate API types
         if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
+
+      # Cache Vitest results per branch
+      - name: Cache Vitest
+        uses: actions/cache@v5
+        with:
+          path: web-app/node_modules/.vitest
+          key: vitest-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/src/**/*.ts', 'web-app/src/**/*.tsx', 'web-app/src/**/*.test.ts', 'web-app/src/**/*.test.tsx') }}
+          restore-keys: |
+            vitest-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            vitest-${{ runner.os }}-
 
       - name: Run tests
         run: npm test
@@ -180,12 +220,17 @@ jobs:
         with:
           node-version: '20'
 
+      # Cache node_modules per branch with fallback to main
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
         with:
           path: web-app/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -201,6 +246,16 @@ jobs:
       - name: Generate API types
         if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
+
+      # Cache Vite build artifacts per branch
+      - name: Cache Vite build
+        uses: actions/cache@v5
+        with:
+          path: web-app/node_modules/.vite
+          key: vite-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/src/**/*.ts', 'web-app/src/**/*.tsx', 'web-app/vite.config.ts') }}
+          restore-keys: |
+            vite-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            vite-${{ runner.os }}-
 
       - name: Build
         run: npm run build
@@ -229,12 +284,17 @@ jobs:
         with:
           node-version: '20'
 
+      # Cache node_modules per branch with fallback to main
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
         with:
           path: web-app/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -271,12 +331,17 @@ jobs:
         with:
           node-version: '20'
 
+      # Cache node_modules per branch with fallback to main
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
         with:
           path: web-app/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -292,12 +357,15 @@ jobs:
         id: playwright-version
         run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
 
+      # Cache Playwright browsers with fallback to older versions
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ matrix.browser }}-${{ steps.playwright-version.outputs.version }}
+          key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            playwright-${{ runner.os }}-${{ matrix.browser }}-
 
       - name: Install Playwright browser
         if: steps.playwright-cache.outputs.cache-hit != 'true'
@@ -335,12 +403,17 @@ jobs:
         with:
           node-version: '20'
 
+      # Cache node_modules per branch with fallback to main
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v5
         with:
           path: web-app/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('web-app/package-lock.json') }}
+          key: node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -23,27 +23,76 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: web-app/package-lock.json
+
+      # Cache node_modules per branch with fallback to main
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: web-app/node_modules
+          key: node-modules-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('web-app/package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-${{ github.head_ref }}-
+            node-modules-${{ runner.os }}-main-
+            node-modules-${{ runner.os }}-
+
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
+
+      # Cache generated API types (shared across branches)
       - name: Cache generated API types
         id: api-cache
         uses: actions/cache@v5
         with:
           path: web-app/src/api/schema.ts
           key: api-types-${{ hashFiles('docs/api/volleymanager-openapi.yaml', 'web-app/package-lock.json') }}
+
       - name: Generate API types
         if: steps.api-cache.outputs.cache-hit != 'true'
         run: npm run generate:api
+
+      # Cache ESLint results per branch
+      - name: Cache ESLint
+        uses: actions/cache@v5
+        with:
+          path: web-app/.eslintcache
+          key: eslint-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('web-app/src/**/*.ts', 'web-app/src/**/*.tsx') }}
+          restore-keys: |
+            eslint-${{ runner.os }}-${{ github.head_ref }}-
+            eslint-${{ runner.os }}-
+
       - name: Lint
-        run: npm run lint
+        run: npm run lint -- --cache --cache-location .eslintcache
+
+      # Cache Vitest results per branch
+      - name: Cache Vitest
+        uses: actions/cache@v5
+        with:
+          path: web-app/node_modules/.vitest
+          key: vitest-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('web-app/src/**/*.ts', 'web-app/src/**/*.tsx', 'web-app/src/**/*.test.ts', 'web-app/src/**/*.test.tsx') }}
+          restore-keys: |
+            vitest-${{ runner.os }}-${{ github.head_ref }}-
+            vitest-${{ runner.os }}-
+
       - name: Test
         run: npm test
+
+      # Cache Vite build artifacts per branch
+      - name: Cache Vite build
+        uses: actions/cache@v5
+        with:
+          path: web-app/node_modules/.vite
+          key: vite-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('web-app/src/**/*.ts', 'web-app/src/**/*.tsx', 'web-app/vite.config.ts') }}
+          restore-keys: |
+            vite-${{ runner.os }}-${{ github.head_ref }}-
+            vite-${{ runner.os }}-
+
       - name: Build for PR Preview
         run: npm run build
         env:
@@ -51,8 +100,10 @@ jobs:
           VITE_API_PROXY_URL: ${{ vars.VITE_API_PROXY_URL }}
           VITE_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
           VITE_OJP_API_KEY: ${{ secrets.VITE_OJP_API_KEY }}
+
       - name: Add .nojekyll for GitHub Pages
         run: touch dist/.nojekyll
+
       - name: Upload web-app artifact
         uses: actions/upload-artifact@v4
         with:
@@ -68,18 +119,43 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: help-site/package-lock.json
+
+      # Cache node_modules per branch with fallback to main
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: help-site/node_modules
+          key: help-site-node-modules-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('help-site/package-lock.json') }}
+          restore-keys: |
+            help-site-node-modules-${{ runner.os }}-${{ github.head_ref }}-
+            help-site-node-modules-${{ runner.os }}-main-
+            help-site-node-modules-${{ runner.os }}-
+
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
+
+      # Cache Astro build artifacts per branch
+      - name: Cache Astro build
+        uses: actions/cache@v5
+        with:
+          path: help-site/node_modules/.astro
+          key: astro-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('help-site/src/**/*', 'help-site/astro.config.mjs') }}
+          restore-keys: |
+            astro-${{ runner.os }}-${{ github.head_ref }}-
+            astro-${{ runner.os }}-
+
       - name: Build Help Site
         run: npm run build
         env:
           ASTRO_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/help
+
       - name: Upload help-site artifact
         uses: actions/upload-artifact@v4
         with:
@@ -95,21 +171,57 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: ocr-poc/package-lock.json
+
+      # Cache node_modules per branch with fallback to main
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: ocr-poc/node_modules
+          key: ocr-poc-node-modules-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('ocr-poc/package-lock.json') }}
+          restore-keys: |
+            ocr-poc-node-modules-${{ runner.os }}-${{ github.head_ref }}-
+            ocr-poc-node-modules-${{ runner.os }}-main-
+            ocr-poc-node-modules-${{ runner.os }}-
+
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
+
+      # Cache ESLint results per branch
+      - name: Cache ESLint
+        uses: actions/cache@v5
+        with:
+          path: ocr-poc/.eslintcache
+          key: ocr-poc-eslint-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('ocr-poc/src/**/*.ts', 'ocr-poc/src/**/*.tsx') }}
+          restore-keys: |
+            ocr-poc-eslint-${{ runner.os }}-${{ github.head_ref }}-
+            ocr-poc-eslint-${{ runner.os }}-
+
       - name: Lint OCR POC
-        run: npm run lint
+        run: npm run lint -- --cache --cache-location .eslintcache
+
+      # Cache Vite build artifacts per branch
+      - name: Cache Vite build
+        uses: actions/cache@v5
+        with:
+          path: ocr-poc/node_modules/.vite
+          key: ocr-poc-vite-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('ocr-poc/src/**/*.ts', 'ocr-poc/src/**/*.tsx', 'ocr-poc/vite.config.ts') }}
+          restore-keys: |
+            ocr-poc-vite-${{ runner.os }}-${{ github.head_ref }}-
+            ocr-poc-vite-${{ runner.os }}-
+
       - name: Build OCR POC
         run: npm run build
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/ocr-poc/
           VITE_OCR_ENDPOINT: ${{ vars.VITE_OCR_ENDPOINT }}
+
       - name: Upload ocr-poc artifact
         uses: actions/upload-artifact@v4
         with:

--- a/ocr-poc/.gitignore
+++ b/ocr-poc/.gitignore
@@ -12,6 +12,9 @@ dist/
 *.log
 npm-debug.log*
 
+# ESLint cache
+.eslintcache
+
 # Editor
 .vscode/
 .idea/

--- a/web-app/.gitignore
+++ b/web-app/.gitignore
@@ -27,6 +27,9 @@ yarn-error.log*
 # Test coverage
 coverage/
 
+# ESLint cache
+.eslintcache
+
 # Playwright
 test-results/
 playwright-report/


### PR DESCRIPTION
## Summary
- Add comprehensive per-branch caching to speed up subsequent builds
- **node_modules**: Cache per branch with fallback to main branch
- **ESLint**: Cache lint results per branch (.eslintcache)
- **Vite**: Cache build artifacts per branch (node_modules/.vite)
- **Vitest**: Cache test results per branch (node_modules/.vitest)
- **Astro**: Cache help-site build artifacts per branch
- **Playwright**: Add fallback keys for browser cache

Applied to both workflows:
- `deploy-pr-preview.yml` - PR preview builds
- `ci.yml` - Main CI pipeline (lint, test, build, E2E, Lighthouse)

## Test Plan
- Create a PR that modifies web-app files
- Push additional commits to the same PR
- Verify subsequent builds are faster due to cache hits
- Check GitHub Actions logs for cache restore/save operations