### PR TITLE
feat(claude): add automatic validation with parallel subagents for web

### DIFF
--- a/.claude/agents/validator.md
+++ b/.claude/agents/validator.md
@@ -1,0 +1,97 @@
+# Validator Agent
+
+A specialized agent for running pre-push validation with parallel execution.
+
+## Description
+
+Runs lint, knip, and tests in parallel using subagents, then builds if all pass. Optimized for speed on Claude Code web.
+
+## Instructions
+
+You are the validation orchestrator. When invoked, perform these steps:
+
+### Step 1: Change Detection
+
+Check what changed to determine required validations:
+
+```bash
+git diff --name-only HEAD 2>/dev/null || echo "no-git"
+git diff --name-only --cached 2>/dev/null || echo "no-staged"
+```
+
+**Skip validation if**:
+- Only `.md` files changed (documentation)
+- No source files changed
+
+**Run only lint if**:
+- Only `.json` files in `i18n/locales/` changed
+
+### Step 2: Generate API Types (if needed)
+
+If `docs/api/volleymanager-openapi.yaml` changed:
+
+```bash
+cd /home/user/volleykit/web-app && npm run generate:api
+```
+
+### Step 3: Parallel Validation
+
+**CRITICAL**: Launch these THREE subagents IN PARALLEL using a SINGLE response with multiple Task tool calls.
+
+Each subagent should use `subagent_type: "Bash"` for direct command execution:
+
+**Subagent 1 - Lint**:
+```
+subagent_type: Bash
+prompt: cd /home/user/volleykit/web-app && npm run lint
+```
+
+**Subagent 2 - Knip**:
+```
+subagent_type: Bash
+prompt: cd /home/user/volleykit/web-app && npm run knip
+```
+
+**Subagent 3 - Test**:
+```
+subagent_type: Bash
+prompt: cd /home/user/volleykit/web-app && npm test
+```
+
+### Step 4: Build (Sequential)
+
+**Only if ALL parallel checks passed**, run the build:
+
+```bash
+cd /home/user/volleykit/web-app && npm run build
+```
+
+### Step 5: Summary
+
+Output a concise mobile-friendly summary:
+
+**All pass**:
+```
+## Validation Complete
+
+✓ Lint  ✓ Knip  ✓ Test  ✓ Build
+
+Ready to push!
+```
+
+**With failures**:
+```
+## Validation Complete
+
+✓ Lint  ✗ Knip  ✓ Test  ⊘ Build
+
+Issues:
+- Knip: [brief error summary]
+```
+
+## Status Icons
+
+- `✓` Pass
+- `✗` Fail
+- `⊘` Skipped (dependency failed)
+- `◐` Running

--- a/.claude/agents/validator.md
+++ b/.claude/agents/validator.md
@@ -31,7 +31,7 @@ git diff --name-only --cached 2>/dev/null || echo "no-staged"
 If `docs/api/volleymanager-openapi.yaml` changed:
 
 ```bash
-cd /home/user/volleykit/web-app && npm run generate:api
+cd web-app && npm run generate:api
 ```
 
 ### Step 3: Parallel Validation
@@ -43,19 +43,19 @@ Each subagent should use `subagent_type: "Bash"` for direct command execution:
 **Subagent 1 - Lint**:
 ```
 subagent_type: Bash
-prompt: cd /home/user/volleykit/web-app && npm run lint
+prompt: cd web-app && npm run lint
 ```
 
 **Subagent 2 - Knip**:
 ```
 subagent_type: Bash
-prompt: cd /home/user/volleykit/web-app && npm run knip
+prompt: cd web-app && npm run knip
 ```
 
 **Subagent 3 - Test**:
 ```
 subagent_type: Bash
-prompt: cd /home/user/volleykit/web-app && npm test
+prompt: cd web-app && npm test
 ```
 
 ### Step 4: Build (Sequential)
@@ -63,7 +63,7 @@ prompt: cd /home/user/volleykit/web-app && npm test
 **Only if ALL parallel checks passed**, run the build:
 
 ```bash
-cd /home/user/volleykit/web-app && npm run build
+cd web-app && npm run build
 ```
 
 ### Step 5: Summary
@@ -88,6 +88,14 @@ Ready to push!
 Issues:
 - Knip: [brief error summary]
 ```
+
+## Error Handling
+
+If a subagent times out or fails unexpectedly:
+- Note the failure in the summary with `✗` status
+- Include a brief error description
+- Suggest manual execution: `cd web-app && npm run <command>`
+- Do NOT proceed to build if any check fails
 
 ## Status Icons
 

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -18,7 +18,7 @@ git diff --name-only --cached 2>/dev/null
 
 If `volleymanager-openapi.yaml` changed:
 ```bash
