### PR TITLE
fix(ocr): use roster-only aspect ratio for manuscript scoresheets

### DIFF
--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -18,9 +18,9 @@ const ELECTRONIC_WIDTH = 17;
 const ELECTRONIC_HEIGHT = 20;
 const ELECTRONIC_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
-/** Aspect ratio for manuscript scoresheet roster section (23:20 landscape) */
-const MANUSCRIPT_WIDTH = 23;
-const MANUSCRIPT_HEIGHT = 20;
+/** Aspect ratio for manuscript scoresheet roster section (20:23 portrait) */
+const MANUSCRIPT_WIDTH = 20;
+const MANUSCRIPT_HEIGHT = 23;
 const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
 
 /** Minimum zoom level */

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -18,9 +18,9 @@ const ELECTRONIC_WIDTH = 17;
 const ELECTRONIC_HEIGHT = 20;
 const ELECTRONIC_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
-/** Aspect ratio for manuscript scoresheet (7:5 landscape) */
-const MANUSCRIPT_WIDTH = 7;
-const MANUSCRIPT_HEIGHT = 5;
+/** Aspect ratio for manuscript scoresheet roster section (23:20 landscape) */
+const MANUSCRIPT_WIDTH = 23;
+const MANUSCRIPT_HEIGHT = 20;
 const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
 
 /** Minimum zoom level */

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -18,9 +18,9 @@ const ELECTRONIC_WIDTH = 17;
 const ELECTRONIC_HEIGHT = 20;
 const ELECTRONIC_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
-/** Aspect ratio for manuscript scoresheet roster section (20:23 portrait) */
-const MANUSCRIPT_WIDTH = 20;
-const MANUSCRIPT_HEIGHT = 23;
+/** Aspect ratio for manuscript scoresheet roster section (4:5 portrait) */
+const MANUSCRIPT_WIDTH = 4;
+const MANUSCRIPT_HEIGHT = 5;
 const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
 
 /** Minimum zoom level */

--- a/web-app/src/features/validation/components/ScoresheetGuide.tsx
+++ b/web-app/src/features/validation/components/ScoresheetGuide.tsx
@@ -22,10 +22,10 @@ const TABLE_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
 /**
  * Aspect ratio dimensions for manuscript scoresheet roster section
- * 20:23 portrait format matches the roster area of Swiss volleyball scoresheets
+ * 4:5 portrait format matches the roster area of Swiss volleyball scoresheets
  */
-const MANUSCRIPT_WIDTH = 20;
-const MANUSCRIPT_HEIGHT = 23;
+const MANUSCRIPT_WIDTH = 4;
+const MANUSCRIPT_HEIGHT = 5;
 const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
 
 interface ScoresheetGuideProps {

--- a/web-app/src/features/validation/components/ScoresheetGuide.tsx
+++ b/web-app/src/features/validation/components/ScoresheetGuide.tsx
@@ -22,10 +22,10 @@ const TABLE_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
 /**
  * Aspect ratio dimensions for manuscript scoresheet roster section
- * 23:20 landscape format matches the roster area of Swiss volleyball scoresheets
+ * 20:23 portrait format matches the roster area of Swiss volleyball scoresheets
  */
-const MANUSCRIPT_WIDTH = 23;
-const MANUSCRIPT_HEIGHT = 20;
+const MANUSCRIPT_WIDTH = 20;
+const MANUSCRIPT_HEIGHT = 23;
 const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
 
 interface ScoresheetGuideProps {

--- a/web-app/src/features/validation/components/ScoresheetGuide.tsx
+++ b/web-app/src/features/validation/components/ScoresheetGuide.tsx
@@ -6,7 +6,7 @@
  *
  * Supports two aspect ratios based on scoresheet type:
  * - Electronic (4:5 portrait): For player list table capture from screenshots
- * - Manuscript (7:5 landscape): For full physical scoresheet capture
+ * - Manuscript (4:5 portrait): For roster section capture from physical scoresheets
  */
 
 import type { ScoresheetType } from "@/features/ocr/utils/scoresheet-detector";
@@ -44,8 +44,9 @@ export function ScoresheetGuide({ scoresheetType }: ScoresheetGuideProps) {
   const aspectRatio = isElectronic ? TABLE_ASPECT_RATIO : MANUSCRIPT_ASPECT_RATIO;
 
   // Calculate frame dimensions based on aspect ratio
-  // For electronic (portrait): width is smaller than height (e.g., 80% width, 100% height)
-  // For manuscript (landscape): width is larger than height (e.g., 100% width, 71% height)
+  // Both electronic and manuscript use portrait orientation (4:5)
+  // Electronic uses smaller frame width (70%) for tighter focus on player list
+  // Manuscript uses larger frame width (90%) for broader roster capture
   const frameStyle = isElectronic
     ? {
         width: "70%",

--- a/web-app/src/features/validation/components/ScoresheetGuide.tsx
+++ b/web-app/src/features/validation/components/ScoresheetGuide.tsx
@@ -21,11 +21,11 @@ const ELECTRONIC_HEIGHT = 5;
 const TABLE_ASPECT_RATIO = ELECTRONIC_WIDTH / ELECTRONIC_HEIGHT;
 
 /**
- * Aspect ratio dimensions for manuscript scoresheet
- * 7:5 landscape format matches A4 paper scoresheets
+ * Aspect ratio dimensions for manuscript scoresheet roster section
+ * 23:20 landscape format matches the roster area of Swiss volleyball scoresheets
  */
-const MANUSCRIPT_WIDTH = 7;
-const MANUSCRIPT_HEIGHT = 5;
+const MANUSCRIPT_WIDTH = 23;
+const MANUSCRIPT_HEIGHT = 20;
 const MANUSCRIPT_ASPECT_RATIO = MANUSCRIPT_WIDTH / MANUSCRIPT_HEIGHT;
 
 interface ScoresheetGuideProps {


### PR DESCRIPTION
## Summary
- Changed manuscript capture from full scoresheet (7:5 landscape) to roster-only (4:5 portrait)
- The 4:5 ratio (0.8) matches the actual roster section proportions

## Test Plan
- [ ] Test manuscript scoresheet capture to verify portrait frame aligns with roster section
- [ ] Verify electronic scoresheet capture is unchanged