### PR TITLE
fix(ocr): hide bounding boxes when not precise and show raw text

### DIFF
--- a/web-app/src/features/ocr/hooks/useOCRScoresheet.test.ts
+++ b/web-app/src/features/ocr/hooks/useOCRScoresheet.test.ts
@@ -42,6 +42,7 @@ N.\tName of the player\tLicense\tN.\tName of the player\tLicense
 1\tMÜLLER ANNA\tOK\t1\tSCHMIDT LISA\tOK`,
       lines: [],
       words: [],
+      hasPreciseBoundingBoxes: false,
     };
     mockEngine.recognize.mockResolvedValue(mockOCRResult);
 
@@ -85,6 +86,7 @@ N.\tName of the player\tLicense\tN.\tName of the player\tLicense
       fullText: 'Team A\tTeam B',
       lines: [],
       words: [],
+      hasPreciseBoundingBoxes: false,
     };
     mockEngine.recognize.mockResolvedValue(mockOCRResult);
 
@@ -130,7 +132,7 @@ N.\tName of the player\tLicense\tN.\tName of the player\tLicense
 
     // Resolve and wait
     await act(async () => {
-      resolveRecognize!({ fullText: '', lines: [], words: [] });
+      resolveRecognize!({ fullText: '', lines: [], words: [], hasPreciseBoundingBoxes: false });
       await processPromise;
     });
 
@@ -148,7 +150,7 @@ N.\tName of the player\tLicense\tN.\tName of the player\tLicense
     mockEngine.recognize.mockImplementation(async () => {
       // Simulate progress updates
       capturedProgressCallback?.({ status: 'Processing...', progress: 50 });
-      return { fullText: '', lines: [], words: [] };
+      return { fullText: '', lines: [], words: [], hasPreciseBoundingBoxes: false };
     });
 
     const { result } = renderHook(() => useOCRScoresheet());

--- a/web-app/src/features/ocr/services/mistral-ocr.ts
+++ b/web-app/src/features/ocr/services/mistral-ocr.ts
@@ -266,6 +266,9 @@ export class MistralOCR implements OCREngine {
       fullText,
       lines,
       words,
+      // Mistral OCR returns text only, not pixel-level bounding boxes.
+      // The bbox values above are estimated from word/line positions in text,
+      // so they don't align with actual image coordinates.
       hasPreciseBoundingBoxes: false,
     };
   }

--- a/web-app/src/features/ocr/services/mistral-ocr.ts
+++ b/web-app/src/features/ocr/services/mistral-ocr.ts
@@ -266,6 +266,7 @@ export class MistralOCR implements OCREngine {
       fullText,
       lines,
       words,
+      hasPreciseBoundingBoxes: false,
     };
   }
 

--- a/web-app/src/features/ocr/services/stub-ocr.ts
+++ b/web-app/src/features/ocr/services/stub-ocr.ts
@@ -85,6 +85,7 @@ function generateMockResult(text: string): OCRResult {
     fullText: text,
     lines,
     words: lines.flatMap((line) => line.words),
+    hasPreciseBoundingBoxes: false,
   };
 }
 

--- a/web-app/src/features/ocr/services/stub-ocr.ts
+++ b/web-app/src/features/ocr/services/stub-ocr.ts
@@ -85,6 +85,8 @@ function generateMockResult(text: string): OCRResult {
     fullText: text,
     lines,
     words: lines.flatMap((line) => line.words),
+    // Stub OCR uses estimated bounding boxes (same as MistralOCR).
+    // Real pixel coordinates are not available from mock data.
     hasPreciseBoundingBoxes: false,
   };
 }

--- a/web-app/src/features/ocr/types.ts
+++ b/web-app/src/features/ocr/types.ts
@@ -52,6 +52,8 @@ export interface OCRResult {
   lines: OCRLine[];
   /** All words with confidence scores */
   words: OCRWord[];
+  /** Whether bounding boxes are precise pixel coordinates (false = estimated) */
+  hasPreciseBoundingBoxes: boolean;
 }
 
 /**

--- a/web-app/src/features/ocr/utils/player-list-parser.test.ts
+++ b/web-app/src/features/ocr/utils/player-list-parser.test.ts
@@ -305,7 +305,7 @@ function createOCRResult(fullText: string, lines: OCRLine[]): OCRResult {
   for (const line of lines) {
     allWords.push(...line.words);
   }
-  return { fullText, lines, words: allWords };
+  return { fullText, lines, words: allWords, hasPreciseBoundingBoxes: false };
 }
 
 describe('parseGameSheetWithOCR', () => {
@@ -316,6 +316,7 @@ N.\tName of the player\tLicense\tN.\tName of the player\tLicense
 1\tPLAYER ONE\tOK\t1\tPLAYER TWO\tOK`,
       lines: [],
       words: [],
