### PR TITLE
fix(ci): set HOME=/root for Firefox E2E tests in container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,9 @@ jobs:
     defaults:
       run:
         working-directory: web-app
+    # Firefox requires HOME to be owned by current user in containers
+    env:
+      HOME: /root
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Fix Firefox E2E tests failing in GitHub Actions container due to HOME directory ownership issue
- Set `HOME=/root` environment variable at the E2E job level to allow Firefox to launch correctly

## Test Plan
- [ ] Verify Firefox E2E tests pass on main branch after merge
- [ ] Confirm Chromium and WebKit tests still work correctly