### PR TITLE
feat(pwa): add daily game badge to PWA app icon

### DIFF
--- a/web-app/src/features/assignments/AssignmentsPage.tsx
+++ b/web-app/src/features/assignments/AssignmentsPage.tsx
@@ -34,6 +34,7 @@ import {
   OnCallCard,
   type OnCallAssignment,
 } from "@/features/referee-backup";
+import { useDailyGameBadge } from "./hooks/useDailyGameBadge";
 
 /**
  * Discriminated union for items that can be displayed in the assignments list.
@@ -160,6 +161,9 @@ export function AssignmentsPage() {
 
   // Fetch on-call (Pikett) assignments - only in full API mode
   const { data: onCallAssignments } = useMyOnCallAssignments();
+
+  // Update PWA badge with today's game count (only for regular assignments, not calendar mode)
+  useDailyGameBadge(isCalendarMode ? [] : (upcomingData ?? []));
 
   // Compute calendar-specific data (filter by upcoming/past and association)
   const calendarUpcoming = useMemo(() => {

--- a/web-app/src/features/assignments/hooks/useDailyGameBadge.test.ts
+++ b/web-app/src/features/assignments/hooks/useDailyGameBadge.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useDailyGameBadge, countTodaysGames } from "./useDailyGameBadge";
+import type { Assignment } from "@/api/client";
+
+// Mock the badge service
+const mockSetBadge = vi.fn().mockResolvedValue({ success: true });
+const mockClearBadge = vi.fn().mockResolvedValue({ success: true });
+const mockIsSupported = vi.fn(() => true);
+
+vi.mock("@/shared/services/badge", () => ({
+  badgeService: {
+    isSupported: () => mockIsSupported(),
+    setBadge: (count: number) => mockSetBadge(count),
+    clearBadge: () => mockClearBadge(),
+  },
+  badgeOperations: {
+    resetCache: vi.fn(),
+    getLastBadgeCount: vi.fn(() => null),
+  },
+}));
+
+// Helper to create a mock assignment with a specific date
+function createMockAssignment(
+  dateTime: string,
+  status: "active" | "cancelled" | "archived" = "active",
+): Assignment {
+  return {
+    __identity: `assignment-${Math.random()}`,
+    refereeConvocationStatus: status,
+    refereePosition: "head-one",
+    refereeGame: {
+      game: {
+        startingDateTime: dateTime,
+      },
+    },
+  } as Assignment;
+}
+
+// Helper to get today's date at a specific time
+function getTodayAt(hours: number, minutes = 0): string {
+  const today = new Date();
+  today.setHours(hours, minutes, 0, 0);
+  return today.toISOString();
+}
+
+// Helper to get tomorrow's date
+function getTomorrow(): string {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(14, 0, 0, 0);
+  return tomorrow.toISOString();
+}
+
+// Helper to get yesterday's date
+function getYesterday(): string {
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  yesterday.setHours(14, 0, 0, 0);
+  return yesterday.toISOString();
+}
+
+describe("countTodaysGames", () => {
+  it("returns 0 for empty array", () => {
+    expect(countTodaysGames([])).toBe(0);
+  });
+
+  it("counts active assignments for today", () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10)),
+      createMockAssignment(getTodayAt(14)),
+      createMockAssignment(getTodayAt(18)),
+    ];
+
+    expect(countTodaysGames(assignments)).toBe(3);
+  });
+
+  it("excludes cancelled assignments", () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10), "active"),
+      createMockAssignment(getTodayAt(14), "cancelled"),
+      createMockAssignment(getTodayAt(18), "active"),
+    ];
+
+    expect(countTodaysGames(assignments)).toBe(2);
+  });
+
+  it("excludes archived assignments", () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10), "active"),
+      createMockAssignment(getTodayAt(14), "archived"),
+    ];
+
+    expect(countTodaysGames(assignments)).toBe(1);
+  });
+
+  it("excludes assignments not for today", () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10), "active"),
+      createMockAssignment(getTomorrow(), "active"),
+      createMockAssignment(getYesterday(), "active"),
+    ];
+
+    expect(countTodaysGames(assignments)).toBe(1);
+  });
+
+  it("handles assignments without dates", () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10)),
+      {
+        __identity: "no-date",
+        refereeConvocationStatus: "active",
+        refereePosition: "head-one",
+        refereeGame: {
+          game: {},
+        },
+      } as Assignment,
+    ];
+
+    expect(countTodaysGames(assignments)).toBe(1);
+  });
+
+  it("handles assignments with null refereeGame", () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10)),
+      {
+        __identity: "no-game",
+        refereeConvocationStatus: "active",
+        refereePosition: "head-one",
+      } as Assignment,
+    ];
+
+    expect(countTodaysGames(assignments)).toBe(1);
+  });
+
+  it("handles invalid date strings gracefully", () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10)),
+      createMockAssignment("not-a-date"),
+    ];
+
+    // Invalid dates should be filtered out (isToday returns false for Invalid Date)
+    expect(countTodaysGames(assignments)).toBe(1);
+  });
+});
+
+describe("useDailyGameBadge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsSupported.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns today's game count", () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10)),
+      createMockAssignment(getTodayAt(14)),
+    ];
+
+    const { result } = renderHook(() => useDailyGameBadge(assignments));
+
+    expect(result.current.todaysGameCount).toBe(2);
+  });
+
+  it("returns isSupported status", () => {
+    const { result } = renderHook(() => useDailyGameBadge([]));
+
+    expect(result.current.isSupported).toBe(true);
+  });
+
+  it("returns false when API is not supported", () => {
+    mockIsSupported.mockReturnValue(false);
+
+    const { result } = renderHook(() => useDailyGameBadge([]));
+
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  it("provides updateBadge function", () => {
+    const { result } = renderHook(() => useDailyGameBadge([]));
+
+    expect(typeof result.current.updateBadge).toBe("function");
+  });
+
+  it("provides clearBadge function", () => {
+    const { result } = renderHook(() => useDailyGameBadge([]));
+
+    expect(typeof result.current.clearBadge).toBe("function");
+  });
+
+  it("respects enabled option", () => {
+    const assignments = [createMockAssignment(getTodayAt(10))];
+
+    const { result } = renderHook(() =>
+      useDailyGameBadge(assignments, { enabled: false }),
+    );
+
+    expect(result.current.todaysGameCount).toBe(1);
+    // Badge should not be set when disabled
+    expect(mockSetBadge).not.toHaveBeenCalled();
+  });
+
+  it("updates count when assignments change", () => {
+    const initialAssignments = [createMockAssignment(getTodayAt(10))];
+    const updatedAssignments = [
+      createMockAssignment(getTodayAt(10)),
+      createMockAssignment(getTodayAt(14)),
+      createMockAssignment(getTodayAt(18)),
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ assignments }) => useDailyGameBadge(assignments),
+      { initialProps: { assignments: initialAssignments } },
+    );
+
+    expect(result.current.todaysGameCount).toBe(1);
+
+    rerender({ assignments: updatedAssignments });
+
+    expect(result.current.todaysGameCount).toBe(3);
+  });
+
+  it("returns 0 for empty assignments", () => {
+    const { result } = renderHook(() => useDailyGameBadge([]));
+
+    expect(result.current.todaysGameCount).toBe(0);
+  });
+
+  it("calls setBadge on mount when there are games today", async () => {
+    const assignments = [
+      createMockAssignment(getTodayAt(10)),
+      createMockAssignment(getTodayAt(14)),
+    ];
+
+    renderHook(() => useDailyGameBadge(assignments));
+
+    // Wait for useEffect to run
+    await vi.waitFor(() => {
+      expect(mockSetBadge).toHaveBeenCalledWith(2);
+    });
+  });
+
+  it("does not call setBadge when not supported", async () => {
+    mockIsSupported.mockReturnValue(false);
+
+    const assignments = [createMockAssignment(getTodayAt(10))];
+    renderHook(() => useDailyGameBadge(assignments));
+
+    // Give time for any potential calls
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(mockSetBadge).not.toHaveBeenCalled();
+  });
+});

--- a/web-app/src/features/assignments/hooks/useDailyGameBadge.ts
+++ b/web-app/src/features/assignments/hooks/useDailyGameBadge.ts
@@ -8,7 +8,7 @@
  * with push notifications to update badges when the app is closed.
  */
 
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { isToday } from "date-fns";
 import { badgeService } from "@/shared/services/badge";
 import type { Assignment } from "@/api/client";
