### PR TITLE
feat(ocr): add manuscript parser and data collection tools

### DIFF
--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -488,6 +488,9 @@ function renderResultsState(container) {
               <button class="btn btn-outline btn-block" id="btn-export-json">
                 Export Full Sample (JSON)
               </button>
+              <button class="btn btn-outline btn-block" id="btn-copy-json">
+                Copy JSON to Clipboard
+              </button>
               <button class="btn btn-outline btn-block" id="btn-export-text">
                 Export Raw Text
               </button>
@@ -524,6 +527,21 @@ function renderResultsState(container) {
     if (result && appContext.sheetType) {
       const sample = collectSample(result, appContext.sheetType);
       exportSampleAsJSON(sample);
+    }
+  });
+
+  const copyJsonBtn = document.getElementById('btn-copy-json');
+  copyJsonBtn?.addEventListener('click', async () => {
+    if (result && appContext.sheetType) {
+      const sample = collectSample(result, appContext.sheetType);
+      const json = JSON.stringify(sample, null, 2);
+      const success = await copyToClipboard(json);
+      if (success) {
+        copyJsonBtn.textContent = '✓ Copied!';
+        setTimeout(() => {
+          copyJsonBtn.textContent = 'Copy JSON to Clipboard';
+        }, 2000);
+      }
     }
   });
 

--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -27,6 +27,13 @@ import {
 } from './services/DataCollector.js';
 
 /* ==============================================
+ * CONSTANTS
+ * ============================================== */
+
+/** Duration in ms to show copy success feedback before resetting button text */
+const COPY_FEEDBACK_DURATION_MS = 2000;
+
+/* ==============================================
  * APPLICATION STATE
  * ============================================== */
 
@@ -87,6 +94,26 @@ let playerComparison = null;
 
 /** @type {RosterCropEditor | null} */
 let rosterCropEditor = null;
