### PR TITLE
fix(e2e): generate HTML report on CI for artifact upload

### DIFF
--- a/web-app/playwright.config.ts
+++ b/web-app/playwright.config.ts
@@ -23,7 +23,11 @@ export default defineConfig({
   // 4 workers balances parallelism with resource usage across 5 browser projects
   workers: process.env.CI ? 4 : undefined,
   // Reporter to use
-  reporter: process.env.CI ? 'github' : 'html',
+  // CI: github (inline annotations) + html (artifact upload)
+  // Local: html only
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : 'html',
   // Shared settings for all the projects below
   use: {
     // Base URL for navigation actions like `await page.goto('/')`


### PR DESCRIPTION
## Summary
- Configure Playwright to use both `github` and `html` reporters on CI
- The `github` reporter provides inline annotations in PR diffs
- The `html` reporter generates the report directory for artifact upload

## Test Plan
- CI workflow should now successfully upload playwright-report/ artifacts
- E2E test results will be viewable in the HTML report artifact