### PR TITLE
feat(ocr): add scoresheet type selection and camera guides

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -64,7 +64,7 @@
     {
       "name": "Total JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "475 kB",
+      "limit": "500 kB",
       "gzip": true
     }
   ],

--- a/web-app/src/features/ocr/hooks/useOCRScoresheet.ts
+++ b/web-app/src/features/ocr/hooks/useOCRScoresheet.ts
@@ -14,6 +14,7 @@ import type {
   UseOCRScoresheetReturn,
   OCREngine,
 } from '../types';
+import type { ScoresheetType } from '../utils/scoresheet-detector';
 import { OCRFactory } from '../services/ocr-factory';
 import { parseGameSheetWithOCR } from '../utils/player-list-parser';
 
@@ -58,9 +59,14 @@ export function useOCRScoresheet(): UseOCRScoresheetReturn {
 
   /**
    * Process an image and extract player data
+   * @param imageBlob - The image to process
+   * @param scoresheetType - Type of scoresheet (electronic or manuscript)
    */
   const processImage = useCallback(
-    async (imageBlob: Blob): Promise<ParsedGameSheet | null> => {
+    async (
+      imageBlob: Blob,
+      scoresheetType: ScoresheetType = 'electronic',
+    ): Promise<ParsedGameSheet | null> => {
       // Reset state
       setIsProcessing(true);
       setProgress(null);
@@ -81,7 +87,7 @@ export function useOCRScoresheet(): UseOCRScoresheetReturn {
         const ocrResult = await engine.recognize(imageBlob);
 
         // Parse the OCR result into structured data (uses bounding boxes for column detection)
-        const parsed = parseGameSheetWithOCR(ocrResult);
+        const parsed = parseGameSheetWithOCR(ocrResult, { type: scoresheetType });
 
         // Clean up
         await engine.terminate();

--- a/web-app/src/features/ocr/index.ts
+++ b/web-app/src/features/ocr/index.ts
@@ -75,6 +75,7 @@ export { StubOCR } from './services/stub-ocr';
 export {
   parseGameSheet,
   parseGameSheetWithType,
+  parseGameSheetWithOCR,
   parseElectronicSheet,
   parsePlayerName,
   parseOfficialName,
@@ -82,7 +83,10 @@ export {
   getAllPlayers,
   getAllOfficials,
 } from './utils/player-list-parser';
-export type { ParseGameSheetOptions } from './utils/player-list-parser';
+export type {
+  ParseGameSheetOptions,
+  ParseGameSheetWithOCROptions,
+} from './utils/player-list-parser';
 
 // Manuscript parsing
 export { parseManuscriptSheet } from './utils/manuscript-parser';

--- a/web-app/src/features/ocr/types.ts
+++ b/web-app/src/features/ocr/types.ts
@@ -208,12 +208,18 @@ export interface OCRScoresheetState {
   error: Error | null;
 }
 
+/** Scoresheet type for OCR processing */
+export type ScoresheetTypeForOCR = 'electronic' | 'manuscript';
+
 /**
  * Actions returned by useOCRScoresheet hook
  */
 export interface OCRScoresheetActions {
   /** Process an image and extract player data */
-  processImage: (imageBlob: Blob) => Promise<ParsedGameSheet | null>;
+  processImage: (
+    imageBlob: Blob,
+    scoresheetType?: ScoresheetTypeForOCR,
+  ) => Promise<ParsedGameSheet | null>;
   /** Reset state to initial values */
   reset: () => void;
   /** Cancel ongoing processing */

--- a/web-app/src/features/ocr/types.ts
+++ b/web-app/src/features/ocr/types.ts
@@ -208,9 +208,6 @@ export interface OCRScoresheetState {
   error: Error | null;
 }
 
-/** Scoresheet type for OCR processing */
-export type ScoresheetTypeForOCR = 'electronic' | 'manuscript';
-
 /**
  * Actions returned by useOCRScoresheet hook
  */
@@ -218,7 +215,7 @@ export interface OCRScoresheetActions {
   /** Process an image and extract player data */
   processImage: (
     imageBlob: Blob,
-    scoresheetType?: ScoresheetTypeForOCR,
+    scoresheetType?: 'electronic' | 'manuscript',
   ) => Promise<ParsedGameSheet | null>;
   /** Reset state to initial values */
   reset: () => void;

--- a/web-app/src/features/ocr/utils/player-list-parser.ts
+++ b/web-app/src/features/ocr/utils/player-list-parser.ts
@@ -1067,21 +1067,39 @@ function processLineWithOCR(
 }
 
 /**
+ * Options for parseGameSheetWithOCR
+ */
+export interface ParseGameSheetWithOCROptions {
+  /** Type of scoresheet (affects parsing strategy). Defaults to 'electronic'. */
+  type?: ScoresheetType;
+}
+
+/**
  * Parse a game sheet using full OCR result with bounding box data.
  *
  * This parser uses the word bounding boxes to accurately determine
  * which column single-row entries belong to, instead of using heuristics.
  *
  * @param ocrResult - Full OCR result with lines and word bounding boxes
+ * @param options - Parser options (type selection)
  * @returns Parsed game sheet with both teams
  *
  * @example
  * ```typescript
  * const ocrResult = await ocrEngine.recognize(imageBlob);
- * const parsed = parseGameSheetWithOCR(ocrResult);
+ * const parsed = parseGameSheetWithOCR(ocrResult, { type: 'electronic' });
  * ```
  */
-export function parseGameSheetWithOCR(ocrResult: OCRResult): ParsedGameSheet {
+export function parseGameSheetWithOCR(
+  ocrResult: OCRResult,
+  options?: ParseGameSheetWithOCROptions,
+): ParsedGameSheet {
+  const type = options?.type ?? 'electronic';
+
+  // For manuscript scoresheets, use the dedicated manuscript parser
+  if (type === 'manuscript') {
+    return parseManuscriptSheet(ocrResult.fullText);
+  }
   const warnings: string[] = [];
 
   // If no lines available, fall back to text-only parsing

--- a/web-app/src/features/ocr/utils/player-list-parser.ts
+++ b/web-app/src/features/ocr/utils/player-list-parser.ts
@@ -1100,6 +1100,7 @@ export function parseGameSheetWithOCR(
   if (type === 'manuscript') {
     return parseManuscriptSheet(ocrResult.fullText);
   }
+
   const warnings: string[] = [];
 
   // If no lines available, fall back to text-only parsing

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -32,7 +32,7 @@ const FRAME_HEIGHT_RATIO = 0.7;
 const FRAME_WIDTH_RATIO = 0.85;
 
 /** Minimum zoom level */
-const MIN_ZOOM = 0.5;
+const MIN_ZOOM = 0.1;
 
 /** Maximum zoom level */
 const MAX_ZOOM = 3;

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -1,0 +1,342 @@
+/**
+ * ImageCropEditor Component
+ *
+ * Pan/zoom image editor for cropping scoresheet images to the correct aspect ratio.
+ * The user can drag and pinch-zoom the image to position it within a fixed-aspect-ratio frame.
+ *
+ * Based on the OCR POC ImageEditor pattern with React implementation.
+ */
+
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import { useTranslation } from "@/shared/hooks/useTranslation";
+import { X, Check } from "@/shared/components/icons";
+import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
+
+/** Aspect ratio for electronic scoresheet (4:5 portrait) */
+const ELECTRONIC_WIDTH = 4;
+const ELECTRONIC_HEIGHT = 5;
+const ELECTRONIC_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
+
+/** Aspect ratio for manuscript scoresheet (7:5 landscape) */
+const MANUSCRIPT_WIDTH = 7;
+const MANUSCRIPT_HEIGHT = 5;
+const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
+
+/** Frame padding from viewport edge */
+const FRAME_PADDING_PX = 24;
+
+/** Frame height as ratio of available space */
+const FRAME_HEIGHT_RATIO = 0.7;
+
+/** Frame width as ratio of available space */
+const FRAME_WIDTH_RATIO = 0.85;
+
+/** Minimum zoom level */
+const MIN_ZOOM = 0.5;
+
+/** Maximum zoom level */
+const MAX_ZOOM = 3;
+
+/** Zoom out multiplier for wheel scroll */
+const ZOOM_OUT_DELTA = 0.9;
+
+/** Zoom in multiplier for wheel scroll */
+const ZOOM_IN_DELTA = 1.1;
+
+/** JPEG quality for output */
+const JPEG_QUALITY = 0.92;
+
+interface ImageCropEditorProps {
+  /** Image blob to crop */
+  imageBlob: Blob;
+  /** Type of scoresheet (affects aspect ratio) */
+  scoresheetType: ScoresheetType;
+  /** Called when user confirms the crop */
+  onConfirm: (croppedBlob: Blob) => void;
+  /** Called when user cancels */
+  onCancel: () => void;
+}
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+/**
+ * Image crop editor with pan/zoom functionality.
+ * Shows a fixed-aspect-ratio frame and lets the user position the image within it.
+ */
+export function ImageCropEditor({
+  imageBlob,
+  scoresheetType,
+  onConfirm,
+  onCancel,
+}: ImageCropEditorProps) {
+  const { t } = useTranslation();
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  // Image state - use useMemo for URL to avoid setState in effect
+  const imageUrl = useMemo(() => URL.createObjectURL(imageBlob), [imageBlob]);
+  const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
+
+  // Cleanup object URL on unmount or when imageBlob changes
+  useEffect(() => {
+    return () => URL.revokeObjectURL(imageUrl);
+  }, [imageUrl]);
+
+  // Interaction state
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef<Position>({ x: 0, y: 0 });
+  const positionStartRef = useRef<Position>({ x: 0, y: 0 });
+
+  // Frame dimensions
+  const [frameSize, setFrameSize] = useState({ width: 0, height: 0 });
+
+  const aspectRatio =
+    scoresheetType === "electronic"
+      ? ELECTRONIC_ASPECT_RATIO
+      : MANUSCRIPT_ASPECT_RATIO;
+
+  // Compute initial zoom based on image and frame sizes
+  const initialZoom = useMemo(() => {
+    if (imageSize.width === 0 || frameSize.width === 0) return 1;
+    const scaleX = frameSize.width / imageSize.width;
+    const scaleY = frameSize.height / imageSize.height;
+    const computed = Math.max(scaleX, scaleY);
+    return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, computed));
+  }, [imageSize, frameSize]);
+
+  // Transform state - initialize with computed values
+  const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+
+  // Track if we've initialized zoom for the current image
+  const initializedRef = useRef(false);
+
+  // Load image dimensions and reset initialization flag when image changes
+  useEffect(() => {
+    initializedRef.current = false;
+
+    const img = new Image();
+    img.onload = () => {
+      setImageSize({ width: img.width, height: img.height });
+    };
+    img.src = imageUrl;
+  }, [imageUrl]);
+
+  // Calculate frame size based on viewport
+  useEffect(() => {
+    const updateFrameSize = () => {
+      if (!viewportRef.current) return;
+
+      const viewport = viewportRef.current.getBoundingClientRect();
+      const availableWidth = viewport.width - FRAME_PADDING_PX * 2;
+      const availableHeight = viewport.height - FRAME_PADDING_PX * 2;
+
+      let frameWidth: number;
+      let frameHeight: number;
+
+      if (availableWidth / availableHeight > aspectRatio) {
+        // Viewport is wider - constrain by height
+        frameHeight = availableHeight * FRAME_HEIGHT_RATIO;
+        frameWidth = frameHeight * aspectRatio;
+      } else {
+        // Viewport is taller - constrain by width
+        frameWidth = availableWidth * FRAME_WIDTH_RATIO;
+        frameHeight = frameWidth / aspectRatio;
+      }
+
+      setFrameSize({ width: frameWidth, height: frameHeight });
+    };
+
+    updateFrameSize();
+    window.addEventListener("resize", updateFrameSize);
+    return () => window.removeEventListener("resize", updateFrameSize);
+  }, [aspectRatio]);
+
+  // Initialize zoom when image loads (only once per image)
+  // This is intentional one-time initialization guarded by ref, not cascading renders
+  useEffect(() => {
+    if (imageSize.width > 0 && frameSize.width > 0 && !initializedRef.current) {
+      initializedRef.current = true;
+      setZoom(initialZoom); // eslint-disable-line react-hooks/set-state-in-effect
+      setPosition({ x: 0, y: 0 });
+    }
+  }, [imageSize, frameSize, initialZoom]);
+
+  // Mouse/touch handlers
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      setIsDragging(true);
+      dragStartRef.current = { x: e.clientX, y: e.clientY };
+      positionStartRef.current = position;
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [position],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDragging) return;
+
+      const dx = e.clientX - dragStartRef.current.x;
+      const dy = e.clientY - dragStartRef.current.y;
+
+      setPosition({
+        x: positionStartRef.current.x + dx,
+        y: positionStartRef.current.y + dy,
+      });
+    },
+    [isDragging],
+  );
+
+  const handlePointerUp = useCallback((e: React.PointerEvent) => {
+    setIsDragging(false);
+    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+  }, []);
+
+  // Wheel zoom
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? ZOOM_OUT_DELTA : ZOOM_IN_DELTA;
+    setZoom((z) => Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z * delta)));
+  }, []);
+
+  // Crop and export
+  const handleConfirm = useCallback(() => {
+    if (!imageRef.current || !viewportRef.current) return;
+
+    const viewport = viewportRef.current.getBoundingClientRect();
+    const img = imageRef.current;
+
+    // Calculate crop area in image coordinates
+    const viewportCenterX = viewport.width / 2;
+    const viewportCenterY = viewport.height / 2;
+
+    // Frame center is at viewport center
+    const frameCenterX = viewportCenterX;
+    const frameCenterY = viewportCenterY;
+
+    // Image center is at viewport center + position offset
+    const imageCenterX = viewportCenterX + position.x;
+    const imageCenterY = viewportCenterY + position.y;
+
+    // Frame top-left relative to image
+    const frameLeftOnImage = (frameCenterX - imageCenterX) / zoom;
+    const frameTopOnImage = (frameCenterY - imageCenterY) / zoom;
+
+    // Convert to image coordinates
+    const cropX = imageSize.width / 2 + frameLeftOnImage - frameSize.width / 2 / zoom;
+    const cropY = imageSize.height / 2 + frameTopOnImage - frameSize.height / 2 / zoom;
+    const cropWidth = frameSize.width / zoom;
+    const cropHeight = frameSize.height / zoom;
+
+    // Create canvas and crop
+    const canvas = document.createElement("canvas");
+    canvas.width = frameSize.width;
+    canvas.height = frameSize.height;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.drawImage(
+      img,
+      Math.max(0, cropX),
+      Math.max(0, cropY),
+      cropWidth,
+      cropHeight,
+      0,
+      0,
+      frameSize.width,
+      frameSize.height,
+    );
+
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          onConfirm(blob);
+        }
+      },
+      "image/jpeg",
+      JPEG_QUALITY,
+    );
+  }, [imageSize, frameSize, position, zoom, onConfirm]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-gray-900">
+      {/* Viewport */}
+      <div
+        ref={viewportRef}
+        className="relative flex-1 overflow-hidden cursor-grab active:cursor-grabbing touch-none"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onWheel={handleWheel}
+      >
+        {/* Image */}
+        <img
+          ref={imageRef}
+          src={imageUrl}
+          alt=""
+          className="absolute pointer-events-none select-none"
+          style={{
+            left: "50%",
+            top: "50%",
+            transform: `translate(-50%, -50%) translate(${position.x}px, ${position.y}px) scale(${zoom})`,
+            maxWidth: "none",
+          }}
+          draggable={false}
+        />
+
+        {/* Frame overlay */}
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          {/* Dark overlay with cutout using box-shadow */}
+          <div
+            className="relative border-2 border-white/90 rounded-sm"
+            style={{
+              width: frameSize.width,
+              height: frameSize.height,
+              boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.5)",
+            }}
+          >
+            {/* Corner markers */}
+            <div className="absolute -top-0.5 -left-0.5 w-5 h-5 border-t-4 border-l-4 border-white rounded-tl" />
+            <div className="absolute -top-0.5 -right-0.5 w-5 h-5 border-t-4 border-r-4 border-white rounded-tr" />
+            <div className="absolute -bottom-0.5 -left-0.5 w-5 h-5 border-b-4 border-l-4 border-white rounded-bl" />
+            <div className="absolute -bottom-0.5 -right-0.5 w-5 h-5 border-b-4 border-r-4 border-white rounded-br" />
+          </div>
+        </div>
+      </div>
+
+      {/* Hint */}
+      <div className="flex-shrink-0 py-2 text-center">
+        <span className="inline-block px-3 py-1 text-sm text-gray-300 bg-white/10 rounded">
+          {t("validation.ocr.photoGuide.alignScoresheet")}
+        </span>
+      </div>
+
+      {/* Controls */}
+      <div className="flex-shrink-0 flex gap-4 p-4 bg-white dark:bg-gray-800">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 flex items-center justify-center gap-2 min-h-12 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-lg font-medium transition-colors"
+        >
+          <X className="w-5 h-5" aria-hidden="true" />
+          {t("validation.ocr.cancel")}
+        </button>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          className="flex-1 flex items-center justify-center gap-2 min-h-12 px-4 py-3 text-white bg-primary-500 hover:bg-primary-600 rounded-lg font-medium transition-colors"
+        >
+          <Check className="w-5 h-5" aria-hidden="true" />
+          {t("common.confirm")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/features/validation/components/OCRCaptureModal.tsx
+++ b/web-app/src/features/validation/components/OCRCaptureModal.tsx
@@ -68,6 +68,14 @@ export function OCRCaptureModal({
     };
   }, [stopCamera]);
 
