### PR TITLE
feat(ocr-poc): integrate main app's parsing logic

### DIFF
--- a/ocr-poc/src/components/PlayerComparison.js
+++ b/ocr-poc/src/components/PlayerComparison.js
@@ -22,10 +22,11 @@ import { getMockReferenceData } from '../services/MockReferenceData.js';
 import { TeamConfirmationModal } from './TeamConfirmationModal.js';
 
 /**
- * Types are imported from the main app's OCR feature barrel file.
- * @typedef {import('@volleykit/ocr').ParsedPlayer} ParsedPlayer
- * @typedef {import('@volleykit/ocr').ParsedOfficial} ParsedOfficial
- * @typedef {import('@volleykit/ocr').ParsedTeam} ParsedTeam
+ * Types are imported from the main app's OCR feature types file directly.
+ * We avoid the barrel file since it exports React hooks which require React.
+ * @typedef {import('@volleykit/ocr/types').ParsedPlayer} ParsedPlayer
+ * @typedef {import('@volleykit/ocr/types').ParsedOfficial} ParsedOfficial
+ * @typedef {import('@volleykit/ocr/types').ParsedTeam} ParsedTeam
  * @typedef {import('../services/MockReferenceData.js').ReferencePlayer} ReferencePlayer
  * @typedef {import('../services/MockReferenceData.js').ReferenceOfficial} ReferenceOfficial
  * @typedef {import('../services/MockReferenceData.js').ReferenceTeam} ReferenceTeam

--- a/ocr-poc/src/components/PlayerComparison.js
+++ b/ocr-poc/src/components/PlayerComparison.js
@@ -22,9 +22,10 @@ import { getMockReferenceData } from '../services/MockReferenceData.js';
 import { TeamConfirmationModal } from './TeamConfirmationModal.js';
 
 /**
- * @typedef {import('@volleykit/ocr/types').ParsedPlayer} ParsedPlayer
- * @typedef {import('@volleykit/ocr/types').ParsedOfficial} ParsedOfficial
- * @typedef {import('@volleykit/ocr/types').ParsedTeam} ParsedTeam
+ * Types are imported from the main app's OCR feature barrel file.
+ * @typedef {import('@volleykit/ocr').ParsedPlayer} ParsedPlayer
+ * @typedef {import('@volleykit/ocr').ParsedOfficial} ParsedOfficial
+ * @typedef {import('@volleykit/ocr').ParsedTeam} ParsedTeam
  * @typedef {import('../services/MockReferenceData.js').ReferencePlayer} ReferencePlayer
  * @typedef {import('../services/MockReferenceData.js').ReferenceOfficial} ReferenceOfficial
  * @typedef {import('../services/MockReferenceData.js').ReferenceTeam} ReferenceTeam

--- a/ocr-poc/src/services/PlayerListParser.js
+++ b/ocr-poc/src/services/PlayerListParser.js
@@ -9,12 +9,13 @@
  * - Manuscript scoresheets (handwritten with OCR error correction)
  * - Bounding box-aware parsing for better column detection
  * - Swiss-specific formats (tabular layout, multilingual headers)
+ *
+ * NOTE: We import from specific utility files rather than the barrel file
+ * because the barrel file exports React hooks which would require React.
  */
 
-// Import from the main app's OCR feature barrel file
-// Using the barrel export ensures we're using the public API
+// Import parsing utilities directly (no React dependency)
 import {
-  // Parsing utilities
   parseGameSheet as parseElectronicSheet,
   parseGameSheetWithType,
   parseGameSheetWithOCR,
@@ -23,13 +24,16 @@ import {
   normalizeName,
   getAllPlayers,
   getAllOfficials,
-  // Roster comparison utilities
+} from '@volleykit/ocr/utils/player-list-parser';
+
+// Import roster comparison utilities directly (no React dependency)
+import {
   compareRosters,
   compareTeamRosters,
   calculateMatchScore,
   calculateNameSimilarity,
   normalizeForComparison,
-} from '@volleykit/ocr';
+} from '@volleykit/ocr/utils/roster-comparison';
 
 /**
  * Parse a game sheet from OCR text.

--- a/ocr-poc/src/services/PlayerListParser.js
+++ b/ocr-poc/src/services/PlayerListParser.js
@@ -11,8 +11,10 @@
  * - Swiss-specific formats (tabular layout, multilingual headers)
  */
 