@@ -114,24 +114,15 @@ export function useDailyGameBadge(
     void updateBadge();
   }, [todaysGameCount, enabled, isSupported]);
 
-  // Clear badge on unmount (optional behavior)
-  useEffect(() => {
-    return () => {
-      // Don't clear on unmount - badge should persist when navigating
-      // Uncomment if you want to clear when the component unmounts:
-      // void badgeService.clearBadge();
-    };
-  }, []);
-
-  const updateBadge = async () => {
+  const updateBadge = useCallback(async () => {
     await badgeService.setBadge(todaysGameCount);
     lastSetCountRef.current = todaysGameCount;
-  };
+  }, [todaysGameCount]);
 
-  const clearBadge = async () => {
+  const clearBadge = useCallback(async () => {
     await badgeService.clearBadge();
     lastSetCountRef.current = 0;
-  };
+  }, []);
 
   return {
     todaysGameCount,

--- a/web-app/src/features/assignments/hooks/useDailyGameBadge.ts
+++ b/web-app/src/features/assignments/hooks/useDailyGameBadge.ts
@@ -1,0 +1,142 @@
+/**
+ * Hook to manage the PWA app badge showing today's game count.
+ *
+ * Updates the badge whenever assignments are fetched, showing the number
+ * of active games scheduled for today.
+ *
+ * Future: This hook's logic can be extracted for use in a service worker
+ * with push notifications to update badges when the app is closed.
+ */
+
+import { useEffect, useMemo, useRef } from "react";
+import { isToday } from "date-fns";
+import { badgeService } from "@/shared/services/badge";
+import type { Assignment } from "@/api/client";
+
+/**
+ * Count the number of active games scheduled for today
+ */
+export function countTodaysGames(assignments: Assignment[]): number {
+  return assignments.filter((assignment) => {
+    // Only count active assignments (not cancelled or archived)
+    if (assignment.refereeConvocationStatus !== "active") {
+      return false;
+    }
+
+    const gameDateTime = assignment.refereeGame?.game?.startingDateTime;
+    if (!gameDateTime) {
+      return false;
+    }
+
+    try {
+      const gameDate = new Date(gameDateTime);
+      return isToday(gameDate);
+    } catch {
+      return false;
+    }
+  }).length;
+}
+
+export interface UseDailyGameBadgeOptions {
+  /** Whether badge updates are enabled (default: true) */
+  enabled?: boolean;
+}
+
+export interface UseDailyGameBadgeResult {
+  /** Number of games scheduled for today */
+  todaysGameCount: number;
+  /** Whether the Badging API is supported */
+  isSupported: boolean;
+  /** Manually update the badge */
+  updateBadge: () => Promise<void>;
+  /** Clear the badge */
+  clearBadge: () => Promise<void>;
+}
+
+/**
+ * Hook to display today's game count on the PWA app badge.
+ *
+ * @param assignments - Array of assignments to count from
+ * @param options - Configuration options
+ * @returns Badge state and control methods
+ *
+ * @example
+ * ```tsx
+ * function AssignmentsPage() {
+ *   const { data: assignments = [] } = useUpcomingAssignments();
+ *   const { todaysGameCount, isSupported } = useDailyGameBadge(assignments);
+ *
+ *   return (
+ *     <div>
+ *       {isSupported && todaysGameCount > 0 && (
+ *         <span>Badge shows: {todaysGameCount}</span>
+ *       )}
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useDailyGameBadge(
+  assignments: Assignment[],
+  options: UseDailyGameBadgeOptions = {},
+): UseDailyGameBadgeResult {
+  const { enabled = true } = options;
+
+  // Memoize the count to avoid recalculating on every render
+  const todaysGameCount = useMemo(
+    () => countTodaysGames(assignments),
+    [assignments],
+  );
+
+  // Track if we've already set this count to avoid duplicate API calls
+  const lastSetCountRef = useRef<number | null>(null);
+
+  const isSupported = badgeService.isSupported();
+
+  // Update badge when count changes
+  useEffect(() => {
+    if (!enabled || !isSupported) {
+      return;
+    }
+
+    // Skip if count hasn't changed
+    if (lastSetCountRef.current === todaysGameCount) {
+      return;
+    }
+
+    const updateBadge = async () => {
+      const result = await badgeService.setBadge(todaysGameCount);
+      if (result.success) {
+        lastSetCountRef.current = todaysGameCount;
+      }
+    };
+
+    void updateBadge();
+  }, [todaysGameCount, enabled, isSupported]);
+
+  // Clear badge on unmount (optional behavior)
+  useEffect(() => {
+    return () => {
+      // Don't clear on unmount - badge should persist when navigating
+      // Uncomment if you want to clear when the component unmounts:
+      // void badgeService.clearBadge();
+    };
+  }, []);
+
+  const updateBadge = async () => {
+    await badgeService.setBadge(todaysGameCount);
+    lastSetCountRef.current = todaysGameCount;
+  };
+
+  const clearBadge = async () => {
+    await badgeService.clearBadge();
+    lastSetCountRef.current = 0;
+  };
+
+  return {
+    todaysGameCount,
+    isSupported,
+    updateBadge,
+    clearBadge,
+  };
+}

--- a/web-app/src/shared/services/badge/badge-service.test.ts
+++ b/web-app/src/shared/services/badge/badge-service.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { badgeService, badgeOperations } from "./badge-service";
+
+describe("badgeService", () => {
+  const mockSetAppBadge = vi.fn().mockResolvedValue(undefined);
+  const mockClearAppBadge = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    // Reset mocks and cache before each test
+    vi.clearAllMocks();
+    badgeOperations.resetCache();
+  });
+
+  afterEach(() => {
+    // Clean up navigator mocks
+    if ("setAppBadge" in navigator) {
+      // @ts-expect-error - cleaning up test mock
+      delete navigator.setAppBadge;
+    }
+    if ("clearAppBadge" in navigator) {
+      // @ts-expect-error - cleaning up test mock
+      delete navigator.clearAppBadge;
+    }
+  });
+
+  describe("isSupported", () => {
+    it("returns false when Badging API is not available", () => {
+      expect(badgeService.isSupported()).toBe(false);
+    });
+
+    it("returns true when setAppBadge is available", () => {
+      Object.defineProperty(navigator, "setAppBadge", {
+        value: mockSetAppBadge,
+        configurable: true,
+      });
+
+      expect(badgeService.isSupported()).toBe(true);
+    });
+  });
+
+  describe("setBadge", () => {
+    it("returns error when API is not supported", async () => {
+      const result = await badgeService.setBadge(5);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not supported");
+    });
+
+    it("calls setAppBadge with the count when supported", async () => {
+      Object.defineProperty(navigator, "setAppBadge", {
+        value: mockSetAppBadge,
+        configurable: true,
+      });
+      Object.defineProperty(navigator, "clearAppBadge", {
+        value: mockClearAppBadge,
+        configurable: true,
+      });
+
+      const result = await badgeService.setBadge(5);
+
+      expect(result.success).toBe(true);
+      expect(mockSetAppBadge).toHaveBeenCalledWith(5);
+    });
+
+    it("calls clearAppBadge when count is 0", async () => {
+      Object.defineProperty(navigator, "setAppBadge", {
+        value: mockSetAppBadge,
+        configurable: true,
+      });
+      Object.defineProperty(navigator, "clearAppBadge", {
+        value: mockClearAppBadge,
+        configurable: true,
+      });
+
+      const result = await badgeService.setBadge(0);
+
+      expect(result.success).toBe(true);
+      expect(mockClearAppBadge).toHaveBeenCalled();
+      expect(mockSetAppBadge).not.toHaveBeenCalled();
+    });
+
+    it("handles API errors gracefully", async () => {
+      const error = new Error("Permission denied");
+      Object.defineProperty(navigator, "setAppBadge", {
+        value: vi.fn().mockRejectedValue(error),
+        configurable: true,
+      });
+
+      const result = await badgeService.setBadge(5);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Permission denied");
+    });
+  });
+
+  describe("clearBadge", () => {
+    it("clears the badge by setting count to 0", async () => {
+      Object.defineProperty(navigator, "setAppBadge", {
+        value: mockSetAppBadge,
+        configurable: true,
+      });
+      Object.defineProperty(navigator, "clearAppBadge", {
+        value: mockClearAppBadge,
+        configurable: true,
+      });
+
+      const result = await badgeService.clearBadge();
+
+      expect(result.success).toBe(true);
+      expect(mockClearAppBadge).toHaveBeenCalled();
+    });
+  });
+
+  describe("badgeOperations", () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, "setAppBadge", {
+        value: mockSetAppBadge,
+        configurable: true,
+      });
+      Object.defineProperty(navigator, "clearAppBadge", {
+        value: mockClearAppBadge,
+        configurable: true,
+      });
+    });
+
+    it("setBadgeWithOptions skips update when skipIfUnchanged is true and count matches", async () => {
+      // First call sets the badge
+      await badgeOperations.setBadgeWithOptions(5);
+      expect(mockSetAppBadge).toHaveBeenCalledTimes(1);
+
+      // Second call with same count and skipIfUnchanged should skip
+      await badgeOperations.setBadgeWithOptions(5, { skipIfUnchanged: true });
+      expect(mockSetAppBadge).toHaveBeenCalledTimes(1); // Still 1
+
+      // Third call with different count should update
+      await badgeOperations.setBadgeWithOptions(10, { skipIfUnchanged: true });
+      expect(mockSetAppBadge).toHaveBeenCalledTimes(2);
+    });
+
+    it("getLastBadgeCount returns the last set count", async () => {
+      expect(badgeOperations.getLastBadgeCount()).toBeNull();
+
+      await badgeService.setBadge(3);
+      expect(badgeOperations.getLastBadgeCount()).toBe(3);
+
+      await badgeService.setBadge(7);
+      expect(badgeOperations.getLastBadgeCount()).toBe(7);
+    });
+
+    it("resetCache clears the last badge count", async () => {
+      await badgeService.setBadge(5);
+      expect(badgeOperations.getLastBadgeCount()).toBe(5);
+
+      badgeOperations.resetCache();
+      expect(badgeOperations.getLastBadgeCount()).toBeNull();
+    });
+  });
+});

--- a/web-app/src/shared/services/badge/badge-service.ts
+++ b/web-app/src/shared/services/badge/badge-service.ts
@@ -1,0 +1,119 @@
+/**
+ * Badge Service
+ *
+ * Abstraction layer for the App Badging API.
+ * Designed to work from both the main thread and service worker.
+ *
+ * Browser Support:
+ * - Desktop: Chrome 81+, Edge 84+ (Windows/macOS only)
+ * - iOS/iPadOS: Safari 16.4+
+ * - Android: Not supported (use Push Notifications instead)
+ *
+ * Future: This service can be imported into a service worker
+ * to update badges from push notification handlers.
+ */
+
+import type { BadgeResult, BadgeService, BadgeUpdateOptions } from "./types";
+
+// Track the last badge value to avoid unnecessary API calls
+let lastBadgeCount: number | null = null;
+
+/**
+ * Check if the Badging API is available
+ */
+function isSupported(): boolean {
+  return (
+    typeof navigator !== "undefined" && "setAppBadge" in navigator
+  );
+}
+
+/**
+ * Set the app badge to a specific count
+ *
+ * @param count - Number to display (0 clears the badge)
+ * @param options - Optional settings for the update
+ * @returns Result indicating success or failure
+ */
+async function setBadge(
+  count: number,
+  options: BadgeUpdateOptions = {},
+): Promise<BadgeResult> {
+  const { skipIfUnchanged = false } = options;
+
+  // Skip if unchanged and option is set
+  if (skipIfUnchanged && lastBadgeCount === count) {
+    return { success: true };
+  }
+
+  if (!isSupported()) {
+    return {
+      success: false,
+      error: "Badging API not supported in this browser",
+    };
+  }
+
+  try {
+    if (count === 0) {
+      await navigator.clearAppBadge();
+    } else {
+      await navigator.setAppBadge(count);
+    }
+    lastBadgeCount = count;
+    return { success: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      success: false,
+      error: `Failed to set badge: ${message}`,
+    };
+  }
+}
+
+/**
+ * Clear the app badge
+ *
+ * @returns Result indicating success or failure
+ */
+async function clearBadge(): Promise<BadgeResult> {
+  return setBadge(0);
+}
+
+/**
+ * Badge service singleton
+ *
+ * Usage:
+ * ```typescript
+ * import { badgeService } from '@/shared/services/badge';
+ *
+ * if (badgeService.isSupported()) {
+ *   await badgeService.setBadge(3);
+ * }
+ * ```
+ */
+export const badgeService: BadgeService = {
+  isSupported,
+  setBadge: (count: number) => setBadge(count),
+  clearBadge,
+};
+
+/**
+ * Extended badge operations for advanced use cases
+ */
+export const badgeOperations = {
+  /**
+   * Set badge with options
+   */
+  setBadgeWithOptions: setBadge,
+
+  /**
+   * Get the last known badge count (for debugging/testing)
+   */
+  getLastBadgeCount: (): number | null => lastBadgeCount,
+
+  /**
+   * Reset the cached badge count (useful for testing)
+   */
+  resetCache: (): void => {
+    lastBadgeCount = null;
+  },
+};

--- a/web-app/src/shared/services/badge/index.ts
+++ b/web-app/src/shared/services/badge/index.ts
@@ -1,0 +1,6 @@
+export { badgeService, badgeOperations } from "./badge-service";
+export type {
+  BadgeResult,
+  BadgeService,
+  BadgeUpdateOptions,
+} from "./types";

--- a/web-app/src/shared/services/badge/types.ts
+++ b/web-app/src/shared/services/badge/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Badge service types
+ *
+ * Designed for extensibility - the same types can be used
+ * from both the main app and service worker in the future.
+ */
+
+/**
+ * Result of a badge operation
+ */
+export interface BadgeResult {
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** Error message if operation failed */
+  error?: string;
+}
+
+/**
+ * Badge service interface - can be implemented for different contexts
+ * (main thread, service worker, etc.)
+ */
+export interface BadgeService {
+  /** Check if the Badging API is supported */
+  isSupported(): boolean;
+  /** Set the badge to a specific count (0 clears the badge) */
+  setBadge(count: number): Promise<BadgeResult>;
+  /** Clear the badge */
+  clearBadge(): Promise<BadgeResult>;
+}
+
+/**
+ * Options for badge updates
+ */
+export interface BadgeUpdateOptions {
+  /** Only update if the count has changed from the previous value */
+  skipIfUnchanged?: boolean;
+}


### PR DESCRIPTION
## Summary
- Add Badging API support to display today's game count on the PWA app icon when installed
- Create badge service abstraction layer (`src/shared/services/badge/`) designed for future service worker integration
- Add React hook (`useDailyGameBadge`) that connects assignments data to badge updates
- Currently updates when app is open, architecture ready for push notification-based updates later

## Test Plan
- [ ] Install PWA on Windows/macOS Chrome/Edge or iOS Safari 16.4+
- [ ] Verify badge shows count of today's games on app icon
- [ ] Verify badge updates when assignments are fetched
- [ ] Verify badge clears when there are no games today
- [ ] Run `npm test` - all 3263 tests pass
- [ ] Run `npm run build` - production build succeeds