+  // Connect stream to video element when camera step is active
+  useEffect(() => {
+    if (step === "camera" && streamRef.current && videoRef.current) {
+      videoRef.current.srcObject = streamRef.current;
+      videoRef.current.play().catch(console.error);
+    }
+  }, [step]);
+
   // Handle Escape key to close modal or go back
   useEffect(() => {
     if (!isOpen) return;
@@ -102,12 +110,7 @@ export function OCRCaptureModal({
       });
 
       streamRef.current = stream;
-
-      if (videoRef.current) {
-        videoRef.current.srcObject = stream;
-        await videoRef.current.play();
-      }
-
+      // Step change triggers useEffect to connect stream to video element
       setStep("camera");
     } catch (err) {
       console.error("Camera access error:", err);

--- a/web-app/src/features/validation/components/OCRCaptureModal.tsx
+++ b/web-app/src/features/validation/components/OCRCaptureModal.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState, useCallback, useEffect } from "react";
 import { useTranslation } from "@/shared/hooks/useTranslation";
 import { Camera, Image, X, AlertCircle } from "@/shared/components/icons";
+import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
+import { ScoresheetGuide } from "./ScoresheetGuide";
 
 const MAX_FILE_SIZE_MB = 10;
 const BYTES_PER_KB = 1024;
@@ -9,6 +11,8 @@ const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
 interface OCRCaptureModalProps {
   isOpen: boolean;
+  /** Type of scoresheet being captured (affects guide aspect ratio) */
+  scoresheetType: ScoresheetType;
   onClose: () => void;
   onImageSelected: (blob: Blob) => void;
 }
@@ -19,6 +23,7 @@ interface OCRCaptureModalProps {
  */
 export function OCRCaptureModal({
   isOpen,
+  scoresheetType,
   onClose,
   onImageSelected,
 }: OCRCaptureModalProps) {
@@ -112,6 +117,11 @@ export function OCRCaptureModal({
           <p className="text-sm text-gray-600 dark:text-gray-300">
             {t("validation.ocr.scanScoresheetDescription")}
           </p>
+
+          {/* Scoresheet guide preview */}
+          <div className="relative aspect-[4/3] bg-gray-100 dark:bg-gray-700 rounded-lg overflow-hidden">
+            <ScoresheetGuide scoresheetType={scoresheetType} />
+          </div>
 
           {/* Error message */}
           {error && (

--- a/web-app/src/features/validation/components/OCRCaptureModal.tsx
+++ b/web-app/src/features/validation/components/OCRCaptureModal.tsx
@@ -291,11 +291,6 @@ export function OCRCaptureModal({
             {t("validation.ocr.scanScoresheetDescription")}
           </p>
 
-          {/* Scoresheet guide preview */}
-          <div className="relative aspect-[4/3] bg-gray-100 dark:bg-gray-700 rounded-lg overflow-hidden">
-            <ScoresheetGuide scoresheetType={scoresheetType} />
-          </div>
-
           {/* Error message */}
           {error && (
             <div

--- a/web-app/src/features/validation/components/OCRCaptureModal.tsx
+++ b/web-app/src/features/validation/components/OCRCaptureModal.tsx
@@ -3,11 +3,24 @@ import { useTranslation } from "@/shared/hooks/useTranslation";
 import { Camera, Image, X, AlertCircle } from "@/shared/components/icons";
 import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
 import { ScoresheetGuide } from "./ScoresheetGuide";
+import { ImageCropEditor } from "./ImageCropEditor";
 
 const MAX_FILE_SIZE_MB = 10;
 const BYTES_PER_KB = 1024;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * BYTES_PER_KB * BYTES_PER_KB;
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+/** Video constraints for camera preview */
+const VIDEO_CONSTRAINTS: MediaTrackConstraints = {
+  facingMode: "environment",
+  width: { ideal: 1920 },
+  height: { ideal: 1080 },
+};
+
+/** JPEG quality for captured photos */
+const JPEG_QUALITY = 0.92;
+
+type CaptureStep = "select" | "camera" | "crop";
 
 interface OCRCaptureModalProps {
   isOpen: boolean;
@@ -19,7 +32,7 @@ interface OCRCaptureModalProps {
 
 /**
  * Modal for capturing or selecting an image for OCR processing.
- * Supports camera capture and file selection.
+ * Supports live camera preview with guides and file selection with cropping.
  */
 export function OCRCaptureModal({
   isOpen,
@@ -29,17 +42,115 @@ export function OCRCaptureModal({
 }: OCRCaptureModalProps) {
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const cameraInputRef = useRef<HTMLInputElement>(null);
-  const [error, setError] = useState<string | null>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
 
+  const [step, setStep] = useState<CaptureStep>("select");
+  const [error, setError] = useState<string | null>(null);
+  const [selectedImage, setSelectedImage] = useState<Blob | null>(null);
+  const [cameraError, setCameraError] = useState(false);
+
+  // Clean up camera stream
+  const stopCamera = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      stopCamera();
+    };
+  }, [stopCamera]);
+
+  // Handle Escape key to close modal or go back
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        if (step === "camera") {
+          stopCamera();
+          setStep("select");
+        } else if (step === "crop") {
+          setSelectedImage(null);
+          setStep("select");
+        } else {
+          onClose();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, step, onClose, stopCamera]);
+
+  // Start camera preview
+  const startCamera = useCallback(async () => {
+    setError(null);
+    setCameraError(false);
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: VIDEO_CONSTRAINTS,
+        audio: false,
+      });
+
+      streamRef.current = stream;
+
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+      }
+
+      setStep("camera");
+    } catch (err) {
+      console.error("Camera access error:", err);
+      setCameraError(true);
+      setError(t("validation.ocr.errors.cameraNotAvailable"));
+    }
+  }, [t]);
+
+  // Capture photo from camera
+  const capturePhoto = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          stopCamera();
+          setSelectedImage(blob);
+          setStep("crop");
+        }
+      },
+      "image/jpeg",
+      JPEG_QUALITY,
+    );
+  }, [stopCamera]);
+
+  // Handle file selection
   const handleFileChange = useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
       if (!file) return;
 
       // Reset file input to allow re-selecting the same file
       event.target.value = "";
-
       setError(null);
 
       // Validate file type
@@ -54,10 +165,10 @@ export function OCRCaptureModal({
         return;
       }
 
-      onImageSelected(file);
-      onClose();
+      setSelectedImage(file);
+      setStep("crop");
     },
-    [onImageSelected, onClose, t],
+    [t],
   );
 
   const handleSelectImage = useCallback(() => {
@@ -65,27 +176,86 @@ export function OCRCaptureModal({
     fileInputRef.current?.click();
   }, []);
 
-  const handleTakePhoto = useCallback(() => {
-    setError(null);
-    cameraInputRef.current?.click();
+  // Handle crop confirmation
+  const handleCropConfirm = useCallback(
+    (croppedBlob: Blob) => {
+      onImageSelected(croppedBlob);
+      onClose();
+    },
+    [onImageSelected, onClose],
+  );
+
+  // Handle crop cancel
+  const handleCropCancel = useCallback(() => {
+    setSelectedImage(null);
+    setStep("select");
   }, []);
 
-  // Handle Escape key to close modal
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
+  // Handle camera cancel
+  const handleCameraCancel = useCallback(() => {
+    stopCamera();
+    setStep("select");
+  }, [stopCamera]);
 
   if (!isOpen) return null;
 
+  // Show crop editor
+  if (step === "crop" && selectedImage) {
+    return (
+      <ImageCropEditor
+        imageBlob={selectedImage}
+        scoresheetType={scoresheetType}
+        onConfirm={handleCropConfirm}
+        onCancel={handleCropCancel}
+      />
+    );
+  }
+
+  // Show camera preview
+  if (step === "camera") {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col bg-gray-900">
+        {/* Video preview with guide overlay */}
+        <div className="relative flex-1 min-h-0 overflow-hidden">
+          <video
+            ref={videoRef}
+            className="w-full h-full object-cover bg-gray-800"
+            autoPlay
+            playsInline
+            muted
+          />
+          {/* Guide overlay */}
+          <ScoresheetGuide scoresheetType={scoresheetType} />
+        </div>
+
+        {/* Camera controls */}
+        <div className="flex-shrink-0 flex items-center justify-between px-6 py-4 bg-gray-900 safe-area-bottom">
+          <button
+            type="button"
+            onClick={handleCameraCancel}
+            className="px-4 py-2 text-white bg-gray-700 hover:bg-gray-600 rounded-lg font-medium transition-colors"
+          >
+            {t("validation.ocr.cancel")}
+          </button>
+
+          {/* Capture button */}
+          <button
+            type="button"
+            onClick={capturePhoto}
+            className="w-16 h-16 rounded-full bg-white hover:bg-gray-100 flex items-center justify-center transition-colors"
+            aria-label={t("validation.ocr.takePhoto")}
+          >
+            <div className="w-12 h-12 rounded-full bg-danger-500" />
+          </button>
+
+          {/* Spacer for centering */}
+          <div className="w-20" />
+        </div>
+      </div>
+    );
+  }
+
+  // Show selection UI
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
@@ -141,10 +311,10 @@ export function OCRCaptureModal({
 
           {/* Action buttons */}
           <div className="space-y-3">
-            {/* Take Photo button */}
+            {/* Take Photo button - use live camera if available */}
             <button
               type="button"
-              onClick={handleTakePhoto}
+              onClick={cameraError ? handleSelectImage : startCamera}
               className="w-full flex items-center justify-center gap-3 px-4 py-3 text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors font-medium"
             >
               <Camera className="w-5 h-5" aria-hidden="true" />
@@ -171,20 +341,11 @@ export function OCRCaptureModal({
             </button>
           </div>
 
-          {/* Hidden file inputs */}
+          {/* Hidden file input */}
           <input
             ref={fileInputRef}
             type="file"
             accept={ACCEPTED_IMAGE_TYPES.join(",")}
-            onChange={handleFileChange}
-            className="hidden"
-            aria-hidden="true"
-          />
-          <input
-            ref={cameraInputRef}
-            type="file"
-            accept="image/*"
-            capture="environment"
             onChange={handleFileChange}
             className="hidden"
             aria-hidden="true"

--- a/web-app/src/features/validation/components/OCRPanel.tsx
+++ b/web-app/src/features/validation/components/OCRPanel.tsx
@@ -6,6 +6,7 @@ import type {
   ParsedTeam,
   PlayerComparisonResult,
 } from "@/features/ocr";
+import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
 import type { RosterPlayer } from "@/features/validation/hooks/useNominationList";
 import { OCRCaptureModal } from "./OCRCaptureModal";
 import { PlayerComparisonList } from "./PlayerComparisonList";
@@ -32,6 +33,8 @@ interface OCRPanelProps {
   onClose: () => void;
   /** Whether the panel is open */
   isOpen: boolean;
+  /** Type of scoresheet (affects guide aspect ratio). Defaults to electronic. */
+  scoresheetType?: ScoresheetType;
 }
 
 /**
@@ -45,6 +48,7 @@ export function OCRPanel({
   onApplyResults,
   onClose,
   isOpen,
+  scoresheetType = "electronic",
 }: OCRPanelProps) {
   const { t } = useTranslation();
   const { processImage, isProcessing, progress, error, reset } =
@@ -375,6 +379,7 @@ export function OCRPanel({
       {/* Capture modal */}
       <OCRCaptureModal
         isOpen={showCaptureModal}
+        scoresheetType={scoresheetType}
         onClose={() => setShowCaptureModal(false)}
         onImageSelected={handleImageSelected}
       />

--- a/web-app/src/features/validation/components/ScoresheetGuide.tsx
+++ b/web-app/src/features/validation/components/ScoresheetGuide.tsx
@@ -1,0 +1,101 @@
+/**
+ * ScoresheetGuide Component
+ *
+ * Provides a visual overlay guide for framing scoresheets when capturing images.
+ * Displays a frame with the correct aspect ratio to help users align scoresheets.
+ *
+ * Supports two aspect ratios based on scoresheet type:
+ * - Electronic (4:5 portrait): For player list table capture from screenshots
+ * - Manuscript (7:5 landscape): For full physical scoresheet capture
+ */
+
+import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
+import { useTranslation } from "@/shared/hooks/useTranslation";
+
+/**
+ * Aspect ratio dimensions for electronic scoresheet player list
+ * 4:5 portrait format matches Swiss volleyball scoresheet tables
+ */
+const ELECTRONIC_WIDTH = 4;
+const ELECTRONIC_HEIGHT = 5;
+const TABLE_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
+
+/**
+ * Aspect ratio dimensions for manuscript scoresheet
+ * 7:5 landscape format matches A4 paper scoresheets
+ */
+const MANUSCRIPT_WIDTH = 7;
+const MANUSCRIPT_HEIGHT = 5;
+const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
+
+interface ScoresheetGuideProps {
+  /** Type of scoresheet being captured */
+  scoresheetType: ScoresheetType;
+}
+
+/**
+ * Visual overlay guide for scoresheet image capture.
+ * Shows a frame with the appropriate aspect ratio and alignment hints.
+ */
+export function ScoresheetGuide({ scoresheetType }: ScoresheetGuideProps) {
+  const { t } = useTranslation();
+
+  const isElectronic = scoresheetType === "electronic";
+  const aspectRatio = isElectronic ? TABLE_ASPECT_RATIO : MANUSCRIPT_ASPECT_RATIO;
+
+  // Calculate frame dimensions based on aspect ratio
+  // For electronic (portrait): width is smaller than height (e.g., 80% width, 100% height)
+  // For manuscript (landscape): width is larger than height (e.g., 100% width, 71% height)
+  const frameStyle = isElectronic
+    ? {
+        width: "70%",
+        aspectRatio: `${aspectRatio}`,
+      }
+    : {
+        width: "90%",
+        aspectRatio: `${aspectRatio}`,
+      };
+
+  const hintText = isElectronic
+    ? t("validation.ocr.photoGuide.electronicHint")
+    : t("validation.ocr.photoGuide.manuscriptHint");
+
+  return (
+    <div className="absolute inset-0 pointer-events-none flex items-center justify-center">
+      {/* Semi-transparent overlay with cutout */}
+      <div className="absolute inset-0 bg-black/40" />
+
+      {/* Guide frame */}
+      <div
+        className="relative border-2 border-white/80 rounded-lg bg-transparent z-10"
+        style={frameStyle}
+      >
+        {/* Corner markers */}
+        <div className="absolute -top-0.5 -left-0.5 w-6 h-6 border-t-4 border-l-4 border-white rounded-tl-lg" />
+        <div className="absolute -top-0.5 -right-0.5 w-6 h-6 border-t-4 border-r-4 border-white rounded-tr-lg" />
+        <div className="absolute -bottom-0.5 -left-0.5 w-6 h-6 border-b-4 border-l-4 border-white rounded-bl-lg" />
+        <div className="absolute -bottom-0.5 -right-0.5 w-6 h-6 border-b-4 border-r-4 border-white rounded-br-lg" />
+
+        {/* Center crosshair */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="w-8 h-0.5 bg-white/50" />
+          <div className="absolute w-0.5 h-8 bg-white/50" />
+        </div>
+
+        {/* Hint text at bottom */}
+        <div className="absolute -bottom-10 left-0 right-0 text-center">
+          <span className="text-sm text-white/90 bg-black/50 px-3 py-1 rounded-full">
+            {hintText}
+          </span>
+        </div>
+      </div>
+
+      {/* Alignment instruction at top */}
+      <div className="absolute top-4 left-0 right-0 text-center z-10">
+        <span className="text-sm font-medium text-white/90 bg-black/50 px-4 py-2 rounded-lg">
+          {t("validation.ocr.photoGuide.alignScoresheet")}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -705,6 +705,18 @@ const de: Translations = {
       cancel: "Abbrechen",
       players: "Spieler",
       coaches: "Trainer",
+      scoresheetType: {
+        title: "Spielberichtstyp",
+        electronic: "Elektronisch",
+        electronicDescription: "Gedruckter/digitaler Spielbericht",
+        manuscript: "Handschriftlich",
+        manuscriptDescription: "Handgeschriebener Spielbericht",
+      },
+      photoGuide: {
+        alignScoresheet: "Spielbericht im Rahmen ausrichten",
+        electronicHint: "Spielerliste horizontal positionieren",
+        manuscriptHint: "Gesamte Spielberichtsseite erfassen",
+      },
       comparison: {
         title: "Spielervergleich",
         matched: "Übereinstimmend",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -698,6 +698,18 @@ const en: Translations = {
       cancel: "Cancel",
       players: "Players",
       coaches: "Coaches",
+      scoresheetType: {
+        title: "Scoresheet Type",
+        electronic: "Electronic",
+        electronicDescription: "Printed/digital scoresheet",
+        manuscript: "Manuscript",
+        manuscriptDescription: "Handwritten scoresheet",
+      },
+      photoGuide: {
+        alignScoresheet: "Align the scoresheet within the frame",
+        electronicHint: "Position the player list section horizontally",
+        manuscriptHint: "Capture the full scoresheet page",
+      },
       comparison: {
         title: "Player Comparison",
         matched: "Matched",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -705,6 +705,18 @@ const fr: Translations = {
       cancel: "Annuler",
       players: "Joueurs",
       coaches: "Entraîneurs",
+      scoresheetType: {
+        title: "Type de feuille de match",
+        electronic: "Électronique",
+        electronicDescription: "Feuille de match imprimée/numérique",
+        manuscript: "Manuscrite",
+        manuscriptDescription: "Feuille de match écrite à la main",
+      },
+      photoGuide: {
+        alignScoresheet: "Alignez la feuille de match dans le cadre",
+        electronicHint: "Positionnez la liste des joueurs horizontalement",
+        manuscriptHint: "Capturez la page complète de la feuille de match",
+      },
       comparison: {
         title: "Comparaison des joueurs",
         matched: "Correspondant",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -700,6 +700,18 @@ const it: Translations = {
       cancel: "Annulla",
       players: "Giocatori",
       coaches: "Allenatori",
+      scoresheetType: {
+        title: "Tipo di referto",
+        electronic: "Elettronico",
+        electronicDescription: "Referto stampato/digitale",
+        manuscript: "Manoscritto",
+        manuscriptDescription: "Referto scritto a mano",
+      },
+      photoGuide: {
+        alignScoresheet: "Allinea il referto nel riquadro",
+        electronicHint: "Posiziona la lista giocatori orizzontalmente",
+        manuscriptHint: "Cattura l'intera pagina del referto",
+      },
       comparison: {
         title: "Confronto giocatori",
         matched: "Corrispondente",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -533,6 +533,18 @@ export interface Translations {
       cancel: string;
       players: string;
       coaches: string;
+      scoresheetType: {
+        title: string;
+        electronic: string;
+        electronicDescription: string;
+        manuscript: string;
+        manuscriptDescription: string;
+      };
+      photoGuide: {
+        alignScoresheet: string;
+        electronicHint: string;
+        manuscriptHint: string;
+      };
       comparison: {
         title: string;
         matched: string;

--- a/web-app/src/shared/components/icons.tsx
+++ b/web-app/src/shared/components/icons.tsx
@@ -21,6 +21,7 @@ export { Camera } from "lucide-react";
 export { Check } from "lucide-react";
 export { SkipForward } from "lucide-react";
 export { FileText } from "lucide-react";
+export { PenTool } from "lucide-react";
 export { AlertCircle } from "lucide-react";
 export { User } from "lucide-react";
 export { UserPlus } from "lucide-react";


### PR DESCRIPTION
## Summary
- Add scoresheet type selection UI (electronic/manuscript) in OCR entry modal
- Create ScoresheetGuide component with aspect ratio overlays for camera capture
- Pass scoresheet type through the component chain to the parser
- Add translations for all 4 languages (de, en, fr, it)

## Test Plan
- [ ] Verify electronic scoresheet type shows 4:5 portrait guide
- [ ] Verify manuscript scoresheet type shows 7:5 landscape guide
- [ ] Verify type selection buttons work correctly in OCR entry modal
- [ ] Verify translations are correct in all 4 languages
- [ ] Verify OCR parsing routes to correct parser based on type