### PR TITLE
feat(claude): add validation skill and commands for mobile development

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -3,7 +3,7 @@
 Run production build only.
 
 ```bash
-cd /home/user/volleykit/web-app && npm run build
+cd web-app && npm run build
 ```
 
 Output: `✓ Build` or `✗ Build: [error summary]`

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,9 @@
+# Quick Build Check
+
+Run production build only.
+
+```bash
+cd /home/user/volleykit/web-app && npm run build
+```
+
+Output: `✓ Build` or `✗ Build: [error summary]`

--- a/.claude/commands/knip.md
+++ b/.claude/commands/knip.md
@@ -1,0 +1,9 @@
+# Quick Knip Check
+
+Run dead code detection only.
+
+```bash
+cd web-app && npm run knip
+```
+
+Output: `✓ Knip` or `✗ Knip: [unused exports summary]`

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,9 @@
+# Quick Lint Check
+
+Run lint only (fastest validation).
+
+```bash
+cd /home/user/volleykit/web-app && npm run lint
+```
+
+Output: `✓ Lint` or `✗ Lint: [first error]`

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -3,7 +3,7 @@
 Run lint only (fastest validation).
 
 ```bash
-cd /home/user/volleykit/web-app && npm run lint
+cd web-app && npm run lint
 ```
 
 Output: `✓ Lint` or `✗ Lint: [first error]`

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,9 @@
+# Quick Test Check
+
+Run tests only.
+
+```bash
+cd /home/user/volleykit/web-app && npm test
+```
+
+Output: `✓ Test (N passed)` or `✗ Test: [failed test names]`

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -3,7 +3,7 @@
 Run tests only.
 
 ```bash
-cd /home/user/volleykit/web-app && npm test
+cd web-app && npm test
 ```
 
 Output: `✓ Test (N passed)` or `✗ Test: [failed test names]`

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -4,33 +4,38 @@ Run validation before pushing. Optimized for mobile with parallel execution.
 
 ## Instructions
 
-1. **Detect changes** (quick check what files changed):
+1. **Detect changes** (check uncommitted files):
 ```bash
-cd /home/user/volleykit/web-app && git diff --name-only HEAD 2>/dev/null | head -20
+git diff --name-only && git diff --name-only --cached
 ```
 
-2. **Run parallel validations** using Task tool sub-agents:
+2. **Generate API types** (if OpenAPI spec changed):
+```bash
+cd web-app && npm run generate:api
+```
 
-Launch ALL THREE of these agents IN PARALLEL (single message, multiple Task calls):
+3. **Run parallel validations** using Task tool sub-agents:
+
+Launch ALL THREE agents IN PARALLEL (single message, multiple Task calls):
 
 **Agent 1 - Lint**:
 - subagent_type: "general-purpose"
-- prompt: "cd /home/user/volleykit/web-app && npm run lint. Reply with ONLY: LINT: PASS or LINT: FAIL with first 3 errors"
+- prompt: "cd web-app && npm run lint. Reply: LINT: PASS or LINT: FAIL with first 3 errors"
 
 **Agent 2 - Knip**:
 - subagent_type: "general-purpose"
-- prompt: "cd /home/user/volleykit/web-app && npm run knip. Reply with ONLY: KNIP: PASS or KNIP: FAIL with summary"
+- prompt: "cd web-app && npm run knip. Reply: KNIP: PASS or KNIP: FAIL with summary"
 
 **Agent 3 - Test**:
 - subagent_type: "general-purpose"
-- prompt: "cd /home/user/volleykit/web-app && npm test. Reply with ONLY: TEST: PASS (N passed) or TEST: FAIL with failed test names"
+- prompt: "cd web-app && npm test. Reply: TEST: PASS (N passed) or TEST: FAIL with failed names"
 
-3. **Build** (only if all parallel checks pass):
+4. **Build** (only if all parallel checks pass):
 ```bash
-cd /home/user/volleykit/web-app && npm run build
+cd web-app && npm run build
 ```
 
