### PR TITLE
feat(ocr): replace custom pan/zoom with react-easy-crop library

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -17,6 +17,7 @@
         "pluscodes": "^3.0.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "react-easy-crop": "^5.5.6",
         "react-router-dom": "^7.10.1",
         "tailwindcss": "^4.1.17",
         "zod": "^4.3.5",
@@ -8556,6 +8557,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -9205,6 +9212,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.6.tgz",
+      "integrity": "sha512-Jw3/ozs8uXj3NpL511Suc4AHY+mLRO23rUgipXvNYKqezcFSYHxe4QXibBymkOoY6oOtLVMPO2HNPRHYvMPyTw==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-is": {
@@ -10529,9 +10550,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -52,6 +52,12 @@
     {
       "name": "OCR Feature (lazy-loaded)",
       "path": "dist/assets/chunk-OCRPanel-*.js",
+      "limit": "12 kB",
+      "gzip": true
+    },
+    {
+      "name": "Image Cropper (lazy-loaded)",
+      "path": "dist/assets/chunk-cropper-*.js",
       "limit": "10 kB",
       "gzip": true
     },
@@ -64,7 +70,7 @@
     {
       "name": "Total JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "500 kB",
+      "limit": "510 kB",
       "gzip": true
     }
   ],
@@ -78,6 +84,7 @@
     "pluscodes": "^3.0.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-easy-crop": "^5.5.6",
     "react-router-dom": "^7.10.1",
     "tailwindcss": "^4.1.17",
     "zod": "^4.3.5",

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -13,9 +13,9 @@ import { X, Check, RotateCcw, RotateCw, AlertCircle } from "@/shared/components/
 import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
 import { getCroppedImage } from "../utils/image-crop";
 
-/** Aspect ratio for electronic scoresheet (5:7 portrait) */
-const ELECTRONIC_WIDTH = 5;
-const ELECTRONIC_HEIGHT = 7;
+/** Aspect ratio for electronic scoresheet (3:4 portrait) */
+const ELECTRONIC_WIDTH = 3;
+const ELECTRONIC_HEIGHT = 4;
 const ELECTRONIC_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
 /** Aspect ratio for manuscript scoresheet (7:5 landscape) */

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -13,9 +13,9 @@ import { X, Check, RotateCcw, RotateCw, AlertCircle } from "@/shared/components/
 import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
 import { getCroppedImage } from "../utils/image-crop";
 
-/** Aspect ratio for electronic scoresheet (3:4 portrait) */
-const ELECTRONIC_WIDTH = 3;
-const ELECTRONIC_HEIGHT = 4;
+/** Aspect ratio for electronic scoresheet (17:20 portrait, ~0.85) */
+const ELECTRONIC_WIDTH = 17;
+const ELECTRONIC_HEIGHT = 20;
 const ELECTRONIC_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
 /** Aspect ratio for manuscript scoresheet (7:5 landscape) */

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -12,9 +12,9 @@ import { useTranslation } from "@/shared/hooks/useTranslation";
 import { X, Check, RotateCcw, RotateCw, AlertCircle } from "@/shared/components/icons";
 import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
 
-/** Aspect ratio for electronic scoresheet (4:5 portrait) */
-const ELECTRONIC_WIDTH = 4;
-const ELECTRONIC_HEIGHT = 5;
+/** Aspect ratio for electronic scoresheet (5:7 portrait) */
+const ELECTRONIC_WIDTH = 5;
+const ELECTRONIC_HEIGHT = 7;
 const ELECTRONIC_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
 /** Aspect ratio for manuscript scoresheet (7:5 landscape) */

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -1,15 +1,15 @@
 /**
  * ImageCropEditor Component
  *
- * Pan/zoom image editor for cropping scoresheet images to the correct aspect ratio.
- * The user can drag and pinch-zoom the image to position it within a fixed-aspect-ratio frame.
- *
- * Based on the OCR POC ImageEditor pattern with React implementation.
+ * Pan/zoom/rotate image editor for cropping scoresheet images to the correct aspect ratio.
+ * Uses react-easy-crop for reliable touch gestures and coordinate calculations.
  */
 
