### PR TITLE
fix(e2e): disable tour auto-start to prevent navigation blocking

### DIFF
--- a/web-app/e2e/app.spec.ts
+++ b/web-app/e2e/app.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 
 /**
  * Core app E2E tests - focused on browser-specific behavior only.

--- a/web-app/e2e/assignments.spec.ts
+++ b/web-app/e2e/assignments.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { LoginPage, AssignmentsPage, NavigationPage } from "./pages";
 
 /**

--- a/web-app/e2e/calendar-mode.spec.ts
+++ b/web-app/e2e/calendar-mode.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { LoginPage, NavigationPage } from "./pages";
 
 // Calendar Mode E2E tests: login flow, navigation restrictions, and banner display.

--- a/web-app/e2e/capture-screenshots.spec.ts
+++ b/web-app/e2e/capture-screenshots.spec.ts
@@ -7,6 +7,7 @@
  * Screenshots are saved to ../help-site/public/images/screenshots/
  */
 import { test, expect, type Page, type BrowserContext } from '@playwright/test';
+import { disableTours } from './fixtures';
 import { LoginPage, AssignmentsPage, NavigationPage, ExchangesPage, CompensationsPage } from './pages';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -65,19 +66,12 @@ test.beforeAll(() => {
 
 // Helper to dismiss all tours and PWA notifications by setting localStorage
 async function setupCleanEnvironment(page: Page) {
-  await page.addInitScript(() => {
-    // Pre-dismiss all tours to avoid them interfering with screenshots
-    const tourState = {
-      state: {
-        completedTours: ['assignments', 'compensations', 'exchange', 'settings'],
-        dismissedTours: [],
-      },
-      version: 0,
-    };
-    localStorage.setItem('volleykit-tour', JSON.stringify(tourState));
+  // Use shared helper to disable tours
+  await disableTours(page);
 
-    // Disable PWA prompts by mocking the service worker registration
-    // This prevents "App ready for offline use" notifications
+  // Disable PWA prompts by mocking the service worker registration
+  // This prevents "App ready for offline use" notifications
+  await page.addInitScript(() => {
     if ('serviceWorker' in navigator) {
       // Override the ready promise to prevent PWA notifications
       Object.defineProperty(navigator.serviceWorker, 'ready', {

--- a/web-app/e2e/compensations.spec.ts
+++ b/web-app/e2e/compensations.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { LoginPage, CompensationsPage, NavigationPage } from "./pages";
 
 /**

--- a/web-app/e2e/exchanges.spec.ts
+++ b/web-app/e2e/exchanges.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures";
 import { LoginPage, ExchangesPage, NavigationPage } from "./pages";
 
 /**

--- a/web-app/e2e/fixtures.ts
+++ b/web-app/e2e/fixtures.ts
@@ -1,5 +1,30 @@
 /* eslint-disable react-hooks/rules-of-hooks -- Playwright fixtures use 'use' callback, not React hooks */
-import { test as base, expect } from "@playwright/test";
+import { test as base, expect, type Page } from "@playwright/test";
+
+/**
+ * Pre-complete all tours to prevent them from auto-starting.
+ *
+ * Tours auto-start in demo mode after 500ms and disable navigation
+ * links while active, which causes E2E tests to fail when trying
+ * to click disabled navigation elements.
+ *
+ * This helper can be used:
+ * - Automatically via the `test` fixture for standard tests
+ * - Manually via `disableTours(page)` for dynamically created pages
+ */
+export async function disableTours(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    // Zustand persist format for the tour store
+    const tourState = {
+      state: {
+        completedTours: ["assignments", "compensations", "exchange", "settings"],
+        dismissedTours: [],
+      },
+      version: 0,
+    };
+    localStorage.setItem("volleykit-tour", JSON.stringify(tourState));
+  });
+}
 
 /**
  * Custom test fixtures for E2E tests.
@@ -13,22 +38,7 @@ export const test = base.extend({
    * This runs before each test and sets up the browser state.
    */
   page: async ({ page }, use) => {
-    // Pre-complete all tours to prevent them from auto-starting.
-    // Tours auto-start in demo mode after 500ms and disable navigation
-    // links while active, which causes E2E tests to fail when trying
-    // to click disabled navigation elements.
-    await page.addInitScript(() => {
-      // Zustand persist format for the tour store
-      const tourState = {
-        state: {
-          completedTours: ["assignments", "compensations", "exchange", "settings"],
-          dismissedTours: [],
-        },
-        version: 0,
-      };
-      localStorage.setItem("volleykit-tour", JSON.stringify(tourState));
-    });
-
+    await disableTours(page);
     await use(page);
   },
 });

--- a/web-app/e2e/fixtures.ts
+++ b/web-app/e2e/fixtures.ts
@@ -1,0 +1,37 @@
+/* eslint-disable react-hooks/rules-of-hooks -- Playwright fixtures use 'use' callback, not React hooks */
+import { test as base, expect } from "@playwright/test";
+
+/**
+ * Custom test fixtures for E2E tests.
+ *
+ * This extends the base Playwright test with additional setup
+ * that runs before each test.
+ */
+export const test = base.extend({
+  /**
+   * Override the page fixture to pre-configure localStorage.
+   * This runs before each test and sets up the browser state.
+   */
+  page: async ({ page }, use) => {
+    // Pre-complete all tours to prevent them from auto-starting.
+    // Tours auto-start in demo mode after 500ms and disable navigation
+    // links while active, which causes E2E tests to fail when trying
+    // to click disabled navigation elements.
+    await page.addInitScript(() => {
+      // Zustand persist format for the tour store
+      const tourState = {
+        state: {
+          completedTours: ["assignments", "compensations", "exchange", "settings"],
+          dismissedTours: [],
+        },
+        version: 0,
+      };
+      localStorage.setItem("volleykit-tour", JSON.stringify(tourState));
+    });
+
+    await use(page);
+  },
+});
+
+// Re-export expect for convenience
+export { expect };


### PR DESCRIPTION
## Summary

- Fixes E2E test failures in WebKit where navigation links were disabled during tour auto-start
- Adds custom Playwright fixture that pre-completes all tours in localStorage before each test
- Extracts reusable `disableTours()` helper for use with dynamically created pages
- Consolidates duplicate tour-disabling logic from `capture-screenshots.spec.ts`

## Root Cause

Tours auto-start in demo mode after 500ms and set `aria-disabled="true"` on non-active navigation links. Playwright correctly identifies these elements as disabled and refuses to click them, causing test timeouts.

## Changes

1. **`e2e/fixtures.ts`** - New file with:
   - `disableTours(page)` - Reusable helper to pre-complete all tours
   - Custom `test` fixture that automatically applies tour disabling

2. **`e2e/*.spec.ts`** - Updated all E2E tests to import from `./fixtures`

3. **`e2e/capture-screenshots.spec.ts`** - Refactored to use shared `disableTours()` helper

## Test plan

- [x] Verified lint passes
- [x] Verified unit tests pass (3121 tests)
- [x] Verified Chromium E2E tests pass locally (52 passed)
- [ ] CI E2E tests on all browsers (webkit, chromium, firefox, mobile)