### PR TITLE
feat(ocr): add birth date extraction and improve manuscript parser

### DIFF
--- a/web-app/src/features/ocr/types.ts
+++ b/web-app/src/features/ocr/types.ts
@@ -106,6 +106,8 @@ export interface ParsedPlayer {
   rawName: string;
   /** License status (e.g., "NOT", "LFP") */
   licenseStatus: string;
+  /** Birth date in DD.MM.YY format (from Swiss manuscript scoresheets) */
+  birthDate?: string;
 }
 
 /**

--- a/web-app/src/features/ocr/utils/manuscript-parser.test.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.test.ts
@@ -446,6 +446,18 @@ describe('Concatenated Data Splitting', () => {
       const numbers = splitConcatenatedNumbers('135789');
       expect(numbers).toEqual([1, 3, 5, 7, 8, 9]);
     });
+
+    it('handles consecutive two-digit-looking numbers', () => {
+      // Edge case: 1011121314 could be interpreted multiple ways
+      // With single-digit preference, should split as: 1, 0(skip), 1, 1, 1, 2, 1, 3, 1, 4
+      // But zeros are skipped, so we get: 1, 1, 1, 1, 2, 1, 3, 1, 4
+      const numbers = splitConcatenatedNumbers('1011121314');
+      // Since we prefer single digits, each digit 1-9 is taken individually
+      expect(numbers.length).toBeGreaterThan(5);
+      expect(numbers[0]).toBe(1); // First digit
+      // Zeros are skipped as invalid jersey numbers
+      expect(numbers).not.toContain(0);
+    });
   });
 });
 

--- a/web-app/src/features/ocr/utils/manuscript-parser.test.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.test.ts
@@ -552,15 +552,43 @@ LIBEROS («L»)
     expect(result.teamA.name).not.toContain('4 8 4 8');
   });
 
-  it('adds warning when jersey numbers cannot be extracted from concatenated data', () => {
-    const ocrText = `PunktePointsPunti\tTV Test
-NameNomNome
-data\tS. AngeliL. Collier`;
+  it('extracts birth dates and pairs them with player names', () => {
+    const ocrText = `PunktePointsPunti\tTV St. Johann\tVTV Horw
+NameNomNome\tNameNomNome
+data\t20.2.9721.1.9713.1.97\t513\tS. AngeliL. CollierO. Follouier\t5.5.9028.6.92\t517\tN. HeutschelJ. Brunner`;
 
     const result = parseManuscriptSheet(ocrText);
 
-    // Should have warning about jersey numbers
-    expect(result.warnings.some((w) => w.includes('jersey numbers'))).toBe(true);
+    // Team A should have players with paired DOBs
+    expect(result.teamA.players.length).toBeGreaterThanOrEqual(3);
+
+    // First player should have first DOB
+    const firstPlayer = result.teamA.players[0];
+    expect(firstPlayer?.birthDate).toBe('20.2.97');
+
+    // Second player should have second DOB
+    const secondPlayer = result.teamA.players[1];
+    expect(secondPlayer?.birthDate).toBe('21.1.97');
+
+    // Third player should have third DOB
+    const thirdPlayer = result.teamA.players[2];
+    expect(thirdPlayer?.birthDate).toBe('13.1.97');
+  });
+
+  it('extracts birth dates from libero lines', () => {
+    const ocrText = `PunktePointsPunti\tTV Test\tVTV Test
+NameNomNome
+LIBEROS («L»)\tLIBEROS («L»)
+2\t20.2.97\t5\tS. Angeli\t10.6.92\t7\tS. Candido`;
+
+    const result = parseManuscriptSheet(ocrText);
+
+    // Should parse liberos with DOBs
+    const teamALibero = result.teamA.players.find((p) => p.rawName.includes('Angeli'));
+    expect(teamALibero?.birthDate).toBe('20.2.97');
+
+    const teamBLibero = result.teamB.players.find((p) => p.rawName.includes('Candido'));
+    expect(teamBLibero?.birthDate).toBe('10.6.92');
   });
 });
 

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -464,7 +464,7 @@ const MIN_VALID_TEAM_NAME_LENGTH = 3;
 function cleanSwissMarkers(text: string): string {
   return text
     .replace(/aader\/ou\/o\s*B?\s*/gi, ' ')