-cd /home/user/volleykit/web-app && npm run generate:api
+cd web-app && npm run generate:api
 ```
 
 ### Step 3: Parallel Validation (CRITICAL)
@@ -26,15 +26,15 @@ cd /home/user/volleykit/web-app && npm run generate:api
 **Launch ALL THREE subagents in a SINGLE message** using the Task tool:
 
 ```
-Task 1: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm run lint", description: "Run lint check" }
-Task 2: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm run knip", description: "Run knip check" }
-Task 3: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm test", description: "Run test suite" }
+Task 1: { subagent_type: "Bash", prompt: "cd web-app && npm run lint", description: "Run lint check" }
+Task 2: { subagent_type: "Bash", prompt: "cd web-app && npm run knip", description: "Run knip check" }
+Task 3: { subagent_type: "Bash", prompt: "cd web-app && npm test", description: "Run test suite" }
 ```
 
 ### Step 4: Build (only if all pass)
 
 ```bash
-cd /home/user/volleykit/web-app && npm run build
+cd web-app && npm run build
 ```
 
 ### Step 5: Summary

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -1,43 +1,47 @@
 # Pre-Push Validation
 
-Run validation before pushing. Optimized for mobile with parallel execution.
+Run validation before pushing. Uses parallel subagents for speed on Claude Code web.
 
 ## Instructions
 
-1. **Detect changes** (check uncommitted files):
+### Step 1: Detect Changes
+
 ```bash
-git diff --name-only && git diff --name-only --cached
+git diff --name-only HEAD 2>/dev/null
+git diff --name-only --cached 2>/dev/null
 ```
 
-2. **Generate API types** (if OpenAPI spec changed):
+- **Skip all**: Only `.md` files changed
+- **Lint only**: Only `.json` locale files changed
+
+### Step 2: Generate API Types (if needed)
+
+If `volleymanager-openapi.yaml` changed:
 ```bash
-cd web-app && npm run generate:api
+cd /home/user/volleykit/web-app && npm run generate:api
 ```
 
-3. **Run parallel validations** using Task tool sub-agents:
+### Step 3: Parallel Validation (CRITICAL)
 
-Launch ALL THREE agents IN PARALLEL (single message, multiple Task calls):
+**Launch ALL THREE subagents in a SINGLE message** using the Task tool:
 
-**Agent 1 - Lint**:
-- subagent_type: "general-purpose"
-- prompt: "cd web-app && npm run lint. Reply: LINT: PASS or LINT: FAIL with first 3 errors"
+```
+Task 1: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm run lint", description: "Run lint check" }
+Task 2: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm run knip", description: "Run knip check" }
+Task 3: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm test", description: "Run test suite" }
+```
 
-**Agent 2 - Knip**:
-- subagent_type: "general-purpose"
-- prompt: "cd web-app && npm run knip. Reply: KNIP: PASS or KNIP: FAIL with summary"
+### Step 4: Build (only if all pass)
 
-**Agent 3 - Test**:
-- subagent_type: "general-purpose"
-- prompt: "cd web-app && npm test. Reply: TEST: PASS (N passed) or TEST: FAIL with failed names"
-
-4. **Build** (only if all parallel checks pass):
 ```bash
-cd web-app && npm run build
+cd /home/user/volleykit/web-app && npm run build
 ```
 
-5. **Output concise summary**:
+### Step 5: Summary
 
 ```
+## Validation Results
+
 ✓ Lint  ✓ Knip  ✓ Test  ✓ Build
 
 Ready to push!
@@ -45,8 +49,10 @@ Ready to push!
 
 Or on failure:
 ```
-✓ Lint  ✗ Knip  ✓ Test  ⊘ Build
+## Validation Results
+
+✓ Lint  ✗ Test  ⊘ Build
 
 Issues:
-- Knip: unused export in helpers.ts
+- Test: [failed test names]
 ```

--- a/.claude/skills/validate.md
+++ b/.claude/skills/validate.md
@@ -36,7 +36,7 @@ git diff --name-only --cached 2>/dev/null
 
 If `volleymanager-openapi.yaml` changed:
 ```bash
-cd /home/user/volleykit/web-app && npm run generate:api
+cd web-app && npm run generate:api
 ```
 
 ### Phase 3: Parallel Validation (MUST USE SUBAGENTS)