+      hasPreciseBoundingBoxes: false,
     };
 
     const result = parseGameSheetWithOCR(ocrResult);

--- a/web-app/src/features/validation/components/OCREntryModal.tsx
+++ b/web-app/src/features/validation/components/OCREntryModal.tsx
@@ -1015,8 +1015,6 @@ function OCRImageOverlay({
     return containerWidth / imageSize.width;
   }, [imageSize, containerWidth]);
 
-  const hasPreciseBboxes = ocrResult.hasPreciseBoundingBoxes;
-
   return (
     <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3">
       <div className="flex items-center justify-between mb-2">
@@ -1029,7 +1027,7 @@ function OCRImageOverlay({
             {t("validation.ocr.rawData.imageOverlay")}
           </span>
         </div>
-        {hasPreciseBboxes && (
+        {ocrResult.hasPreciseBoundingBoxes && (
           <button
             type="button"
             onClick={() => setShowOverlay(!showOverlay)}
@@ -1043,7 +1041,7 @@ function OCRImageOverlay({
       </div>
 
       {/* Legend - only show when we have precise bounding boxes */}
-      {hasPreciseBboxes && (
+      {ocrResult.hasPreciseBoundingBoxes && (
         <div className="flex items-center gap-4 mb-2 text-xs">
           <div className="flex items-center gap-1">
             <span className="w-3 h-3 rounded border-2 border-success-500 bg-success-500/20" />
@@ -1073,7 +1071,7 @@ function OCRImageOverlay({
         />
 
         {/* Bounding box overlay - only show when we have precise bounding boxes */}
-        {hasPreciseBboxes && showOverlay && imageSize && (
+        {ocrResult.hasPreciseBoundingBoxes && showOverlay && imageSize && (
           <svg
             className="absolute top-0 left-0 pointer-events-none"
             style={{
@@ -1113,7 +1111,7 @@ function OCRImageOverlay({
       </div>
 
       {/* Raw OCR text - shown when bounding boxes are not precise */}
-      {!hasPreciseBboxes && ocrResult.fullText && (
+      {!ocrResult.hasPreciseBoundingBoxes && ocrResult.fullText && (
         <div className="mt-3">
           <div className="flex items-center gap-2 mb-2">
             <span className="text-xs font-medium text-gray-500 dark:text-gray-400">

--- a/web-app/src/features/validation/components/OCREntryModal.tsx
+++ b/web-app/src/features/validation/components/OCREntryModal.tsx
@@ -1015,6 +1015,8 @@ function OCRImageOverlay({
     return containerWidth / imageSize.width;
   }, [imageSize, containerWidth]);
 
+  const hasPreciseBboxes = ocrResult.hasPreciseBoundingBoxes;
+
   return (
     <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3">
       <div className="flex items-center justify-between mb-2">
@@ -1027,32 +1029,36 @@ function OCRImageOverlay({
             {t("validation.ocr.rawData.imageOverlay")}
           </span>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowOverlay(!showOverlay)}
-          className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
-        >
-          {showOverlay
-            ? t("validation.ocr.rawData.hideOverlay")
-            : t("validation.ocr.rawData.showOverlay")}
-        </button>
+        {hasPreciseBboxes && (
+          <button
+            type="button"
+            onClick={() => setShowOverlay(!showOverlay)}
+            className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+          >
+            {showOverlay
+              ? t("validation.ocr.rawData.hideOverlay")
+              : t("validation.ocr.rawData.showOverlay")}
+          </button>
+        )}
       </div>
 
-      {/* Legend */}
-      <div className="flex items-center gap-4 mb-2 text-xs">
-        <div className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded border-2 border-success-500 bg-success-500/20" />
-          <span className="text-gray-600 dark:text-gray-400">
-            {t("validation.ocr.rawData.matchedWords")}
-          </span>
+      {/* Legend - only show when we have precise bounding boxes */}
+      {hasPreciseBboxes && (
+        <div className="flex items-center gap-4 mb-2 text-xs">
+          <div className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded border-2 border-success-500 bg-success-500/20" />
+            <span className="text-gray-600 dark:text-gray-400">
+              {t("validation.ocr.rawData.matchedWords")}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded border-2 border-gray-400 bg-gray-400/20" />
+            <span className="text-gray-600 dark:text-gray-400">
+              {t("validation.ocr.rawData.otherWords")}
+            </span>
+          </div>
         </div>
-        <div className="flex items-center gap-1">
-          <span className="w-3 h-3 rounded border-2 border-gray-400 bg-gray-400/20" />
-          <span className="text-gray-600 dark:text-gray-400">
-            {t("validation.ocr.rawData.otherWords")}
-          </span>
-        </div>
-      </div>
+      )}
 
       {/* Image container */}
       <div
@@ -1066,8 +1072,8 @@ function OCRImageOverlay({
           className="w-full h-auto"
         />
 
-        {/* Bounding box overlay */}
-        {showOverlay && imageSize && (
+        {/* Bounding box overlay - only show when we have precise bounding boxes */}
+        {hasPreciseBboxes && showOverlay && imageSize && (
           <svg
             className="absolute top-0 left-0 pointer-events-none"
             style={{
@@ -1105,6 +1111,20 @@ function OCRImageOverlay({
         {ocrResult.words.filter((w) => isMatchedWord(w.text)).length}{" "}
         {t("validation.ocr.rawData.wordsMatched")}
       </div>
+
+      {/* Raw OCR text - shown when bounding boxes are not precise */}
+      {!hasPreciseBboxes && ocrResult.fullText && (
+        <div className="mt-3">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+              {t("validation.ocr.rawData.rawText")}
+            </span>
+          </div>
+          <pre className="text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-900 p-3 rounded border border-gray-200 dark:border-gray-700 overflow-auto max-h-64 whitespace-pre-wrap break-words">
+            {ocrResult.fullText}
+          </pre>
+        </div>
+      )}
     </div>
   );
 }

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -758,6 +758,7 @@ const de: Translations = {
         capturedImage: "Aufgenommenes Spielberichtsbild",
         wordsDetected: "Wörter erkannt",
         wordsMatched: "übereinstimmend",
+        rawText: "OCR-Rohtext",
       },
     },
   },

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -751,6 +751,7 @@ const en: Translations = {
         capturedImage: "Captured scoresheet image",
         wordsDetected: "words detected",
         wordsMatched: "matched",
+        rawText: "Raw OCR text",
       },
     },
   },

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -758,6 +758,7 @@ const fr: Translations = {
         capturedImage: "Image de la feuille de match capturée",
         wordsDetected: "mots détectés",
         wordsMatched: "correspondants",
+        rawText: "Texte OCR brut",
       },
     },
   },

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -753,6 +753,7 @@ const it: Translations = {
         capturedImage: "Immagine del referto catturata",
         wordsDetected: "parole rilevate",
         wordsMatched: "corrispondenti",
+        rawText: "Testo OCR grezzo",
       },
     },
   },

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -586,6 +586,7 @@ export interface Translations {
         capturedImage: string;
         wordsDetected: string;
         wordsMatched: string;
+        rawText: string;
       };
     };
   };


### PR DESCRIPTION
## Summary
- Adds `hasPreciseBoundingBoxes` flag to `OCRResult` type to indicate when bounding boxes are real pixel coordinates vs estimated
- Hides the bounding box overlay, toggle button, and legend when bounding boxes are not precise (Mistral OCR)
- Shows raw OCR text in a scrollable panel when bounding boxes are unavailable
- Updates translations in all 4 languages (de, en, fr, it)

## Test Plan
- [ ] Run OCR on a scoresheet using Mistral OCR
- [ ] Verify bounding box overlay and controls are hidden
- [ ] Verify raw OCR text is displayed instead
- [ ] Check all validation passes (lint, knip, test, build)