-// Import from the main app's OCR feature
+// Import from the main app's OCR feature barrel file
+// Using the barrel export ensures we're using the public API
 import {
+  // Parsing utilities
   parseGameSheet as parseElectronicSheet,
   parseGameSheetWithType,
   parseGameSheetWithOCR,
@@ -21,15 +23,13 @@ import {
   normalizeName,
   getAllPlayers,
   getAllOfficials,
-} from '@volleykit/ocr/utils/player-list-parser';
-
-import {
+  // Roster comparison utilities
   compareRosters,
   compareTeamRosters,
   calculateMatchScore,
   calculateNameSimilarity,
   normalizeForComparison,
-} from '@volleykit/ocr/utils/roster-comparison';
+} from '@volleykit/ocr';
 
 /**
  * Parse a game sheet from OCR text.

--- a/ocr-poc/src/services/PlayerListParser.js
+++ b/ocr-poc/src/services/PlayerListParser.js
@@ -1,512 +1,76 @@
 /**
  * Player List Parser
  *
- * Parses OCR text output into structured player lists for both teams.
- * Handles the tab-separated format from Mistral OCR.
+ * Bridge module that imports parsing logic from the main web-app.
+ * This allows the OCR POC to use the same parsing logic as the production app.
  *
- * Expected OCR format:
- * Row 1: TeamA Name<tab>TeamB Name
- * Row 2: N.<tab>Name of the player<tab>N.<tab>Name of the player (headers)
- * Row 3+: Number<tab>LASTNAME FIRSTNAME<tab>License<tab>Number<tab>LASTNAME FIRSTNAME<tab>License
- * ...
- * LIBERO section: L1<tab>Number LASTNAME FIRSTNAME<tab>License<tab>L1<tab>Number LASTNAME FIRSTNAME<tab>License
- * OFFICIAL MEMBERS section: C<tab>Name<tab>C<tab>Name (coaches), AC<tab>Name<tab>AC<tab>Name (assistants)
+ * The main app has comprehensive parsing support for:
+ * - Electronic scoresheets (tab-separated format)
+ * - Manuscript scoresheets (handwritten with OCR error correction)
+ * - Bounding box-aware parsing for better column detection
+ * - Swiss-specific formats (tabular layout, multilingual headers)
  */
 
-/**
- * @typedef {Object} ParsedPlayer
- * @property {number | null} shirtNumber - Player's shirt number (from OCR, not used for matching)
- * @property {string} lastName - Player's last name (normalized)
- * @property {string} firstName - Player's first name (normalized)
- * @property {string} displayName - Full display name
- * @property {string} rawName - Original name from OCR
- * @property {string} licenseStatus - License status (NOT/LFP)
- */
+// Import from the main app's OCR feature
+import {
+  parseGameSheet as parseElectronicSheet,
+  parseGameSheetWithType,
+  parseGameSheetWithOCR,
+  parsePlayerName,
+  parseOfficialName,
+  normalizeName,
+  getAllPlayers,
+  getAllOfficials,
+} from '@volleykit/ocr/utils/player-list-parser';
+
+import {
+  compareRosters,
+  compareTeamRosters,
+  calculateMatchScore,
+  calculateNameSimilarity,
+  normalizeForComparison,
+} from '@volleykit/ocr/utils/roster-comparison';
 
 /**
- * @typedef {Object} ParsedOfficial
- * @property {string} role - Role: 'C' (coach), 'AC' (assistant coach), 'AC2', 'AC3'
- * @property {string} lastName - Last name (normalized)
- * @property {string} firstName - First name (normalized)
- * @property {string} displayName - Full display name
- * @property {string} rawName - Original name from OCR
+ * Parse a game sheet from OCR text.
+ *
+ * This function automatically selects the appropriate parser based on the
+ * scoresheet type (electronic vs manuscript).
+ *
+ * @param {string} ocrText - Raw OCR text from scanning the scoresheet
+ * @param {{ type?: 'electronic' | 'manuscript' }} [options] - Parser options
+ * @returns {import('@volleykit/ocr/types').ParsedGameSheet} Parsed game sheet with both teams
+ *
+ * @example
+ * // Parse electronic scoresheet (default)
+ * const result = parseGameSheet(ocrText);
+ *
+ * @example
+ * // Parse manuscript (handwritten) scoresheet
+ * const result = parseGameSheet(ocrText, { type: 'manuscript' });
  */
