### PR TITLE
fix(auth): improve login redirect detection for PWA standalone mode

### DIFF
--- a/web-app/src/shared/stores/auth.test.ts
+++ b/web-app/src/shared/stores/auth.test.ts
@@ -470,8 +470,8 @@ describe("useAuthStore", () => {
       );
       expect(options.method).toBe("POST");
       expect(options.credentials).toBe("include");
-      // Should NOT use redirect: "manual" (allows browser to process cookies)
-      expect(options.redirect).toBeUndefined();
+      // Explicit redirect: "follow" for consistent behavior in PWA standalone mode
+      expect(options.redirect).toBe("follow");
 
       const body = new URLSearchParams(options.body as string);
       expect(body.get("__trustedProperties")).toBe("trusted-props-value");


### PR DESCRIPTION
## Summary
- Add explicit `redirect: "follow"` option for consistent behavior across browsers and PWA modes
- Check `response.redirected` flag in addition to URL pattern matching for robust success detection
- Prioritize CSRF token detection over URL-based success detection in PWA standalone mode
- Add test coverage for PWA-specific redirect handling scenarios

## Test Plan
- [x] Unit tests pass for auth-parsers module including new PWA mode test cases
- [x] All existing tests continue to pass
- [x] Lint, knip, and build validation passes
- [ ] Manual testing: Install app as PWA and verify login works in standalone mode