### PR TITLE
fix(ocr): show loading state immediately when processing starts

### DIFF
--- a/web-app/src/features/validation/components/OCRCaptureModal.tsx
+++ b/web-app/src/features/validation/components/OCRCaptureModal.tsx
@@ -182,12 +182,16 @@ export function OCRCaptureModal({
   }, []);
 
   // Handle crop confirmation
+  // Note: We only call onImageSelected, not onClose. The parent component
+  // (OCREntryModal/OCRPanel) is responsible for closing this modal by setting
+  // showCaptureModal to false in their handleImageSelected callback.
+  // Calling onClose here would race with the parent's state updates and could
+  // reset the step to "intro" before the processing step is shown.
   const handleCropConfirm = useCallback(
     (croppedBlob: Blob) => {
       onImageSelected(croppedBlob);
-      onClose();
     },
-    [onImageSelected, onClose],
+    [onImageSelected],
   );
 
   // Handle crop cancel

--- a/web-app/src/features/validation/components/OCREntryModal.tsx
+++ b/web-app/src/features/validation/components/OCREntryModal.tsx
@@ -112,7 +112,6 @@ export function OCREntryModal({
   const { t } = useTranslation();
   const {
     processImage,
-    isProcessing,
     progress,
     error,
     reset,
@@ -502,7 +501,7 @@ export function OCREntryModal({
         )}
 
         {/* Processing step */}
-        {step === "processing" && isProcessing && (
+        {step === "processing" && (
           <div
             className="flex flex-col items-center justify-center min-h-[50vh]"
             role="status"


### PR DESCRIPTION
## Summary

- Fixed race condition in OCREntryModal where loading spinner wouldn't appear
- Removed redundant `isProcessing` check that caused timing issue with `step` state
- Now matches OCRPanel.tsx behavior which only checks step state

## Test Plan

- [ ] Open validation wizard and select OCR scan
- [ ] Take or select an image
- [ ] Verify loading spinner appears immediately after image selection
- [ ] Verify progress bar updates as OCR processes