### PR TITLE
feat(api): add referee backup (Pikett) API client foundation

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -3,6 +3,7 @@ import {
   assignmentsResponseSchema,
   compensationsResponseSchema,
   exchangesResponseSchema,
+  refereeBackupResponseSchema,
   validateResponse,
 } from "./validation";
 import { mockApi } from "./mock-api";
@@ -18,6 +19,7 @@ import {
   ASSIGNMENT_PROPERTIES,
   EXCHANGE_PROPERTIES,
   COMPENSATION_PROPERTIES,
+  REFEREE_BACKUP_PROPERTIES,
 } from "./property-configs";
 import {
   MAX_FILE_SIZE_BYTES,
@@ -57,6 +59,8 @@ export type FileResource = Schemas["FileResource"];
 export type GameDetails = Schemas["GameDetails"];
 export type PersonSearchResult = Schemas["PersonSearchResult"];
 export type PersonSearchResponse = Schemas["PersonSearchResponse"];
+export type RefereeBackupEntry = Schemas["RefereeBackupEntry"];
+export type RefereeBackupSearchResponse = Schemas["RefereeBackupSearchResponse"];
 
 export interface PersonSearchFilter {
   firstName?: string;
@@ -685,6 +689,32 @@ export const api = {
       const errorMessage = await parseErrorResponse(response);
       throw new Error(`PUT switchRoleAndAttribute: ${errorMessage}`);
     }
+  },
+
+  // Referee Backup (Pikett)
+  /**
+   * Search referee backup (Pikett) assignments.
+   * Returns on-call referees for NLA and NLB games within the specified date range.
+   *
+   * @param config - Search configuration with date filters
+   * @returns Promise with referee backup entries
+   */
+  async searchRefereeBackups(
+    config: SearchConfiguration = {},
+  ): Promise<RefereeBackupSearchResponse> {
+    const data = await apiRequest<unknown>(
+      "/indoorvolleyball.refadmin/api%5crefereeconvocationrefereebackup/search",
+      "POST",
+      {
+        searchConfiguration: {
+          ...config,
+          customFilters: [{ name: "myReferees" }],
+        },
+        propertyRenderConfiguration: REFEREE_BACKUP_PROPERTIES,
+      },
+    );
+    validateResponse(data, refereeBackupResponseSchema, "searchRefereeBackups");
+    return data as RefereeBackupSearchResponse;
   },
 };
 

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -29,6 +29,7 @@ import type {
   PersonSearchFilter,
   PersonSearchResponse,
   PersonSearchResult,
+  RefereeBackupSearchResponse,
 } from "./client";
 import { useDemoStore, DEMO_USER_PERSON_IDENTITY } from "@/shared/stores/demo";
 import {
@@ -773,6 +774,23 @@ export const mockApi = {
         store.setActiveAssociation(occupation.associationCode as DemoCode);
       }
     }
+  },
+
+  /**
+   * Search referee backup (Pikett) assignments.
+   * In demo mode, returns an empty list since this feature is admin-only.
+   */
+  async searchRefereeBackups(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required for API interface compatibility
+    _config: SearchConfiguration = {},
+  ): Promise<RefereeBackupSearchResponse> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+
+    // Demo mode doesn't include referee backup data (admin-only feature)
+    return {
+      items: [],
+      totalItemsCount: 0,
+    };
   },
 };
 

--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -160,3 +160,21 @@ export const COMPENSATION_PROPERTIES = [
   "refereeGame.game.isVolleyCupGameWithoutNationalAssociationLeagueCategoryTeams",
   "refereeGame.game.displayName",
 ];
+
+/**
+ * Property configuration for referee backup (Pikett) endpoint.
+ * Used to fetch on-call referee schedules for NLA/NLB games.
+ */
+export const REFEREE_BACKUP_PROPERTIES = [
+  "date",
+  "weekday",
+  "calendarWeek",
+  "joinedNlaReferees",
+  "joinedNlbReferees",
+  // NLA referee details
+  "nlaReferees.*.indoorReferee.person.primaryEmailAddress",
+  "nlaReferees.*.indoorReferee.person.primaryPhoneNumber",
+  // NLB referee details
+  "nlbReferees.*.indoorReferee.person.primaryEmailAddress",
+  "nlbReferees.*.indoorReferee.person.primaryPhoneNumber",
+];

--- a/web-app/src/api/queryKeys.ts
+++ b/web-app/src/api/queryKeys.ts
@@ -217,4 +217,22 @@ export const queryKeys = {
     assignmentsByCode: (code: string) =>
       [...queryKeys.calendar.assignments(), code] as const,
   },
+
+  /**
+   * Referee backup (Pikett) query keys for on-call referee management.
+   * Used by referee administrators to view on-call schedules for NLA/NLB games.
+   */
+  refereeBackup: {
+    /** Base key - invalidates ALL referee backup queries */
+    all: ["refereeBackup"] as const,
+    /** Parent key for all list queries */
+    lists: () => [...queryKeys.refereeBackup.all, "list"] as const,
+    /**
+     * Specific list query with search configuration.
+     * @param config - Search configuration filters and sorting
+     * @param associationKey - In demo mode: demoAssociationCode. In production: activeOccupationId.
+     */
+    list: (config?: SearchConfiguration, associationKey?: string | null) =>
+      [...queryKeys.refereeBackup.lists(), config, associationKey] as const,
+  },
 } as const;