-4. **Output concise summary**:
+5. **Output concise summary**:
 
 ```
 ✓ Lint  ✓ Knip  ✓ Test  ✓ Build

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -1,0 +1,47 @@
+# Pre-Push Validation
+
+Run validation before pushing. Optimized for mobile with parallel execution.
+
+## Instructions
+
+1. **Detect changes** (quick check what files changed):
+```bash
+cd /home/user/volleykit/web-app && git diff --name-only HEAD 2>/dev/null | head -20
+```
+
+2. **Run parallel validations** using Task tool sub-agents:
+
+Launch ALL THREE of these agents IN PARALLEL (single message, multiple Task calls):
+
+**Agent 1 - Lint**:
+- subagent_type: "general-purpose"
+- prompt: "cd /home/user/volleykit/web-app && npm run lint. Reply with ONLY: LINT: PASS or LINT: FAIL with first 3 errors"
+
+**Agent 2 - Knip**:
+- subagent_type: "general-purpose"
+- prompt: "cd /home/user/volleykit/web-app && npm run knip. Reply with ONLY: KNIP: PASS or KNIP: FAIL with summary"
+
+**Agent 3 - Test**:
+- subagent_type: "general-purpose"
+- prompt: "cd /home/user/volleykit/web-app && npm test. Reply with ONLY: TEST: PASS (N passed) or TEST: FAIL with failed test names"
+
+3. **Build** (only if all parallel checks pass):
+```bash
+cd /home/user/volleykit/web-app && npm run build
+```
+
+4. **Output concise summary**:
+
+```
+✓ Lint  ✓ Knip  ✓ Test  ✓ Build
+
+Ready to push!
+```
+
+Or on failure:
+```
+✓ Lint  ✗ Knip  ✓ Test  ⊘ Build
+
+Issues:
+- Knip: unused export in helpers.ts
+```

--- a/.claude/skills/validate.md
+++ b/.claude/skills/validate.md
@@ -1,0 +1,138 @@
+# Validate Skill
+
+Run pre-push validation optimized for mobile (iPhone) development. Uses parallel sub-agents for speed.
+
+## Trigger Phrases
+
+Invoke this skill when user says any of:
+- "validate", "validation", "run validation"
+- "check before push", "pre-push check"
+- "run checks", "run all checks"
+- "lint test build", "full check"
+
+## Instructions
+
+When this skill is invoked, perform validation with these steps:
+
+### 1. Quick Change Detection
+
+First, detect what changed to determine required validations:
+
+```bash
+cd /home/user/volleykit/web-app
+git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only --cached || git diff --name-only
+```
+
+Categorize changes:
+- **Source files**: `*.ts`, `*.tsx`, `*.js`, `*.jsx` → needs lint, test, build
+- **OpenAPI spec**: `volleymanager-openapi.yaml` → needs generate:api first
+- **Test files only**: `*.test.ts`, `*.test.tsx` → needs test only
+- **Locale files**: `*.json` in `i18n/locales/` → needs lint only
+- **Docs only**: `*.md` files → skip all validation
+
+### 2. Parallel Validation (Sub-Agents)
+
+**CRITICAL**: Launch these sub-agents IN PARALLEL using a SINGLE message with multiple Task tool calls.
+
+For source file changes, spawn these agents simultaneously:
+
+#### Agent 1: Lint Check
+```
+subagent_type: "general-purpose"
+prompt: |
+  Run ESLint in /home/user/volleykit/web-app:
+  cd /home/user/volleykit/web-app && npm run lint
+
+  Return ONLY this format:
+  LINT: PASS or LINT: FAIL
+  [If fail, include first 5 error lines]
+```
+
+#### Agent 2: Dead Code Check
+```
+subagent_type: "general-purpose"
+prompt: |
+  Run Knip dead code detection in /home/user/volleykit/web-app:
+  cd /home/user/volleykit/web-app && npm run knip
+
+  Return ONLY this format:
+  KNIP: PASS or KNIP: FAIL
+  [If fail, include summary of unused exports]
+```
+
+#### Agent 3: Test Suite
+```
+subagent_type: "general-purpose"
+prompt: |
+  Run Vitest in /home/user/volleykit/web-app:
+  cd /home/user/volleykit/web-app && npm test
+
+  Return ONLY this format:
+  TEST: PASS (X passed) or TEST: FAIL (X passed, Y failed)
+  [If fail, list failed test names only]
+```
+
+### 3. Sequential Build (Only if Parallel Checks Pass)
+
+If ALL parallel checks pass, run build:
+
+```bash
+cd /home/user/volleykit/web-app && npm run build
+```
+
+### 4. Mobile-Friendly Summary
+
+Output a concise summary using this exact format:
+
+```
+## Validation Results
+
+✓ Lint     ✓ Knip     ✓ Test     ✓ Build
+
+Ready to push!
+```
+
+Or on failure:
+
+```
+## Validation Results
+
+✓ Lint     ✗ Knip     ✓ Test     ⊘ Build (skipped)
+
+### Issues
+- Knip: 2 unused exports in src/utils/helpers.ts
+
+Fix issues and re-run validation.
+```
+
+### Status Icons (Mobile-Optimized)
+- `✓` Pass (green checkmark)
+- `✗` Fail (red X)
+- `⊘` Skipped
+- `◐` Running (if showing progress)
+
+### Smart Skip Rules
+
+Skip validations when safe:
+- **No source changes**: Skip all (docs/config only)
+- **Test files only**: Skip lint, knip, build - run test only
+- **Locale JSON only**: Run lint only
+- **OpenAPI changes**: Run generate:api before other checks
+
+### Error Handling
+
+If a sub-agent times out or fails unexpectedly:
+1. Note the failed check
+2. Continue with other results
+3. Suggest running the failed check manually
+
+### Example Invocations
+
+User says: "validate" or "check" or "run validation"
+→ Run full validation flow above
+
+User says: "quick validate" or "lint only"
+→ Run only lint check, skip others
+
+User says: "test only"
+→ Run only test suite

--- a/.claude/skills/validate.md
+++ b/.claude/skills/validate.md
@@ -16,32 +16,46 @@ When this skill is invoked, perform validation with these steps:
 
 ### 1. Quick Change Detection
 
-First, detect what changed to determine required validations:
+First, detect what changed to determine required validations. Check both staged and unstaged changes:
 
 ```bash
