### PR TITLE
feat(validation): allow opening validation modal in safe mode with dismiss button

### DIFF
--- a/web-app/src/features/assignments/hooks/useAssignmentActions.test.ts
+++ b/web-app/src/features/assignments/hooks/useAssignmentActions.test.ts
@@ -432,15 +432,18 @@ describe("useAssignmentActions", () => {
       expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
     });
 
-    it("should block validate game when safe mode is enabled for unvalidated games", () => {
+    it("should allow opening validate game modal when safe mode is enabled for unvalidated games", () => {
+      // Safe mode now allows opening the modal - the modal shows SafeModeButtons
+      // with a "Dismiss" button instead of blocking entirely
       const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() });
 
       act(() => {
         result.current.validateGameModal.open(mockAssignment);
       });
 
-      expect(result.current.validateGameModal.isOpen).toBe(false);
-      expect(toast.warning).toHaveBeenCalledWith("settings.safeModeBlocked");
+      expect(result.current.validateGameModal.isOpen).toBe(true);
+      expect(result.current.validateGameModal.assignment).toBe(mockAssignment);
+      expect(toast.warning).not.toHaveBeenCalled();
     });
 
     it("should allow validate game when safe mode is enabled for already validated games", () => {

--- a/web-app/src/features/assignments/hooks/useAssignmentActions.ts
+++ b/web-app/src/features/assignments/hooks/useAssignmentActions.ts
@@ -65,21 +65,13 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
 
   const openValidateGame = useCallback(
     (assignment: Assignment) => {
-      // Allow viewing already validated games in safe mode (read-only)
-      const isAlreadyValidated = isGameAlreadyValidated(assignment);
-      if (
-        !isAlreadyValidated &&
-        guard({
-          context: "useAssignmentActions",
-          action: "game validation",
-        })
-      ) {
-        return;
-      }
-
+      // Safe mode no longer blocks opening the validation modal.
+      // Instead, when in safe mode, the modal shows a "Dismiss" button
+      // that closes without making any API calls, allowing users to
+      // preview the validation workflow without modifying data.
       validateGameModal.open(assignment);
     },
-    [guard, validateGameModal],
+    [validateGameModal],
   );
 
   const openPdfReport = useCallback(

--- a/web-app/src/features/validation/components/ValidateGameModal.test.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.test.tsx
@@ -26,6 +26,18 @@ vi.mock("@/shared/stores/auth", () => ({
   useAuthStore: vi.fn((selector) => selector({ dataSource: "api" })),
 }));
 
+vi.mock("@/shared/stores/settings", () => ({
+  useSettingsStore: vi.fn((selector) => {
+    const state = {
+      isSafeModeEnabled: false,
+      isSafeValidationEnabled: false,
+      isOCREnabled: false,
+    };
+    // Handle both selector function and direct access patterns
+    return typeof selector === "function" ? selector(state) : state;
+  }),
+}));
+
 function createMockAssignment(overrides: Partial<Assignment> = {}): Assignment {
   return {
     __identity: "assignment-1",

--- a/web-app/src/features/validation/components/ValidateGameModal.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.tsx
@@ -17,6 +17,7 @@ import {
   ValidationSuccessToast,
   StepRenderer,
   ValidatedModeButtons,
+  SafeModeButtons,
   EditModeButtons,
   OCREntryModal,
 } from ".";
@@ -310,6 +311,13 @@ function ValidateGameModalComponent({
         <div className="flex justify-between gap-3 pt-4 border-t border-border-default dark:border-border-default-dark mt-4">
           {wizard.isValidated ? (
             <ValidatedModeButtons
+              navigation={navigation}
+              onBack={wizard.goBack}
+              onNext={wizard.goNext}
+              onClose={onClose}
+            />
+          ) : wizard.isInSafeMode ? (
+            <SafeModeButtons
               navigation={navigation}
               onBack={wizard.goBack}
               onNext={wizard.goNext}

--- a/web-app/src/features/validation/components/WizardButtons.tsx
+++ b/web-app/src/features/validation/components/WizardButtons.tsx
@@ -49,6 +49,50 @@ export function ValidatedModeButtons({
   );
 }
 
+interface SafeModeButtonsProps {
+  navigation: WizardNavigationState;
+  onBack: () => void;
+  onNext: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Navigation buttons shown when safe mode is enabled.
+ * Read-only mode with Previous/Next/Dismiss buttons.
+ * Dismiss closes without making any API calls.
+ */
+export function SafeModeButtons({
+  navigation,
+  onBack,
+  onNext,
+  onClose,
+}: SafeModeButtonsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div>
+        {!navigation.isFirstStep && (
+          <Button variant="secondary" onClick={onBack}>
+            {t("validation.wizard.previous")}
+          </Button>
+        )}
+      </div>
+      <div>
+        {navigation.isLastStep ? (
+          <Button variant="primary" onClick={onClose}>
+            {t("validation.wizard.dismiss")}
+          </Button>
+        ) : (
+          <Button variant="primary" onClick={onNext}>
+            {t("validation.wizard.next")}
+          </Button>
+        )}
+      </div>
+    </>
+  );
+}
+
 interface EditModeState {
   isFinalizing: boolean;
   isLoadingGameDetails: boolean;

--- a/web-app/src/features/validation/components/WizardButtons.tsx
+++ b/web-app/src/features/validation/components/WizardButtons.tsx
@@ -6,23 +6,25 @@ interface WizardNavigationState {
   isLastStep: boolean;
 }
 
-interface ValidatedModeButtonsProps {
+interface ReadOnlyModeButtonsProps {
   navigation: WizardNavigationState;
   onBack: () => void;
   onNext: () => void;
   onClose: () => void;
+  closeLabel: string;
 }
 
 /**
- * Navigation buttons shown when viewing an already-validated game.
- * Read-only mode with Previous/Next/Close buttons.
+ * Shared navigation buttons for read-only modes (validated/safe mode).
+ * Shows Previous/Next buttons with a customizable close button on last step.
  */
-export function ValidatedModeButtons({
+function ReadOnlyModeButtons({
   navigation,
   onBack,
   onNext,
   onClose,
-}: ValidatedModeButtonsProps) {
+  closeLabel,
+}: ReadOnlyModeButtonsProps) {
   const { t } = useTranslation();
 
   return (
@@ -37,7 +39,7 @@ export function ValidatedModeButtons({
       <div>
         {navigation.isLastStep ? (
           <Button variant="primary" onClick={onClose}>
-            {t("common.close")}
+            {closeLabel}
           </Button>
         ) : (
           <Button variant="primary" onClick={onNext}>
@@ -47,6 +49,22 @@ export function ValidatedModeButtons({
       </div>
     </>
   );
+}
+
+interface ValidatedModeButtonsProps {
+  navigation: WizardNavigationState;
+  onBack: () => void;
+  onNext: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Navigation buttons shown when viewing an already-validated game.
+ * Read-only mode with Previous/Next/Close buttons.
+ */
+export function ValidatedModeButtons(props: ValidatedModeButtonsProps) {
+  const { t } = useTranslation();
+  return <ReadOnlyModeButtons {...props} closeLabel={t("common.close")} />;
 }
 
 interface SafeModeButtonsProps {
@@ -61,36 +79,9 @@ interface SafeModeButtonsProps {
  * Read-only mode with Previous/Next/Dismiss buttons.
  * Dismiss closes without making any API calls.
  */
-export function SafeModeButtons({
-  navigation,
-  onBack,
-  onNext,
-  onClose,
-}: SafeModeButtonsProps) {
+export function SafeModeButtons(props: SafeModeButtonsProps) {
   const { t } = useTranslation();
-
-  return (
-    <>
-      <div>
-        {!navigation.isFirstStep && (
-          <Button variant="secondary" onClick={onBack}>
-            {t("validation.wizard.previous")}
-          </Button>
-        )}
-      </div>
-      <div>
-        {navigation.isLastStep ? (
-          <Button variant="primary" onClick={onClose}>
-            {t("validation.wizard.dismiss")}
-          </Button>
-        ) : (
-          <Button variant="primary" onClick={onNext}>
-            {t("validation.wizard.next")}
-          </Button>
-        )}
-      </div>
-    </>
-  );
+  return <ReadOnlyModeButtons {...props} closeLabel={t("validation.wizard.dismiss")} />;
 }
 
 interface EditModeState {

--- a/web-app/src/features/validation/components/index.ts
+++ b/web-app/src/features/validation/components/index.ts
@@ -14,7 +14,7 @@ export { RosterValidationWarningDialog } from "./RosterValidationWarningDialog";
 export { SafeValidationCompleteModal } from "./SafeValidationCompleteModal";
 export { ValidationSuccessToast } from "./ValidationSuccessToast";
 export { StepRenderer } from "./StepRenderer";
-export { ValidatedModeButtons, EditModeButtons } from "./WizardButtons";
+export { ValidatedModeButtons, SafeModeButtons, EditModeButtons } from "./WizardButtons";
 export { OCRCaptureModal } from "./OCRCaptureModal";
 export { OCRPanel } from "./OCRPanel";
 export { PlayerComparisonList } from "./PlayerComparisonList";

--- a/web-app/src/features/validation/hooks/useValidateGameWizard.ts
+++ b/web-app/src/features/validation/hooks/useValidateGameWizard.ts
@@ -42,6 +42,10 @@ export interface UseValidateGameWizardResult {
   goToStep: (index: number) => void;
   wizardSteps: ValidationStep[];
 
+  // Safe mode state
+  /** True when safe mode is enabled and not in demo mode - modal is read-only */
+  isInSafeMode: boolean;
+
   // Validation state
   validationState: ReturnType<typeof useValidationState>["state"];
   isDirty: boolean;
@@ -116,9 +120,11 @@ export function useValidateGameWizard({
   const [successToast, setSuccessToast] = useState<string | null>(null);
   const [isAddPlayerSheetOpen, setIsAddPlayerSheetOpen] = useState(false);
 
-  // Check if safe validation mode is enabled (only applies when not in demo mode)
+  // Check if safe mode or safe validation mode is enabled (only applies when not in demo mode)
   const dataSource = useAuthStore((s) => s.dataSource);
+  const isSafeModeEnabled = useSettingsStore((s) => s.isSafeModeEnabled);
   const isSafeValidationEnabled = useSettingsStore((s) => s.isSafeValidationEnabled);
+  const isInSafeMode = dataSource !== "demo" && isSafeModeEnabled;
   const useSafeValidation = dataSource !== "demo" && isSafeValidationEnabled;
 
   const gameId = assignment.refereeGame?.game?.__identity;
@@ -388,6 +394,9 @@ export function useValidateGameWizard({
     stepsMarkedDone,
     goToStep,
     wizardSteps,
+
+    // Safe mode state
+    isInSafeMode,
 
     // Validation state
     validationState,

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -683,6 +683,7 @@ const de: Translations = {
       next: "Weiter",
       validate: "Validieren",
       finish: "Abschliessen",
+      dismiss: "Schliessen",
       stepOf: "Schritt {current} von {total}",
       saving: "Speichern...",
       markAsReviewed: "Als geprüft markieren",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -676,6 +676,7 @@ const en: Translations = {
       next: "Next",
       validate: "Validate",
       finish: "Finish",
+      dismiss: "Dismiss",
       stepOf: "Step {current} of {total}",
       saving: "Saving...",
       markAsReviewed: "Mark as reviewed",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -683,6 +683,7 @@ const fr: Translations = {
       next: "Suivant",
       validate: "Valider",
       finish: "Terminer",
+      dismiss: "Fermer",
       stepOf: "Étape {current} sur {total}",
       saving: "Enregistrement...",
       markAsReviewed: "Marquer comme vérifié",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -678,6 +678,7 @@ const it: Translations = {
       next: "Avanti",
       validate: "Valida",
       finish: "Termina",
+      dismiss: "Chiudi",
       stepOf: "Passo {current} di {total}",
       saving: "Salvataggio...",
       markAsReviewed: "Segna come verificato",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -511,6 +511,7 @@ export interface Translations {
       next: string;
       validate: string;
       finish: string;
+      dismiss: string;
       stepOf: string;
       saving: string;
       markAsReviewed: string;


### PR DESCRIPTION
## Summary
- Safe mode no longer blocks opening the validation modal
- When safe mode is enabled, the modal displays SafeModeButtons with a "Dismiss" button that closes without making any API calls
- This allows users to preview the validation workflow without modifying data

## Test Plan
- [x] All existing tests pass (3121 tests)
- [x] Updated test for safe mode behavior in useAssignmentActions
- [x] Added mock for useSettingsStore in ValidateGameModal tests
- [x] Lint, knip, and build all pass