### PR TITLE
fix(validation): make validation wizard fully read-only in safe mode

### DIFF
--- a/web-app/src/features/validation/components/StepRenderer.tsx
+++ b/web-app/src/features/validation/components/StepRenderer.tsx
@@ -114,7 +114,7 @@ export function StepRenderer({
         <ScorerPanel
           key={validation.pendingScorer?.__identity ?? "no-pending-scorer"}
           onScorerChange={handlers.setScorer}
-          readOnly={validation.isValidated}
+          readOnly={validation.isValidated || validation.isInSafeMode}
           readOnlyScorerName={validation.validatedInfo?.scorerName}
           readOnlyScorerBirthday={validation.validatedInfo?.scorerBirthday}
           initialScorer={

--- a/web-app/src/features/validation/components/StepRenderer.tsx
+++ b/web-app/src/features/validation/components/StepRenderer.tsx
@@ -17,6 +17,8 @@ interface LoadingState {
 
 interface ValidationInfo {
   isValidated: boolean;
+  /** True when safe mode is enabled - roster editing is disabled */
+  isInSafeMode: boolean;
   validatedInfo: UseValidationStateResult["validatedInfo"];
   pendingScorer: UseValidationStateResult["pendingScorer"];
   scoresheetNotRequired: boolean;
@@ -89,7 +91,7 @@ export function StepRenderer({
           assignment={assignment}
           onModificationsChange={handlers.setHomeRosterModifications}
           onAddPlayerSheetOpenChange={handlers.onAddPlayerSheetOpenChange}
-          readOnly={validation.isValidated}
+          readOnly={validation.isValidated || validation.isInSafeMode}
           initialModifications={validation.state.homeRoster.playerModifications}
           initialCoachModifications={validation.state.homeRoster.coachModifications}
           prefetchedNominationList={validation.homeNominationList}
@@ -101,7 +103,7 @@ export function StepRenderer({
           assignment={assignment}
           onModificationsChange={handlers.setAwayRosterModifications}
           onAddPlayerSheetOpenChange={handlers.onAddPlayerSheetOpenChange}
-          readOnly={validation.isValidated}
+          readOnly={validation.isValidated || validation.isInSafeMode}
           initialModifications={validation.state.awayRoster.playerModifications}
           initialCoachModifications={validation.state.awayRoster.coachModifications}
           prefetchedNominationList={validation.awayNominationList}

--- a/web-app/src/features/validation/components/StepRenderer.tsx
+++ b/web-app/src/features/validation/components/StepRenderer.tsx
@@ -132,7 +132,7 @@ export function StepRenderer({
       {currentStepId === "scoresheet" && (
         <ScoresheetPanel
           onScoresheetChange={handlers.setScoresheet}
-          readOnly={validation.isValidated}
+          readOnly={validation.isValidated || validation.isInSafeMode}
           hasScoresheet={validation.validatedInfo?.hasScoresheet}
           scoresheetNotRequired={validation.scoresheetNotRequired}
         />

--- a/web-app/src/features/validation/components/ValidateGameModal.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.tsx
@@ -191,6 +191,7 @@ function ValidateGameModalComponent({
 
   const validationInfo = {
     isValidated: wizard.isValidated,
+    isInSafeMode: wizard.isInSafeMode,
     validatedInfo: wizard.validatedInfo,
     pendingScorer: wizard.pendingScorer,
     scoresheetNotRequired: wizard.scoresheetNotRequired,


### PR DESCRIPTION
## Summary

Make the entire validation wizard read-only when safe mode is enabled. This ensures users cannot accidentally modify any game data when in safe mode.

### Changes

- Pass `isInSafeMode` from the wizard hook to all validation panels
- All four wizard panels now check `readOnly={validation.isValidated || validation.isInSafeMode}`:
  - **HomeRosterPanel**: Add/remove player and coach buttons disabled
  - **AwayRosterPanel**: Add/remove player and coach buttons disabled
  - **ScorerPanel**: Scorer search/selection disabled
  - **ScoresheetPanel**: Scoresheet upload disabled

### Behavior in Safe Mode

- Wizard navigation (Previous/Next) still works for viewing
- All editing controls are disabled
- "Dismiss" button closes the modal without saving
- No API calls are made to modify data

## Test Plan

- [ ] Enable safe mode in settings
- [ ] Open the validation modal for a game
- [ ] Verify all panels are read-only:
  - [ ] Home roster: add/remove player and coach buttons hidden
  - [ ] Away roster: add/remove player and coach buttons hidden
  - [ ] Scorer: search field and selection disabled
  - [ ] Scoresheet: upload button disabled
- [ ] Disable safe mode and verify all editing controls work normally