-cd /home/user/volleykit/web-app
-git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only --cached || git diff --name-only
+# From project root, detect all uncommitted changes
+git diff --name-only          # Unstaged changes
+git diff --name-only --cached # Staged changes
+git status --porcelain        # All modified/untracked files
 ```
 
 Categorize changes:
-- **Source files**: `*.ts`, `*.tsx`, `*.js`, `*.jsx` → needs lint, test, build
-- **OpenAPI spec**: `volleymanager-openapi.yaml` → needs generate:api first
+- **Source files**: `*.ts`, `*.tsx`, `*.js`, `*.jsx` → needs full validation
+- **OpenAPI spec**: `docs/api/volleymanager-openapi.yaml` → needs generate:api first
 - **Test files only**: `*.test.ts`, `*.test.tsx` → needs test only
 - **Locale files**: `*.json` in `i18n/locales/` → needs lint only
 - **Docs only**: `*.md` files → skip all validation
 
-### 2. Parallel Validation (Sub-Agents)
+### 2. Generate API Types (If Needed)
+
+**Run FIRST if OpenAPI spec changed**:
+
+```bash
+cd web-app && npm run generate:api
+```
+
+This must complete before lint/test/build since they depend on generated types.
+
+### 3. Parallel Validation (Sub-Agents)
 
 **CRITICAL**: Launch these sub-agents IN PARALLEL using a SINGLE message with multiple Task tool calls.
 
-For source file changes, spawn these agents simultaneously:
+**Validation order per CLAUDE.md**: generate:api → lint → knip → test → build
+
+Lint, knip, and test can run in parallel since they're independent. Build must wait for all to pass.
 
 #### Agent 1: Lint Check
 ```
 subagent_type: "general-purpose"
 prompt: |
-  Run ESLint in /home/user/volleykit/web-app:
-  cd /home/user/volleykit/web-app && npm run lint
+  Run ESLint in the web-app directory:
+  cd web-app && npm run lint
 
   Return ONLY this format:
   LINT: PASS or LINT: FAIL
@@ -52,8 +66,8 @@ prompt: |
 ```
 subagent_type: "general-purpose"
 prompt: |
-  Run Knip dead code detection in /home/user/volleykit/web-app:
-  cd /home/user/volleykit/web-app && npm run knip
+  Run Knip dead code detection in the web-app directory:
+  cd web-app && npm run knip
 
   Return ONLY this format:
   KNIP: PASS or KNIP: FAIL
@@ -64,30 +78,30 @@ prompt: |
 ```
 subagent_type: "general-purpose"
 prompt: |
-  Run Vitest in /home/user/volleykit/web-app:
-  cd /home/user/volleykit/web-app && npm test
+  Run Vitest tests in the web-app directory:
+  cd web-app && npm test
 
   Return ONLY this format:
   TEST: PASS (X passed) or TEST: FAIL (X passed, Y failed)
   [If fail, list failed test names only]
 ```
 
-### 3. Sequential Build (Only if Parallel Checks Pass)
+### 4. Sequential Build (Only if Parallel Checks Pass)
 
 If ALL parallel checks pass, run build:
 
 ```bash
-cd /home/user/volleykit/web-app && npm run build
+cd web-app && npm run build
 ```
 
-### 4. Mobile-Friendly Summary
+### 5. Mobile-Friendly Summary
 
 Output a concise summary using this exact format:
 
 ```
 ## Validation Results
 
-✓ Lint     ✓ Knip     ✓ Test     ✓ Build
+✓ Lint  ✓ Knip  ✓ Test  ✓ Build
 
 Ready to push!
 ```
@@ -97,19 +111,17 @@ Or on failure:
 ```
 ## Validation Results
 
-✓ Lint     ✗ Knip     ✓ Test     ⊘ Build (skipped)
+✓ Lint  ✗ Knip  ✓ Test  ⊘ Build
 
-### Issues
-- Knip: 2 unused exports in src/utils/helpers.ts
-
-Fix issues and re-run validation.
+Issues:
+- Knip: 2 unused exports in helpers.ts
 ```
 
 ### Status Icons (Mobile-Optimized)
-- `✓` Pass (green checkmark)
-- `✗` Fail (red X)
+- `✓` Pass
+- `✗` Fail
 - `⊘` Skipped
-- `◐` Running (if showing progress)
+- `◐` Running
 
 ### Smart Skip Rules
 


### PR DESCRIPTION
## Summary
- Add parallel validation system optimized for iPhone Claude Code
- `validate.md` skill with parallel sub-agents for lint, knip, and test
- `/validate`, `/lint`, `/test`, `/build` commands for quick validation
- Mobile-friendly emoji status output (✓/✗/⊘)

## Test Plan
- [x] Tested parallel validation with sub-agents (all passed)
- [x] Verified build passes after parallel checks
- [ ] Test commands on iPhone Claude Code