### PR TITLE
fix(api): add identity fields to on-call API request

### DIFF
--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -171,9 +171,15 @@ export const REFEREE_BACKUP_PROPERTIES = [
   "calendarWeek",
   "joinedNlaReferees",
   "joinedNlbReferees",
+  // NLA referee identity (required for filtering user's assignments)
+  "nlaReferees.*.indoorReferee.persistenceObjectIdentifier",
+  "nlaReferees.*.indoorReferee.person.persistenceObjectIdentifier",
   // NLA referee details
   "nlaReferees.*.indoorReferee.person.primaryEmailAddress",
   "nlaReferees.*.indoorReferee.person.primaryPhoneNumber",
+  // NLB referee identity (required for filtering user's assignments)
+  "nlbReferees.*.indoorReferee.persistenceObjectIdentifier",
+  "nlbReferees.*.indoorReferee.person.persistenceObjectIdentifier",
   // NLB referee details
   "nlbReferees.*.indoorReferee.person.primaryEmailAddress",
   "nlbReferees.*.indoorReferee.person.primaryPhoneNumber",


### PR DESCRIPTION
## Summary
- Add `persistenceObjectIdentifier` fields to `REFEREE_BACKUP_PROPERTIES` so on-call (Pikett) assignments can be filtered by the current user
- Without these fields, the API returns referee data but client-side filtering in `isUserAssignment()` cannot match the user ID

## Test Plan
- [ ] Deploy to production and verify on-call assignments now appear for users who have them
- [ ] Verify demo mode still works correctly (it explicitly sets these fields in mock data)