-    .replace(/punkte[^]*?punti\s*/i, ' ')
+    .replace(/punkte[\s\S]*?punti\s*/i, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -767,7 +767,7 @@ function extractConcatenatedData(parts: string[]): {
   const secondHalfNames: string[] = [];
   const firstHalfDates: string[] = [];
   const secondHalfDates: string[] = [];
-  const midpoint = parts.length / 2;
+  const midpoint = Math.ceil(parts.length / 2);
 
   for (let partIndex = 0; partIndex < parts.length; partIndex++) {
     const part = parts[partIndex]!;

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -9,6 +9,11 @@
  * - Handles common OCR character misreads (0/O, 1/I/l, 5/S, etc.)
  * - More flexible spacing and delimiter handling
  * - Fuzzy number recognition
+ *
+ * Supports two manuscript formats:
+ * 1. Simple sequential format: Team A section followed by Team B section
+ * 2. Swiss tabular format: Two-column layout with both teams side-by-side,
+ *    where OCR reads horizontally concatenating data from both columns
  */
 
 import type {
@@ -217,6 +222,585 @@ export function parseOfficialName(rawName: string): {
   const displayName = `${firstName} ${lastName}`;
 
   return { lastName, firstName, displayName };
+}
+
+// =============================================================================
+// Swiss Tabular Format Detection
+// =============================================================================
+
+/**
+ * Multilingual header labels found in Swiss manuscript scoresheets
+ * These indicate a tabular format where OCR reads horizontally
+ */
+const SWISS_HEADER_PATTERNS = [
+  /punkte.*points.*punti/i, // Score header (DE/FR/IT)
+  /lizenz.*licence.*licenza/i, // License header (DE/FR/IT)
+  /spieler.*joueur.*giocatore/i, // Player header (DE/FR/IT)
+  /name.*nom.*nome/i, // Name header (DE/FR/IT)
+  /mannschaft.*equipe.*squadra/i, // Team header (DE/FR/IT)
+  /offizielle.*officiels.*ufficiali/i, // Officials header (DE/FR/IT)
+  /kapitän.*capitaine.*capitano/i, // Captain header (DE/FR/IT)
+  /trainer.*entraîneur.*allenatore/i, // Trainer header (DE/FR/IT)
+  /aader\/ou\/o/i, // Common marker for "and/or" in Swiss forms
+];
+
+/**
+ * Patterns for noise lines that should be filtered out
+ */
+const NOISE_PATTERNS = [
+  /^[\d\s.]+$/, // Lines with only numbers, spaces, dots (e.g., "4 8 4 8 . 4 8...")
+  /^[\"T\":\s]+$/i, // Quote marks and colons
+  /^\d+$/, // Single numbers
+  /^[\d\s]{10,}$/, // Long sequences of digits and spaces
+];
+
+/**
+ * Check if a line is noise that should be filtered
+ */
+function isNoiseLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length < 2) return true;
+  return NOISE_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+/**
+ * Detect if the OCR text appears to be from a Swiss tabular manuscript format
+ */
+export function isSwissTabularFormat(ocrText: string): boolean {
+  const lines = ocrText.split('\n');
+
+  // Check for Swiss multilingual headers
+  const hasSwissHeaders = lines.some((line) =>
+    SWISS_HEADER_PATTERNS.some((pattern) => pattern.test(line)),
+  );
+
+  // Check for tab-separated content with multiple columns
+  const tabSeparatedLines = lines.filter((line) => line.includes('\t'));
+  const hasTabularStructure = tabSeparatedLines.length >= 3;
+
+  // Check for concatenated names pattern (e.g., "S. AngeliL. Collier")
+  const hasConcatenatedNames = /[A-Z]\.\s*[A-Za-zÀ-ÿ]+[A-Z]\.\s*[A-Za-zÀ-ÿ]+/.test(ocrText);
+
+  return hasSwissHeaders && (hasTabularStructure || hasConcatenatedNames);
+}
+
+// =============================================================================
+// Concatenated Data Splitting Utilities
+// =============================================================================
+
+/**
+ * Split concatenated names like "S. AngeliL. CollierO. Follouier"
+ * into individual names ["S. Angeli", "L. Collier", "O. Follouier"]
+ *
+ * Handles patterns:
+ * - Initial + dot + LastName (e.g., "S. Angeli")
+ * - Full names with uppercase start after lowercase
+ */
+export function splitConcatenatedNames(text: string): string[] {
+  if (!text || text.trim().length === 0) return [];
+
+  // Pattern: uppercase letter + dot + space? + name, followed by another uppercase
+  // or: lowercase letter followed by uppercase (word boundary)
+  const names: string[] = [];
+
+  // First try splitting on pattern: "NameX." where X is an uppercase letter starting next name
+  // Pattern matches: end of one name (lowercase) followed by start of next (uppercase + dot)
+  const splitPattern = /([a-zà-ÿ])([A-Z]\.)/g;
+  const withMarkers = text.replace(splitPattern, '$1|||$2');
+
+  // Also split where a lowercase letter is followed by uppercase (without dot)
+  // This handles "SuterA." -> "Suter" + "A."
+  const furtherSplit = withMarkers.replace(/([a-zà-ÿ])([A-Z][a-zà-ÿ])/g, '$1|||$2');
+
+  const parts = furtherSplit.split('|||').filter((p) => p.trim().length > 0);
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed.length >= 2) {
+      names.push(trimmed);
+    }
+  }
+
+  return names;
+}
+
+/**
+ * Split concatenated birth dates like "20.2.9721.1.9713.1.97"
+ * into individual dates ["20.2.97", "21.1.97", "13.1.97"]
+ */
+export function splitConcatenatedDates(text: string): string[] {
+  if (!text || text.trim().length === 0) return [];
+
+  const dates: string[] = [];
+  let remaining = text;
+
+  // Process dates iteratively - each date is D.M.YY or DD.M.YY or DD.MM.YY format
+  // We need to be greedy about finding dates but careful about year boundaries
+  while (remaining.length > 0) {
+    // Try to match a date at the start of remaining string
+    // Pattern for 4-digit years: only valid years (1900-2099)
+    const match4 = remaining.match(/^(\d{1,2})\.(\d{1,2})\.((?:19|20)\d{2})/);
+    if (match4) {
+      dates.push(match4[0]);
+      remaining = remaining.substring(match4[0].length);
+      continue;
+    }
+
+    // Pattern for 2-digit years (most common in Swiss forms)
+    const match2 = remaining.match(/^(\d{1,2})\.(\d{1,2})\.(\d{2})/);
+    if (match2) {
+      dates.push(match2[0]);
+      remaining = remaining.substring(match2[0].length);
+      continue;
+    }
+
+    // No date found at start, skip one character and try again
+    remaining = remaining.substring(1);
+  }
+
+  return dates;
+}
+
+/**
+ * Split concatenated jersey numbers like "51396102581915"
+ * This is tricky as we don't know boundaries. Use heuristics:
+ * - Numbers 1-9 are single digit
+ * - Numbers 10-99 are two digits
+ * - Prefer single digits when ambiguous (volleyball typically uses 1-20)
+ */
+export function splitConcatenatedNumbers(text: string, expectedCount?: number): number[] {
+  if (!text || text.trim().length === 0) return [];
+
+  const cleaned = text.replace(/\D/g, ''); // Remove non-digits
+  if (cleaned.length === 0) return [];
+
+  const numbers: number[] = [];
+  let i = 0;
+
+  while (i < cleaned.length) {
+    const oneDigit = parseInt(cleaned[i]!, 10);
+
+    // If we have an expected count, use it to guide decisions
+    if (expectedCount !== undefined) {
+      const remainingChars = cleaned.length - i;
+      const remainingNeeded = expectedCount - numbers.length;
+      // If we need more numbers than remaining chars, take single digits
+      if (remainingNeeded >= remainingChars && oneDigit >= 1) {
+        numbers.push(oneDigit);
+        i += 1;
+        continue;
+      }
+    }
+
+    // Try two-digit number if we have room
+    if (i + 1 < cleaned.length) {
+      const twoDigit = parseInt(cleaned.substring(i, i + 2), 10);
+
+      // If first digit is 0, skip it (invalid jersey number)
+      if (cleaned[i] === '0') {
+        i += 1;
+        continue;
+      }
+
+      // Prefer single digit for most cases (volleyball numbers 1-20 are common)
+      // Only take two digits if the single digit would be 0 or if two-digit is clearly intended
+      if (oneDigit >= 1 && oneDigit <= 9) {
+        numbers.push(oneDigit);
+        i += 1;
+        continue;
+      }
+
+      // For numbers starting with 0, skip the leading zero
+      if (twoDigit >= 10 && twoDigit <= 99) {
+        numbers.push(twoDigit);
+        i += 2;
+        continue;
+      }
+    }
+
+    // Single digit remaining or default
+    if (oneDigit >= 1) {
+      numbers.push(oneDigit);
+    }
+    i += 1;
+  }
+
+  return numbers;
+}
+
+// =============================================================================
+// Swiss Tabular Format Team Name Extraction
+// =============================================================================
+
+/**
+ * Extract team names from Swiss scoresheet header
+ * Header format: "PunktePointsPunti\tAader/ou/oB TV St. Johann\tVTV Horw 1 Aader/ou/oB"
+ */
+export function extractSwissTeamNames(ocrText: string): { teamA: string; teamB: string } {
+  const lines = ocrText.split('\n');
+
+  for (const line of lines) {
+    // Look for line containing team names (has tab separators and team-like content)
+    if (!line.includes('\t')) continue;
+
+    const parts = line.split('\t').map((p) => p.trim());
+
+    // Skip header-only lines (all parts match header patterns)
+    if (parts.every((p) => SWISS_HEADER_PATTERNS.some((pat) => pat.test(p)))) {
+      continue;
+    }
+
+    // Clean up the full line by removing Swiss form markers
+    const fullLine = parts.join(' ');
+    const cleanedLine = fullLine
+      .replace(/aader\/ou\/o\s*B?\s*/gi, ' ')
+      .replace(/punkte.*punti\s*/i, ' ')
+      .replace(/\d+\s*/g, ' ') // Remove standalone numbers (like "1" in "VTV Horw 1")
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    // Try to find team names by looking for volleyball club patterns
+    // Pattern: club prefix (TV, VTV, VBC, etc.) followed by team name
+    // Use a simpler pattern that captures until the next club prefix or end
+    const clubPattern = /\b(VTV|TV|VBC|BC|VC|SC|FC|STV|TSV|USC|US)\s+([A-Za-zÀ-ÿ.\s]+?)(?=\s+(?:VTV|TV|VBC|BC|VC|SC|FC|STV|TSV|USC|US)\b|\s*$)/gi;
+
+    const matches = [...cleanedLine.matchAll(clubPattern)];
+
+    if (matches.length >= 2) {
+      return {
+        teamA: `${matches[0]![1]} ${matches[0]![2]}`.trim(),
+        teamB: `${matches[1]![1]} ${matches[1]![2]}`.trim(),
+      };
+    } else if (matches.length === 1) {
+      return {
+        teamA: `${matches[0]![1]} ${matches[0]![2]}`.trim(),
+        teamB: '',
+      };
+    }
+
+    // Alternative approach: look for club prefixes directly in parts
+    const foundTeams: string[] = [];
+    for (const part of parts) {
+      // Clean the part
+      const cleanedPart = part
+        .replace(/aader\/ou\/o\s*B?\s*/gi, ' ')
+        .replace(/punkte.*punti\s*/i, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+      // Look for club prefix anywhere in the part
+      const clubMatch = cleanedPart.match(/\b(VTV|TV|VBC|BC|VC|SC|FC|STV|TSV|USC|US)\s+([A-Za-zÀ-ÿ.\s\d]+)/i);
+      if (clubMatch) {
+        const teamName = `${clubMatch[1]} ${clubMatch[2]}`.replace(/\s+\d+\s*$/, '').trim();
+        if (teamName.length > 3 && !foundTeams.includes(teamName)) {
+          foundTeams.push(teamName);
+        }
+      }
+    }
+
+    if (foundTeams.length >= 2) {
+      return { teamA: foundTeams[0]!, teamB: foundTeams[1]! };
+    } else if (foundTeams.length === 1) {
+      return { teamA: foundTeams[0]!, teamB: '' };
+    }
+  }
+
+  return { teamA: '', teamB: '' };
+}
+
+// =============================================================================
+// Swiss Tabular Format Parsing
+// =============================================================================
+
+/**
+ * Parse a tab-separated libero line from Swiss format
+ * Format: "2\t20.2.97\t5\tS. Angeli\t10.6.92\t7\tS. Candido"
+ * Returns players for both teams
+ */
+function parseSwissLiberoLine(line: string): { teamA: ParsedPlayer | null; teamB: ParsedPlayer | null } {
+  const parts = line.split('\t').map((p) => p.trim()).filter((p) => p.length > 0);
+
+  // Need at least some parts to parse
+  if (parts.length < 3) {
+    return { teamA: null, teamB: null };
+  }
+
+  let teamAPlayer: ParsedPlayer | null = null;
+  let teamBPlayer: ParsedPlayer | null = null;
+
+  // Find patterns: number, possible date, number, name
+  // Team A data comes first, then Team B
+  let currentIndex = 0;
+
+  // Skip row number if present (first part being just a small number)
+  if (/^\d{1,2}$/.test(parts[0]!) && parseInt(parts[0]!, 10) <= 14) {
+    currentIndex = 1;
+  }
+
+  // Parse Team A libero
+  // Look for: [date], number, name
+  if (currentIndex < parts.length) {
+    let dateA = '';
+    let numberA: number | null = null;
+    let nameA = '';
+
+    // Check if current is a date
+    if (/^\d{1,2}\.\d{1,2}\.\d{2,4}$/.test(parts[currentIndex]!)) {
+      dateA = parts[currentIndex]!;
+      currentIndex++;
+    }
+
+    // Next should be jersey number
+    if (currentIndex < parts.length && /^\d{1,2}$/.test(parts[currentIndex]!)) {
+      numberA = parseInt(parts[currentIndex]!, 10);
+      if (numberA > 99) numberA = null;
+      currentIndex++;
+    }
+
+    // Next should be name
+    if (currentIndex < parts.length && /^[A-Za-zÀ-ÿ]/.test(parts[currentIndex]!)) {
+      nameA = parts[currentIndex]!;
+      currentIndex++;
+    }
+
+    if (nameA) {
+      const parsed = parsePlayerName(nameA);
+      teamAPlayer = {
+        shirtNumber: numberA,
+        lastName: parsed.lastName,
+        firstName: parsed.firstName,
+        displayName: parsed.displayName,
+        rawName: nameA,
+        licenseStatus: '',
+      };
+    }
+  }
+
+  // Parse Team B libero (similar pattern)
+  if (currentIndex < parts.length) {
+    let dateB = '';
+    let numberB: number | null = null;
+    let nameB = '';
+
+    // Check if current is a date
+    if (/^\d{1,2}\.\d{1,2}\.\d{2,4}$/.test(parts[currentIndex]!)) {
+      dateB = parts[currentIndex]!;
+      currentIndex++;
+    }
+
+    // Next should be jersey number
+    if (currentIndex < parts.length && /^\d{1,2}$/.test(parts[currentIndex]!)) {
+      numberB = parseInt(parts[currentIndex]!, 10);
+      if (numberB > 99) numberB = null;
+      currentIndex++;
+    }
+
+    // Next should be name
+    if (currentIndex < parts.length && /^[A-Za-zÀ-ÿ]/.test(parts[currentIndex]!)) {
+      nameB = parts[currentIndex]!;
+      currentIndex++;
+    }
+
+    if (nameB) {
+      const parsed = parsePlayerName(nameB);
+      teamBPlayer = {
+        shirtNumber: numberB,
+        lastName: parsed.lastName,
+        firstName: parsed.firstName,
+        displayName: parsed.displayName,
+        rawName: nameB,
+        licenseStatus: '',
+      };
+    }
+  }
+
+  return { teamA: teamAPlayer, teamB: teamBPlayer };
+}
+
+/**
+ * Parse a tab-separated officials line from Swiss format
+ * Format: "C\tM. Lorentz\tC\tA. Zbinden"
+ */
+function parseSwissOfficialsLine(line: string): { teamA: ParsedOfficial | null; teamB: ParsedOfficial | null } {
+  const parts = line.split('\t').map((p) => p.trim()).filter((p) => p.length > 0);
+
+  let teamAOfficial: ParsedOfficial | null = null;
+  let teamBOfficial: ParsedOfficial | null = null;
+
+  let currentIndex = 0;
+
+  // Parse Team A official
+  if (currentIndex < parts.length) {
+    const role = parts[currentIndex]!.toUpperCase();
+    if (VALID_ROLES.has(role)) {
+      currentIndex++;
+      if (currentIndex < parts.length && /^[A-Za-zÀ-ÿ]/.test(parts[currentIndex]!)) {
+        const name = parts[currentIndex]!;
+        const parsed = parseOfficialName(name);
+        teamAOfficial = {
+          role: role as OfficialRole,
+          lastName: parsed.lastName,
+          firstName: parsed.firstName,
+          displayName: parsed.displayName,
+          rawName: name,
+        };
+        currentIndex++;
+      }
+    }
+  }
+
+  // Parse Team B official
+  if (currentIndex < parts.length) {
+    const role = parts[currentIndex]!.toUpperCase();
+    if (VALID_ROLES.has(role)) {
+      currentIndex++;
+      if (currentIndex < parts.length && /^[A-Za-zÀ-ÿ]/.test(parts[currentIndex]!)) {
+        const name = parts[currentIndex]!;
+        const parsed = parseOfficialName(name);
+        teamBOfficial = {
+          role: role as OfficialRole,
+          lastName: parsed.lastName,
+          firstName: parsed.firstName,
+          displayName: parsed.displayName,
+          rawName: name,
+        };
+        currentIndex++;
+      }
+    }
+  }
+
+  return { teamA: teamAOfficial, teamB: teamBOfficial };
+}
+
+/**
+ * Parse Swiss tabular manuscript format
+ * This format has both teams side-by-side with OCR reading horizontally
+ */
+function parseSwissTabularSheet(ocrText: string): ParsedGameSheet {
+  const warnings: string[] = [];
+  const lines = ocrText.split('\n').map((l) => l.trim());
+
+  // Extract team names
+  const teamNames = extractSwissTeamNames(ocrText);
+
+  const teamA: ParsedTeam = {
+    name: teamNames.teamA,
+    players: [],
+    officials: [],
+  };
+
+  const teamB: ParsedTeam = {
+    name: teamNames.teamB,
+    players: [],
+    officials: [],
+  };
+
+  // Track which section we're in
+  let inLiberoSection = false;
+  let inOfficialsSection = false;
+  let foundConcatenatedData = false;
+
+  for (const line of lines) {
+    // Skip noise lines
+    if (isNoiseLine(line)) continue;
+
+    // Skip pure header lines
+    if (SWISS_HEADER_PATTERNS.some((pattern) => pattern.test(line)) && !line.includes('\t')) {
+      continue;
+    }
+
+    // Check for section markers
+    if (isLiberoMarker(line)) {
+      inLiberoSection = true;
+      inOfficialsSection = false;
+      continue;
+    }
+
+    if (isOfficialsMarker(line)) {
+      inOfficialsSection = true;
+      inLiberoSection = false;
+      continue;
+    }
+
+    if (isEndMarker(line)) {
+      break;
+    }
+
+    // Handle tab-separated lines (better structured)
+    if (line.includes('\t')) {
+      if (inOfficialsSection || /^[CA]C?\d?\t/i.test(line)) {
+        const officials = parseSwissOfficialsLine(line);
+        if (officials.teamA) teamA.officials.push(officials.teamA);
+        if (officials.teamB) teamB.officials.push(officials.teamB);
+        continue;
+      }
+
+      if (inLiberoSection) {
+        const liberos = parseSwissLiberoLine(line);
+        if (liberos.teamA) teamA.players.push(liberos.teamA);
+        if (liberos.teamB) teamB.players.push(liberos.teamB);
+        continue;
+      }
+
+      // Check for concatenated names in tab-separated data
+      const parts = line.split('\t');
+      for (const part of parts) {
+        // Look for concatenated names pattern
+        if (/[A-Z]\.\s*[A-Za-zÀ-ÿ]+[A-Z]\.\s*[A-Za-zÀ-ÿ]+/.test(part)) {
+          foundConcatenatedData = true;
+          const names = splitConcatenatedNames(part);
+
+          // Determine which team based on position in line
+          const partIndex = parts.indexOf(part);
+          const isFirstHalf = partIndex < parts.length / 2;
+
+          for (const name of names) {
+            const parsed = parsePlayerName(name);
+            const player: ParsedPlayer = {
+              shirtNumber: null, // Can't reliably extract from concatenated data
+              lastName: parsed.lastName,
+              firstName: parsed.firstName,
+              displayName: parsed.displayName,
+              rawName: name,
+              licenseStatus: '',
+            };
+
+            if (isFirstHalf && teamA.players.length < 14) {
+              teamA.players.push(player);
+            } else if (!isFirstHalf && teamB.players.length < 14) {
+              teamB.players.push(player);
+            } else if (teamA.players.length < 14) {
+              teamA.players.push(player);
+            } else {
+              teamB.players.push(player);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // If we found concatenated data, add a warning about jersey numbers
+  if (foundConcatenatedData) {
+    warnings.push(
+      'Player jersey numbers could not be reliably extracted from concatenated OCR data',
+    );
+  }
+
+  if (teamA.players.length === 0) {
+    warnings.push('No players found for Team A');
+  }
+  if (teamB.players.length === 0) {
+    warnings.push('No players found for Team B');
+  }
+
+  if (teamA.officials.length === 0 && teamB.officials.length === 0) {
+    warnings.push(
+      'No officials (coaches) found - the OFFICIAL MEMBERS section may not have been recognized',
+    );
+  }
+
+  return { teamA, teamB, warnings };
 }
 
 // =============================================================================
@@ -601,6 +1185,12 @@ export function parseManuscriptSheet(ocrText: string): ParsedGameSheet {
     return { teamA: { ...emptyTeam }, teamB: { ...emptyTeam }, warnings };
   }
 
+  // Check if this is a Swiss tabular format (two-column layout)
+  if (isSwissTabularFormat(ocrText)) {
+    return parseSwissTabularSheet(ocrText);
+  }
+
+  // Fall back to standard sequential format parsing
   // Try to split into team sections
   const sections = splitIntoTeamSections(lines);
 


### PR DESCRIPTION
## Summary
- Add `birthDate` field to `ParsedPlayer` interface for Swiss manuscript scoresheets
- Extract and pair birth dates with player names from concatenated OCR data
- Extract birth dates from libero section lines
- Remove jersey number warning (not needed for matching)
- Refactor complex functions to reduce cognitive complexity and fix lint issues
- Add constants for magic numbers to improve code quality

## Test Plan
- [x] All 3164 existing tests pass
- [x] New tests added for DOB extraction from concatenated data
- [x] New tests added for DOB extraction from libero lines
- [x] Lint passes with 0 warnings
- [x] Build succeeds