### PR TITLE
perf(ci): optimize E2E with Docker image and tiered browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
 #              ├──> knip       │                      │
 #              ├──> test       │                      │
 #              └──> build ─────┼──> bundle-size       │
-#                              ├──> e2e (sharded)     │
+#                              ├──> e2e (3 shards) ───┼──> e2e-report
 #                              └──> lighthouse        │
 #                                                     │
 #   audit (independent) ──────────────────────────────┘
@@ -36,6 +36,7 @@ on:
 # - Per-branch caching with main fallback for faster PR builds
 # - E2E tests use sharding (3 shards) for parallel execution
 # - PRs run chromium only; main branch runs chromium + firefox + webkit
+# - e2e-report merges shard reports into a single HTML report for debugging
 #
 # =============================================================================
 
@@ -304,7 +305,7 @@ jobs:
           path: web-app/dist
 
       - name: Run E2E tests
-        run: npx playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/3
+        run: npx playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/3 --retries=2
 
       - name: Upload test results
         uses: actions/upload-artifact@v5
@@ -313,6 +314,41 @@ jobs:
           name: playwright-report-${{ matrix.browser }}-shard-${{ matrix.shard }}
           path: web-app/playwright-report/
           retention-days: 7
+
+  # Merge E2E shard reports into single HTML report for easier debugging
+  e2e-report:
+    name: E2E Report
+    needs: e2e
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          working-directory: web-app
+
+      - name: Download all shard reports
+        uses: actions/download-artifact@v5
+        with:
+          pattern: playwright-report-*
+          path: web-app/all-reports
+          merge-multiple: false
+
+      - name: Merge reports
+        run: npx playwright merge-reports --reporter=html ./all-reports/*
+
+      - name: Upload merged report
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-report-merged
+          path: web-app/playwright-report/
+          retention-days: 14
 
   # Lighthouse performance audit - uses build artifact
   lighthouse:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,15 +305,15 @@ jobs:
           path: web-app/dist
 
       - name: Run E2E tests
-        run: npx playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/3 --retries=2
+        run: npx playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/3 --retries=2 --reporter=blob
 
-      - name: Upload test results
+      - name: Upload blob report
         uses: actions/upload-artifact@v5
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report-${{ matrix.browser }}-shard-${{ matrix.shard }}
-          path: web-app/playwright-report/
-          retention-days: 7
+          name: blob-report-${{ matrix.browser }}-shard-${{ matrix.shard }}
+          path: web-app/blob-report/
+          retention-days: 1
 
   # Merge E2E shard reports into single HTML report for easier debugging
   e2e-report:
@@ -333,15 +333,15 @@ jobs:
         with:
           working-directory: web-app
 
-      - name: Download all shard reports
+      - name: Download all blob reports
         uses: actions/download-artifact@v5
         with:
-          pattern: playwright-report-*
-          path: web-app/all-reports
-          merge-multiple: false
+          pattern: blob-report-*
+          path: web-app/all-blob-reports
+          merge-multiple: true
 
       - name: Merge reports
-        run: npx playwright merge-reports --reporter=html ./all-reports/*
+        run: npx playwright merge-reports --reporter=html ./all-blob-reports
 
       - name: Upload merged report
         uses: actions/upload-artifact@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ on:
 #              ├──> knip       │                      │
 #              ├──> test       │                      │
 #              └──> build ─────┼──> bundle-size       │
-#                              ├──> e2e (chromium)    │
-#                              ├──> e2e (firefox)     │
+#                              ├──> e2e (sharded)     │
 #                              └──> lighthouse        │
 #                                                     │
 #   audit (independent) ──────────────────────────────┘
@@ -35,6 +34,8 @@ on:
 # - audit runs independently (doesn't need API types)
 # - build artifact is shared by bundle-size, e2e, and lighthouse
 # - Per-branch caching with main fallback for faster PR builds
+# - E2E tests use sharding (3 shards) for parallel execution
+# - PRs run chromium only; main branch runs chromium + firefox + webkit
 #
 # =============================================================================
 
@@ -267,16 +268,23 @@ jobs:
       - name: Check bundle size
         run: npm run size
 
-  # E2E tests - matrix across browsers, uses build artifact
+  # E2E tests - sharded across browsers, uses build artifact
+  # PRs: chromium only (fast feedback)
+  # main: chromium + firefox + webkit (full coverage)
+  # Uses pre-built Playwright Docker image (browsers pre-installed)
   e2e:
-    name: E2E (${{ matrix.browser }})
+    name: E2E (${{ matrix.browser }} ${{ matrix.shard }}/3)
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox]
+        # PRs: chromium only; main: all browsers
+        browser: ${{ github.event_name == 'pull_request' && fromJson('["chromium"]') || fromJson('["chromium", "firefox", "webkit"]') }}
+        shard: [1, 2, 3]
     defaults:
       run:
         working-directory: web-app
@@ -295,36 +303,14 @@ jobs:
           name: web-app-dist
           path: web-app/dist
 
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
-
-      # Cache Playwright browsers with fallback to older versions
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ steps.playwright-version.outputs.version }}
-          restore-keys: |
-            playwright-${{ runner.os }}-${{ matrix.browser }}-
-
-      # Install browser if not cached, always install system deps (fast & idempotent)
-      - name: Install Playwright browser
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install ${{ matrix.browser }}
-
-      - name: Install Playwright system dependencies
-        run: npx playwright install-deps ${{ matrix.browser }}
-
       - name: Run E2E tests
-        run: npx playwright test --project=${{ matrix.browser }}
+        run: npx playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/3
 
       - name: Upload test results
         uses: actions/upload-artifact@v5
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report-${{ matrix.browser }}
+          name: playwright-report-${{ matrix.browser }}-shard-${{ matrix.shard }}
           path: web-app/playwright-report/
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
 #              ├──> knip       │                      │
 #              ├──> test       │                      │
 #              └──> build ─────┼──> bundle-size       │
-#                              ├──> e2e (3 shards) ───┼──> e2e-report
+#                              ├──> e2e (per browser) │
 #                              └──> lighthouse        │
 #                                                     │
 #   audit (independent) ──────────────────────────────┘
@@ -34,9 +34,8 @@ on:
 # - audit runs independently (doesn't need API types)
 # - build artifact is shared by bundle-size, e2e, and lighthouse
 # - Per-branch caching with main fallback for faster PR builds
-# - E2E tests use sharding (3 shards) for parallel execution
 # - PRs run chromium only; main branch runs chromium + firefox + webkit
-# - e2e-report merges shard reports into a single HTML report for debugging
+# - E2E uses pre-built Playwright Docker image (no browser install overhead)
 #
 # =============================================================================
 
@@ -269,12 +268,12 @@ jobs:
       - name: Check bundle size
         run: npm run size
 
-  # E2E tests - sharded across browsers, uses build artifact
+  # E2E tests - per browser, uses build artifact
   # PRs: chromium only (fast feedback)
   # main: chromium + firefox + webkit (full coverage)
   # Uses pre-built Playwright Docker image (browsers pre-installed)
   e2e:
-    name: E2E (${{ matrix.browser }} ${{ matrix.shard }}/3)
+    name: E2E (${{ matrix.browser }})
     needs: build
     runs-on: ubuntu-latest
     container:
@@ -285,7 +284,6 @@ jobs:
       matrix:
         # PRs: chromium only; main: all browsers
         browser: ${{ github.event_name == 'pull_request' && fromJson('["chromium"]') || fromJson('["chromium", "firefox", "webkit"]') }}
-        shard: [1, 2, 3]
     defaults:
       run:
         working-directory: web-app
@@ -305,50 +303,15 @@ jobs:
           path: web-app/dist
 
       - name: Run E2E tests
-        run: npx playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shard }}/3 --retries=2 --reporter=blob
+        run: npx playwright test --project=${{ matrix.browser }} --retries=2
 
-      - name: Upload blob report
+      - name: Upload test results
         uses: actions/upload-artifact@v5
         if: ${{ !cancelled() }}
         with:
-          name: blob-report-${{ matrix.browser }}-shard-${{ matrix.shard }}
-          path: web-app/blob-report/
-          retention-days: 1
-
-  # Merge E2E shard reports into single HTML report for easier debugging
-  e2e-report:
-    name: E2E Report
-    needs: e2e
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web-app
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js with dependencies
-        uses: ./.github/actions/setup-node-deps
-        with:
-          working-directory: web-app
-
-      - name: Download all blob reports
-        uses: actions/download-artifact@v5
-        with:
-          pattern: blob-report-*
-          path: web-app/all-blob-reports
-          merge-multiple: true
-
-      - name: Merge reports
-        run: npx playwright merge-reports --reporter=html ./all-blob-reports
-
-      - name: Upload merged report
-        uses: actions/upload-artifact@v5
-        with:
-          name: playwright-report-merged
+          name: playwright-report-${{ matrix.browser }}
           path: web-app/playwright-report/
-          retention-days: 14
+          retention-days: 7
 
   # Lighthouse performance audit - uses build artifact
   lighthouse:


### PR DESCRIPTION
## Summary

Optimize E2E CI pipeline while keeping test suite small enough that sharding overhead isn't worth it.

**Changes:**
- Use pre-built Playwright Docker image (`mcr.microsoft.com/playwright:v1.57.0-noble`)
- PRs: chromium only for fast feedback (1 job)
- main: chromium + firefox + webkit for full coverage (3 parallel jobs)
- Add explicit `--retries=2` flag for visibility
- Reduce timeout from 30 to 15 minutes

**Removed (overhead > benefit for small test suite):**
- ~~Sharding~~ - 3x setup overhead outweighed parallelism
- ~~e2e-report merge job~~ - no longer needed

## Changes

| Before | After |
|--------|-------|
| 2 jobs (chromium, firefox) | PRs: 1 job (chromium) |
| | main: 3 jobs (chromium, firefox, webkit) |
| Browser install per job (~30-60s) | Pre-installed in Docker |
| 30 min timeout | 15 min timeout |
| No webkit | webkit on main branch |

## Test Plan

- CI workflow validates on push
- PR runs single chromium E2E job
- Main branch runs 3 browser jobs in parallel