--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -315,6 +315,92 @@ export const personSearchResponseSchema = z.object({
   totalItemsCount: z.number().optional(),
 });
 
+// Referee backup (Pikett) schemas
+
+// Person details for a backup referee
+const backupRefereePersonSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    persistenceObjectIdentifier: uuidSchema.optional(),
+    associationId: z.number().optional().nullable(),
+    displayName: z.string().optional(),
+    firstName: z.string().optional(),
+    lastName: z.string().optional(),
+    gender: z.enum(["m", "f"]).optional().nullable(),
+    correspondenceLanguage: z.string().optional(),
+    primaryEmailAddress: z
+      .object({
+        emailAddress: z.string().optional(),
+        isPrimary: z.boolean().optional(),
+        __identity: uuidSchema.optional(),
+      })
+      .passthrough()
+      .optional()
+      .nullable(),
+    primaryPhoneNumber: z
+      .object({
+        localNumber: z.string().optional(),
+        normalizedLocalNumber: z.string().optional(),
+        numberType: z.string().optional(),
+        isPrimary: z.boolean().optional(),
+        __identity: uuidSchema.optional(),
+      })
+      .passthrough()
+      .optional()
+      .nullable(),
+  })
+  .passthrough();
+
+// Indoor referee details for backup assignment
+const backupIndoorRefereeSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    persistenceObjectIdentifier: uuidSchema.optional(),
+    person: backupRefereePersonSchema.optional(),
+    refereeInformation: z.string().optional(),
+    transportationMode: z.string().optional().nullable(),
+    validated: z.boolean().optional(),
+    mobilePhoneNumbers: z.string().optional().nullable(),
+    privatePostalAddresses: z.string().optional().nullable(),
+  })
+  .passthrough();
+
+// Backup referee assignment
+const backupRefereeAssignmentSchema = z
+  .object({
+    __identity: uuidSchema,
+    indoorReferee: backupIndoorRefereeSchema.optional(),
+    isDispensed: z.boolean().optional(),
+    hasFutureRefereeConvocations: z.boolean().optional(),
+    hasResigned: z.boolean().optional(),
+    unconfirmedFutureRefereeConvocations: z.boolean().optional(),
+    originId: z.number().optional(),
+    createdBy: z.string().optional(),
+    updatedBy: z.string().optional(),
+  })
+  .passthrough();
+
+// Referee backup entry (a single date with assigned backup referees)
+export const refereeBackupEntrySchema = z
+  .object({
+    __identity: uuidSchema,
+    date: z.string().datetime({ offset: true }),
+    weekday: z.string(),
+    calendarWeek: z.number(),
+    joinedNlaReferees: z.string().optional().nullable(),
+    joinedNlbReferees: z.string().optional().nullable(),
+    nlaReferees: z.array(backupRefereeAssignmentSchema).optional(),
+    nlbReferees: z.array(backupRefereeAssignmentSchema).optional(),
+  })
+  .passthrough();
+
+// Referee backup search response
+export const refereeBackupResponseSchema = z.object({
+  items: z.array(refereeBackupEntrySchema),
+  totalItemsCount: z.number(),
+  entityTemplate: z.unknown().optional().nullable(),
+});
+
 // Type exports inferred from Zod schemas
 export type ValidatedPersonSearchResult = z.infer<
   typeof personSearchResultSchema