-import { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
+import Cropper from "react-easy-crop";
+import type { Area, Point } from "react-easy-crop";
 import { useTranslation } from "@/shared/hooks/useTranslation";
-import { X, Check } from "@/shared/components/icons";
+import { X, Check, RotateCcw, RotateCw } from "@/shared/components/icons";
 import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
 
 /** Aspect ratio for electronic scoresheet (4:5 portrait) */
@@ -22,29 +22,20 @@ const MANUSCRIPT_WIDTH = 7;
 const MANUSCRIPT_HEIGHT = 5;
 const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
 
-/** Frame padding from viewport edge */
-const FRAME_PADDING_PX = 24;
-
-/** Frame height as ratio of available space */
-const FRAME_HEIGHT_RATIO = 0.7;
-
-/** Frame width as ratio of available space */
-const FRAME_WIDTH_RATIO = 0.85;
-
 /** Minimum zoom level */
-const MIN_ZOOM = 0.1;
+const MIN_ZOOM = 0.5;
 
 /** Maximum zoom level */
 const MAX_ZOOM = 3;
 
-/** Zoom out multiplier for wheel scroll */
-const ZOOM_OUT_DELTA = 0.9;
-
-/** Zoom in multiplier for wheel scroll */
-const ZOOM_IN_DELTA = 1.1;
+/** Rotation step in degrees */
+const ROTATION_STEP = 90;
 
 /** JPEG quality for output */
 const JPEG_QUALITY = 0.92;
+
+/** Degrees in half a circle (for radians conversion) */
+const DEGREES_PER_HALF_CIRCLE = 180;
 
 interface ImageCropEditorProps {
   /** Image blob to crop */
@@ -57,13 +48,113 @@ interface ImageCropEditorProps {
   onCancel: () => void;
 }
 
-interface Position {
-  x: number;
-  y: number;
+/**
+ * Creates a cropped image from the source image and crop area.
+ * Handles rotation by drawing onto a rotated canvas.
+ */
+async function getCroppedImage(
+  imageSrc: string,
+  pixelCrop: Area,
+  rotation: number,
+): Promise<Blob> {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    throw new Error("Could not get canvas context");
+  }
+
+  // Calculate bounding box of the rotated image
+  const rotRad = (rotation * Math.PI) / DEGREES_PER_HALF_CIRCLE;
+  const { width: bBoxWidth, height: bBoxHeight } = getRotatedBoundingBox(
+    image.width,
+    image.height,
+    rotation,
+  );
+
+  // Set canvas size to the bounding box
+  canvas.width = bBoxWidth;
+  canvas.height = bBoxHeight;
+
+  // Translate to center, rotate, then translate back
+  ctx.translate(bBoxWidth / 2, bBoxHeight / 2);
+  ctx.rotate(rotRad);
+  ctx.translate(-image.width / 2, -image.height / 2);
+
+  // Draw the rotated image
+  ctx.drawImage(image, 0, 0);
+
+  // Extract the cropped area
+  const croppedCanvas = document.createElement("canvas");
+  const croppedCtx = croppedCanvas.getContext("2d");
+
+  if (!croppedCtx) {
+    throw new Error("Could not get cropped canvas context");
+  }
+
+  croppedCanvas.width = pixelCrop.width;
+  croppedCanvas.height = pixelCrop.height;
+
+  croppedCtx.drawImage(
+    canvas,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    pixelCrop.width,
+    pixelCrop.height,
+  );
+
+  return new Promise((resolve, reject) => {
+    croppedCanvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Failed to create blob from canvas"));
+        }
+      },
+      "image/jpeg",
+      JPEG_QUALITY,
+    );
+  });
 }
 
 /**
- * Image crop editor with pan/zoom functionality.
+ * Creates an Image element from a source URL.
+ */
+function createImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener("load", () => resolve(image));
+    image.addEventListener("error", (error) => reject(error));
+    image.src = url;
+  });
+}
+
+/**
+ * Calculates the bounding box dimensions of a rotated rectangle.
+ */
+function getRotatedBoundingBox(
+  width: number,
+  height: number,
+  rotation: number,
+): { width: number; height: number } {
+  const rotRad = (rotation * Math.PI) / DEGREES_PER_HALF_CIRCLE;
+  const sinRot = Math.abs(Math.sin(rotRad));
+  const cosRot = Math.abs(Math.cos(rotRad));
+
+  return {
+    width: width * cosRot + height * sinRot,
+    height: width * sinRot + height * cosRot,
+  };
+}
+
+/**
+ * Image crop editor with pan/zoom/rotate functionality.
  * Shows a fixed-aspect-ratio frame and lets the user position the image within it.
  */
 export function ImageCropEditor({
@@ -73,295 +164,107 @@ export function ImageCropEditor({
   onCancel,
 }: ImageCropEditorProps) {
   const { t } = useTranslation();
-  const viewportRef = useRef<HTMLDivElement>(null);
-  const imageRef = useRef<HTMLImageElement>(null);
 
-  // Image state - use useMemo for URL to avoid setState in effect
+  // Create object URL for the image
   const imageUrl = useMemo(() => URL.createObjectURL(imageBlob), [imageBlob]);
-  const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
 
-  // Cleanup object URL on unmount or when imageBlob changes
-  useEffect(() => {
-    return () => URL.revokeObjectURL(imageUrl);
-  }, [imageUrl]);
-
-  // Interaction state
-  const [isDragging, setIsDragging] = useState(false);
-  const dragStartRef = useRef<Position>({ x: 0, y: 0 });
-  const positionStartRef = useRef<Position>({ x: 0, y: 0 });
-
-  // Pinch zoom state
-  const pinchStartDistanceRef = useRef<number>(0);
-  const pinchStartZoomRef = useRef<number>(1);
-
-  // Frame dimensions
-  const [frameSize, setFrameSize] = useState({ width: 0, height: 0 });
+  // Crop state
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [rotation, setRotation] = useState(0);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   const aspectRatio =
     scoresheetType === "electronic"
       ? ELECTRONIC_ASPECT_RATIO
       : MANUSCRIPT_ASPECT_RATIO;
 
-  // Compute initial zoom based on image and frame sizes
-  const initialZoom = useMemo(() => {
-    if (imageSize.width === 0 || frameSize.width === 0) return 1;
-    const scaleX = frameSize.width / imageSize.width;
-    const scaleY = frameSize.height / imageSize.height;
-    const computed = Math.max(scaleX, scaleY);
-    return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, computed));
-  }, [imageSize, frameSize]);
+  const onCropComplete = useCallback(
+    (_croppedArea: Area, croppedAreaPixels: Area) => {
+      setCroppedAreaPixels(croppedAreaPixels);
+    },
+    [],
+  );
 
-  // Transform state - initialize with computed values
-  const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
+  const handleRotateLeft = useCallback(() => {
+    setRotation((r) => r - ROTATION_STEP);
+  }, []);
 
-  // Track if we've initialized zoom for the current image
-  const initializedRef = useRef(false);
+  const handleRotateRight = useCallback(() => {
+    setRotation((r) => r + ROTATION_STEP);
+  }, []);
 
-  // Load image dimensions and reset initialization flag when image changes
-  useEffect(() => {
-    initializedRef.current = false;
+  const handleConfirm = useCallback(async () => {
+    if (!croppedAreaPixels) return;
 
-    const img = new Image();
-    img.onload = () => {
-      setImageSize({ width: img.width, height: img.height });
-    };
-    img.src = imageUrl;
-  }, [imageUrl]);
-
-  // Calculate frame size based on viewport
-  useEffect(() => {
-    const updateFrameSize = () => {
-      if (!viewportRef.current) return;
-
-      const viewport = viewportRef.current.getBoundingClientRect();
-      const availableWidth = viewport.width - FRAME_PADDING_PX * 2;
-      const availableHeight = viewport.height - FRAME_PADDING_PX * 2;
-
-      let frameWidth: number;
-      let frameHeight: number;
-
-      if (availableWidth / availableHeight > aspectRatio) {
-        // Viewport is wider - constrain by height
-        frameHeight = availableHeight * FRAME_HEIGHT_RATIO;
-        frameWidth = frameHeight * aspectRatio;
-      } else {
-        // Viewport is taller - constrain by width
-        frameWidth = availableWidth * FRAME_WIDTH_RATIO;
-        frameHeight = frameWidth / aspectRatio;
-      }
-
-      setFrameSize({ width: frameWidth, height: frameHeight });
-    };
-
-    updateFrameSize();
-    window.addEventListener("resize", updateFrameSize);
-    return () => window.removeEventListener("resize", updateFrameSize);
-  }, [aspectRatio]);
-
-  // Initialize zoom when image loads (only once per image)
-  // This is intentional one-time initialization guarded by ref, not cascading renders
-  useEffect(() => {
-    if (imageSize.width > 0 && frameSize.width > 0 && !initializedRef.current) {
-      initializedRef.current = true;
-      setZoom(initialZoom); // eslint-disable-line react-hooks/set-state-in-effect
-      setPosition({ x: 0, y: 0 });
+    setIsProcessing(true);
+    try {
+      const croppedBlob = await getCroppedImage(
+        imageUrl,
+        croppedAreaPixels,
+        rotation,
+      );
+      onConfirm(croppedBlob);
+    } catch (error) {
+      console.error("Failed to crop image:", error);
+      // Still allow user to try again
+      setIsProcessing(false);
     }
-  }, [imageSize, frameSize, initialZoom]);
-
-  // Mouse/touch handlers
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      e.preventDefault();
-      setIsDragging(true);
-      dragStartRef.current = { x: e.clientX, y: e.clientY };
-      positionStartRef.current = position;
-      (e.target as HTMLElement).setPointerCapture(e.pointerId);
-    },
-    [position],
-  );
-
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (!isDragging) return;
-
-      const dx = e.clientX - dragStartRef.current.x;
-      const dy = e.clientY - dragStartRef.current.y;
-
-      setPosition({
-        x: positionStartRef.current.x + dx,
-        y: positionStartRef.current.y + dy,
-      });
-    },
-    [isDragging],
-  );
-
-  const handlePointerUp = useCallback((e: React.PointerEvent) => {
-    setIsDragging(false);
-    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
-  }, []);
-
-  // Wheel zoom
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
-    const delta = e.deltaY > 0 ? ZOOM_OUT_DELTA : ZOOM_IN_DELTA;
-    setZoom((z) => Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z * delta)));
-  }, []);
-
-  // Calculate distance between two touch points (called only when length >= 2)
-  const getTouchDistance = useCallback((touches: React.TouchList): number => {
-    const touch0 = touches[0];
-    const touch1 = touches[1];
-    if (!touch0 || !touch1) return 0;
-    const dx = touch0.clientX - touch1.clientX;
-    const dy = touch0.clientY - touch1.clientY;
-    return Math.sqrt(dx * dx + dy * dy);
-  }, []);
-
-  // Pinch zoom handlers
-  const handleTouchStart = useCallback(
-    (e: React.TouchEvent) => {
-      if (e.touches.length === 2) {
-        e.preventDefault();
-        pinchStartDistanceRef.current = getTouchDistance(e.touches);
-        pinchStartZoomRef.current = zoom;
-      }
-    },
-    [zoom, getTouchDistance],
-  );
-
-  const handleTouchMove = useCallback(
-    (e: React.TouchEvent) => {
-      if (e.touches.length === 2 && pinchStartDistanceRef.current > 0) {
-        e.preventDefault();
-        const currentDistance = getTouchDistance(e.touches);
-        const scale = currentDistance / pinchStartDistanceRef.current;
-        const newZoom = pinchStartZoomRef.current * scale;
-        setZoom(Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom)));
-      }
-    },
-    [getTouchDistance],
-  );
-
-  const handleTouchEnd = useCallback(() => {
-    pinchStartDistanceRef.current = 0;
-  }, []);
-
-  // Crop and export
-  const handleConfirm = useCallback(() => {
-    if (!imageRef.current || !viewportRef.current) return;
-
-    const viewport = viewportRef.current.getBoundingClientRect();
-    const img = imageRef.current;
-
-    // Calculate crop area in image coordinates
-    const viewportCenterX = viewport.width / 2;
-    const viewportCenterY = viewport.height / 2;
-
-    // Frame center is at viewport center
-    const frameCenterX = viewportCenterX;
-    const frameCenterY = viewportCenterY;
-
-    // Image center is at viewport center + position offset
-    const imageCenterX = viewportCenterX + position.x;
-    const imageCenterY = viewportCenterY + position.y;
-
-    // Frame top-left relative to image
-    const frameLeftOnImage = (frameCenterX - imageCenterX) / zoom;
-    const frameTopOnImage = (frameCenterY - imageCenterY) / zoom;
-
-    // Convert to image coordinates
-    const cropX = imageSize.width / 2 + frameLeftOnImage - frameSize.width / 2 / zoom;
-    const cropY = imageSize.height / 2 + frameTopOnImage - frameSize.height / 2 / zoom;
-    const cropWidth = frameSize.width / zoom;
-    const cropHeight = frameSize.height / zoom;
-
-    // Create canvas and crop
-    const canvas = document.createElement("canvas");
-    canvas.width = frameSize.width;
-    canvas.height = frameSize.height;
-
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    ctx.drawImage(
-      img,
-      Math.max(0, cropX),
-      Math.max(0, cropY),
-      cropWidth,
-      cropHeight,
-      0,
-      0,
-      frameSize.width,
-      frameSize.height,
-    );
-
-    canvas.toBlob(
-      (blob) => {
-        if (blob) {
-          onConfirm(blob);
-        }
-      },
-      "image/jpeg",
-      JPEG_QUALITY,
-    );
-  }, [imageSize, frameSize, position, zoom, onConfirm]);
+  }, [croppedAreaPixels, imageUrl, rotation, onConfirm]);
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-gray-900">
-      {/* Viewport */}
-      <div
-        ref={viewportRef}
-        className="relative flex-1 overflow-hidden cursor-grab active:cursor-grabbing touch-none"
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
-        onWheel={handleWheel}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-      >
-        {/* Image */}
-        <img
-          ref={imageRef}
-          src={imageUrl}
-          alt=""
-          className="absolute pointer-events-none select-none"
-          style={{
-            left: "50%",
-            top: "50%",
-            transform: `translate(-50%, -50%) translate(${position.x}px, ${position.y}px) scale(${zoom})`,
-            maxWidth: "none",
+      {/* Cropper viewport */}
+      <div className="relative flex-1">
+        <Cropper
+          image={imageUrl}
+          crop={crop}
+          zoom={zoom}
+          rotation={rotation}
+          aspect={aspectRatio}
+          minZoom={MIN_ZOOM}
+          maxZoom={MAX_ZOOM}
+          onCropChange={setCrop}
+          onZoomChange={setZoom}
+          onRotationChange={setRotation}
+          onCropComplete={onCropComplete}
+          showGrid={true}
+          classes={{
+            containerClassName: "!absolute !inset-0",
+            cropAreaClassName: "!border-2 !border-white/90",
           }}
-          draggable={false}
         />
-
-        {/* Frame overlay */}
-        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-          {/* Dark overlay with cutout using box-shadow */}
-          <div
-            className="relative border-2 border-white/90 rounded-sm"
-            style={{
-              width: frameSize.width,
-              height: frameSize.height,
-              boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.5)",
-            }}
-          >
-            {/* Corner markers */}
-            <div className="absolute -top-0.5 -left-0.5 w-5 h-5 border-t-4 border-l-4 border-white rounded-tl" />
-            <div className="absolute -top-0.5 -right-0.5 w-5 h-5 border-t-4 border-r-4 border-white rounded-tr" />
-            <div className="absolute -bottom-0.5 -left-0.5 w-5 h-5 border-b-4 border-l-4 border-white rounded-bl" />
-            <div className="absolute -bottom-0.5 -right-0.5 w-5 h-5 border-b-4 border-r-4 border-white rounded-br" />
-          </div>
-        </div>
       </div>
 
-      {/* Hint */}
-      <div className="flex-shrink-0 py-2 text-center">
-        <span className="inline-block px-3 py-1 text-sm text-gray-300 bg-white/10 rounded">
-          {t("validation.ocr.photoGuide.alignScoresheet")}
-        </span>
+      {/* Hint and rotation controls */}
+      <div className="flex-shrink-0 py-2 px-4">
+        <div className="flex items-center justify-between">
+          {/* Rotate left */}
+          <button
+            type="button"
+            onClick={handleRotateLeft}
+            className="p-2 text-gray-300 hover:text-white bg-white/10 hover:bg-white/20 rounded-full transition-colors"
+            aria-label={t("validation.ocr.rotateLeft")}
+          >
+            <RotateCcw className="w-6 h-6" aria-hidden="true" />
+          </button>
+
+          {/* Hint text */}
+          <span className="px-3 py-1 text-sm text-gray-300 bg-white/10 rounded">
+            {t("validation.ocr.photoGuide.alignScoresheet")}
+          </span>
+
+          {/* Rotate right */}
+          <button
+            type="button"
+            onClick={handleRotateRight}
+            className="p-2 text-gray-300 hover:text-white bg-white/10 hover:bg-white/20 rounded-full transition-colors"
+            aria-label={t("validation.ocr.rotateRight")}
+          >
+            <RotateCw className="w-6 h-6" aria-hidden="true" />
+          </button>
+        </div>
       </div>
 
       {/* Controls */}
@@ -369,7 +272,8 @@ export function ImageCropEditor({
         <button
           type="button"
           onClick={onCancel}
-          className="flex-1 flex items-center justify-center gap-2 min-h-12 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-lg font-medium transition-colors"
+          disabled={isProcessing}
+          className="flex-1 flex items-center justify-center gap-2 min-h-12 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-lg font-medium transition-colors disabled:opacity-50"
         >
           <X className="w-5 h-5" aria-hidden="true" />
           {t("validation.ocr.cancel")}
@@ -377,10 +281,11 @@ export function ImageCropEditor({
         <button
           type="button"
           onClick={handleConfirm}
-          className="flex-1 flex items-center justify-center gap-2 min-h-12 px-4 py-3 text-white bg-primary-500 hover:bg-primary-600 rounded-lg font-medium transition-colors"
+          disabled={isProcessing || !croppedAreaPixels}
+          className="flex-1 flex items-center justify-center gap-2 min-h-12 px-4 py-3 text-white bg-primary-500 hover:bg-primary-600 rounded-lg font-medium transition-colors disabled:opacity-50"
         >
           <Check className="w-5 h-5" aria-hidden="true" />
-          {t("common.confirm")}
+          {isProcessing ? t("validation.ocr.processing") : t("common.confirm")}
         </button>
       </div>
     </div>

--- a/web-app/src/features/validation/utils/image-crop.test.ts
+++ b/web-app/src/features/validation/utils/image-crop.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  degreesToRadians,
+  getRotatedBoundingBox,
+} from "./image-crop";
+
+describe("image-crop utilities", () => {
+  describe("degreesToRadians", () => {
+    it("converts 0 degrees to 0 radians", () => {
+      expect(degreesToRadians(0)).toBe(0);
+    });
+
+    it("converts 90 degrees to π/2 radians", () => {
+      expect(degreesToRadians(90)).toBeCloseTo(Math.PI / 2);
+    });
+
+    it("converts 180 degrees to π radians", () => {
+      expect(degreesToRadians(180)).toBeCloseTo(Math.PI);
+    });
+
+    it("converts 360 degrees to 2π radians", () => {
+      expect(degreesToRadians(360)).toBeCloseTo(2 * Math.PI);
+    });
+
+    it("converts negative degrees correctly", () => {
+      expect(degreesToRadians(-90)).toBeCloseTo(-Math.PI / 2);
+    });
+
+    it("converts 45 degrees to π/4 radians", () => {
+      expect(degreesToRadians(45)).toBeCloseTo(Math.PI / 4);
+    });
+  });
+
+  describe("getRotatedBoundingBox", () => {
+    it("returns same dimensions for 0 degree rotation", () => {
+      const result = getRotatedBoundingBox(100, 50, 0);
+      expect(result.width).toBeCloseTo(100);
+      expect(result.height).toBeCloseTo(50);
+    });
+
+    it("returns same dimensions for 360 degree rotation", () => {
+      const result = getRotatedBoundingBox(100, 50, 360);
+      expect(result.width).toBeCloseTo(100);
+      expect(result.height).toBeCloseTo(50);
+    });
+
+    it("swaps dimensions for 90 degree rotation", () => {
+      const result = getRotatedBoundingBox(100, 50, 90);
+      expect(result.width).toBeCloseTo(50);
+      expect(result.height).toBeCloseTo(100);
+    });
+
+    it("swaps dimensions for -90 degree rotation", () => {
+      const result = getRotatedBoundingBox(100, 50, -90);
+      expect(result.width).toBeCloseTo(50);
+      expect(result.height).toBeCloseTo(100);
+    });
+
+    it("swaps dimensions for 270 degree rotation", () => {
+      const result = getRotatedBoundingBox(100, 50, 270);
+      expect(result.width).toBeCloseTo(50);
+      expect(result.height).toBeCloseTo(100);
+    });
+
+    it("returns same dimensions for 180 degree rotation", () => {
+      const result = getRotatedBoundingBox(100, 50, 180);
+      expect(result.width).toBeCloseTo(100);
+      expect(result.height).toBeCloseTo(50);
+    });
+
+    it("calculates larger bounding box for 45 degree rotation", () => {
+      // For 45 degrees, bounding box should be larger than both dimensions
+      const result = getRotatedBoundingBox(100, 100, 45);
+      // For a 100x100 square rotated 45°, the bounding box is ~141.4 x 141.4
+      const expected = 100 * Math.sqrt(2);
+      expect(result.width).toBeCloseTo(expected);
+      expect(result.height).toBeCloseTo(expected);
+    });
+
+    it("handles non-square rectangles at 45 degrees", () => {
+      const result = getRotatedBoundingBox(100, 50, 45);
+      // At 45°: sin(45) = cos(45) ≈ 0.707
+      // width = 100 * 0.707 + 50 * 0.707 ≈ 106.1
+      // height = 100 * 0.707 + 50 * 0.707 ≈ 106.1
+      const sin45 = Math.sin(Math.PI / 4);
+      const expectedWidth = 100 * sin45 + 50 * sin45;
+      const expectedHeight = 100 * sin45 + 50 * sin45;
+      expect(result.width).toBeCloseTo(expectedWidth);
+      expect(result.height).toBeCloseTo(expectedHeight);
+    });
+
+    it("handles zero width", () => {
+      const result = getRotatedBoundingBox(0, 100, 45);
+      expect(result.width).toBeCloseTo(100 * Math.sin(Math.PI / 4));
+      expect(result.height).toBeCloseTo(100 * Math.cos(Math.PI / 4));
+    });
+
+    it("handles zero height", () => {
+      const result = getRotatedBoundingBox(100, 0, 45);
+      expect(result.width).toBeCloseTo(100 * Math.cos(Math.PI / 4));
+      expect(result.height).toBeCloseTo(100 * Math.sin(Math.PI / 4));
+    });
+
+    it("handles large rotation values (720 degrees)", () => {
+      // 720 degrees = 2 full rotations = 0 degrees effective
+      const result = getRotatedBoundingBox(100, 50, 720);
+      expect(result.width).toBeCloseTo(100);
+      expect(result.height).toBeCloseTo(50);
+    });
+  });
+});

--- a/web-app/src/features/validation/utils/image-crop.ts
+++ b/web-app/src/features/validation/utils/image-crop.ts
@@ -1,0 +1,150 @@
+/**
+ * Image cropping utilities for the scoresheet OCR feature.
+ * Handles rotation, cropping, and canvas operations.
+ */
+
+/** Degrees in half a circle (for radians conversion) */
+const DEGREES_PER_HALF_CIRCLE = 180;
+
+/** Default JPEG quality for output */
+const DEFAULT_JPEG_QUALITY = 0.92;
+
+/**
+ * Represents a crop area with position and dimensions.
+ */
+export interface CropArea {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Converts degrees to radians.
+ */
+export function degreesToRadians(degrees: number): number {
+  return (degrees * Math.PI) / DEGREES_PER_HALF_CIRCLE;
+}
+
+/**
+ * Calculates the bounding box dimensions of a rotated rectangle.
+ * When a rectangle is rotated, it needs a larger bounding box to contain it.
+ *
+ * @param width - Original width of the rectangle
+ * @param height - Original height of the rectangle
+ * @param rotation - Rotation angle in degrees
+ * @returns The width and height of the bounding box
+ */
+export function getRotatedBoundingBox(
+  width: number,
+  height: number,
+  rotation: number,
+): { width: number; height: number } {
+  const rotRad = degreesToRadians(rotation);
+  const sinRot = Math.abs(Math.sin(rotRad));
+  const cosRot = Math.abs(Math.cos(rotRad));
+
+  return {
+    width: width * cosRot + height * sinRot,
+    height: width * sinRot + height * cosRot,
+  };
+}
+
+/**
+ * Creates an Image element from a source URL.
+ * Returns a promise that resolves when the image is loaded.
+ *
+ * @param url - The image URL (can be a blob URL or regular URL)
+ * @returns Promise resolving to the loaded HTMLImageElement
+ */
+export function createImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener("load", () => resolve(image));
+    image.addEventListener("error", (error) => reject(error));
+    image.src = url;
+  });
+}
+
+/**
+ * Creates a cropped image from the source image and crop area.
+ * Handles rotation by first drawing the rotated image onto a canvas,
+ * then extracting the crop area from that canvas.
+ *
+ * @param imageSrc - Source image URL
+ * @param pixelCrop - Crop area in pixels (relative to rotated image)
+ * @param rotation - Rotation angle in degrees
+ * @param quality - JPEG quality (0-1), defaults to 0.92
+ * @returns Promise resolving to the cropped image as a Blob
+ */
+export async function getCroppedImage(
+  imageSrc: string,
+  pixelCrop: CropArea,
+  rotation: number,
+  quality: number = DEFAULT_JPEG_QUALITY,
+): Promise<Blob> {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    throw new Error("Could not get canvas context");
+  }
+
+  // Calculate bounding box of the rotated image
+  const rotRad = degreesToRadians(rotation);
+  const { width: bBoxWidth, height: bBoxHeight } = getRotatedBoundingBox(
+    image.width,
+    image.height,
+    rotation,
+  );
+
+  // Set canvas size to the bounding box
+  canvas.width = bBoxWidth;
+  canvas.height = bBoxHeight;
+
+  // Translate to center, rotate, then translate back
+  ctx.translate(bBoxWidth / 2, bBoxHeight / 2);
+  ctx.rotate(rotRad);
+  ctx.translate(-image.width / 2, -image.height / 2);
+
+  // Draw the rotated image
+  ctx.drawImage(image, 0, 0);
+
+  // Extract the cropped area
+  const croppedCanvas = document.createElement("canvas");
+  const croppedCtx = croppedCanvas.getContext("2d");
+
+  if (!croppedCtx) {
+    throw new Error("Could not get cropped canvas context");
+  }
+
+  croppedCanvas.width = pixelCrop.width;
+  croppedCanvas.height = pixelCrop.height;
+
+  croppedCtx.drawImage(
+    canvas,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    pixelCrop.width,
+    pixelCrop.height,
+  );
+
+  return new Promise((resolve, reject) => {
+    croppedCanvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Failed to create blob from canvas"));
+        }
+      },
+      "image/jpeg",
+      quality,
+    );
+  });
+}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -704,6 +704,8 @@ const de: Translations = {
       useResults: "Ergebnisse anwenden",
       continueToValidation: "Weiter",
       cancel: "Abbrechen",
+      rotateLeft: "Nach links drehen",
+      rotateRight: "Nach rechts drehen",
       players: "Spieler",
       coaches: "Trainer",
       scoresheetType: {

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -697,6 +697,8 @@ const en: Translations = {
       useResults: "Apply Results",
       continueToValidation: "Continue",
       cancel: "Cancel",
+      rotateLeft: "Rotate left",
+      rotateRight: "Rotate right",
       players: "Players",
       coaches: "Coaches",
       scoresheetType: {

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -704,6 +704,8 @@ const fr: Translations = {
       useResults: "Appliquer les résultats",
       continueToValidation: "Continuer",
       cancel: "Annuler",
+      rotateLeft: "Pivoter à gauche",
+      rotateRight: "Pivoter à droite",
       players: "Joueurs",
       coaches: "Entraîneurs",
       scoresheetType: {

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -699,6 +699,8 @@ const it: Translations = {
       useResults: "Applica risultati",
       continueToValidation: "Continua",
       cancel: "Annulla",
+      rotateLeft: "Ruota a sinistra",
+      rotateRight: "Ruota a destra",
       players: "Giocatori",
       coaches: "Allenatori",
       scoresheetType: {

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -532,6 +532,8 @@ export interface Translations {
       useResults: string;
       continueToValidation: string;
       cancel: string;
+      rotateLeft: string;
+      rotateRight: string;
       players: string;
       coaches: string;
       scoresheetType: {

--- a/web-app/src/shared/components/icons.tsx
+++ b/web-app/src/shared/components/icons.tsx
@@ -43,6 +43,8 @@ export { Car } from "lucide-react";
 export { TrainFront } from "lucide-react";
 export { Navigation } from "lucide-react";
 export { SlidersHorizontal } from "lucide-react";
+export { RotateCcw } from "lucide-react";
+export { RotateCw } from "lucide-react";
 
 // Status icons
 export { CheckCircle } from "lucide-react";

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -159,14 +159,16 @@ export default defineConfig(({ mode }) => {
           //   - Main App Bundle (index-*.js):     ~117 kB, limit 145 kB (+28 kB headroom)
           //   - Vendor Chunks (combined):         ~47 kB,  limit 50 kB  (+3 kB headroom)
           //   - PDF Library (pdf-lib-*.js):       ~181 kB, limit 185 kB (+4 kB headroom) - lazy-loaded
-          //   - OCR Feature (OCRPanel-*.js):      ~8 kB,   limit 10 kB  (+2 kB headroom) - lazy-loaded
-          //   - Total JS Bundle:                  ~470 kB, limit 475 kB (+5 kB headroom)
+          //   - Image Cropper (cropper-*.js):     ~6 kB,   limit 10 kB  (+4 kB headroom) - lazy-loaded
+          //   - OCR Feature (OCRPanel-*.js):      ~8 kB,   limit 12 kB  (+4 kB headroom) - lazy-loaded
+          //   - Total JS Bundle:                  ~480 kB, limit 510 kB (+30 kB headroom)
           manualChunks: {
             'react-vendor': ['react', 'react-dom'],
             'router': ['react-router-dom'],
             'state': ['zustand', '@tanstack/react-query'],
             'validation': ['zod'],
             'pdf-lib': ['pdf-lib'],
+            'cropper': ['react-easy-crop'],
           },
         },
       },


### PR DESCRIPTION
## Summary

- Replace buggy custom `ImageCropEditor` with `react-easy-crop` library for reliable pan/zoom/rotate
- Add rotation controls (90° left/right buttons) to allow correcting image orientation
- Extract image crop utilities to separate file with 17 unit tests
- Fix memory leak by adding `URL.revokeObjectURL` cleanup
- Add user-friendly error feedback when image cropping fails
- Configure lazy-loaded cropper chunk (7.24 kB gzip)
- Adjust electronic scoresheet aspect ratio to 0.85 (17:20)

### Issues Fixed

The previous custom implementation had several bugs:
- Missing pan constraints (users could pan beyond image bounds)
- Single-touch pan not working on mobile (only pinch-zoom worked)
- Complex error-prone coordinate calculations
- Initial zoom not fitting entire image properly
- No rotation support for incorrectly oriented photos

### New Dependencies

- `react-easy-crop` (~7 kB gzip) - battle-tested library with 125k+ weekly downloads

## Test Plan

- [x] Unit tests pass (17 new tests for image crop utilities)
- [ ] Verify pan/zoom works smoothly on desktop
- [ ] Test rotation buttons rotate image 90°
- [ ] Verify touch gestures work on mobile (pan, pinch-zoom)
- [ ] Confirm cropped image output is correct after rotation
- [ ] Check bundle size limits pass in CI