@@ -44,16 +44,16 @@ cd /home/user/volleykit/web-app && npm run generate:api
 **Launch ALL THREE subagents in a SINGLE message** using the Task tool:
 
 ```
-Task 1: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm run lint", description: "Run lint check" }
-Task 2: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm run knip", description: "Run knip check" }
-Task 3: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm test", description: "Run test suite" }
+Task 1: { subagent_type: "Bash", prompt: "cd web-app && npm run lint", description: "Run lint check" }
+Task 2: { subagent_type: "Bash", prompt: "cd web-app && npm run knip", description: "Run knip check" }
+Task 3: { subagent_type: "Bash", prompt: "cd web-app && npm test", description: "Run test suite" }
 ```
 
 ### Phase 4: Build (Sequential)
 
 **Only after ALL parallel checks pass**:
 ```bash
-cd /home/user/volleykit/web-app && npm run build
+cd web-app && npm run build
 ```
 
 ### Phase 5: Summary
@@ -83,6 +83,14 @@ Issues:
 - `✗` Fail
 - `⊘` Skipped
 - `◐` Running
+
+## Error Handling
+
+If a subagent times out or fails unexpectedly:
+- Note the failure in the summary with `✗` status
+- Include a brief error description
+- Suggest manual execution: `cd web-app && npm run <command>`
+- Do NOT proceed to build if any check fails
 
 ## Quick Variants
 

--- a/.claude/skills/validate.md
+++ b/.claude/skills/validate.md
@@ -1,102 +1,64 @@
-# Validate Skill
+---
+name: validate
+description: Run pre-push validation (lint, knip, test, build) with parallel subagents
+autoInvoke: before-push
+---
 
-Run pre-push validation optimized for mobile (iPhone) development. Uses parallel sub-agents for speed.
+# Validation Skill
 
-## Trigger Phrases
+Run pre-push validation using parallel subagents for maximum speed on Claude Code web.
 
-Invoke this skill when user says any of:
-- "validate", "validation", "run validation"
-- "check before push", "pre-push check"
-- "run checks", "run all checks"
-- "lint test build", "full check"
+## When to Use (Automatic Triggers)
 
-## Instructions
+**AUTOMATICALLY invoke this skill when**:
+- User says "push", "git push", or is about to push code
+- User says "validate", "check", "run checks", "pre-push"
+- User asks to "commit and push" changes
+- After completing code changes that modify `.ts`, `.tsx`, `.js`, `.jsx` files
+- User says "ready to push" or "before I push"
 
-When this skill is invoked, perform validation with these steps:
+## Execution Strategy
 
-### 1. Quick Change Detection
+**CRITICAL**: Use parallel subagents for speed. Launch lint, knip, and test simultaneously.
 
-First, detect what changed to determine required validations. Check both staged and unstaged changes:
+### Phase 1: Quick Check (5 seconds)
 
+Determine what changed:
 ```bash
-# From project root, detect all uncommitted changes
-git diff --name-only          # Unstaged changes
-git diff --name-only --cached # Staged changes
-git status --porcelain        # All modified/untracked files
+git diff --name-only HEAD 2>/dev/null
+git diff --name-only --cached 2>/dev/null
 ```
 
-Categorize changes:
-- **Source files**: `*.ts`, `*.tsx`, `*.js`, `*.jsx` → needs full validation
-- **OpenAPI spec**: `docs/api/volleymanager-openapi.yaml` → needs generate:api first
-- **Test files only**: `*.test.ts`, `*.test.tsx` → needs test only
-- **Locale files**: `*.json` in `i18n/locales/` → needs lint only
-- **Docs only**: `*.md` files → skip all validation
+**Skip all if**: Only `.md` documentation files changed
+**Lint only if**: Only `.json` locale files changed
 
-### 2. Generate API Types (If Needed)
+### Phase 2: API Generation (if needed)
 
-**Run FIRST if OpenAPI spec changed**:
-
+If `volleymanager-openapi.yaml` changed:
 ```bash
-cd web-app && npm run generate:api
+cd /home/user/volleykit/web-app && npm run generate:api
 ```
 
-This must complete before lint/test/build since they depend on generated types.
+### Phase 3: Parallel Validation (MUST USE SUBAGENTS)
 
-### 3. Parallel Validation (Sub-Agents)
+**Launch ALL THREE subagents in a SINGLE message** using the Task tool:
 
-**CRITICAL**: Launch these sub-agents IN PARALLEL using a SINGLE message with multiple Task tool calls.
-
-**Validation order per CLAUDE.md**: generate:api → lint → knip → test → build
-
-Lint, knip, and test can run in parallel since they're independent. Build must wait for all to pass.
-
-#### Agent 1: Lint Check
 ```
-subagent_type: "general-purpose"
-prompt: |
-  Run ESLint in the web-app directory:
-  cd web-app && npm run lint
-
-  Return ONLY this format:
-  LINT: PASS or LINT: FAIL
-  [If fail, include first 5 error lines]
+Task 1: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm run lint", description: "Run lint check" }
+Task 2: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm run knip", description: "Run knip check" }
+Task 3: { subagent_type: "Bash", prompt: "cd /home/user/volleykit/web-app && npm test", description: "Run test suite" }
 ```
 
