### PR TITLE
feat(pwa): add automatic version check for force updates

### DIFF
--- a/web-app/src/features/settings/components/AppInfoSection.tsx
+++ b/web-app/src/features/settings/components/AppInfoSection.tsx
@@ -65,7 +65,12 @@ function AppInfoSectionComponent({ showUpdates }: AppInfoSectionProps) {
             <span className="text-text-muted dark:text-text-muted-dark">
               {t("settings.version")}
             </span>
-            <span className="text-text-primary dark:text-text-primary-dark">{__APP_VERSION__}</span>
+            <span className="text-text-primary dark:text-text-primary-dark">
+              {__APP_VERSION__}{" "}
+              <span className="text-text-muted dark:text-text-muted-dark font-mono text-xs">
+                ({__GIT_HASH__})
+              </span>
+            </span>
           </div>
           <div className="flex justify-between">
             <span className="text-text-muted dark:text-text-muted-dark">

--- a/web-app/src/types/pwa.d.ts
+++ b/web-app/src/types/pwa.d.ts
@@ -3,6 +3,8 @@
 declare const __PWA_ENABLED__: boolean;
 // __APP_VERSION__ is the version from package.json
 declare const __APP_VERSION__: string;
+// __GIT_HASH__ is the short git commit hash at build time (for PWA update detection)
+declare const __GIT_HASH__: string;
 
 // Type declarations for vite-plugin-pwa's vanilla register module
 declare module "virtual:pwa-register" {


### PR DESCRIPTION
## Summary
- Generate version.json during build with git hash and build timestamp
- Inject version check script into index.html (runs before React loads)
- Compare bundled git hash against deployed version.json
- If mismatch: skip waiting SW, clear caches, and reload
- Display git hash in Settings for easier debugging

## Test Plan
- [ ] Build the app and verify version.json is generated in dist/
- [ ] Verify the version check script is injected into dist/index.html
- [ ] Check Settings page shows version with git hash
- [ ] Deploy and verify force update triggers when version mismatches