--- a/web-app/src/features/assignments/api/calendar-client.ts
+++ b/web-app/src/features/assignments/api/calendar-client.ts
@@ -49,6 +49,7 @@ import type {
   GameDetails,
   PossibleNominationsResponse,
   PersonSearchResponse,
+  RefereeBackupSearchResponse,
 } from "@/api/client";
 import {
   fetchCalendarAssignments,
@@ -315,5 +316,9 @@ export const calendarApi = {
 
   async switchRoleAndAttribute(): Promise<void> {
     throw new CalendarModeNotSupportedError("Role switching");
+  },
+
+  async searchRefereeBackups(): Promise<RefereeBackupSearchResponse> {
+    throw new CalendarModeNotSupportedError("Referee backups");
   },
 };

--- a/web-app/src/features/referee-backup/hooks/useRefereeBackups.ts
+++ b/web-app/src/features/referee-backup/hooks/useRefereeBackups.ts
@@ -1,0 +1,101 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { startOfDay, endOfDay, addWeeks, format } from "date-fns";
+import {
+  getApiClient,
+  type SearchConfiguration,
+  type RefereeBackupEntry,
+} from "@/api/client";
+import { useAuthStore } from "@/shared/stores/auth";
+import { useDemoStore } from "@/shared/stores/demo";
+import { queryKeys } from "@/api/queryKeys";
+import { DEFAULT_PAGE_SIZE } from "@/shared/hooks/usePaginatedQuery";
+import { MS_PER_MINUTE } from "@/shared/utils/constants";
+
+/** Default number of weeks ahead to fetch referee backups */
+const DEFAULT_WEEKS_AHEAD = 2;
+
+// Format date as YYYY-MM-DD for stable comparison (no time component)
+const formatDateKey = (date: Date): string => format(date, "yyyy-MM-dd");
+
+// Stable empty array for React Query selectors to prevent unnecessary re-renders.
+const EMPTY_BACKUPS: RefereeBackupEntry[] = [];
+
+/**
+ * Hook to fetch referee backup (Pikett) assignments.
+ *
+ * This hook fetches on-call referee schedules for NLA and NLB games.
+ * It's intended for referee administrators to view who is on-call.
+ *
+ * @param weeksAhead - Number of weeks ahead to fetch (default: 2)
+ * @returns Query result with referee backup entries
+ */
+export function useRefereeBackups(weeksAhead: number = DEFAULT_WEEKS_AHEAD) {
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
+  const activeOccupationId = useAuthStore((state) => state.activeOccupationId);
+  const demoAssociationCode = useDemoStore(
+    (state) => state.activeAssociationCode,
+  );
+  const apiClient = getApiClient(dataSource);
+
+  // Use appropriate key for cache invalidation when switching associations
+  const associationKey = isDemoMode ? demoAssociationCode : activeOccupationId;
+
+  // Compute date keys (YYYY-MM-DD) for stable memoization.
+  const todayKey = formatDateKey(new Date());
+  const endDateKey = formatDateKey(addWeeks(new Date(), weeksAhead));
+
+  // Memoize date range to ensure stable query key across tab switches.
+  const dateRange = useMemo(
+    () => ({
+      from: startOfDay(new Date()).toISOString(),
+      to: endOfDay(addWeeks(new Date(), weeksAhead)).toISOString(),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Use date keys for stability, not Date objects
+    [todayKey, endDateKey, weeksAhead],
+  );
+
+  // Build property filters for date range
+  const propertyFilters = useMemo<SearchConfiguration["propertyFilters"]>(
+    () => [
+      {
+        propertyName: "date",
+        dateRange,
+      },
+    ],
+    [dateRange],
+  );
+
+  const config = useMemo<SearchConfiguration>(
+    () => ({
+      offset: 0,
+      limit: DEFAULT_PAGE_SIZE,
+      propertyFilters,
+      propertyOrderings: [
+        {
+          propertyName: "date",
+          descending: false,
+          isSetByUser: true,
+        },
+      ],
+    }),
+    [propertyFilters],
+  );
+
+  // Select items from the response, providing a stable empty array fallback
+  const selectBackups = useMemo(() => {
+    return (data: { items?: RefereeBackupEntry[] }) => {
+      return data.items ?? EMPTY_BACKUPS;
+    };
+  }, []);
+
+  return useQuery({
+    queryKey: queryKeys.refereeBackup.list(config, associationKey),
+    queryFn: () => apiClient.searchRefereeBackups(config),
+    select: selectBackups,
+    staleTime: 2 * MS_PER_MINUTE,
+    // Keep previous data while refetching
+    placeholderData: (prev) => prev,
+  });
+}

--- a/web-app/src/features/referee-backup/index.ts
+++ b/web-app/src/features/referee-backup/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Referee Backup (Pikett) Feature
+ *
+ * This feature provides API client integration for managing on-call
+ * referee schedules for NLA and NLB games.
+ *
+ * Currently implements:
+ * - useRefereeBackups hook for fetching backup schedules
+ *
+ * Future additions may include:
+ * - UI components for displaying backup schedules
+ * - Admin actions for managing backups
+ */
+
+export { useRefereeBackups } from "./hooks/useRefereeBackups";


### PR DESCRIPTION
## Summary

- Add API client infrastructure for referee backup (Pikett/on-call) management
- Regenerate schema types from updated OpenAPI spec
- Create `useRefereeBackups` hook for fetching on-call schedules

This provides the foundation for a future Pikett feature that will allow referee administrators to view on-call schedules for NLA/NLB games.

## Changes

### API Client (`src/api/`)
- `client.ts`: Add `searchRefereeBackups` method with Zod validation
- `validation.ts`: Add Zod schemas for `RefereeBackupEntry` and response
- `queryKeys.ts`: Add `refereeBackup` query keys
- `property-configs.ts`: Add `REFEREE_BACKUP_PROPERTIES` config
- `mock-api.ts`: Add stub returning empty array (admin-only feature)
- `schema.ts`: Regenerated types from OpenAPI spec

### Feature Module (`src/features/referee-backup/`)
- `hooks/useRefereeBackups.ts`: Hook for fetching on-call schedules
- `index.ts`: Feature barrel export

### Calendar Client
- Add stub for interface compatibility

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] Knip passes (`npm run knip`)
- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)