+
+/* ==============================================
+ * HELPERS
+ * ============================================== */
+
+/**
+ * Copy text to clipboard and show feedback on a button
+ * @param {HTMLButtonElement} button - The button to update with feedback
+ * @param {string} text - The text to copy
+ * @param {string} originalLabel - The button's original text to restore
+ */
+async function copyWithFeedback(button, text, originalLabel) {
+  const success = await copyToClipboard(text);
+  if (success) {
+    button.textContent = '✓ Copied!';
+    setTimeout(() => {
+      button.textContent = originalLabel;
+    }, COPY_FEEDBACK_DURATION_MS);
+  }
+}
 
 /* ==============================================
  * STATE MACHINE
@@ -485,19 +512,19 @@ function renderResultsState(container) {
           <details class="ocr-results__details">
             <summary class="ocr-results__summary">📊 Data Export (for parser improvement)</summary>
             <div class="flex flex-col gap-sm mt-md">
-              <button class="btn btn-outline btn-block" id="btn-export-json">
+              <button class="btn btn-outline btn-block" id="btn-export-json" aria-label="Download OCR sample data as JSON file">
                 Export Full Sample (JSON)
               </button>
-              <button class="btn btn-outline btn-block" id="btn-copy-json">
+              <button class="btn btn-outline btn-block" id="btn-copy-json" aria-label="Copy OCR sample JSON data to clipboard">
                 Copy JSON to Clipboard
               </button>
-              <button class="btn btn-outline btn-block" id="btn-export-text">
+              <button class="btn btn-outline btn-block" id="btn-export-text" aria-label="Download raw OCR text as text file">
                 Export Raw Text
               </button>
-              <button class="btn btn-outline btn-block" id="btn-copy-text">
+              <button class="btn btn-outline btn-block" id="btn-copy-text" aria-label="Copy raw OCR text to clipboard">
                 Copy Text to Clipboard
               </button>
-              <button class="btn btn-outline btn-block" id="btn-log-summary">
+              <button class="btn btn-outline btn-block" id="btn-log-summary" aria-label="Log OCR sample summary to browser console">
                 Log Summary to Console
               </button>
             </div>
@@ -532,16 +559,10 @@ function renderResultsState(container) {
 
   const copyJsonBtn = document.getElementById('btn-copy-json');
   copyJsonBtn?.addEventListener('click', async () => {
-    if (result && appContext.sheetType) {
+    if (result && appContext.sheetType && copyJsonBtn) {
       const sample = collectSample(result, appContext.sheetType);
       const json = JSON.stringify(sample, null, 2);
-      const success = await copyToClipboard(json);
-      if (success) {
-        copyJsonBtn.textContent = '✓ Copied!';
-        setTimeout(() => {
-          copyJsonBtn.textContent = 'Copy JSON to Clipboard';
-        }, 2000);
-      }
+      await copyWithFeedback(copyJsonBtn, json, 'Copy JSON to Clipboard');
     }
   });
 
@@ -554,14 +575,8 @@ function renderResultsState(container) {
 
   const copyTextBtn = document.getElementById('btn-copy-text');
   copyTextBtn?.addEventListener('click', async () => {
-    if (result) {
-      const success = await copyToClipboard(result.fullText);
-      if (success) {
-        copyTextBtn.textContent = '✓ Copied!';
-        setTimeout(() => {
-          copyTextBtn.textContent = 'Copy Text to Clipboard';
-        }, 2000);
-      }
+    if (result && copyTextBtn) {
+      await copyWithFeedback(copyTextBtn, result.fullText, 'Copy Text to Clipboard');
     }
   });
 

--- a/ocr-poc/src/main.js
+++ b/ocr-poc/src/main.js
@@ -18,6 +18,13 @@ import { OCRProgress } from './components/OCRProgress.js';
 import { OCRFactory } from './services/ocr/index.js';
 import { PlayerComparison } from './components/PlayerComparison.js';
 import { RosterCropEditor } from './components/RosterCropEditor.js';
+import {
+  collectSample,
+  exportSampleAsJSON,
+  exportRawText,
+  logSampleSummary,
+  copyToClipboard,
+} from './services/DataCollector.js';
 
 /* ==============================================
  * APPLICATION STATE
@@ -472,6 +479,26 @@ function renderResultsState(container) {
               Scan Another Sheet
             </button>
           </div>
+
+          <hr class="mt-lg mb-lg" style="border: none; border-top: 1px solid var(--color-border);" />
+
+          <details class="ocr-results__details">
+            <summary class="ocr-results__summary">📊 Data Export (for parser improvement)</summary>
+            <div class="flex flex-col gap-sm mt-md">
+              <button class="btn btn-outline btn-block" id="btn-export-json">
+                Export Full Sample (JSON)
+              </button>
+              <button class="btn btn-outline btn-block" id="btn-export-text">
+                Export Raw Text
+              </button>
+              <button class="btn btn-outline btn-block" id="btn-copy-text">
+                Copy Text to Clipboard
+              </button>
+              <button class="btn btn-outline btn-block" id="btn-log-summary">
+                Log Summary to Console
+              </button>
+            </div>
+          </details>
         </div>
       </div>
     </div>
@@ -490,6 +517,43 @@ function renderResultsState(container) {
 
   const newScanBtn = document.getElementById('btn-new-scan');
   newScanBtn?.addEventListener('click', handleStartOver);
+
+  // Bind data export buttons
+  const exportJsonBtn = document.getElementById('btn-export-json');
+  exportJsonBtn?.addEventListener('click', () => {
+    if (result && appContext.sheetType) {
+      const sample = collectSample(result, appContext.sheetType);
+      exportSampleAsJSON(sample);
+    }
+  });
+
+  const exportTextBtn = document.getElementById('btn-export-text');
+  exportTextBtn?.addEventListener('click', () => {
+    if (result && appContext.sheetType) {
+      exportRawText(result, appContext.sheetType);
+    }
+  });
+
+  const copyTextBtn = document.getElementById('btn-copy-text');
+  copyTextBtn?.addEventListener('click', async () => {
+    if (result) {
+      const success = await copyToClipboard(result.fullText);
+      if (success) {
+        copyTextBtn.textContent = '✓ Copied!';
+        setTimeout(() => {
+          copyTextBtn.textContent = 'Copy Text to Clipboard';
+        }, 2000);
+      }
+    }
+  });
+
+  const logSummaryBtn = document.getElementById('btn-log-summary');
+  logSummaryBtn?.addEventListener('click', () => {
+    if (result && appContext.sheetType) {
+      const sample = collectSample(result, appContext.sheetType);
+      logSampleSummary(sample);
+    }
+  });
 }
 
 /**

--- a/ocr-poc/src/services/DataCollector.js
+++ b/ocr-poc/src/services/DataCollector.js
@@ -1,0 +1,185 @@
+/**
+ * Data Collector Service
+ *
+ * Collects and exports OCR data samples for parser improvement.
+ * Exports include raw OCR output, sheet type, and parsed results.
+ */
+
+import { parseGameSheet } from './PlayerListParser.js';
+
+/**
+ * @typedef {import('./ocr/StubOCR.js').OCRResult} OCRResult
+ * @typedef {import('./PlayerListParser.js').ParsedGameSheet} ParsedGameSheet
+ */
+
+/**
+ * @typedef {Object} DataSample
+ * @property {string} id - Unique sample ID
+ * @property {string} timestamp - ISO timestamp
+ * @property {'electronic' | 'manuscript'} sheetType - Sheet type
+ * @property {OCRResult} ocrResult - Raw OCR result
+ * @property {ParsedGameSheet | null} parsedResult - Parsed game sheet (if successful)
+ * @property {string | null} parseError - Parse error message (if failed)
+ * @property {Object} stats - Statistics about the OCR result
+ */
+
+/**
+ * Generate a unique ID for a sample
+ * @returns {string}
+ */
+function generateId() {
+  return `sample-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Calculate statistics from OCR result
+ * @param {OCRResult} ocrResult
+ * @returns {Object}
+ */
+function calculateStats(ocrResult) {
+  const lines = ocrResult.fullText.split('\n').filter((l) => l.trim().length > 0);
+  const tabLines = lines.filter((l) => l.includes('\t'));
+  const avgConfidence =
+    ocrResult.words.length > 0
+      ? Math.round(ocrResult.words.reduce((sum, w) => sum + w.confidence, 0) / ocrResult.words.length)
+      : 0;
+
+  // Count lines matching player pattern (number followed by name)
+  const playerPatternRegex = /^\d{1,2}[\s\t.:_-]+[A-Za-zÀ-ÿ]/;
+  const playerLikeLines = lines.filter((l) => playerPatternRegex.test(l.trim()));
+
+  // Check for common section markers
+  const hasOfficialMarker = lines.some((l) => l.toUpperCase().includes('OFFICIAL'));
+  const hasLiberoMarker = lines.some((l) => l.toUpperCase().includes('LIBERO'));
+  const hasSignatureMarker = lines.some((l) => l.toUpperCase().includes('SIGNATURE'));
+
+  return {
+    totalLines: lines.length,
+    tabSeparatedLines: tabLines.length,
+    tabLineRatio: lines.length > 0 ? (tabLines.length / lines.length).toFixed(2) : 0,
+    totalWords: ocrResult.words.length,
+    avgConfidence,
+    playerLikeLines: playerLikeLines.length,
+    hasOfficialMarker,
+    hasLiberoMarker,
+    hasSignatureMarker,
+    charCount: ocrResult.fullText.length,
+  };
+}
+
+/**
+ * Collect a data sample from OCR result
+ * @param {OCRResult} ocrResult - The OCR result
+ * @param {'electronic' | 'manuscript'} sheetType - The sheet type
+ * @returns {DataSample}
+ */
+export function collectSample(ocrResult, sheetType) {
+  let parsedResult = null;
+  let parseError = null;
+
+  try {
+    parsedResult = parseGameSheet(ocrResult.fullText);
+  } catch (error) {
+    parseError = error instanceof Error ? error.message : String(error);
+  }
+
+  return {
+    id: generateId(),
+    timestamp: new Date().toISOString(),
+    sheetType,
+    ocrResult,
+    parsedResult,
+    parseError,
+    stats: calculateStats(ocrResult),
+  };
+}
+
+/**
+ * Export sample as downloadable JSON file
+ * @param {DataSample} sample - The sample to export
+ */
+export function exportSampleAsJSON(sample) {
+  const json = JSON.stringify(sample, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `ocr-sample-${sample.sheetType}-${sample.id}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Export just the raw OCR text as a text file
+ * @param {OCRResult} ocrResult - The OCR result
+ * @param {'electronic' | 'manuscript'} sheetType - The sheet type
+ */
+export function exportRawText(ocrResult, sheetType) {
+  const blob = new Blob([ocrResult.fullText], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `ocr-text-${sheetType}-${Date.now()}.txt`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Log sample summary to console for quick inspection
+ * @param {DataSample} sample
+ */
+export function logSampleSummary(sample) {
+  console.log('=== OCR Data Sample ===');
+  console.log('ID:', sample.id);
+  console.log('Type:', sample.sheetType);
+  console.log('Timestamp:', sample.timestamp);
+  console.log('\n--- Statistics ---');
+  console.table(sample.stats);
+
+  if (sample.parsedResult) {
+    console.log('\n--- Parsed Result ---');
+    console.log('Team A:', sample.parsedResult.teamA.name);
+    console.log('  Players:', sample.parsedResult.teamA.players.length);
+    console.log('  Officials:', sample.parsedResult.teamA.officials.length);
+    console.log('Team B:', sample.parsedResult.teamB.name);
+    console.log('  Players:', sample.parsedResult.teamB.players.length);
+    console.log('  Officials:', sample.parsedResult.teamB.officials.length);
+    console.log('Warnings:', sample.parsedResult.warnings);
+  } else {
+    console.log('\n--- Parse Error ---');
+    console.log(sample.parseError);
+  }
+
+  console.log('\n--- Raw OCR Text ---');
+  console.log(sample.ocrResult.fullText);
+  console.log('======================');
+}
+
+/**
+ * Copy OCR text to clipboard
+ * @param {string} text - Text to copy
+ * @returns {Promise<boolean>} - Whether copy succeeded
+ */
+export async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Fallback for older browsers
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const success = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return success;
+  }
+}

--- a/ocr-poc/src/services/DataCollector.js
+++ b/ocr-poc/src/services/DataCollector.js
@@ -24,11 +24,23 @@ import { parseGameSheet } from './PlayerListParser.js';
  */
 
 /**
+ * Start index for slicing base36 random string (skip "0." prefix from toString(36))
+ */
+const RANDOM_SUFFIX_START = 2;
+
+/**
+ * End index for slicing base36 random string (produces 6-char suffix)
+ */
+const RANDOM_SUFFIX_END = 8;
+
+/**
  * Generate a unique ID for a sample
+ * Format: sample-{timestamp}-{6-char-random}
  * @returns {string}
  */
 function generateId() {
-  return `sample-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const randomSuffix = Math.random().toString(36).slice(RANDOM_SUFFIX_START, RANDOM_SUFFIX_END);
+  return `sample-${Date.now()}-${randomSuffix}`;
 }
 
 /**

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -211,6 +211,18 @@ body {
   background-color: var(--color-gray-300);
 }
 
+/* Outline button */
+.btn-outline {
+  background-color: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-strong);
+}
+
+.btn-outline:hover:not(:disabled) {
+  background-color: var(--color-gray-100);
+  border-color: var(--color-gray-400);
+}
+
 /* Full width button variant */
 .btn-block {
   width: 100%;

--- a/web-app/src/features/ocr/index.ts
+++ b/web-app/src/features/ocr/index.ts
@@ -74,12 +74,21 @@ export { StubOCR } from './services/stub-ocr';
 // Player list parsing
 export {
   parseGameSheet,
+  parseGameSheetWithType,
+  parseElectronicSheet,
   parsePlayerName,
   parseOfficialName,
   normalizeName,
   getAllPlayers,
   getAllOfficials,
 } from './utils/player-list-parser';
+export type { ParseGameSheetOptions } from './utils/player-list-parser';
+
+// Manuscript parsing
+export { parseManuscriptSheet } from './utils/manuscript-parser';
+
+// Scoresheet type
+export type { ScoresheetType } from './utils/scoresheet-detector';
 
 // Roster comparison
 export {

--- a/web-app/src/features/ocr/utils/manuscript-parser.test.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseManuscriptSheet,
+  correctDigits,
+  correctLetters,
+  extractShirtNumber,
+  normalizeName,
+  parsePlayerName,
+  parseOfficialName,
+} from './manuscript-parser';
+
+describe('OCR Error Correction', () => {
+  describe('correctDigits', () => {
+    it('corrects O to 0', () => {
+      expect(correctDigits('O')).toBe('0');
+      expect(correctDigits('1O')).toBe('10');
+    });
+
+    it('corrects I/l to 1', () => {
+      expect(correctDigits('I')).toBe('1');
+      expect(correctDigits('l')).toBe('1');
+      expect(correctDigits('Il')).toBe('11');
+    });
+
+    it('corrects S/s to 5', () => {
+      expect(correctDigits('S')).toBe('5');
+      expect(correctDigits('s')).toBe('5');
+    });
+
+    it('preserves valid digits', () => {
+      expect(correctDigits('123')).toBe('123');
+      expect(correctDigits('99')).toBe('99');
+    });
+  });
+
+  describe('correctLetters', () => {
+    it('corrects 0 to O', () => {
+      expect(correctLetters('0')).toBe('O');
+      expect(correctLetters('M0LLER')).toBe('MOLLER');
+    });
+
+    it('corrects 1 to I', () => {
+      expect(correctLetters('1')).toBe('I');
+    });
+
+    it('corrects 5 to S', () => {
+      expect(correctLetters('5CHMIDT')).toBe('SCHMIDT');
+    });
+
+    it('preserves valid letters', () => {
+      expect(correctLetters('MÜLLER')).toBe('MÜLLER');
+    });
+  });
+
+  describe('extractShirtNumber', () => {
+    it('extracts valid numbers', () => {
+      expect(extractShirtNumber('1')).toBe(1);
+      expect(extractShirtNumber('12')).toBe(12);
+      expect(extractShirtNumber('99')).toBe(99);
+    });
+
+    it('corrects OCR errors in numbers', () => {
+      expect(extractShirtNumber('O1')).toBe(1); // O -> 0, but 01 -> 1
+      expect(extractShirtNumber('l2')).toBe(12); // l -> 1
+      expect(extractShirtNumber('I5')).toBe(15); // I -> 1
+    });
+
+    it('returns null for invalid numbers', () => {
+      expect(extractShirtNumber('')).toBe(null);
+      expect(extractShirtNumber('100')).toBe(null); // > 99
+      expect(extractShirtNumber('abc')).toBe(null);
+    });
+
+    it('handles whitespace', () => {
+      expect(extractShirtNumber('  12  ')).toBe(12);
+    });
+  });
+});
+
+describe('Name Parsing', () => {
+  describe('normalizeName', () => {
+    it('converts to title case', () => {
+      expect(normalizeName('MÜLLER')).toBe('Müller');
+      expect(normalizeName('anna maria')).toBe('Anna Maria');
+    });
+
+    it('handles empty strings', () => {
+      expect(normalizeName('')).toBe('');
+    });
+
+    it('applies letter corrections', () => {
+      expect(normalizeName('M0LLER')).toBe('Moller');
+    });
+  });
+
+  describe('parsePlayerName', () => {
+    it('parses LASTNAME FIRSTNAME format', () => {
+      const result = parsePlayerName('MÜLLER ANNA');
+      expect(result.lastName).toBe('Müller');
+      expect(result.firstName).toBe('Anna');
+      expect(result.displayName).toBe('Anna Müller');
+    });
+
+    it('handles single name', () => {
+      const result = parsePlayerName('MÜLLER');
+      expect(result.lastName).toBe('Müller');
+      expect(result.firstName).toBe('');
+    });
+
+    it('handles multiple first names', () => {
+      const result = parsePlayerName('MÜLLER ANNA MARIA');
+      expect(result.lastName).toBe('Müller');
+      expect(result.firstName).toBe('Anna Maria');
+    });
+
+    it('handles empty input', () => {
+      const result = parsePlayerName('');
+      expect(result.lastName).toBe('');
+      expect(result.firstName).toBe('');
+    });
+  });
+
+  describe('parseOfficialName', () => {
+    it('parses Firstname Lastname format', () => {
+      const result = parseOfficialName('Hans Trainer');
+      expect(result.firstName).toBe('Hans');
+      expect(result.lastName).toBe('Trainer');
+    });
+
+    it('handles single name', () => {
+      const result = parseOfficialName('Coach');
+      expect(result.lastName).toBe('Coach');
+      expect(result.firstName).toBe('');
+    });
+  });
+});
+
+describe('parseManuscriptSheet', () => {
+  it('parses a basic manuscript scoresheet', () => {
+    const ocrText = `Team A VBC Heimteam
+1 MÜLLER ANNA
+2 WEBER MARIE
+3 SCHMIDT LISA
+
+Team B VBC Gastteam
+4 FISCHER JULIA
+5 KOCH CLARA
+6 BRUNNER LEA`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(3);
+    expect(result.teamA.players[0]!.lastName).toBe('Müller');
+    expect(result.teamA.players[0]!.firstName).toBe('Anna');
+    expect(result.teamA.players[0]!.shirtNumber).toBe(1);
+
+    expect(result.teamB.players).toHaveLength(3);
+    expect(result.teamB.players[0]!.lastName).toBe('Fischer');
+    expect(result.teamB.players[0]!.shirtNumber).toBe(4);
+  });
+
+  it('handles OCR errors in numbers', () => {
+    const ocrText = `Team A
+O1 MÜLLER ANNA
+l2 WEBER MARIE`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(2);
+    expect(result.teamA.players[0]!.shirtNumber).toBe(1); // O1 -> 01 -> 1
+    expect(result.teamA.players[1]!.shirtNumber).toBe(12); // l2 -> 12
+  });
+
+  it('handles various number-name separators', () => {
+    const ocrText = `Team A
+1. MÜLLER ANNA
+2: WEBER MARIE
+3 - SCHMIDT LISA`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(3);
+    expect(result.teamA.players[0]!.lastName).toBe('Müller');
+    expect(result.teamA.players[1]!.lastName).toBe('Weber');
+    expect(result.teamA.players[2]!.lastName).toBe('Schmidt');
+  });
+
+  it('parses officials', () => {
+    const ocrText = `Team A
+1 MÜLLER ANNA
+C Hans Trainer
+AC Maria Assistentin`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(1);
+    expect(result.teamA.officials).toHaveLength(2);
+    expect(result.teamA.officials[0]!.role).toBe('C');
+    expect(result.teamA.officials[0]!.displayName).toBe('Hans Trainer');
+    expect(result.teamA.officials[1]!.role).toBe('AC');
+  });
+
+  it('handles empty input', () => {
+    const result = parseManuscriptSheet('');
+    expect(result.warnings).toContain('No OCR text provided');
+    expect(result.teamA.players).toHaveLength(0);
+    expect(result.teamB.players).toHaveLength(0);
+  });
+
+  it('handles missing team B', () => {
+    const ocrText = `Team A VBC Heimteam
+1 MÜLLER ANNA
+2 WEBER MARIE`;
+
+    const result = parseManuscriptSheet(ocrText);
+    expect(result.teamA.players).toHaveLength(2);
+    expect(result.teamB.players).toHaveLength(0);
+  });
+
+  it('detects HOME/AWAY team markers', () => {
+    const ocrText = `HOME VBC Heim
+1 MÜLLER ANNA
+
+AWAY VBC Gast
+2 FISCHER JULIA`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(1);
+    expect(result.teamA.players[0]!.lastName).toBe('Müller');
+    expect(result.teamB.players).toHaveLength(1);
+    expect(result.teamB.players[0]!.lastName).toBe('Fischer');
+  });
+
+  it('ignores libero markers but parses libero players', () => {
+    const ocrText = `Team A
+1 MÜLLER ANNA
+LIBERO
+2 BRUNNER LEA`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(2);
+    expect(result.teamA.players[1]!.lastName).toBe('Brunner');
+  });
+
+  it('stops parsing at signature section', () => {
+    const ocrText = `Team A
+1 MÜLLER ANNA
+SIGNATURES
+Some signature text`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(1);
+  });
+
+  it('handles German team markers', () => {
+    const ocrText = `MANNSCHAFT A VBC Zürich
+1 MÜLLER ANNA
+
+MANNSCHAFT B VBC Basel
+2 WEBER MARIE`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(1);
+    expect(result.teamB.players).toHaveLength(1);
+  });
+
+  it('handles French team markers', () => {
+    const ocrText = `ÉQUIPE A VBC Genève
+1 MÜLLER ANNA
+
+ÉQUIPE B VBC Lausanne
+2 FISCHER JULIA`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    expect(result.teamA.players).toHaveLength(1);
+    expect(result.teamB.players).toHaveLength(1);
+  });
+});
+
+describe('parseGameSheetWithType', () => {
+  // Import at test time to avoid circular dependency issues
+  it('routes to manuscript parser when type is manuscript', async () => {
+    const { parseGameSheetWithType } = await import('./player-list-parser');
+
+    const ocrText = `Team A VBC Test
+1 MÜLLER ANNA`;
+
+    const result = parseGameSheetWithType(ocrText, { type: 'manuscript' });
+
+    expect(result.teamA.players).toHaveLength(1);
+    expect(result.teamA.players[0]!.lastName).toBe('Müller');
+  });
+
+  it('routes to electronic parser by default', async () => {
+    const { parseGameSheetWithType } = await import('./player-list-parser');
+
+    const ocrText = `VBC Heimteam\tVBC Gastteam
+N.\tName of the player\tLicense\tN.\tName of the player\tLicense
+1\tMÜLLER ANNA\tOK\t3\tSCHMIDT LISA\tOK`;
+
+    const result = parseGameSheetWithType(ocrText);
+
+    expect(result.teamA.players).toHaveLength(1);
+    expect(result.teamA.players[0]!.lastName).toBe('Müller');
+    expect(result.teamB.players).toHaveLength(1);
+  });
+
+  it('routes to electronic parser when type is electronic', async () => {
+    const { parseGameSheetWithType } = await import('./player-list-parser');
+
+    const ocrText = `VBC Heimteam\tVBC Gastteam
+N.\tName of the player\tLicense\tN.\tName of the player\tLicense
+1\tMÜLLER ANNA\tOK\t3\tSCHMIDT LISA\tOK`;
+
+    const result = parseGameSheetWithType(ocrText, { type: 'electronic' });
+
+    expect(result.teamA.name).toBe('VBC Heimteam');
+    expect(result.teamB.name).toBe('VBC Gastteam');
+  });
+});

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -1,0 +1,619 @@
+/**
+ * Manuscript Scoresheet Parser
+ *
+ * Parses OCR text from handwritten (manuscript) scoresheets.
+ * Handles common OCR artifacts and variable formatting typical of handwritten text.
+ *
+ * Key differences from electronic parser:
+ * - No consistent tab separation - uses pattern matching
+ * - Handles common OCR character misreads (0/O, 1/I/l, 5/S, etc.)
+ * - More flexible spacing and delimiter handling
+ * - Fuzzy number recognition
+ */
+
+import type {
+  ParsedPlayer,
+  ParsedOfficial,
+  ParsedTeam,
+  ParsedGameSheet,
+  OfficialRole,
+} from '../types';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Maximum valid shirt number */
+const MAX_SHIRT_NUMBER = 99;
+
+/** Minimum name length to consider valid */
+const MIN_NAME_LENGTH = 2;
+
+/** Minimum length for team name text */
+const MIN_TEAM_NAME_LENGTH = 3;
+
+/** Minimum ratio of letters in team name */
+const MIN_LETTER_RATIO = 0.6;
+
+/** Valid official roles */
+const VALID_ROLES = new Set(['C', 'AC', 'AC2', 'AC3', 'AC4']);
+
+// =============================================================================
+// OCR Error Correction Maps
+// =============================================================================
+
+/**
+ * Common OCR character substitutions for digits
+ * Maps misread characters to their likely intended digit
+ */
+const DIGIT_CORRECTIONS: Record<string, string> = {
+  O: '0',
+  o: '0',
+  Q: '0',
+  D: '0',
+  I: '1',
+  l: '1',
+  i: '1',
+  '|': '1',
+  Z: '2',
+  z: '2',
+  E: '3',
+  A: '4',
+  S: '5',
+  s: '5',
+  G: '6',
+  b: '6',
+  T: '7',
+  B: '8',
+  g: '9',
+  q: '9',
+};
+
+/**
+ * Common OCR character substitutions for letters
+ * Maps misread characters to their likely intended letter
+ */
+const LETTER_CORRECTIONS: Record<string, string> = {
+  '0': 'O',
+  '1': 'I',
+  '|': 'I',
+  '5': 'S',
+  '8': 'B',
+  '@': 'A',
+  '&': 'A',
+  '€': 'E',
+  '£': 'L',
+  '¢': 'C',
+};
+
+// =============================================================================
+// OCR Correction Utilities
+// =============================================================================
+
+/**
+ * Correct common OCR errors in a number string
+ */
+export function correctDigits(text: string): string {
+  return text
+    .split('')
+    .map((char) => DIGIT_CORRECTIONS[char] ?? char)
+    .join('');
+}
+
+/**
+ * Correct common OCR errors in a letter string
+ */
+export function correctLetters(text: string): string {
+  return text
+    .split('')
+    .map((char) => LETTER_CORRECTIONS[char] ?? char)
+    .join('');
+}
+
+/**
+ * Try to extract a valid shirt number from a string
+ * Applies OCR corrections and validates the result
+ */
+export function extractShirtNumber(text: string): number | null {
+  if (!text) return null;
+
+  // Clean and correct the text
+  const cleaned = text.trim();
+  const corrected = correctDigits(cleaned);
+
+  // Try to parse as number
+  const match = /^(\d{1,2})$/.exec(corrected);
+  if (match) {
+    const num = parseInt(match[1]!, 10);
+    if (num >= 1 && num <= MAX_SHIRT_NUMBER) {
+      return num;
+    }
+  }
+
+  return null;
+}
+
+// =============================================================================
+// Name Parsing Utilities
+// =============================================================================
+
+/**
+ * Normalize a name from OCR - handles various case formats
+ */
+export function normalizeName(name: string): string {
+  if (!name) return '';
+
+  // Apply letter corrections
+  const corrected = correctLetters(name);
+
+  // Normalize to title case
+  return corrected
+    .toLowerCase()
+    .split(/[\s-]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+/**
+ * Parse a player name - tries both LASTNAME FIRSTNAME and FIRSTNAME LASTNAME formats
+ */
+export function parsePlayerName(rawName: string): {
+  lastName: string;
+  firstName: string;
+  displayName: string;
+} {
+  if (!rawName || typeof rawName !== 'string') {
+    return { lastName: '', firstName: '', displayName: '' };
+  }
+
+  const trimmed = rawName.trim();
+  const parts = trimmed.split(/\s+/).filter((p) => p.length > 0);
+
+  if (parts.length === 0) {
+    return { lastName: '', firstName: '', displayName: '' };
+  }
+
+  if (parts.length === 1) {
+    const lastName = normalizeName(parts[0]!);
+    return { lastName, firstName: '', displayName: lastName };
+  }
+
+  // For manuscript, assume LASTNAME FIRSTNAME format (same as electronic)
+  // The first part is the last name, rest are first names
+  const lastName = normalizeName(parts[0]!);
+  const firstName = parts.slice(1).map(normalizeName).join(' ');
+  const displayName = `${firstName} ${lastName}`;
+
+  return { lastName, firstName, displayName };
+}
+
+/**
+ * Parse an official name - format is typically "Firstname Lastname"
+ */
+export function parseOfficialName(rawName: string): {
+  lastName: string;
+  firstName: string;
+  displayName: string;
+} {
+  if (!rawName || typeof rawName !== 'string') {
+    return { lastName: '', firstName: '', displayName: '' };
+  }
+
+  const trimmed = rawName.trim();
+  const parts = trimmed.split(/\s+/).filter((p) => p.length > 0);
+
+  if (parts.length === 0) {
+    return { lastName: '', firstName: '', displayName: '' };
+  }
+
+  if (parts.length === 1) {
+    const name = normalizeName(parts[0]!);
+    return { lastName: name, firstName: '', displayName: name };
+  }
+
+  // For officials, format is "Firstname Lastname" - last part is last name
+  const lastName = normalizeName(parts[parts.length - 1]!);
+  const firstName = parts.slice(0, -1).map(normalizeName).join(' ');
+  const displayName = `${firstName} ${lastName}`;
+
+  return { lastName, firstName, displayName };
+}
+
+// =============================================================================
+// Line Pattern Detection
+// =============================================================================
+
+/**
+ * Pattern for detecting a player line in manuscript format
+ * Matches: number followed by name, with various separators
+ */
+const PLAYER_LINE_PATTERN = /^(\d{1,2})[\s.:_-]+([A-Za-zÀ-ÿ\s]+)/;
+
+/**
+ * Pattern for detecting a player line with OCR errors
+ * More lenient - allows OCR-misread digits
+ */
+const PLAYER_LINE_LENIENT = /^([0-9OoIlZzSsGgBb]{1,2})[\s.:_-]+([A-Za-zÀ-ÿ\s]+)/;
+
+/**
+ * Pattern for detecting an official line
+ * Matches: C/AC/AC2/AC3/AC4 followed by name
+ */
+const OFFICIAL_LINE_PATTERN = /^(C|AC\d?)[\s.:_-]+([A-Za-zÀ-ÿ\s]+)/i;
+
+/**
+ * Check if a line contains team section marker
+ */
+function isTeamSectionMarker(line: string): boolean {
+  const upper = line.toUpperCase();
+  return (
+    upper.includes('TEAM A') ||
+    upper.includes('TEAM B') ||
+    upper.includes('ÉQUIPE A') ||
+    upper.includes('ÉQUIPE B') ||
+    upper.includes('MANNSCHAFT A') ||
+    upper.includes('MANNSCHAFT B') ||
+    upper.includes('HOME') ||
+    upper.includes('AWAY') ||
+    upper.includes('HEIM') ||
+    upper.includes('GAST')
+  );
+}
+
+/**
+ * Check if a line indicates the libero section
+ */
+function isLiberoMarker(line: string): boolean {
+  return line.toUpperCase().includes('LIBERO');
+}
+
+/**
+ * Check if a line indicates the officials section
+ */
+function isOfficialsMarker(line: string): boolean {
+  const upper = line.toUpperCase();
+  return upper.includes('OFFICIAL') || upper.includes('COACH') || upper.includes('TRAINER');
+}
+
+/**
+ * Check if a line indicates end of player data
+ */
+function isEndMarker(line: string): boolean {
+  const upper = line.toUpperCase();
+  return (
+    upper.includes('SIGNATURE') ||
+    upper.includes('CAPTAIN') ||
+    upper.includes('REFEREE') ||
+    upper.includes('ARBITRE')
+  );
+}
+
+/**
+ * Try to extract a player from a line
+ */
+function tryExtractPlayer(line: string): ParsedPlayer | null {
+  // Try strict pattern first
+  let match = PLAYER_LINE_PATTERN.exec(line);
+  if (!match) {
+    // Try lenient pattern with OCR correction
+    match = PLAYER_LINE_LENIENT.exec(line);
+  }
+
+  if (!match) return null;
+
+  const numberStr = match[1]!;
+  const nameStr = match[2]!.trim();
+
+  // Extract and validate shirt number
+  const shirtNumber = extractShirtNumber(numberStr);
+
+  // Validate name length
+  if (nameStr.length < MIN_NAME_LENGTH) return null;
+
+  const parsed = parsePlayerName(nameStr);
+
+  return {
+    shirtNumber,
+    lastName: parsed.lastName,
+    firstName: parsed.firstName,
+    displayName: parsed.displayName,
+    rawName: nameStr,
+    licenseStatus: '', // Not typically visible in manuscript
+  };
+}
+
+/**
+ * Try to extract an official from a line
+ */
+function tryExtractOfficial(line: string): ParsedOfficial | null {
+  const match = OFFICIAL_LINE_PATTERN.exec(line);
+  if (!match) return null;
+
+  const roleStr = match[1]!.toUpperCase();
+  const nameStr = match[2]!.trim();
+
+  // Validate role
+  if (!VALID_ROLES.has(roleStr)) return null;
+
+  // Validate name length
+  if (nameStr.length < MIN_NAME_LENGTH) return null;
+
+  const parsed = parseOfficialName(nameStr);
+
+  return {
+    role: roleStr as OfficialRole,
+    lastName: parsed.lastName,
+    firstName: parsed.firstName,
+    displayName: parsed.displayName,
+    rawName: nameStr,
+  };
+}
+
+// =============================================================================
+// Team Detection and Splitting
+// =============================================================================
+
+/**
+ * Try to extract team name from a line
+ */
+function extractTeamName(line: string): string | null {
+  const trimmed = line.trim();
+
+  // Skip empty lines
+  if (trimmed.length < MIN_TEAM_NAME_LENGTH) return null;
+
+  // Skip lines that look like player data
+  if (PLAYER_LINE_PATTERN.test(trimmed)) return null;
+  if (PLAYER_LINE_LENIENT.test(trimmed)) return null;
+
+  // Skip section markers
+  if (isLiberoMarker(trimmed)) return null;
+  if (isOfficialsMarker(trimmed)) return null;
+  if (isEndMarker(trimmed)) return null;
+
+  // Check if it looks like a team name (mostly letters, maybe some spaces/hyphens)
+  const letterCount = (trimmed.match(/[A-Za-zÀ-ÿ]/g) ?? []).length;
+  if (letterCount >= MIN_TEAM_NAME_LENGTH && letterCount / trimmed.length > MIN_LETTER_RATIO) {
+    return trimmed;
+  }
+
+  return null;
+}
+
+/**
+ * Split text into sections for two teams
+ * Manuscript sheets may have teams in different arrangements
+ */
+interface TeamSections {
+  teamALines: string[];
+  teamBLines: string[];
+  teamAName: string;
+  teamBName: string;
+}
+
+/** Patterns for Team A markers */
+const TEAM_A_MARKERS = ['TEAM A', 'ÉQUIPE A', 'MANNSCHAFT A', 'HOME', 'HEIM'];
+/** Patterns for Team B markers */
+const TEAM_B_MARKERS = ['TEAM B', 'ÉQUIPE B', 'MANNSCHAFT B', 'AWAY', 'GAST'];
+/** Regex to strip Team A markers from a line */
+const TEAM_A_STRIP_PATTERN = /TEAM\s*A|ÉQUIPE\s*A|MANNSCHAFT\s*A|HOME|HEIM/i;
+/** Regex to strip Team B markers from a line */
+const TEAM_B_STRIP_PATTERN = /TEAM\s*B|ÉQUIPE\s*B|MANNSCHAFT\s*B|AWAY|GAST/i;
+
+/**
+ * Check if line matches Team A markers
+ */
+function isTeamAMarker(upperLine: string): boolean {
+  return TEAM_A_MARKERS.some((marker) => upperLine.includes(marker));
+}
+
+/**
+ * Check if line matches Team B markers
+ */
+function isTeamBMarker(upperLine: string): boolean {
+  return TEAM_B_MARKERS.some((marker) => upperLine.includes(marker));
+}
+
+/**
+ * Extract team name from a marker line
+ */
+function extractNameFromMarker(line: string, stripPattern: RegExp): string {
+  const cleaned = line.replace(stripPattern, '').trim();
+  return extractTeamName(cleaned) ?? '';
+}
+
+/**
+ * Process a line that is a team section marker
+ */
+function processTeamMarker(
+  trimmed: string,
+  result: TeamSections,
+): { team: 'A' | 'B'; isTeamA: boolean } | null {
+  const upper = trimmed.toUpperCase();
+
+  if (isTeamAMarker(upper)) {
+    const name = extractNameFromMarker(trimmed, TEAM_A_STRIP_PATTERN);
+    if (name) result.teamAName = name;
+    return { team: 'A', isTeamA: true };
+  }
+
+  if (isTeamBMarker(upper)) {
+    const name = extractNameFromMarker(trimmed, TEAM_B_STRIP_PATTERN);
+    if (name) result.teamBName = name;
+    return { team: 'B', isTeamA: false };
+  }
+
+  return null;
+}
+
+function splitIntoTeamSections(lines: string[]): TeamSections {
+  const result: TeamSections = {
+    teamALines: [],
+    teamBLines: [],
+    teamAName: '',
+    teamBName: '',
+  };
+
+  let currentTeam: 'A' | 'B' | null = null;
+  let teamASectionFound = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Check for team section markers
+    if (isTeamSectionMarker(trimmed)) {
+      const markerResult = processTeamMarker(trimmed, result);
+      if (markerResult) {
+        currentTeam = markerResult.team;
+        if (markerResult.isTeamA) teamASectionFound = true;
+        continue;
+      }
+    }
+
+    // If we haven't found explicit team sections, try to detect team name
+    if (!teamASectionFound && !result.teamAName) {
+      const teamName = extractTeamName(trimmed);
+      if (teamName) {
+        result.teamAName = teamName;
+        currentTeam = 'A';
+        continue;
+      }
+    }
+
+    // Default to team A if no team is set
+    if (currentTeam === null) {
+      currentTeam = 'A';
+    }
+
+    // Add line to current team
+    if (currentTeam === 'A') {
+      result.teamALines.push(trimmed);
+    } else {
+      result.teamBLines.push(trimmed);
+    }
+  }
+
+  return result;
+}
+
+// =============================================================================
+// Team Parser
+// =============================================================================
+
+/**
+ * Parse a team's lines into players and officials
+ */
+function parseTeamLines(
+  lines: string[],
+  teamName: string,
+): { team: ParsedTeam; warnings: string[] } {
+  const team: ParsedTeam = {
+    name: teamName,
+    players: [],
+    officials: [],
+  };
+  const warnings: string[] = [];
+
+  let inOfficialsSection = false;
+
+  for (const line of lines) {
+    // Check for section transitions
+    if (isOfficialsMarker(line)) {
+      inOfficialsSection = true;
+      continue;
+    }
+    if (isEndMarker(line)) {
+      break;
+    }
+
+    // Skip libero markers
+    if (isLiberoMarker(line)) {
+      continue;
+    }
+
+    if (inOfficialsSection) {
+      const official = tryExtractOfficial(line);
+      if (official) {
+        team.officials.push(official);
+      }
+    } else {
+      // Try to extract player
+      const player = tryExtractPlayer(line);
+      if (player) {
+        team.players.push(player);
+        continue;
+      }
+
+      // If not a player, try official (might be inline with players)
+      const official = tryExtractOfficial(line);
+      if (official) {
+        team.officials.push(official);
+      }
+    }
+  }
+
+  return { team, warnings };
+}
+
+// =============================================================================
+// Main Parser
+// =============================================================================
+
+/**
+ * Parse manuscript (handwritten) scoresheet OCR text
+ *
+ * @param ocrText - Raw OCR text from manuscript scoresheet
+ * @returns Parsed game sheet with both teams
+ *
+ * @example
+ * ```typescript
+ * const result = parseManuscriptSheet(ocrText);
+ * console.log(result.teamA.players); // Parsed players for team A
+ * ```
+ */
+export function parseManuscriptSheet(ocrText: string): ParsedGameSheet {
+  const warnings: string[] = [];
+
+  const emptyTeam: ParsedTeam = { name: '', players: [], officials: [] };
+
+  if (!ocrText || typeof ocrText !== 'string') {
+    warnings.push('No OCR text provided');
+    return { teamA: { ...emptyTeam }, teamB: { ...emptyTeam }, warnings };
+  }
+
+  // Split into lines and filter empty
+  const lines = ocrText
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  if (lines.length === 0) {
+    warnings.push('OCR text contains no lines');
+    return { teamA: { ...emptyTeam }, teamB: { ...emptyTeam }, warnings };
+  }
+
+  // Try to split into team sections
+  const sections = splitIntoTeamSections(lines);
+
+  // Parse each team
+  const teamAResult = parseTeamLines(sections.teamALines, sections.teamAName);
+  const teamBResult = parseTeamLines(sections.teamBLines, sections.teamBName);
+
+  // Collect warnings
+  warnings.push(...teamAResult.warnings);
+  warnings.push(...teamBResult.warnings);
+
+  if (teamAResult.team.players.length === 0) {
+    warnings.push('No players found for Team A');
+  }
+  if (teamBResult.team.players.length === 0 && sections.teamBLines.length > 0) {
+    warnings.push('No players found for Team B');
+  }
+
+  return {
+    teamA: teamAResult.team,
+    teamB: teamBResult.team,
+    warnings,
+  };
+}

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -227,19 +227,20 @@ export function parseOfficialName(rawName: string): {
  * Pattern for detecting a player line in manuscript format
  * Matches: number followed by name, with various separators
  */
-const PLAYER_LINE_PATTERN = /^(\d{1,2})[\s.:_-]+([A-Za-zÀ-ÿ\s]+)/;
+const PLAYER_LINE_PATTERN = /^(\d{1,2})[\s.:_-]+([A-Za-zÀ-ÿ][A-Za-zÀ-ÿ\s]*)/;
 
 /**
  * Pattern for detecting a player line with OCR errors
  * More lenient - allows OCR-misread digits
  */
-const PLAYER_LINE_LENIENT = /^([0-9OoIlZzSsGgBb]{1,2})[\s.:_-]+([A-Za-zÀ-ÿ\s]+)/;
+const PLAYER_LINE_LENIENT = /^([0-9OoIlZzSsGgBb]{1,2})[\s.:_-]+([A-Za-zÀ-ÿ][A-Za-zÀ-ÿ\s]*)/;
 
 /**
  * Pattern for detecting an official line
  * Matches: C/AC/AC2/AC3/AC4 followed by name
+ * Note: Uses case-insensitive flag, so name capture uses lowercase ranges only
  */
-const OFFICIAL_LINE_PATTERN = /^(C|AC\d?)[\s.:_-]+([A-Za-zÀ-ÿ\s]+)/i;
+const OFFICIAL_LINE_PATTERN = /^(C|AC\d?)[\s.:_-]+([a-zà-ÿ][a-zà-ÿ\s]*)/i;
 
 /**
  * Check if a line contains team section marker
@@ -269,10 +270,17 @@ function isLiberoMarker(line: string): boolean {
 
 /**
  * Check if a line indicates the officials section
+ * Note: We only match section headers, not individual official lines
  */
 function isOfficialsMarker(line: string): boolean {
   const upper = line.toUpperCase();
-  return upper.includes('OFFICIAL') || upper.includes('COACH') || upper.includes('TRAINER');
+  // Must contain 'OFFICIAL' or specific section headers
+  // Avoid matching lines like "C Hans Trainer" which contain 'TRAINER'
+  return (
+    upper.includes('OFFICIAL') ||
+    upper.startsWith('COACH') ||
+    /^TRAINER\b/.test(upper)
+  );
 }
 
 /**

--- a/web-app/src/features/ocr/utils/scoresheet-detector.ts
+++ b/web-app/src/features/ocr/utils/scoresheet-detector.ts
@@ -1,0 +1,11 @@
+/**
+ * Scoresheet Type Definition
+ *
+ * Defines the scoresheet types supported by the OCR feature.
+ * The user selects the type manually when scanning a scoresheet.
+ *
+ * - `manuscript`: Handwritten scoresheets with variable formatting
+ * - `electronic`: Printed/electronic scoresheets with consistent tab-separated columns
+ */
+
+export type ScoresheetType = 'manuscript' | 'electronic';


### PR DESCRIPTION
## Summary

- Add manuscript scoresheet parser with OCR error correction for handwritten text
- Add `parseGameSheetWithType` factory function to select parser based on user-selected type
- Add data collection service to POC OCR app for gathering samples to improve parser
- Add copy JSON to clipboard button for easy data collection

## Test Plan

- [x] All 3112 tests pass including 35 new manuscript parser tests
- [x] Lint, knip, and build pass
- [ ] Manual test: Run POC OCR app and verify data export buttons work