-#### Agent 2: Dead Code Check
-```
-subagent_type: "general-purpose"
-prompt: |
-  Run Knip dead code detection in the web-app directory:
-  cd web-app && npm run knip
+### Phase 4: Build (Sequential)
 
-  Return ONLY this format:
-  KNIP: PASS or KNIP: FAIL
-  [If fail, include summary of unused exports]
-```
-
-#### Agent 3: Test Suite
-```
-subagent_type: "general-purpose"
-prompt: |
-  Run Vitest tests in the web-app directory:
-  cd web-app && npm test
-
-  Return ONLY this format:
-  TEST: PASS (X passed) or TEST: FAIL (X passed, Y failed)
-  [If fail, list failed test names only]
-```
-
-### 4. Sequential Build (Only if Parallel Checks Pass)
-
-If ALL parallel checks pass, run build:
-
+**Only after ALL parallel checks pass**:
 ```bash
-cd web-app && npm run build
+cd /home/user/volleykit/web-app && npm run build
 ```
 
-### 5. Mobile-Friendly Summary
+### Phase 5: Summary
 
-Output a concise summary using this exact format:
+Output mobile-friendly results:
 
 ```
 ## Validation Results
@@ -107,44 +69,24 @@ Ready to push!
 ```
 
 Or on failure:
-
 ```
 ## Validation Results
 
-✓ Lint  ✗ Knip  ✓ Test  ⊘ Build
+✓ Lint  ✗ Test  ⊘ Build
 
 Issues:
-- Knip: 2 unused exports in helpers.ts
+- Test: 2 failed in auth.test.ts
 ```
 
-### Status Icons (Mobile-Optimized)
+## Icons
 - `✓` Pass
 - `✗` Fail
 - `⊘` Skipped
 - `◐` Running
 
-### Smart Skip Rules
+## Quick Variants
 
-Skip validations when safe:
-- **No source changes**: Skip all (docs/config only)
-- **Test files only**: Skip lint, knip, build - run test only
-- **Locale JSON only**: Run lint only
-- **OpenAPI changes**: Run generate:api before other checks
-
-### Error Handling
-
-If a sub-agent times out or fails unexpectedly:
-1. Note the failed check
-2. Continue with other results
-3. Suggest running the failed check manually
-
-### Example Invocations
-
-User says: "validate" or "check" or "run validation"
-→ Run full validation flow above
-
-User says: "quick validate" or "lint only"
-→ Run only lint check, skip others
-
-User says: "test only"
-→ Run only test suite
+- `/lint` - Lint only
+- `/test` - Tests only
+- `/build` - Build only
+- `/knip` - Dead code check only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,27 @@ For code reviews and detailed examples, see:
 **Workflow**:
 1. **Implement features/fixes** - Complete the work as required
 2. **Commit along the way** - Make meaningful commits as you progress (logical units of work)
-3. **Run full validation before push** - Before pushing, run all validation phases
+3. **Run full validation before push** - Before pushing, **use the `/validate` skill** to run all validation phases
 4. **Fix any issues** - If validation fails, fix issues and amend/add commits as needed
 5. **Push** - Only after all validations pass
 
-**Before pushing source code changes, run all phases in order**:
+### Automatic Validation with Parallel Subagents
+
+**IMPORTANT FOR CLAUDE CODE WEB**: Before pushing code changes, **automatically invoke the `/validate` skill** which runs validation steps in parallel using subagents for maximum speed.
+
+The `/validate` skill will:
+1. Detect what changed (skip validation for docs-only changes)
+2. Generate API types if OpenAPI spec changed
+3. **Launch lint, knip, and test in parallel** using Task tool subagents
+4. Run build sequentially after parallel checks pass
+5. Output a concise mobile-friendly summary
+
+**Trigger `/validate` automatically when**:
+- User says "push", "git push", or is about to push
+- After completing source code changes (`.ts`, `.tsx`, `.js`, `.jsx`)
+- User says "validate", "check", "run checks", "pre-push"
+
+**Manual validation** (if not using the skill):
 
 ```bash
 cd web-app


### PR DESCRIPTION
## Summary

- Create validation agent definition at `.claude/agents/validator.md`
- Update validate skill with autoInvoke triggers and parallel subagent pattern
- Update validate command with explicit parallel Task tool instructions
- Update CLAUDE.md to encourage automatic `/validate` usage before push

## Test Plan

- [ ] Invoke `/validate` command and verify it launches parallel subagents
- [ ] Test that validation triggers automatically when user mentions "push"
- [ ] Verify the skill description matches trigger phrases