### PR TITLE
fix(transport): include walking time in arrival calculation and add SBB destination setting

### DIFF
--- a/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.tsx
@@ -140,6 +140,7 @@ function AssignmentCardComponent({
     hallCoords,
     hallId,
     city,
+    hallAddress: fullAddress,
     gameStartTime: gameStartingDateTime,
     language: locale,
   });

--- a/web-app/src/features/exchanges/components/ExchangeCard.tsx
+++ b/web-app/src/features/exchanges/components/ExchangeCard.tsx
@@ -109,6 +109,7 @@ function ExchangeCardComponent({
     hallCoords,
     hallId,
     city,
+    hallAddress: fullAddress,
     gameStartTime: gameStartingDateTime,
     language: locale,
   });

--- a/web-app/src/features/settings/components/TravelSettingsSection.tsx
+++ b/web-app/src/features/settings/components/TravelSettingsSection.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { useTranslation } from "@/shared/hooks/useTranslation";
 import { Card, CardContent, CardHeader } from "@/shared/components/Card";
 import { ToggleSwitch } from "@/shared/components/ToggleSwitch";
-import { TrainFront, MapPin, Clock, Info } from "@/shared/components/icons";
+import { TrainFront, MapPin, Clock, Info, Navigation } from "@/shared/components/icons";
 import { useTransportSettings } from "../hooks/useTransportSettings";
 
 /** Badge showing the current association code */
@@ -191,6 +191,49 @@ function TravelSettingsSectionComponent() {
                       <span className="text-sm text-text-muted dark:text-text-muted-dark">
                         {t("common.minutesUnit")}
                       </span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* SBB destination type setting */}
+                <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+                  <div className="py-2">
+                    <div className="flex items-center gap-2 mb-2">
+                      <Navigation className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                      <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                        {t("settings.transport.sbbDestination")}
+                      </span>
+                    </div>
+                    <div className="text-xs text-text-muted dark:text-text-muted-dark mb-3 ml-6">
+                      {t("settings.transport.sbbDestinationDescription")}
+                    </div>
+                    <div className="flex flex-col gap-2 ml-6">
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="radio"
+                          name="sbbDestinationType"
+                          value="address"
+                          checked={transport.sbbDestinationType === "address"}
+                          onChange={() => transport.handleSbbDestinationTypeChange("address")}
+                          className="w-4 h-4 text-primary-600 border-border-default dark:border-border-default-dark focus:ring-primary-500"
+                        />
+                        <span className="text-sm text-text-primary dark:text-text-primary-dark">
+                          {t("settings.transport.sbbDestinationAddress")}
+                        </span>
+                      </label>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="radio"
+                          name="sbbDestinationType"
+                          value="station"
+                          checked={transport.sbbDestinationType === "station"}
+                          onChange={() => transport.handleSbbDestinationTypeChange("station")}
+                          className="w-4 h-4 text-primary-600 border-border-default dark:border-border-default-dark focus:ring-primary-500"
+                        />
+                        <span className="text-sm text-text-primary dark:text-text-primary-dark">
+                          {t("settings.transport.sbbDestinationStation")}
+                        </span>
+                      </label>
                     </div>
                   </div>
                 </div>

--- a/web-app/src/features/settings/hooks/useTransportSettings.ts
+++ b/web-app/src/features/settings/hooks/useTransportSettings.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_MAX_DISTANCE_KM,
   DEFAULT_MAX_TRAVEL_TIME_MINUTES,
   type DistanceFilter,
+  type SbbDestinationType,
 } from "@/shared/stores/settings";
 import { useActiveAssociationCode } from "@/features/auth/hooks/useActiveAssociation";
 import { useTravelTimeAvailable } from "@/shared/hooks/useTravelTime";
