### PR TITLE
feat(worker): add Mistral API health check to /health endpoint

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1179,9 +1179,74 @@ describe("Integration: Origin Validation Error Responses", () => {
       expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
     });
 
-    it("returns 200 with CORS headers when origin is allowed", async () => {
+    it("returns 200 with Mistral status when API key is configured and API is healthy", async () => {
       const { default: worker } = await import("./index");
       const mockEnv = createMockEnv();
+
+      // Mock fetch for Mistral API /v1/models endpoint
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      );
+
+      try {
+        const request = new Request("https://proxy.example.com/health", {
+          headers: {
+            Origin: "https://example.com",
+          },
+        });
+
+        const response = await worker.fetch(request, mockEnv);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+          "https://example.com",
+        );
+        expect(body.status).toBe("ok");
+        expect(body.services.proxy).toBe("ok");
+        expect(body.services.mistral_ocr).toBe("ok");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("returns 503 degraded status when Mistral API returns error", async () => {
+      const { default: worker } = await import("./index");
+      const mockEnv = createMockEnv();
+
+      // Mock fetch for Mistral API returning 401
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response("Unauthorized", { status: 401 }),
+      );
+
+      try {
+        const request = new Request("https://proxy.example.com/health", {
+          headers: {
+            Origin: "https://example.com",
+          },
+        });
+
+        const response = await worker.fetch(request, mockEnv);
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe("degraded");
+        expect(body.services.proxy).toBe("ok");
+        expect(body.services.mistral_ocr).toBe("error");
+        expect(body.services.mistral_ocr_error).toBe("Invalid API key");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("returns 503 degraded status when Mistral API key is not configured", async () => {
+      const { default: worker } = await import("./index");
+      const mockEnv = {
+        ...createMockEnv(),
+        MISTRAL_API_KEY: undefined,
+      };
 
       const request = new Request("https://proxy.example.com/health", {
         headers: {
@@ -1190,11 +1255,40 @@ describe("Integration: Origin Validation Error Responses", () => {
       });
 
       const response = await worker.fetch(request, mockEnv);
+      const body = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
-        "https://example.com",
-      );
+      expect(response.status).toBe(503);
+      expect(body.status).toBe("degraded");
+      expect(body.services.proxy).toBe("ok");
+      expect(body.services.mistral_ocr).toBe("not_configured");
+    });
+
+    it("returns 503 degraded status when Mistral API connection fails", async () => {
+      const { default: worker } = await import("./index");
+      const mockEnv = createMockEnv();
+
+      // Mock fetch to throw network error
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      try {
+        const request = new Request("https://proxy.example.com/health", {
+          headers: {
+            Origin: "https://example.com",
+          },
+        });
+
+        const response = await worker.fetch(request, mockEnv);
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe("degraded");
+        expect(body.services.proxy).toBe("ok");
+        expect(body.services.mistral_ocr).toBe("error");
+        expect(body.services.mistral_ocr_error).toBe("Network error");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -141,6 +141,7 @@ export default {
 
     // Health check endpoint - no authentication needed, no rate limiting
     // Requires CORS headers for browser-based health checks (e.g., OCR availability check)
+    // Verifies Mistral OCR API connectivity by calling /v1/models endpoint
     if (url.pathname === "/health") {
       const origin = request.headers.get("Origin");
       let allowedOrigins: string[];
@@ -178,13 +179,53 @@ export default {
         });
       }
 
+      // Check Mistral API connectivity if API key is configured
+      // Uses /v1/models endpoint as a lightweight health check (no token consumption)
+      let mistralStatus: "ok" | "not_configured" | "error" = "not_configured";
+      let mistralError: string | undefined;
+
+      if (env.MISTRAL_API_KEY) {
+        try {
+          const mistralResponse = await fetch(
+            "https://api.mistral.ai/v1/models",
+            {
+              method: "GET",
+              headers: {
+                Authorization: `Bearer ${env.MISTRAL_API_KEY}`,
+              },
+            },
+          );
+
+          if (mistralResponse.ok) {
+            mistralStatus = "ok";
+          } else {
+            mistralStatus = "error";
+            mistralError =
+              mistralResponse.status === 401
+                ? "Invalid API key"
+                : `API returned ${mistralResponse.status}`;
+          }
+        } catch (error) {
+          mistralStatus = "error";
+          mistralError =
+            error instanceof Error ? error.message : "Connection failed";
+        }
+      }
+
+      const overallStatus = mistralStatus === "ok" ? "ok" : "degraded";
+
       return new Response(
         JSON.stringify({
-          status: "ok",
+          status: overallStatus,
           timestamp: new Date().toISOString(),
+          services: {
+            proxy: "ok",
+            mistral_ocr: mistralStatus,
+            ...(mistralError && { mistral_ocr_error: mistralError }),
+          },
         }),
         {
-          status: 200,
+          status: overallStatus === "ok" ? 200 : 503,
           headers: {
             "Content-Type": "application/json",
             ...corsHeaders(origin!),


### PR DESCRIPTION
## Summary

- Enhanced `/health` endpoint to validate Mistral OCR API connectivity via `/v1/models` endpoint
- Returns detailed service status (proxy + mistral_ocr) with appropriate HTTP status codes
- Lightweight health check that doesn't consume OCR tokens

## Test Plan

- [ ] Verify `/health` returns 200 with `status: "ok"` when Mistral API is healthy
- [ ] Verify `/health` returns 503 with `status: "degraded"` when API key is invalid
- [ ] Verify `/health` returns 503 with `mistral_ocr: "not_configured"` when no API key
- [ ] Unit tests pass (220 tests)