### PR TITLE
refactor(hooks): change validation from pre-push to pre-commit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,19 +29,19 @@ For code reviews and detailed examples, see:
 
 **Workflow**:
 1. **Implement features/fixes** - Complete the work as required
-2. **Commit along the way** - Make meaningful commits as you progress (logical units of work)
-3. **Push** - The pre-push hook automatically validates before allowing the push
+2. **Commit** - The pre-commit hook automatically validates before allowing the commit
+3. **Push** - Push your changes to the remote
 
-### Automatic Pre-Push Validation (Claude Code Web Only)
+### Automatic Pre-Commit Validation (Claude Code Web Only)
 
-A git pre-push hook (`scripts/pre-push-validate.sh`) automatically runs validation before any push **in Claude Code web environment only** (`CLAUDE_CODE_REMOTE=true`). Human developers are not affected and rely on CI. This is configured via devenv and runs:
+A git pre-commit hook (`scripts/pre-commit-validate.sh`) automatically runs validation before any commit **in Claude Code web environment only** (`CLAUDE_CODE_REMOTE=true`). Human developers are not affected and rely on CI. This is configured via devenv and runs:
 
-1. **Detect changes** - Skip validation for docs-only changes
-2. **Generate API types** - If `volleymanager-openapi.yaml` changed
+1. **Detect staged changes** - Skip validation for docs-only changes
+2. **Generate API types** - If `volleymanager-openapi.yaml` is staged
 3. **Run lint, knip, test in PARALLEL** - Maximum speed by running concurrently
 4. **Run build** - Production build (only if parallel steps pass)
 
-The push is **blocked** if any validation step fails. Fix issues and push again.
+The commit is **blocked** if any validation step fails. Fix issues and commit again.
 
 **When validation runs automatically**:
 - Adding, modifying, or deleting `.ts`, `.tsx`, `.js`, `.jsx` files
@@ -218,9 +218,7 @@ worker-deploy  # Deploy worker to Cloudflare
 - **convco**: Conventional commit messages
 - **check-merge-conflicts**: Conflict markers
 - **check-yaml/json**: File validation
-
-**Pre-push** (automatic on push):
-- **pre-push-validate**: Runs lint, knip, tests, and build (see `scripts/pre-push-validate.sh`)
+- **pre-commit-validate**: Runs lint, knip, tests, and build (see `scripts/pre-commit-validate.sh`) - Claude Code web only
 
 ### Without Nix
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -164,13 +164,14 @@
       excludes = [ "tsconfig.*\\.json$" ];
     };
 
-    # Pre-push validation (lint, knip, test, build)
-    pre-push-validate = {
+    # Pre-commit validation (lint, knip, test, build)
+    # Only runs in Claude Code web environment (CLAUDE_CODE_REMOTE=true)
+    pre-commit-validate = {
       enable = true;
-      name = "pre-push-validate";
-      entry = "${config.devenv.root}/scripts/pre-push-validate.sh";
+      name = "pre-commit-validate";
+      entry = "${config.devenv.root}/scripts/pre-commit-validate.sh";
       language = "script";
-      stages = [ "pre-push" ];
+      stages = [ "pre-commit" ];
       pass_filenames = false;
       always_run = true;
     };

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -42,6 +42,12 @@ echo "  Web App: $WEB_APP_DIR"
 # Get list of staged files (for pre-commit hook)
 STAGED_FILES=$(git diff --name-only --cached 2>/dev/null || echo "")
 
+# Early exit if no files are staged
+if [ -z "$STAGED_FILES" ]; then
+    echo -e "${GREEN}No files staged, skipping validation${NC}"
+    exit 0
+fi
+
 # Check if only markdown files are staged
 if echo "$STAGED_FILES" | grep -v '^\s*$' | grep -qvE '\.md$'; then
     HAS_NON_MD=true
@@ -86,7 +92,7 @@ fi
 
 # Create temp directory for parallel job outputs
 TEMP_DIR=$(mktemp -d)
-trap "rm -rf $TEMP_DIR" EXIT
+trap "rm -rf \"$TEMP_DIR\"" EXIT
 
 # Function to run a validation step and capture result
 run_validation() {


### PR DESCRIPTION
## Summary
- Move validation hook (lint, knip, test, build) from pre-push to pre-commit stage
- Update script to check staged files instead of pushed commits
- Add explicit path validation to prevent relative path issues
- Hook only runs in Claude Code web environment (CLAUDE_CODE_REMOTE=true)

## Test Plan
- [ ] Verify hook runs on commit in Claude Code web environment
- [ ] Verify hook is skipped for human developers
- [ ] Verify docs-only changes skip validation
- [ ] Verify source file changes trigger full validation