### PR TITLE
fix(ocr): skip health check and add OCR endpoint to builds

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -86,6 +86,7 @@ jobs:
           VITE_API_PROXY_URL: ${{ vars.VITE_API_PROXY_URL }}
           VITE_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
           VITE_OJP_API_KEY: ${{ secrets.VITE_OJP_API_KEY }}
+          VITE_OCR_ENDPOINT: ${{ vars.VITE_OCR_ENDPOINT }}
 
       - name: Add .nojekyll for GitHub Pages
         run: touch dist/.nojekyll

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -106,6 +106,7 @@ jobs:
           VITE_API_PROXY_URL: ${{ vars.VITE_API_PROXY_URL }}
           VITE_BASE_PATH: ${{ vars.VITE_BASE_PATH || format('/{0}/', github.event.repository.name) }}
           VITE_OJP_API_KEY: ${{ secrets.VITE_OJP_API_KEY }}
+          VITE_OCR_ENDPOINT: ${{ vars.VITE_OCR_ENDPOINT }}
 
       - name: Add .nojekyll for GitHub Pages
         run: touch dist/.nojekyll

--- a/web-app/src/features/ocr/hooks/useOCRScoresheet.test.ts
+++ b/web-app/src/features/ocr/hooks/useOCRScoresheet.test.ts
@@ -6,7 +6,7 @@ import { OCRFactory } from '../services/ocr-factory';
 // Mock the OCRFactory
 vi.mock('../services/ocr-factory', () => ({
   OCRFactory: {
-    createWithFallback: vi.fn(),
+    create: vi.fn(),
   },
 }));
 
@@ -19,7 +19,7 @@ describe('useOCRScoresheet', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(OCRFactory.createWithFallback).mockResolvedValue(mockEngine);
+    vi.mocked(OCRFactory.create).mockReturnValue(mockEngine);
   });
 
   afterEach(() => {
@@ -53,7 +53,7 @@ N.\tName of the player\tLicense\tN.\tName of the player\tLicense
       processResult = await result.current.processImage(imageBlob);
     });
 
-    expect(OCRFactory.createWithFallback).toHaveBeenCalled();
+    expect(OCRFactory.create).toHaveBeenCalled();
     expect(mockEngine.initialize).toHaveBeenCalled();
     expect(mockEngine.recognize).toHaveBeenCalledWith(imageBlob);
     expect(mockEngine.terminate).toHaveBeenCalled();
@@ -140,12 +140,10 @@ N.\tName of the player\tLicense\tN.\tName of the player\tLicense
   it('calls progress callback', async () => {
     let capturedProgressCallback: ((p: { status: string; progress: number }) => void) | undefined;
 
-    vi.mocked(OCRFactory.createWithFallback).mockImplementation(
-      async (onProgress) => {
-        capturedProgressCallback = onProgress;
-        return mockEngine;
-      },
-    );
+    vi.mocked(OCRFactory.create).mockImplementation((onProgress) => {
+      capturedProgressCallback = onProgress;
+      return mockEngine;
+    });
 
     mockEngine.recognize.mockImplementation(async () => {
       // Simulate progress updates

--- a/web-app/src/features/ocr/hooks/useOCRScoresheet.ts
+++ b/web-app/src/features/ocr/hooks/useOCRScoresheet.ts
@@ -78,7 +78,9 @@ export function useOCRScoresheet(): UseOCRScoresheetReturn {
 
       try {
         // Create OCR engine with progress callback
-        const engine = await OCRFactory.createWithFallback((p) => {
+        // Use create() directly to skip health check - the PoC works this way
+        // and createWithFallback's health check may fail in some environments
+        const engine = OCRFactory.create((p) => {
           setProgress(p);
         });
         engineRef.current = engine;

--- a/web-app/src/features/validation/components/OCRPanel.tsx
+++ b/web-app/src/features/validation/components/OCRPanel.tsx
@@ -268,7 +268,7 @@ export function OCRPanel({
           )}
 
           {/* Processing step */}
-          {step === "processing" && isProcessing && (
+          {step === "processing" && (
             <div
               className="py-8 flex flex-col items-center justify-center"
               role="status"

--- a/web-app/src/features/validation/components/OCRPanel.tsx
+++ b/web-app/src/features/validation/components/OCRPanel.tsx
@@ -51,8 +51,7 @@ export function OCRPanel({
   scoresheetType = "electronic",
 }: OCRPanelProps) {
   const { t } = useTranslation();
-  const { processImage, isProcessing, progress, error, reset } =
-    useOCRScoresheet();
+  const { processImage, progress, error, reset } = useOCRScoresheet();
 
   const [step, setStep] = useState<OCRPanelStep>("capture");
   const [showCaptureModal, setShowCaptureModal] = useState(false);


### PR DESCRIPTION
## Summary
- Use `OCRFactory.create()` instead of `createWithFallback()` to skip health check that was preventing OCR from working in the main app
- Add `VITE_OCR_ENDPOINT` to web-app production build (deploy-web.yml)
- Add `VITE_OCR_ENDPOINT` to PR preview builds (deploy-pr-preview.yml)
- Update tests to use synchronous `create()` mock

## Test Plan
- Deploy PR preview and test OCR on validated games
- Verify OCR progress bar appears after image capture
- Verify OCR API is called (check network tab)