-
-/**
- * @typedef {Object} ParsedTeam
- * @property {string} name - Team name
- * @property {ParsedPlayer[]} players - All players (including liberos)
- * @property {ParsedOfficial[]} officials - Coaches and assistant coaches
- */
-
-/**
- * @typedef {Object} ParsedGameSheet
- * @property {ParsedTeam} teamA - First team (left column)
- * @property {ParsedTeam} teamB - Second team (right column)
- * @property {string[]} warnings - Any parsing warnings
- */
-
-/**
- * Normalize a name from OCR (UPPERCASE) to title case
- * @param {string} name - Name in uppercase
- * @returns {string} - Name in title case
- */
-function normalizeName(name) {
-  if (!name) {
-    return '';
+export function parseGameSheet(ocrText, options) {
+  if (options?.type) {
+    return parseGameSheetWithType(ocrText, options);
   }
-  return name
-    .toLowerCase()
-    .split(/[\s-]+/)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ');
+  // Default to electronic parser for backwards compatibility
+  return parseElectronicSheet(ocrText);
 }
 
-/**
- * Parse a player name in "LASTNAME FIRSTNAME [MIDDLENAME]" format
- * @param {string} rawName - Raw name from OCR
- * @returns {{ lastName: string, firstName: string, displayName: string }}
- */
-function parsePlayerName(rawName) {
-  if (!rawName || typeof rawName !== 'string') {
-    return { lastName: '', firstName: '', displayName: '' };
-  }
-
-  const trimmed = rawName.trim();
-  const parts = trimmed.split(/\s+/).filter((p) => p.length > 0);
-
-  if (parts.length === 0) {
-    return { lastName: '', firstName: '', displayName: '' };
-  }
-
-  if (parts.length === 1) {
-    const lastName = normalizeName(parts[0]);
-    return { lastName, firstName: '', displayName: lastName };
-  }
-
-  // First part is always last name, rest are first names
-  const lastName = normalizeName(parts[0]);
-  const firstName = parts.slice(1).map(normalizeName).join(' ');
-  const displayName = `${firstName} ${lastName}`;
-
-  return { lastName, firstName, displayName };
-}
-
-/**
- * Parse an official name - format is "Firstname Lastname" (not reversed like players)
- * @param {string} rawName - Raw name from OCR
- * @returns {{ lastName: string, firstName: string, displayName: string }}
- */
-function parseOfficialName(rawName) {
-  if (!rawName || typeof rawName !== 'string') {
-    return { lastName: '', firstName: '', displayName: '' };
-  }
-
-  const trimmed = rawName.trim();
-  const parts = trimmed.split(/\s+/).filter((p) => p.length > 0);
-
-  if (parts.length === 0) {
-    return { lastName: '', firstName: '', displayName: '' };
-  }
-
-  if (parts.length === 1) {
-    const name = normalizeName(parts[0]);
-    return { lastName: name, firstName: '', displayName: name };
-  }
-
-  // For officials, format is "Firstname Lastname" - last part is last name
-  const lastName = normalizeName(parts[parts.length - 1]);
-  const firstName = parts.slice(0, -1).map(normalizeName).join(' ');
-  const displayName = `${firstName} ${lastName}`;
-
-  return { lastName, firstName, displayName };
-}
-
-/**
- * Parse a libero entry which has format "Number LASTNAME FIRSTNAME"
- * @param {string} entry - Libero entry like "1 ZOLLER MILENA TIMEA"
- * @returns {{ number: number | null, name: string }}
- */
-function parseLiberoEntry(entry) {
-  if (!entry || typeof entry !== 'string') {
-    return { number: null, name: '' };
-  }
-
-  const trimmed = entry.trim();
-  const match = trimmed.match(/^(\d+)\s+(.+)$/);
-
-  if (match) {
-    return {
-      number: parseInt(match[1], 10),
-      name: match[2],
-    };
-  }
-
-  return { number: null, name: trimmed };
-}
-
-/**
- * Check if a line starts the officials section
- * @param {string} line - Line to check
- * @returns {boolean}
- */
-function isOfficialsHeader(line) {
-  const upper = line.toUpperCase();
-  return upper.includes('OFFICIAL MEMBERS') || upper.includes('ADMITTED ON THE BENCH');
-}
-
-/**
- * Check if a line marks the end of all data (signatures section)
- * @param {string} line - Line to check
- * @returns {boolean}
- */
-function isSignaturesSection(line) {
-  const upper = line.toUpperCase();
-  return upper.includes('SIGNATURES') || upper.includes('TEAM CAPTAIN');
-}
-
-/**
- * Check if a role string is a valid official role
- * @param {string} role - Role to check
- * @returns {boolean}
- */
-function isOfficialRole(role) {
-  const normalized = role.toUpperCase().trim();
-  return ['C', 'AC', 'AC2', 'AC3', 'AC4'].includes(normalized);
-}
-
-/**
- * Check if a line is a section header
- * @param {string} line - Line to check
- * @returns {boolean}
- */
-function isSectionHeader(line) {
-  const headers = ['LIBERO', 'N.', 'Name of the player'];
-  return headers.some((h) => line.toUpperCase().includes(h.toUpperCase()));
-}
-
-/**
- * Find the start of the player list section in OCR text
- * Looks for the "N." + "Name of the player" header row
- * @param {string[]} lines - Array of OCR lines
- * @returns {{ startIndex: number, teamNamesIndex: number }} - Index where player list starts, and team names line
- */
-function findPlayerListStart(lines) {
-  // Look for the header row with "N." and "Name of the player"
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const upperLine = line.toUpperCase();
-
-    // Check for the player list header row
-    if (upperLine.includes('NAME OF THE PLAYER') || (upperLine.includes('N.') && upperLine.includes('NAME'))) {
-      // The team names should be on the line before the header
-      // Look backwards for a line that looks like team names (contains team identifiers)
-      let teamNamesIndex = -1;
-      for (let j = i - 1; j >= 0 && j >= i - 3; j--) {
-        const prevLine = lines[j];
-        // Team names line typically contains two names separated by tab
-        // or has "A " / "B " prefixes for team identification
-        const parts = prevLine.split('\t').filter((p) => p.trim().length > 0);
-        if (parts.length >= 2) {
-          // Check if this looks like team names (not numeric score data)
-          const hasNonNumericContent = parts.some((p) => /[a-zA-Z]{3,}/.test(p));
-          if (hasNonNumericContent) {
-            teamNamesIndex = j;
-            break;
-          }
-        }
-      }
-      return { startIndex: i + 1, teamNamesIndex };
-    }
-  }
-
-  // Fallback: look for lines that match player data pattern (number + name + license)
-  for (let i = 0; i < lines.length; i++) {
-    const parts = lines[i].split('\t');
-    if (parts.length >= 3) {
-      const firstPart = parts[0].trim();
-      // Check if first part is a jersey number (1-99)
-      if (/^\d{1,2}$/.test(firstPart)) {
-        const num = parseInt(firstPart, 10);
-        if (num >= 1 && num <= 99) {
-          // Check if second part looks like a name (uppercase letters)
-          const secondPart = parts[1].trim();
-          if (/^[A-Z\s]+$/.test(secondPart) && secondPart.length > 3) {
-            return { startIndex: i, teamNamesIndex: i - 1 };
-          }
-        }
-      }
-    }
-  }
-
-  return { startIndex: 0, teamNamesIndex: -1 };
-}
-
-/**
- * Parse the OCR text output into structured player lists
- * @param {string} ocrText - Raw OCR text from Mistral
- * @returns {ParsedGameSheet}
- */
-export function parseGameSheet(ocrText) {
-  /** @type {string[]} */
-  const warnings = [];
-
-  /** @type {ParsedTeam} */
-  const teamA = { name: '', players: [], officials: [] };
-
-  /** @type {ParsedTeam} */
-  const teamB = { name: '', players: [], officials: [] };
-
-  if (!ocrText || typeof ocrText !== 'string') {
-    warnings.push('No OCR text provided');
-    return { teamA, teamB, warnings };
-  }
-
-  // Split into lines and filter empty ones
-  const allLines = ocrText
-    .split('\n')
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0);
-
-  // Find where the player list section starts (skip score data, set data, etc.)
-  const { startIndex, teamNamesIndex } = findPlayerListStart(allLines);
-
-  if (startIndex > 0) {
-    warnings.push(`Skipped ${startIndex} lines of non-player data (score/set information)`);
-  }
-
-  // Extract team names from the identified line (before header row)
-  if (teamNamesIndex >= 0 && teamNamesIndex < allLines.length) {
-    const teamNamesLine = allLines[teamNamesIndex];
-    const nameParts = teamNamesLine.split('\t').map((p) => p.trim()).filter((p) => p.length > 0);
-
-    if (nameParts.length >= 2) {
-      // Remove any "A " or "B " prefixes from team names
-      teamA.name = nameParts[0].replace(/^[AB]\s+/, '').trim();
-      teamB.name = nameParts[1].replace(/^[AB]\s+/, '').trim();
-    } else if (nameParts.length === 1) {
-      teamA.name = nameParts[0].replace(/^[AB]\s+/, '').trim();
-    }
-  }
-
-  // Process only from the player list start
-  const lines = allLines.slice(startIndex);
-
-  if (lines.length === 0) {
-    warnings.push('OCR text contains no lines');
-    return { teamA, teamB, warnings };
-  }
-
-  // If we already found team names via findPlayerListStart, start in players section
-  // Otherwise, we need to parse from header
-  const teamNamesAlreadyFound = teamA.name.length > 0 || teamB.name.length > 0;
-  let currentSection = teamNamesAlreadyFound ? 'players' : 'header';
-  let headerRowsParsed = 0;
-
-  for (const line of lines) {
-    // Check for signatures section (end of all data)
-    if (isSignaturesSection(line)) {
-      currentSection = 'done';
-      continue;
-    }
-
-    if (currentSection === 'done') {
-      continue;
-    }
-
-    // Check for officials section
-    if (isOfficialsHeader(line)) {
-      currentSection = 'officials';
-      continue;
-    }
-
-    // Split by tabs
-    const parts = line.split('\t').map((p) => p.trim());
-
-    // Check for LIBERO section
-    if (line.toUpperCase().includes('LIBERO') && parts.length <= 2) {
-      currentSection = 'libero';
-      continue;
-    }
-
-    // Parse based on current section
-    if (currentSection === 'header') {
-      // First non-header row should be team names (only if not already found)
-      if (headerRowsParsed === 0 && !isSectionHeader(line)) {
-        // Team names row - could be 2 parts (tab-separated) or in various formats
-        if (parts.length >= 2) {
-          teamA.name = parts[0].replace(/^[AB]\s+/, '').trim();
-          teamB.name = parts[1].replace(/^[AB]\s+/, '').trim();
-        } else if (parts.length === 1) {
-          // Single value - might be combined or just one team
-          teamA.name = parts[0].replace(/^[AB]\s+/, '').trim();
-        }
-        headerRowsParsed++;
-        continue;
-      }
-
-      // Skip header row with "N." and "Name of the player"
-      if (isSectionHeader(line)) {
-        currentSection = 'players';
-        continue;
-      }
-
-      headerRowsParsed++;
-      if (headerRowsParsed > 3) {
-        currentSection = 'players';
-      }
-    }
-
-    if (currentSection === 'players') {
-      // Expected format: Number<tab>Name<tab>License<tab>Number<tab>Name<tab>License
-      // Or: Number<tab>Name<tab>License (only one team in row)
-      if (parts.length >= 3) {
-        // Team A player
-        const numA = parseInt(parts[0], 10);
-        const nameA = parts[1];
-        const licenseA = parts[2];
-
-        if (!isNaN(numA) && nameA) {
-          const parsed = parsePlayerName(nameA);
-          teamA.players.push({
-            shirtNumber: numA,
-            lastName: parsed.lastName,
-            firstName: parsed.firstName,
-            displayName: parsed.displayName,
-            rawName: nameA,
-            licenseStatus: licenseA || '',
-          });
-        }
-
-        // Team B player (if present)
-        if (parts.length >= 6) {
-          const numB = parseInt(parts[3], 10);
-          const nameB = parts[4];
-          const licenseB = parts[5];
-
-          if (!isNaN(numB) && nameB) {
-            const parsed = parsePlayerName(nameB);
-            teamB.players.push({
-              shirtNumber: numB,
-              lastName: parsed.lastName,
-              firstName: parsed.firstName,
-              displayName: parsed.displayName,
-              rawName: nameB,
-              licenseStatus: licenseB || '',
-            });
-          }
-        }
-      }
-    }
-
-    if (currentSection === 'libero') {
-      // Libero format: L1<tab>Number Name<tab>License<tab>L1<tab>Number Name<tab>License
-      // Or: L1<tab>Number Name<tab>License (only one team)
-      if (parts.length >= 3) {
-        const entryA = parseLiberoEntry(parts[1]);
-        const licenseA = parts[2];
-
-        if (entryA.name) {
-          const parsed = parsePlayerName(entryA.name);
-          teamA.players.push({
-            shirtNumber: entryA.number,
-            lastName: parsed.lastName,
-            firstName: parsed.firstName,
-            displayName: parsed.displayName,
-            rawName: entryA.name,
-            licenseStatus: licenseA || '',
-          });
-        }
-
-        // Team B libero (if present)
-        if (parts.length >= 6) {
-          const entryB = parseLiberoEntry(parts[4]);
-          const licenseB = parts[5];
-
-          if (entryB.name) {
-            const parsed = parsePlayerName(entryB.name);
-            teamB.players.push({
-              shirtNumber: entryB.number,
-              lastName: parsed.lastName,
-              firstName: parsed.firstName,
-              displayName: parsed.displayName,
-              rawName: entryB.name,
-              licenseStatus: licenseB || '',
-            });
-          }
-        }
-      }
-    }
-
-    if (currentSection === 'officials') {
-      // Officials format: Role<tab>Name<tab>Role<tab>Name
-      // Or: Role<tab>Name (only one team)
-      // Roles: C (coach), AC (assistant coach), AC2, AC3
-      if (parts.length >= 2) {
-        const roleA = parts[0];
-        const nameA = parts[1];
-
-        if (isOfficialRole(roleA) && nameA) {
-          const parsed = parseOfficialName(nameA);
-          teamA.officials.push({
-            role: roleA.toUpperCase(),
-            lastName: parsed.lastName,
-            firstName: parsed.firstName,
-            displayName: parsed.displayName,
-            rawName: nameA,
-          });
-        }
-
-        // Team B official (if present)
-        if (parts.length >= 4) {
-          const roleB = parts[2];
-          const nameB = parts[3];
-
-          if (isOfficialRole(roleB) && nameB) {
-            const parsed = parseOfficialName(nameB);
-            teamB.officials.push({
-              role: roleB.toUpperCase(),
-              lastName: parsed.lastName,
-              firstName: parsed.firstName,
-              displayName: parsed.displayName,
-              rawName: nameB,
-            });
-          }
-        }
-      }
-    }
-  }
-
-  // Add warnings if teams have no players
-  if (teamA.players.length === 0) {
-    warnings.push('No players found for Team A');
-  }
-  if (teamB.players.length === 0) {
-    warnings.push('No players found for Team B');
-  }
-
-  // Warn if officials section wasn't found or parsed
-  if (teamA.officials.length === 0 && teamB.officials.length === 0) {
-    warnings.push('No officials (coaches) found - the OFFICIAL MEMBERS section may not have been recognized');
-  }
-
-  return { teamA, teamB, warnings };
-}
-
-/**
- * Get all players for a team
- * @param {ParsedTeam} team
- * @returns {ParsedPlayer[]}
- */
-export function getAllPlayers(team) {
-  return team.players;
-}
-
-/**
- * Get all officials for a team
- * @param {ParsedTeam} team
- * @returns {ParsedOfficial[]}
- */
-export function getAllOfficials(team) {
-  return team.officials;
-}
+// Re-export all utilities for use in POC components
+export {
+  parseElectronicSheet,
+  parseGameSheetWithType,
+  parseGameSheetWithOCR,
+  parsePlayerName,
+  parseOfficialName,
+  normalizeName,
+  getAllPlayers,
+  getAllOfficials,
+  // Roster comparison utilities
+  compareRosters,
+  compareTeamRosters,
+  calculateMatchScore,
+  calculateNameSimilarity,
+  normalizeForComparison,
+};