@@ -49,6 +50,8 @@ export function useTransportSettings() {
     setMaxTravelTimeForAssociation,
     arrivalBufferByAssociation,
     setArrivalBufferForAssociation,
+    sbbDestinationType,
+    setSbbDestinationType,
   } = useSettingsStore(
     useShallow((state) => ({
       homeLocation: state.homeLocation,
@@ -62,6 +65,8 @@ export function useTransportSettings() {
       setMaxTravelTimeForAssociation: state.setMaxTravelTimeForAssociation,
       arrivalBufferByAssociation: state.travelTimeFilter.arrivalBufferByAssociation,
       setArrivalBufferForAssociation: state.setArrivalBufferForAssociation,
+      sbbDestinationType: state.travelTimeFilter.sbbDestinationType ?? "address",
+      setSbbDestinationType: state.setSbbDestinationType,
     })),
   );
 
@@ -209,6 +214,13 @@ export function useTransportSettings() {
     [associationCode, setMaxTravelTimeForAssociation],
   );
 
+  const handleSbbDestinationTypeChange = useCallback(
+    (type: SbbDestinationType) => {
+      setSbbDestinationType(type);
+    },
+    [setSbbDestinationType],
+  );
+
   const hasHomeLocation = Boolean(homeLocation);
   const hasAssociation = Boolean(associationCode);
   const canEnableTransport = hasHomeLocation && isTransportAvailable && hasAssociation;
@@ -225,6 +237,7 @@ export function useTransportSettings() {
     showClearConfirm,
     hasHomeLocation,
     canEnableTransport,
+    sbbDestinationType: sbbDestinationType as SbbDestinationType,
 
     // Constants
     minArrivalBuffer: MIN_ARRIVAL_BUFFER_MINUTES,
@@ -242,6 +255,7 @@ export function useTransportSettings() {
     handleArrivalBufferChange,
     handleMaxDistanceChange,
     handleMaxTravelTimeChange,
+    handleSbbDestinationTypeChange,
     setShowClearConfirm,
   };
 }

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -425,6 +425,10 @@ const de: Translations = {
       maxTravelTimeDescription: "Tauschangebote mit längerer Reisezeit ausblenden",
       arrivalTime: "Ankunft vor Spielbeginn",
       arrivalTimeDescription: "Minuten vor Spielbeginn ankommen",
+      sbbDestination: "SBB-Ziel",
+      sbbDestinationDescription: "Wählen Sie, wohin der SBB-Link führen soll",
+      sbbDestinationAddress: "Sporthalle (inkl. Fussweg)",
+      sbbDestinationStation: "Letzte ÖV-Haltestelle",
       cacheInfo:
         "Reisezeiten werden nach Tagestyp (Werktag/Samstag/Sonntag) für 14 Tage zwischengespeichert.",
       cacheEntries: "{count} gespeicherte Routen",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -422,6 +422,10 @@ const en: Translations = {
       maxTravelTimeDescription: "Hide exchanges with longer travel times",
       arrivalTime: "Arrive before game",
       arrivalTimeDescription: "Minutes to arrive before game start",
+      sbbDestination: "SBB destination",
+      sbbDestinationDescription: "Choose where the SBB link should route to",
+      sbbDestinationAddress: "Sports hall (incl. walking)",
+      sbbDestinationStation: "Last public transport stop",
       cacheInfo:
         "Travel times are cached by day type (weekday/Saturday/Sunday) for 14 days.",
       cacheEntries: "{count} cached routes",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -424,6 +424,10 @@ const fr: Translations = {
       maxTravelTimeDescription: "Masquer les échanges avec des temps de trajet plus longs",
       arrivalTime: "Arrivée avant le match",
       arrivalTimeDescription: "Minutes d'arrivée avant le début du match",
+      sbbDestination: "Destination CFF",
+      sbbDestinationDescription: "Choisissez où le lien CFF doit mener",
+      sbbDestinationAddress: "Salle de sport (y.c. marche)",
+      sbbDestinationStation: "Dernier arrêt de transport public",
       cacheInfo:
         "Les temps de trajet sont mis en cache par type de jour (semaine/samedi/dimanche) pendant 14 jours.",
       cacheEntries: "{count} trajets en cache",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -422,6 +422,10 @@ const it: Translations = {
       maxTravelTimeDescription: "Nascondi scambi con tempi di viaggio più lunghi",
       arrivalTime: "Arrivo prima della partita",
       arrivalTimeDescription: "Minuti di anticipo all'arrivo",
+      sbbDestination: "Destinazione FFS",
+      sbbDestinationDescription: "Scegli dove deve portare il link FFS",
+      sbbDestinationAddress: "Palestra (incl. cammino)",
+      sbbDestinationStation: "Ultima fermata trasporto pubblico",
       cacheInfo:
         "I tempi di viaggio sono memorizzati in cache per tipo di giorno (feriale/sabato/domenica) per 14 giorni.",
       cacheEntries: "{count} percorsi in cache",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -291,6 +291,10 @@ export interface Translations {
       maxTravelTimeDescription: string;
       arrivalTime: string;
       arrivalTimeDescription: string;
+      sbbDestination: string;
+      sbbDestinationDescription: string;
+      sbbDestinationAddress: string;
+      sbbDestinationStation: string;
       cacheInfo: string;
       cacheEntries: string;
       refreshCache: string;

--- a/web-app/src/shared/hooks/useSbbUrl.ts
+++ b/web-app/src/shared/hooks/useSbbUrl.ts
@@ -5,7 +5,7 @@
 
 import { useState, useCallback } from "react";
 import { useAuthStore } from "@/shared/stores/auth";
-import { useSettingsStore } from "@/shared/stores/settings";
+import { useSettingsStore, type SbbDestinationType } from "@/shared/stores/settings";
 import { useActiveAssociationCode } from "@/features/auth/hooks/useActiveAssociation";
 import {
   calculateTravelTime,
@@ -17,9 +17,14 @@ import {
   setCachedTravelTime,
   type Coordinates,
   type StationInfo,
+  type TravelTimeResult,
 } from "@/shared/services/transport";
-import { generateSbbUrl, calculateArrivalTime, openSbbUrl } from "@/shared/utils/sbb-url";
+import { generateSbbUrl, calculateArrivalTime, openSbbUrl, type SbbUrlParams } from "@/shared/utils/sbb-url";
 import type { Locale } from "@/i18n";
+import type { UserLocation } from "@/shared/stores/settings";
+
+/** Milliseconds per minute for time calculations */
+const MS_PER_MINUTE = 60000;
 
 interface UseSbbUrlOptions {
   /** Hall coordinates for routing */
@@ -28,6 +33,8 @@ interface UseSbbUrlOptions {
   hallId: string | undefined;
   /** City name as fallback destination */
   city: string | undefined;
+  /** Full hall address for final destination (e.g., "Sporthalle, Hauptstrasse 1, 8000 Zürich") */
+  hallAddress: string | null | undefined;
   /** Game start time */
   gameStartTime: string | undefined;
   /** Language for the URL */
@@ -48,16 +55,101 @@ interface UseSbbUrlResult {
 }
 
 /**
+ * Calculate arrival time, adjusting for walking time when routing to station only.
+ */
+function getAdjustedArrivalTime(
+  gameDate: Date,
+  arrivalBuffer: number,
+  routeToStation: boolean,
+  walkingMinutes: number,
+): Date {
+  const baseArrivalTime = calculateArrivalTime(gameDate, arrivalBuffer);
+  if (routeToStation && walkingMinutes > 0) {
+    return new Date(baseArrivalTime.getTime() - walkingMinutes * MS_PER_MINUTE);
+  }
+  return baseArrivalTime;
+}
+
+/**
+ * Build SBB URL parameters from context.
+ */
+function buildSbbUrlParams(
+  city: string,
+  gameDate: Date,
+  arrivalTime: Date,
+  language: Locale,
+  originAddress: string | undefined,
+  destAddress: string | undefined,
+  originStation?: StationInfo,
+  destinationStation?: StationInfo,
+): SbbUrlParams {
+  return {
+    destination: city,
+    date: gameDate,
+    arrivalTime,
+    language,
+    originStation,
+    destinationStation,
+    originAddress,
+    destinationAddress: destAddress,
+  };
+}
+
+/**
+ * Fetch or retrieve cached trip data.
+ */
+async function fetchTripData(
+  homeLocation: UserLocation,
+  hallCoords: Coordinates,
+  hallId: string,
+  gameDate: Date,
+  city: string,
+  arrivalTime: Date,
+): Promise<TravelTimeResult> {
+  const homeLocationHash = hashLocation(homeLocation);
+  const dayType = getDayType(gameDate);
+
+  // Check cache first
+  const cachedResult = getCachedTravelTime(hallId, homeLocationHash, dayType);
+  if (cachedResult) {
+    return cachedResult;
+  }
+
+  // Fetch trip data
+  const fromCoords: Coordinates = {
+    latitude: homeLocation.latitude,
+    longitude: homeLocation.longitude,
+  };
+
+  let tripResult: TravelTimeResult;
+  if (isOjpConfigured()) {
+    tripResult = await calculateTravelTime(fromCoords, hallCoords, {
+      targetArrivalTime: arrivalTime,
+    });
+  } else {
+    tripResult = await calculateMockTravelTime(fromCoords, hallCoords, {
+      originLabel: "Home",
+      destinationLabel: city,
+    });
+  }
+
+  // Cache the result
+  setCachedTravelTime(hallId, homeLocationHash, dayType, tripResult);
+  return tripResult;
+}
+
+/**
  * Hook to generate and open SBB URLs with proper station IDs.
  * Fetches trip data on demand and caches results.
  */
 export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
-  const { hallCoords, hallId, city, gameStartTime, language } = options;
+  const { hallCoords, hallId, city, hallAddress, gameStartTime, language } = options;
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [originStation, setOriginStation] = useState<StationInfo | undefined>();
   const [destinationStation, setDestinationStation] = useState<StationInfo | undefined>();
+  const [finalWalkingMinutes, setFinalWalkingMinutes] = useState<number>(0);
 
   const dataSource = useAuthStore((state) => state.dataSource);
   const isDemoMode = dataSource === "demo";
@@ -66,6 +158,9 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
   const arrivalBuffer = useSettingsStore((state) =>
     state.getArrivalBufferForAssociation(associationCode),
   );
+  const sbbDestinationType = useSettingsStore(
+    (state) => state.travelTimeFilter.sbbDestinationType ?? "address",
+  ) as SbbDestinationType;
 
   const openSbbConnection = useCallback(async () => {
     if (!city || !gameStartTime) {
@@ -73,115 +168,66 @@ export function useSbbUrl(options: UseSbbUrlOptions): UseSbbUrlResult {
     }
 
     const gameDate = new Date(gameStartTime);
-    const arrivalTime = calculateArrivalTime(gameDate, arrivalBuffer);
-
-    // Get fallback address for origin (used when station lookup fails)
+    const routeToStation = sbbDestinationType === "station";
+    const destAddress = routeToStation ? undefined : (hallAddress ?? undefined);
     const originAddress = homeLocation?.source === "geocoded" ? homeLocation.label : undefined;
+    const arrivalTime = getAdjustedArrivalTime(gameDate, arrivalBuffer, routeToStation, finalWalkingMinutes);
 
     // If we already have cached station info, use it directly
     if (originStation && destinationStation) {
-      const url = generateSbbUrl({
-        destination: city,
-        date: gameDate,
-        arrivalTime,
-        language,
-        originStation,
-        destinationStation,
-        originAddress,
-      });
-      openSbbUrl(url);
+      const params = buildSbbUrlParams(city, gameDate, arrivalTime, language, originAddress, destAddress, originStation, destinationStation);
+      openSbbUrl(generateSbbUrl(params));
       return;
     }
 
-    // If we can fetch trip data, try to get the station ID
+    // Check if we can fetch trip data
     const canFetchTrip = homeLocation && hallCoords && hallId && (isDemoMode || isOjpConfigured());
 
-    if (canFetchTrip) {
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const homeLocationHash = hashLocation(homeLocation);
-        const dayType = getDayType(gameDate);
-
-        // Check cache first
-        let tripResult = getCachedTravelTime(hallId, homeLocationHash, dayType);
-
-        if (!tripResult) {
-          // Fetch trip data
-          const fromCoords: Coordinates = {
-            latitude: homeLocation.latitude,
-            longitude: homeLocation.longitude,
-          };
-
-          // Prefer real OJP if configured, fall back to mock transport
-          if (isOjpConfigured()) {
-            tripResult = await calculateTravelTime(fromCoords, hallCoords, {
-              targetArrivalTime: arrivalTime,
-            });
-          } else {
-            tripResult = await calculateMockTravelTime(fromCoords, hallCoords, {
-              // Use simple "Home" label instead of geocoded address for cleaner SBB URLs
-              originLabel: "Home",
-              destinationLabel: city,
-            });
-          }
-
-          // Cache the result
-          setCachedTravelTime(hallId, homeLocationHash, dayType, tripResult);
-        }
-
-        // Update state with station info for future clicks
-        if (tripResult.originStation) {
-          setOriginStation(tripResult.originStation);
-        }
-        if (tripResult.destinationStation) {
-          setDestinationStation(tripResult.destinationStation);
-        }
-
-        // Generate URL with station IDs
-        const url = generateSbbUrl({
-          destination: city,
-          date: gameDate,
-          arrivalTime,
-          language,
-          originStation: tripResult.originStation,
-          destinationStation: tripResult.destinationStation,
-          originAddress,
-        });
-        openSbbUrl(url);
-      } catch (err) {
-        setError(err instanceof Error ? err : new Error("Failed to fetch trip data"));
-
-        // Fall back to URL without station ID but with address
-        const url = generateSbbUrl({
-          destination: city,
-          date: gameDate,
-          arrivalTime,
-          language,
-          originAddress,
-        });
-        openSbbUrl(url);
-      } finally {
-        setIsLoading(false);
-      }
-    } else {
+    if (!canFetchTrip) {
       // No trip data available, use city name and address fallbacks
-      const url = generateSbbUrl({
-        destination: city,
-        date: gameDate,
-        arrivalTime,
-        language,
-        originAddress,
-      });
-      openSbbUrl(url);
+      const params = buildSbbUrlParams(city, gameDate, arrivalTime, language, originAddress, destAddress);
+      openSbbUrl(generateSbbUrl(params));
+      return;
+    }
+
+    // Fetch trip data
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const tripResult = await fetchTripData(homeLocation, hallCoords, hallId, gameDate, city, arrivalTime);
+
+      // Update state with station info for future clicks
+      if (tripResult.originStation) setOriginStation(tripResult.originStation);
+      if (tripResult.destinationStation) setDestinationStation(tripResult.destinationStation);
+      if (tripResult.finalWalkingMinutes !== undefined) setFinalWalkingMinutes(tripResult.finalWalkingMinutes);
+
+      // Recalculate arrival time with actual walking minutes if routing to station
+      const walkingMinutes = tripResult.finalWalkingMinutes ?? 0;
+      const urlArrivalTime = getAdjustedArrivalTime(gameDate, arrivalBuffer, routeToStation, walkingMinutes);
+
+      const params = buildSbbUrlParams(
+        city, gameDate, urlArrivalTime, language, originAddress, destAddress,
+        tripResult.originStation, tripResult.destinationStation,
+      );
+      openSbbUrl(generateSbbUrl(params));
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Failed to fetch trip data"));
+      // Fall back to URL without station ID
+      const params = buildSbbUrlParams(city, gameDate, arrivalTime, language, originAddress, destAddress);
+      openSbbUrl(generateSbbUrl(params));
+    } finally {
+      setIsLoading(false);
     }
   }, [
     city,
+    hallAddress,
     gameStartTime,
     arrivalBuffer,
     originStation,
     destinationStation,
+    finalWalkingMinutes,
+    sbbDestinationType,
     language,
     homeLocation,
     hallCoords,

--- a/web-app/src/shared/services/transport/mock-transport.ts
+++ b/web-app/src/shared/services/transport/mock-transport.ts
@@ -29,6 +29,12 @@ const ID_PAD_LENGTH = 5;
 // Decimal places for coordinate display (0.1 degree precision)
 const COORD_DISPLAY_PRECISION = 10;
 
+// Walking time estimation constants
+const WALKING_TIME_BASE_MINUTES = 5;
+const WALKING_TIME_VARIATION = 6;
+const WALKING_COORD_MULTIPLIER_LAT = 100;
+const WALKING_COORD_MULTIPLIER_LON = 10;
+
 /**
  * Estimate travel time based on straight-line distance.
  * Uses a formula that approximates Swiss public transport:
@@ -128,6 +134,14 @@ export async function calculateMockTravelTime(
     name: options.destinationLabel ?? generateMockStationName(to),
   };
 
+  // Mock walking time from last stop to destination (5-10 minutes typically)
+  // Use a deterministic value based on coordinates for consistency
+  const coordHash =
+    Math.abs(
+      Math.round(to.latitude * WALKING_COORD_MULTIPLIER_LAT + to.longitude * WALKING_COORD_MULTIPLIER_LON),
+    ) % WALKING_TIME_VARIATION;
+  const finalWalkingMinutes = WALKING_TIME_BASE_MINUTES + coordHash;
+
   return {
     durationMinutes,
     departureTime: departureTime.toISOString(),
@@ -135,6 +149,7 @@ export async function calculateMockTravelTime(
     transfers,
     originStation,
     destinationStation,
+    finalWalkingMinutes,
     tripData: undefined,
   };
 }

--- a/web-app/src/shared/services/transport/types.ts
+++ b/web-app/src/shared/services/transport/types.ts
@@ -21,7 +21,7 @@ export interface TravelTimeResult {
   durationMinutes: number;
   /** ISO 8601 departure time */
   departureTime: string;
-  /** ISO 8601 arrival time */
+  /** ISO 8601 arrival time (includes walking to final destination) */
   arrivalTime: string;
   /** Number of transfers required */
   transfers: number;
@@ -29,6 +29,8 @@ export interface TravelTimeResult {
   originStation?: StationInfo;
   /** Destination station info for SBB deep linking */
   destinationStation?: StationInfo;
+  /** Walking time from last public transport stop to destination (minutes) */
+  finalWalkingMinutes?: number;
   /** Raw trip data for future itinerary display */
   tripData?: unknown;
 }

--- a/web-app/src/shared/stores/settings.test.ts
+++ b/web-app/src/shared/stores/settings.test.ts
@@ -23,6 +23,7 @@ const DEFAULT_MODE_SETTINGS: ModeSettings = {
     arrivalBufferMinutes: 30,
     arrivalBufferByAssociation: {},
     cacheInvalidatedAt: null,
+    sbbDestinationType: "address",
   },
   levelFilterEnabled: false,
 };

--- a/web-app/src/shared/stores/settings.ts
+++ b/web-app/src/shared/stores/settings.ts
@@ -32,6 +32,13 @@ export interface DistanceFilter {
 }
 
 /**
+ * SBB destination type for the SBB button.
+ * - 'address': Route to the full sports hall address (includes walking)
+ * - 'station': Route to the last public transport stop only
+ */
+export type SbbDestinationType = "address" | "station";
+
+/**
  * Travel time filter configuration for exchanges.
  * Uses Swiss public transport travel times.
  */
@@ -48,6 +55,8 @@ export interface TravelTimeFilter {
   arrivalBufferByAssociation: Record<string, number>;
   /** Timestamp when cache was last invalidated (home location change) */
   cacheInvalidatedAt: number | null;
+  /** SBB button destination type - 'address' for sports hall, 'station' for last stop */
+  sbbDestinationType: SbbDestinationType;
 }
 
 /** Default arrival buffer for SV (Swiss Volley national) - 60 minutes */
@@ -114,6 +123,7 @@ const DEFAULT_MODE_SETTINGS: ModeSettings = {
     arrivalBufferMinutes: DEFAULT_ARRIVAL_BUFFER_MINUTES,
     arrivalBufferByAssociation: {},
     cacheInvalidatedAt: null,
+    sbbDestinationType: "address",
   },
   levelFilterEnabled: false,
 };
@@ -178,6 +188,7 @@ interface SettingsState {
   setArrivalBufferForAssociation: (associationCode: string, minutes: number) => void;
   getArrivalBufferForAssociation: (associationCode: string | undefined) => number;
   invalidateTravelTimeCache: () => void;
+  setSbbDestinationType: (type: SbbDestinationType) => void;
   setLevelFilterEnabled: (enabled: boolean) => void;
 
   // Reset current mode's settings to defaults (keeps safe mode and other modes)
@@ -454,6 +465,14 @@ export const useSettingsStore = create<SettingsState>()(
           );
         },
 
+        setSbbDestinationType: (type: SbbDestinationType) => {
+          set((state) =>
+            updateModeAndTopLevel(state, (current) => ({
+              travelTimeFilter: { ...current.travelTimeFilter, sbbDestinationType: type },
+            })),
+          );
+        },
+
         setLevelFilterEnabled: (enabled: boolean) => {
           set((state) => updateModeAndTopLevel(state, () => ({ levelFilterEnabled: enabled })));
         },
@@ -596,6 +615,9 @@ export const useSettingsStore = create<SettingsState>()(
                     maxTravelTimeByAssociation:
                       persistedModeSettings.travelTimeFilter?.maxTravelTimeByAssociation ??
                       DEFAULT_MODE_SETTINGS.travelTimeFilter.maxTravelTimeByAssociation,
+                    sbbDestinationType:
+                      persistedModeSettings.travelTimeFilter?.sbbDestinationType ??
+                      DEFAULT_MODE_SETTINGS.travelTimeFilter.sbbDestinationType,
                   },
                   levelFilterEnabled:
                     persistedModeSettings.levelFilterEnabled ??

--- a/web-app/src/shared/utils/sbb-url.test.ts
+++ b/web-app/src/shared/utils/sbb-url.test.ts
@@ -101,6 +101,44 @@ describe("sbb-url", () => {
         expect(url).toContain("nach=Bern");
         expect(url).not.toContain("stops=");
       });
+
+      it("uses destinationAddress when provided without station IDs", () => {
+        const params = {
+          ...baseParams,
+          destinationAddress: "Sporthalle Bern, Sportstrasse 1, 3000 Bern",
+        };
+        const url = generateSbbUrl(params);
+        // Should use the full address instead of just the city
+        expect(url).toContain("nach=Sporthalle+Bern%2C+Sportstrasse+1%2C+3000+Bern");
+        expect(url).not.toContain("stops=");
+      });
+
+      it("uses destinationAddress over destinationStation name when both provided", () => {
+        const params = {
+          ...baseParams,
+          destinationStation: { id: "8507000", name: "Bern" },
+          destinationAddress: "Sporthalle Bern, Sportstrasse 1, 3000 Bern",
+        };
+        const url = generateSbbUrl(params);
+        // Should use the full hall address, not just the station name
+        expect(url).toContain("nach=Sporthalle+Bern%2C+Sportstrasse+1%2C+3000+Bern");
+        // Should use von/nach format because destinationAddress overrides station ID routing
+        expect(url).not.toContain("stops=");
+      });
+
+      it("uses von/nach when destinationAddress overrides station IDs", () => {
+        const params = {
+          ...baseParams,
+          originStation: { id: "8503000", name: "Zürich HB" },
+          destinationStation: { id: "8507000", name: "Bern" },
+          destinationAddress: "Sporthalle Bern, Sportstrasse 1, 3000 Bern",
+        };
+        const url = generateSbbUrl(params);
+        // When destinationAddress is provided, should use von/nach for full route to final destination
+        expect(url).toContain("von=Z%C3%BCrich+HB");
+        expect(url).toContain("nach=Sporthalle+Bern%2C+Sportstrasse+1%2C+3000+Bern");
+        expect(url).not.toContain("stops=");
+      });
     });
 
     describe("stops JSON format (with station IDs)", () => {


### PR DESCRIPTION
## Summary

- Extract final walking duration from OJP `continuousLeg` after the last timed leg to calculate actual arrival time at the sports hall
- Add SBB destination type setting allowing users to choose between routing to the full address (with walking) or just the last public transport stop
- When routing to station only, subtract walking time from target arrival to ensure users have time to walk

## Test plan

- [ ] Verify OJP trips correctly extract walking time from `continuousLeg.duration`
- [ ] Test `selectBestTrip` uses actual arrival time (including walking) for comparison
- [ ] Test SBB URL generation with `destinationAddress` parameter
- [ ] Verify SBB destination type setting persists and updates correctly
- [ ] Test station-only routing subtracts walking time from arrival
- [ ] Confirm mock transport returns consistent `finalWalkingMinutes` values