### PR TITLE
feat(assignments): show on-call (Pikett) assignments in upcoming tab

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -61,6 +61,7 @@ export type PersonSearchResult = Schemas["PersonSearchResult"];
 export type PersonSearchResponse = Schemas["PersonSearchResponse"];
 export type RefereeBackupEntry = Schemas["RefereeBackupEntry"];
 export type RefereeBackupSearchResponse = Schemas["RefereeBackupSearchResponse"];
+export type BackupRefereeAssignment = Schemas["BackupRefereeAssignment"];
 
 export interface PersonSearchFilter {
   firstName?: string;

--- a/web-app/src/features/assignments/AssignmentsPage.test.tsx
+++ b/web-app/src/features/assignments/AssignmentsPage.test.tsx
@@ -23,6 +23,10 @@ const mockUseTour = vi.hoisted(() => ({
 vi.mock("@/features/validation/hooks/useConvocations");
 vi.mock("@/shared/hooks/useTour", () => mockUseTour);
 vi.mock("@/shared/stores/auth");
+vi.mock("@/features/referee-backup", () => ({
+  useMyOnCallAssignments: () => ({ data: [], isLoading: false, error: null }),
+  OnCallCard: () => null,
+}));
 vi.mock("@/shared/hooks/useTranslation", () => ({
   useTranslation: () => ({
     t: (key: string) => {

--- a/web-app/src/features/assignments/AssignmentsPage.tsx
+++ b/web-app/src/features/assignments/AssignmentsPage.tsx
@@ -29,6 +29,7 @@ import { TOUR_DUMMY_ASSIGNMENT } from "@/features/assignments/assignments";
 import { useAuthStore } from "@/shared/stores/auth";
 import { useShallow } from "zustand/react/shallow";
 import { useCalendarAssociationFilter } from "./hooks/useCalendarAssociationFilter";
+import { useMyOnCallAssignments, OnCallCard } from "@/features/referee-backup";
 
 const PdfLanguageModal = lazy(
   () =>
@@ -136,6 +137,9 @@ export function AssignmentsPage() {
   // Association filter for calendar mode (extracts unique associations from data)
   // The filter selection is managed in the AppShell header dropdown
   const { filterByAssociation } = useCalendarAssociationFilter(calendarData ?? []);
+
+  // Fetch on-call (Pikett) assignments - only in full API mode
+  const { data: onCallAssignments } = useMyOnCallAssignments();
 
   // Compute calendar-specific data (filter by upcoming/past and association)
   const calendarUpcoming = useMemo(() => {
@@ -349,7 +353,7 @@ export function AssignmentsPage() {
           />
         )}
 
-        {(!isLoading || showDummyData) && !error && data && data.length === 0 && (
+        {(!isLoading || showDummyData) && !error && data && data.length === 0 && onCallAssignments.length === 0 && (
           <EmptyState
             icon={activeTab === "upcoming" ? "calendar" : "lock"}
             {...getEmptyStateContent(
@@ -359,6 +363,20 @@ export function AssignmentsPage() {
               t,
             )}
           />
+        )}
+
+        {/* On-call assignments section - only in upcoming tab, API or demo mode (not calendar) */}
+        {activeTab === "upcoming" && !isCalendarMode && !showDummyData && onCallAssignments.length > 0 && (
+          <div className="space-y-2 mb-4">
+            <h3 className="text-xs font-medium text-amber-700 dark:text-amber-400 uppercase tracking-wide px-1">
+              {t("onCall.section")}
+            </h3>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {onCallAssignments.map((assignment) => (
+                <OnCallCard key={assignment.id} assignment={assignment} />
+              ))}
+            </div>
+          </div>
         )}
 
         {(!isLoading || showDummyData) && !error && groupedData.length > 0 && (

--- a/web-app/src/features/assignments/AssignmentsPage.tsx
+++ b/web-app/src/features/assignments/AssignmentsPage.tsx
@@ -29,7 +29,27 @@ import { TOUR_DUMMY_ASSIGNMENT } from "@/features/assignments/assignments";
 import { useAuthStore } from "@/shared/stores/auth";
 import { useShallow } from "zustand/react/shallow";
 import { useCalendarAssociationFilter } from "./hooks/useCalendarAssociationFilter";
-import { useMyOnCallAssignments, OnCallCard } from "@/features/referee-backup";
+import {
+  useMyOnCallAssignments,
+  OnCallCard,
+  type OnCallAssignment,
+} from "@/features/referee-backup";
+
+/**
+ * Discriminated union for items that can be displayed in the assignments list.
+ * Allows mixing regular assignments with on-call assignments inline.
+ */
+type DisplayItem =
+  | { type: "assignment"; item: Assignment }
+  | { type: "onCall"; item: OnCallAssignment };
+
+/** Extract date from a display item for sorting/grouping */
+function getDisplayItemDate(item: DisplayItem): string | undefined {
+  if (item.type === "onCall") {
+    return item.item.date;
+  }
+  return item.item.refereeGame?.game?.startingDateTime;
+}
 
 const PdfLanguageModal = lazy(
   () =>
@@ -197,9 +217,46 @@ export function AssignmentsPage() {
     return rawData;
   }, [showDummyData, rawData]);
 
+  // Merge on-call assignments with regular assignments for upcoming tab (API/demo mode only)
+  // Creates a unified list of DisplayItems sorted by date
+  const mergedDisplayItems = useMemo((): DisplayItem[] => {
+    // Only merge for upcoming tab in non-calendar mode
+    if (activeTab !== "upcoming" || isCalendarMode || showDummyData) {
+      return [];
+    }
+
+    const items: DisplayItem[] = [];
+
+    // Add regular assignments
+    if (data) {
+      for (const assignment of data as Assignment[]) {
+        items.push({ type: "assignment", item: assignment });
+      }
+    }
+
+    // Add on-call assignments
+    for (const onCall of onCallAssignments) {
+      items.push({ type: "onCall", item: onCall });
+    }
+
+    // Sort by date ascending
+    return items.sort((a, b) => {
+      const dateA = getDisplayItemDate(a);
+      const dateB = getDisplayItemDate(b);
+      if (!dateA || !dateB) return 0;
+      return new Date(dateA).getTime() - new Date(dateB).getTime();
+    });
+  }, [activeTab, isCalendarMode, showDummyData, data, onCallAssignments]);
+
   // Group assignments by week for visual separation
-  // Handle both regular Assignment and CalendarAssignment types
+  // Handle regular Assignment, CalendarAssignment, and merged DisplayItem types
   const groupedData = useMemo(() => {
+    // Use merged display items for upcoming tab in non-calendar mode
+    if (activeTab === "upcoming" && !isCalendarMode && !showDummyData) {
+      if (mergedDisplayItems.length === 0) return [];
+      return groupByWeek(mergedDisplayItems, getDisplayItemDate);
+    }
+
     if (!data || data.length === 0) return [];
     // For calendar mode, CalendarAssignment has startTime, regular Assignment has refereeGame?.game?.startingDateTime
     // When showDummyData is true, always use regular Assignment extractor since tour dummy is an Assignment
@@ -209,7 +266,7 @@ export function AssignmentsPage() {
         : (a: { refereeGame?: { game?: { startingDateTime?: string } } }) =>
             a.refereeGame?.game?.startingDateTime;
     return groupByWeek(data, getDate as (item: unknown) => string | undefined);
-  }, [data, isCalendarMode, showDummyData]);
+  }, [activeTab, isCalendarMode, showDummyData, mergedDisplayItems, data]);
 
   const getSwipeConfig = useCallback(
     (assignment: Assignment) => {
@@ -296,11 +353,16 @@ export function AssignmentsPage() {
           `}
         >
           {t("assignments.upcoming")}
-          {((isCalendarMode ? calendarUpcoming : upcomingData) ?? []).length > 0 && (
-            <span className="ml-2 px-2 py-0.5 rounded-full bg-primary-100 dark:bg-primary-900 text-primary-800 dark:text-primary-200 text-xs">
-              {(isCalendarMode ? calendarUpcoming : upcomingData)?.length}
-            </span>
-          )}
+          {(() => {
+            const regularCount = (isCalendarMode ? calendarUpcoming : upcomingData)?.length ?? 0;
+            const onCallCount = isCalendarMode ? 0 : onCallAssignments.length;
+            const totalCount = regularCount + onCallCount;
+            return totalCount > 0 ? (
+              <span className="ml-2 px-2 py-0.5 rounded-full bg-primary-100 dark:bg-primary-900 text-primary-800 dark:text-primary-200 text-xs">
+                {totalCount}
+              </span>
+            ) : null;
+          })()}
         </button>
         <button
           role="tab"
@@ -353,7 +415,7 @@ export function AssignmentsPage() {
           />
         )}
 
-        {(!isLoading || showDummyData) && !error && data && data.length === 0 && onCallAssignments.length === 0 && (
+        {(!isLoading || showDummyData) && !error && groupedData.length === 0 && (
           <EmptyState
             icon={activeTab === "upcoming" ? "calendar" : "lock"}
             {...getEmptyStateContent(
@@ -363,20 +425,6 @@ export function AssignmentsPage() {
               t,
             )}
           />
-        )}
-
-        {/* On-call assignments section - only in upcoming tab, API or demo mode (not calendar) */}
-        {activeTab === "upcoming" && !isCalendarMode && !showDummyData && onCallAssignments.length > 0 && (
-          <div className="space-y-2 mb-4">
-            <h3 className="text-xs font-medium text-amber-700 dark:text-amber-400 uppercase tracking-wide px-1">
-              {t("onCall.section")}
-            </h3>
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-              {onCallAssignments.map((assignment) => (
-                <OnCallCard key={assignment.id} assignment={assignment} />
-              ))}
-            </div>
-          </div>
         )}
 
         {(!isLoading || showDummyData) && !error && groupedData.length > 0 && (
@@ -394,7 +442,7 @@ export function AssignmentsPage() {
                     <WeekSeparator week={group.week} />
                   )}
                   {isCalendarMode && !showDummyData
-                    ? // Calendar mode: same card component, no swipe actions
+                    ? // Calendar mode: same card component, limited swipe actions
                       (group.items as CalendarAssignment[]).map(
                         (calendarAssignment, itemIndex) => {
                           const assignment = mapCalendarAssignmentToAssignment(calendarAssignment);
@@ -418,27 +466,60 @@ export function AssignmentsPage() {
                           );
                         },
                       )
-                    : // Regular mode (or tour dummy): render full cards with swipe actions
-                      (group.items as Assignment[]).map(
-                        (assignment, itemIndex) => (
-                          <SwipeableCard
-                            key={assignment.__identity}
-                            swipeConfig={getSwipeConfig(assignment)}
-                          >
-                            {({ isDrawerOpen }) => (
-                              <AssignmentCard
-                                assignment={assignment}
-                                disableExpansion={isDrawerOpen}
-                                dataTour={
-                                  itemsBeforeThisGroup + itemIndex === 0
-                                    ? "assignment-card"
-                                    : undefined
-                                }
-                              />
-                            )}
-                          </SwipeableCard>
-                        ),
-                      )}
+                    : activeTab === "upcoming" && !showDummyData
+                      ? // Upcoming tab (API/demo mode): render mixed DisplayItems
+                        (group.items as DisplayItem[]).map(
+                          (displayItem, itemIndex) => {
+                            if (displayItem.type === "onCall") {
+                              return (
+                                <OnCallCard
+                                  key={displayItem.item.id}
+                                  assignment={displayItem.item}
+                                />
+                              );
+                            }
+                            const assignment = displayItem.item;
+                            return (
+                              <SwipeableCard
+                                key={assignment.__identity}
+                                swipeConfig={getSwipeConfig(assignment)}
+                              >
+                                {({ isDrawerOpen }) => (
+                                  <AssignmentCard
+                                    assignment={assignment}
+                                    disableExpansion={isDrawerOpen}
+                                    dataTour={
+                                      itemsBeforeThisGroup + itemIndex === 0
+                                        ? "assignment-card"
+                                        : undefined
+                                    }
+                                  />
+                                )}
+                              </SwipeableCard>
+                            );
+                          },
+                        )
+                      : // Validation closed tab or tour dummy: render regular assignments
+                        (group.items as Assignment[]).map(
+                          (assignment, itemIndex) => (
+                            <SwipeableCard
+                              key={assignment.__identity}
+                              swipeConfig={getSwipeConfig(assignment)}
+                            >
+                              {({ isDrawerOpen }) => (
+                                <AssignmentCard
+                                  assignment={assignment}
+                                  disableExpansion={isDrawerOpen}
+                                  dataTour={
+                                    itemsBeforeThisGroup + itemIndex === 0
+                                      ? "assignment-card"
+                                      : undefined
+                                  }
+                                />
+                              )}
+                            </SwipeableCard>
+                          ),
+                        )}
                 </Fragment>
               );
             })}

--- a/web-app/src/features/referee-backup/components/OnCallCard.tsx
+++ b/web-app/src/features/referee-backup/components/OnCallCard.tsx
@@ -9,26 +9,17 @@ interface OnCallCardProps {
   assignment: OnCallAssignment;
 }
 
-/**
- * Card component for displaying on-call (Pikett) assignments.
- *
- * Features:
- * - Distinct amber/orange styling to differentiate from regular assignments
- * - Shows date, weekday, and league (NLA/NLB)
- * - Phone icon to indicate on-call status
- * - No swipe actions (on-call assignments don't have validation/exchange)
- *
- * @example
- * ```tsx
- * <OnCallCard assignment={onCallAssignment} />
- * ```
- */
 function OnCallCardComponent({ assignment }: OnCallCardProps) {
   const { t } = useTranslation();
   const { dateLabel, isToday } = useDateFormat(assignment.date);
 
+  const ariaLabel = `${t("onCall.duty")} ${assignment.league} - ${dateLabel}`;
+
   return (
-    <Card className="bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/50">
+    <Card
+      className="bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/50"
+      aria-label={ariaLabel}
+    >
       <CardContent className="p-3">
         <div className="flex items-center gap-3">
           {/* Icon */}

--- a/web-app/src/features/referee-backup/components/OnCallCard.tsx
+++ b/web-app/src/features/referee-backup/components/OnCallCard.tsx
@@ -1,0 +1,81 @@
+import { memo } from "react";
+import { Phone } from "lucide-react";
+import { Card, CardContent } from "@/shared/components/Card";
+import { useDateFormat } from "@/shared/hooks/useDateFormat";
+import { useTranslation } from "@/shared/hooks/useTranslation";
+import type { OnCallAssignment } from "../hooks/useMyOnCallAssignments";
+
+interface OnCallCardProps {
+  assignment: OnCallAssignment;
+}
+
+/**
+ * Card component for displaying on-call (Pikett) assignments.
+ *
+ * Features:
+ * - Distinct amber/orange styling to differentiate from regular assignments
+ * - Shows date, weekday, and league (NLA/NLB)
+ * - Phone icon to indicate on-call status
+ * - No swipe actions (on-call assignments don't have validation/exchange)
+ *
+ * @example
+ * ```tsx
+ * <OnCallCard assignment={onCallAssignment} />
+ * ```
+ */
+function OnCallCardComponent({ assignment }: OnCallCardProps) {
+  const { t } = useTranslation();
+  const { dateLabel, isToday } = useDateFormat(assignment.date);
+
+  return (
+    <Card className="bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/50">
+      <CardContent className="p-3">
+        <div className="flex items-center gap-3">
+          {/* Icon */}
+          <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-100 dark:bg-amber-900/50 flex items-center justify-center">
+            <Phone
+              className="w-5 h-5 text-amber-600 dark:text-amber-400"
+              aria-hidden="true"
+            />
+          </div>
+
+          {/* Date and label */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span
+                className={`text-sm font-medium ${
+                  isToday
+                    ? "text-amber-700 dark:text-amber-300"
+                    : "text-amber-900 dark:text-amber-100"
+                }`}
+              >
+                {dateLabel}
+              </span>
+              {isToday && (
+                <span className="px-1.5 py-0.5 text-xs font-medium bg-amber-200 dark:bg-amber-800 text-amber-800 dark:text-amber-200 rounded">
+                  {t("common.today")}
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-amber-700 dark:text-amber-400">
+              {t("onCall.duty")}
+            </p>
+          </div>
+
+          {/* League badge */}
+          <div
+            className={`flex-shrink-0 px-2 py-1 text-xs font-semibold rounded ${
+              assignment.league === "NLA"
+                ? "bg-amber-200 dark:bg-amber-800 text-amber-900 dark:text-amber-100"
+                : "bg-amber-100 dark:bg-amber-900/70 text-amber-800 dark:text-amber-200"
+            }`}
+          >
+            {assignment.league}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export const OnCallCard = memo(OnCallCardComponent);

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.test.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import {
+  isUserAssignment,
+  extractUserOnCallAssignments,
+} from "./useMyOnCallAssignments";
+import type {
+  RefereeBackupEntry,
+  BackupRefereeAssignment,
+} from "@/api/client";
+
+// Helper to create minimal test assignments with required type casting
+const createTestAssignment = (
+  partial: Partial<BackupRefereeAssignment> & { __identity: string },
+): BackupRefereeAssignment => partial as BackupRefereeAssignment;
+
+describe("isUserAssignment", () => {
+  const userId = "user-123";
+
+  it("returns true when persistenceObjectIdentifier matches", () => {
+    const assignment = createTestAssignment({
+      __identity: "assignment-1",
+      indoorReferee: {
+        persistenceObjectIdentifier: userId,
+      },
+    });
+    expect(isUserAssignment(assignment, userId)).toBe(true);
+  });
+
+  it("returns true when person.persistenceObjectIdentifier matches", () => {
+    const assignment = createTestAssignment({
+      __identity: "assignment-1",
+      indoorReferee: {
+        person: {
+          persistenceObjectIdentifier: userId,
+        },
+      },
+    });
+    expect(isUserAssignment(assignment, userId)).toBe(true);
+  });
+
+  it("returns false when neither ID matches", () => {
+    const assignment = createTestAssignment({
+      __identity: "assignment-1",
+      indoorReferee: {
+        persistenceObjectIdentifier: "other-user",
+      },
+    });
+    expect(isUserAssignment(assignment, userId)).toBe(false);
+  });
+
+  it("returns false when indoorReferee is missing", () => {
+    const assignment = createTestAssignment({
+      __identity: "assignment-1",
+    });
+    expect(isUserAssignment(assignment, userId)).toBe(false);
+  });
+
+  it("prefers persistenceObjectIdentifier over person.persistenceObjectIdentifier", () => {
+    const assignment = createTestAssignment({
+      __identity: "assignment-1",
+      indoorReferee: {
+        persistenceObjectIdentifier: userId,
+        person: {
+          persistenceObjectIdentifier: "other-user",
+        },
+      },
+    });
+    expect(isUserAssignment(assignment, userId)).toBe(true);
+  });
+});
+
+describe("extractUserOnCallAssignments", () => {
+  const userId = "user-123";
+
+  const createAssignment = (id: string, refId: string) =>
+    createTestAssignment({
+      __identity: id,
+      indoorReferee: {
+        persistenceObjectIdentifier: refId,
+      },
+    });
+
+  it("extracts NLA assignments for the user", () => {
+    const entries: RefereeBackupEntry[] = [
+      {
+        __identity: "entry-1",
+        date: "2026-01-15T00:00:00.000Z",
+        weekday: "Mi",
+        calendarWeek: 3,
+        nlaReferees: [createAssignment("nla-1", userId)],
+      },
+    ];
+
+    const result = extractUserOnCallAssignments(entries, userId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "entry-1-NLA",
+      league: "NLA",
+      date: "2026-01-15T00:00:00.000Z",
+    });
+  });
+
+  it("extracts NLB assignments for the user", () => {
+    const entries: RefereeBackupEntry[] = [
+      {
+        __identity: "entry-1",
+        date: "2026-01-15T00:00:00.000Z",
+        weekday: "Mi",
+        calendarWeek: 3,
+        nlbReferees: [createAssignment("nlb-1", userId)],
+      },
+    ];
+
+    const result = extractUserOnCallAssignments(entries, userId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "entry-1-NLB",
+      league: "NLB",
+    });
+  });
+
+  it("extracts both NLA and NLB assignments on the same day", () => {
+    const entries: RefereeBackupEntry[] = [
+      {
+        __identity: "entry-1",
+        date: "2026-01-15T00:00:00.000Z",
+        weekday: "Mi",
+        calendarWeek: 3,
+        nlaReferees: [createAssignment("nla-1", userId)],
+        nlbReferees: [createAssignment("nlb-1", userId)],
+      },
+    ];
+
+    const result = extractUserOnCallAssignments(entries, userId);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.league)).toEqual(["NLA", "NLB"]);
+  });
+
+  it("ignores assignments for other users", () => {
+    const entries: RefereeBackupEntry[] = [
+      {
+        __identity: "entry-1",
+        date: "2026-01-15T00:00:00.000Z",
+        weekday: "Mi",
+        calendarWeek: 3,
+        nlaReferees: [
+          createAssignment("nla-1", "other-user"),
+          createAssignment("nla-2", userId),
+        ],
+      },
+    ];
+
+    const result = extractUserOnCallAssignments(entries, userId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.assignment.__identity).toBe("nla-2");
+  });
+
+  it("handles empty referee arrays", () => {
+    const entries: RefereeBackupEntry[] = [
+      {
+        __identity: "entry-1",
+        date: "2026-01-15T00:00:00.000Z",
+        weekday: "Mi",
+        calendarWeek: 3,
+        nlaReferees: [],
+        nlbReferees: [],
+      },
+    ];
+
+    const result = extractUserOnCallAssignments(entries, userId);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles missing referee arrays", () => {
+    const entries: RefereeBackupEntry[] = [
+      {
+        __identity: "entry-1",
+        date: "2026-01-15T00:00:00.000Z",
+        weekday: "Mi",
+        calendarWeek: 3,
+      },
+    ];
+
+    const result = extractUserOnCallAssignments(entries, userId);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("sorts results by date ascending", () => {
+    const entries: RefereeBackupEntry[] = [
+      {
+        __identity: "entry-2",
+        date: "2026-01-22T00:00:00.000Z",
+        weekday: "Mi",
+        calendarWeek: 4,
+        nlaReferees: [createAssignment("nla-2", userId)],
+      },
+      {
+        __identity: "entry-1",
+        date: "2026-01-15T00:00:00.000Z",
+        weekday: "Mi",
+        calendarWeek: 3,
+        nlaReferees: [createAssignment("nla-1", userId)],
+      },
+    ];
+
+    const result = extractUserOnCallAssignments(entries, userId);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.date).toBe("2026-01-15T00:00:00.000Z");
+    expect(result[1]?.date).toBe("2026-01-22T00:00:00.000Z");
+  });
+
+  it("returns empty array for empty entries", () => {
+    const result = extractUserOnCallAssignments([], userId);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
@@ -1,0 +1,239 @@
+import { useMemo } from "react";
+import { addDays, getISOWeek } from "date-fns";
+import { useRefereeBackups } from "./useRefereeBackups";
+import { useAuthStore } from "@/shared/stores/auth";
+import { generateDemoUuid } from "@/shared/utils/demo-uuid";
+import { DEMO_USER_PERSON_IDENTITY } from "@/shared/stores/demo";
+import type { RefereeBackupEntry, BackupRefereeAssignment } from "@/api/client";
+
+/**
+ * Represents an on-call (Pikett) assignment for the current user.
+ * Simplified from the full backup entry to only include relevant data.
+ */
+export interface OnCallAssignment {
+  /** Unique identifier (combines date and league) */
+  id: string;
+  /** The date of the on-call duty (ISO 8601) */
+  date: string;
+  /** Short weekday name (e.g., "So" for Sunday) */
+  weekday: string;
+  /** Calendar week number */
+  calendarWeek: number;
+  /** League: NLA or NLB */
+  league: "NLA" | "NLB";
+  /** The original backup entry for reference */
+  backupEntry: RefereeBackupEntry;
+  /** The user's specific assignment within the entry */
+  assignment: BackupRefereeAssignment;
+}
+
+/**
+ * Checks if a backup referee assignment belongs to the given user.
+ *
+ * @param assignment - The backup referee assignment to check
+ * @param userId - The current user's ID (person __identity)
+ * @returns true if the assignment belongs to the user
+ */
+function isUserAssignment(
+  assignment: BackupRefereeAssignment,
+  userId: string,
+): boolean {
+  const refereeId =
+    assignment.indoorReferee?.persistenceObjectIdentifier ??
+    assignment.indoorReferee?.person?.persistenceObjectIdentifier;
+  return refereeId === userId;
+}
+
+/**
+ * Extracts on-call assignments for the current user from backup entries.
+ *
+ * @param entries - Referee backup entries
+ * @param userId - Current user's ID
+ * @returns Array of on-call assignments for the user
+ */
+function extractUserOnCallAssignments(
+  entries: RefereeBackupEntry[],
+  userId: string,
+): OnCallAssignment[] {
+  const assignments: OnCallAssignment[] = [];
+
+  for (const entry of entries) {
+    // Check NLA referees
+    const nlaAssignments = entry.nlaReferees ?? [];
+    for (const assignment of nlaAssignments) {
+      if (isUserAssignment(assignment, userId)) {
+        assignments.push({
+          id: `${entry.__identity}-NLA`,
+          date: entry.date,
+          weekday: entry.weekday,
+          calendarWeek: entry.calendarWeek,
+          league: "NLA",
+          backupEntry: entry,
+          assignment,
+        });
+      }
+    }
+
+    // Check NLB referees
+    const nlbAssignments = entry.nlbReferees ?? [];
+    for (const assignment of nlbAssignments) {
+      if (isUserAssignment(assignment, userId)) {
+        assignments.push({
+          id: `${entry.__identity}-NLB`,
+          date: entry.date,
+          weekday: entry.weekday,
+          calendarWeek: entry.calendarWeek,
+          league: "NLB",
+          backupEntry: entry,
+          assignment,
+        });
+      }
+    }
+  }
+
+  // Sort by date (ascending)
+  return assignments.sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+  );
+}
+
+// Weekday abbreviations for demo data
+const WEEKDAY_ABBREV = ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"] as const;
+
+// Day of week constants for date calculations
+const SATURDAY = 6;
+const DAYS_IN_WEEK = 7;
+
+/**
+ * Generates demo on-call assignments for the demo user.
+ * Creates sample on-call duties for upcoming weekends.
+ */
+function generateDemoOnCallAssignments(): OnCallAssignment[] {
+  const now = new Date();
+  const assignments: OnCallAssignment[] = [];
+
+  // Find the next Saturday (on-call duties typically on weekends)
+  const daysUntilSaturday =
+    (SATURDAY - now.getDay() + DAYS_IN_WEEK) % DAYS_IN_WEEK || DAYS_IN_WEEK;
+  const nextSaturday = addDays(now, daysUntilSaturday);
+
+  // Create a demo backup entry for NLA duty this weekend
+  const nlaEntry: RefereeBackupEntry = {
+    __identity: generateDemoUuid("demo-backup-nla"),
+    date: nextSaturday.toISOString(),
+    weekday: WEEKDAY_ABBREV[nextSaturday.getDay()]!,
+    calendarWeek: getISOWeek(nextSaturday),
+    nlaReferees: [
+      {
+        __identity: generateDemoUuid("demo-backup-assignment-nla"),
+        indoorReferee: {
+          persistenceObjectIdentifier: DEMO_USER_PERSON_IDENTITY,
+          person: {
+            firstName: "Demo",
+            lastName: "User",
+            displayName: "Demo User",
+          },
+        },
+        isDispensed: false,
+        hasResigned: false,
+        unconfirmedFutureRefereeConvocations: false,
+      },
+    ],
+  };
+
+  assignments.push({
+    id: `${nlaEntry.__identity}-NLA`,
+    date: nlaEntry.date,
+    weekday: nlaEntry.weekday,
+    calendarWeek: nlaEntry.calendarWeek,
+    league: "NLA",
+    backupEntry: nlaEntry,
+    assignment: nlaEntry.nlaReferees![0]!,
+  });
+
+  // Add an NLB duty for the following weekend
+  const followingSaturday = addDays(nextSaturday, DAYS_IN_WEEK);
+  const nlbEntry: RefereeBackupEntry = {
+    __identity: generateDemoUuid("demo-backup-nlb"),
+    date: followingSaturday.toISOString(),
+    weekday: WEEKDAY_ABBREV[followingSaturday.getDay()]!,
+    calendarWeek: getISOWeek(followingSaturday),
+    nlbReferees: [
+      {
+        __identity: generateDemoUuid("demo-backup-assignment-nlb"),
+        indoorReferee: {
+          persistenceObjectIdentifier: DEMO_USER_PERSON_IDENTITY,
+          person: {
+            firstName: "Demo",
+            lastName: "User",
+            displayName: "Demo User",
+          },
+        },
+        isDispensed: false,
+        hasResigned: false,
+        unconfirmedFutureRefereeConvocations: false,
+      },
+    ],
+  };
+
+  assignments.push({
+    id: `${nlbEntry.__identity}-NLB`,
+    date: nlbEntry.date,
+    weekday: nlbEntry.weekday,
+    calendarWeek: nlbEntry.calendarWeek,
+    league: "NLB",
+    backupEntry: nlbEntry,
+    assignment: nlbEntry.nlbReferees![0]!,
+  });
+
+  return assignments;
+}
+
+/**
+ * Hook to fetch on-call (Pikett) assignments for the current user.
+ *
+ * This hook fetches all referee backup entries and filters them to only
+ * include dates where the current user is assigned as a backup referee.
+ *
+ * @param weeksAhead - Number of weeks ahead to fetch (default: 2)
+ * @returns Query result with the user's on-call assignments
+ *
+ * @example
+ * ```tsx
+ * const { data: onCallAssignments, isLoading } = useMyOnCallAssignments();
+ *
+ * if (onCallAssignments?.length) {
+ *   return onCallAssignments.map(a => (
+ *     <OnCallCard key={a.id} assignment={a} />
+ *   ));
+ * }
+ * ```
+ */
+export function useMyOnCallAssignments(weeksAhead: number = 2) {
+  const userId = useAuthStore((state) => state.user?.id);
+  const dataSource = useAuthStore((state) => state.dataSource);
+  const isDemoMode = dataSource === "demo";
+
+  const { data: backupEntries, ...queryResult } = useRefereeBackups(weeksAhead);
+
+  // Filter and transform backup entries to user's on-call assignments
+  const data = useMemo(() => {
+    // Demo mode: generate sample on-call assignments
+    if (isDemoMode) {
+      return generateDemoOnCallAssignments();
+    }
+
+    // Calendar mode: no on-call data available
+    if (dataSource === "calendar" || !userId || !backupEntries) {
+      return [];
+    }
+
+    // API mode: extract user's assignments from backup entries
+    return extractUserOnCallAssignments(backupEntries, userId);
+  }, [isDemoMode, dataSource, userId, backupEntries]);
+
+  return {
+    ...queryResult,
+    data,
+  };
+}

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
@@ -6,35 +6,26 @@ import { generateDemoUuid } from "@/shared/utils/demo-uuid";
 import { DEMO_USER_PERSON_IDENTITY } from "@/shared/stores/demo";
 import type { RefereeBackupEntry, BackupRefereeAssignment } from "@/api/client";
 
+/** Default number of weeks ahead to fetch on-call assignments */
+const DEFAULT_WEEKS_AHEAD = 2;
+
 /**
  * Represents an on-call (Pikett) assignment for the current user.
- * Simplified from the full backup entry to only include relevant data.
  */
 export interface OnCallAssignment {
-  /** Unique identifier (combines date and league) */
   id: string;
-  /** The date of the on-call duty (ISO 8601) */
   date: string;
-  /** Short weekday name (e.g., "So" for Sunday) */
   weekday: string;
-  /** Calendar week number */
   calendarWeek: number;
-  /** League: NLA or NLB */
   league: "NLA" | "NLB";
-  /** The original backup entry for reference */
   backupEntry: RefereeBackupEntry;
-  /** The user's specific assignment within the entry */
   assignment: BackupRefereeAssignment;
 }
 
 /**
  * Checks if a backup referee assignment belongs to the given user.
- *
- * @param assignment - The backup referee assignment to check
- * @param userId - The current user's ID (person __identity)
- * @returns true if the assignment belongs to the user
  */
-function isUserAssignment(
+export function isUserAssignment(
   assignment: BackupRefereeAssignment,
   userId: string,
 ): boolean {
@@ -46,12 +37,8 @@ function isUserAssignment(
 
 /**
  * Extracts on-call assignments for the current user from backup entries.
- *
- * @param entries - Referee backup entries
- * @param userId - Current user's ID
- * @returns Array of on-call assignments for the user
  */
-function extractUserOnCallAssignments(
+export function extractUserOnCallAssignments(
   entries: RefereeBackupEntry[],
   userId: string,
 ): OnCallAssignment[] {
@@ -191,25 +178,11 @@ function generateDemoOnCallAssignments(): OnCallAssignment[] {
 
 /**
  * Hook to fetch on-call (Pikett) assignments for the current user.
- *
- * This hook fetches all referee backup entries and filters them to only
- * include dates where the current user is assigned as a backup referee.
- *
- * @param weeksAhead - Number of weeks ahead to fetch (default: 2)
- * @returns Query result with the user's on-call assignments
- *
- * @example
- * ```tsx
- * const { data: onCallAssignments, isLoading } = useMyOnCallAssignments();
- *
- * if (onCallAssignments?.length) {
- *   return onCallAssignments.map(a => (
- *     <OnCallCard key={a.id} assignment={a} />
- *   ));
- * }
- * ```
+ * Filters backup entries to only include dates where the user is assigned.
  */
-export function useMyOnCallAssignments(weeksAhead: number = 2) {
+export function useMyOnCallAssignments(
+  weeksAhead: number = DEFAULT_WEEKS_AHEAD,
+) {
   const userId = useAuthStore((state) => state.user?.id);
   const dataSource = useAuthStore((state) => state.dataSource);
   const isDemoMode = dataSource === "demo";

--- a/web-app/src/features/referee-backup/index.ts
+++ b/web-app/src/features/referee-backup/index.ts
@@ -13,6 +13,8 @@
 export { useRefereeBackups } from "./hooks/useRefereeBackups";
 export {
   useMyOnCallAssignments,
+  isUserAssignment,
+  extractUserOnCallAssignments,
   type OnCallAssignment,
 } from "./hooks/useMyOnCallAssignments";
 export { OnCallCard } from "./components/OnCallCard";

--- a/web-app/src/features/referee-backup/index.ts
+++ b/web-app/src/features/referee-backup/index.ts
@@ -4,12 +4,15 @@
  * This feature provides API client integration for managing on-call
  * referee schedules for NLA and NLB games.
  *
- * Currently implements:
- * - useRefereeBackups hook for fetching backup schedules
- *
- * Future additions may include:
- * - UI components for displaying backup schedules
- * - Admin actions for managing backups
+ * Implements:
+ * - useRefereeBackups: Hook for fetching all backup schedules (admin view)
+ * - useMyOnCallAssignments: Hook for fetching current user's on-call duties
+ * - OnCallCard: UI component for displaying on-call assignments
  */
 
 export { useRefereeBackups } from "./hooks/useRefereeBackups";
+export {
+  useMyOnCallAssignments,
+  type OnCallAssignment,
+} from "./hooks/useMyOnCallAssignments";
+export { OnCallCard } from "./components/OnCallCard";

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -214,6 +214,11 @@ const de: Translations = {
     clubAdmin: "Vereinsadministrator",
     associationAdmin: "Verband",
   },
+  onCall: {
+    title: "Pikett",
+    duty: "Pikettdienst",
+    section: "Pikettdienste",
+  },
   assignments: {
     title: "Einsätze",
     upcoming: "Bevorstehend",

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -214,6 +214,11 @@ const en: Translations = {
     clubAdmin: "Club Admin",
     associationAdmin: "Association",
   },
+  onCall: {
+    title: "On-Call",
+    duty: "On-call duty",
+    section: "On-Call Duties",
+  },
   assignments: {
     title: "Assignments",
     upcoming: "Upcoming",

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -214,6 +214,11 @@ const fr: Translations = {
     clubAdmin: "Admin club",
     associationAdmin: "Association",
   },
+  onCall: {
+    title: "Piquet",
+    duty: "Service de piquet",
+    section: "Services de piquet",
+  },
   assignments: {
     title: "Désignations",
     upcoming: "À venir",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -214,6 +214,11 @@ const it: Translations = {
     clubAdmin: "Admin club",
     associationAdmin: "Associazione",
   },
+  onCall: {
+    title: "Picchetto",
+    duty: "Servizio di picchetto",
+    section: "Servizi di picchetto",
+  },
   assignments: {
     title: "Designazioni",
     upcoming: "In programma",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -102,6 +102,11 @@ export interface Translations {
     clubAdmin: string;
     associationAdmin: string;
   };
+  onCall: {
+    title: string;
+    duty: string;
+    section: string;
+  };
   assignments: {
     title: string;
     upcoming: string;


### PR DESCRIPTION
## Summary
- Display referee backup duty assignments alongside regular game assignments in the Assignments page
- On-call assignments shown with distinct amber/orange styling, phone icon, and league badge (NLA/NLB)
- No swipe actions (validation/exchange not applicable for on-call duties)
- Support both API and demo modes

## Test Plan
- [ ] Verify on-call cards appear in upcoming tab when user has Pikett assignments
- [ ] Verify amber styling distinguishes from regular assignment cards
- [ ] Verify demo mode shows sample on-call assignments
- [ ] Verify no swipe actions are available on on-call cards
- [ ] Verify translations work for all 4 languages