--- a/ocr-poc/vite.config.js
+++ b/ocr-poc/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+import path from 'path';
 
 // Base path for GitHub Pages subdirectory deployment
 // In production, this app is served from /volleykit/ocr-poc/
@@ -17,6 +18,12 @@ const MODEL_CACHE_MAX_AGE_DAYS = 30;
 
 export default defineConfig({
   base: BASE_PATH,
+  resolve: {
+    alias: {
+      // Allow importing TypeScript modules from the main web-app
+      '@volleykit/ocr': path.resolve(__dirname, '../web-app/src/features/ocr'),
+    },
+  },
   plugins: [
     VitePWA({
       registerType: 'autoUpdate',


### PR DESCRIPTION
## Summary

- Replace the OCR POC's basic parsing implementation with the sophisticated parsing logic from the main web-app
- Add `@volleykit/ocr` Vite alias to import from main app's OCR feature
- Refactor PlayerListParser.js as a bridge module that re-exports main app utilities
- Update PlayerComparison.js to use imported comparison utilities and pass scoresheet type to parser

Now supports:
- Electronic scoresheet parsing with bounding box column detection
- Manuscript (handwritten) scoresheet parsing with OCR error correction
- Swiss-specific format support (tabular layout, multilingual headers)

## Test Plan

- [ ] Run `npm run build` in ocr-poc directory - should pass
- [ ] Run `npm run lint` in ocr-poc directory - should pass
- [ ] Test electronic scoresheet scanning in POC
- [ ] Test manuscript scoresheet scanning in POC
- [ ] Verify player comparison works with both scoresheet types