### PR TITLE
fix(api): match on-call assignments by person.__identity

### DIFF
--- a/web-app/src/api/property-configs.ts
+++ b/web-app/src/api/property-configs.ts
@@ -172,14 +172,16 @@ export const REFEREE_BACKUP_PROPERTIES = [
   "joinedNlaReferees",
   "joinedNlbReferees",
   // NLA referee identity (required for filtering user's assignments)
-  "nlaReferees.*.indoorReferee.persistenceObjectIdentifier",
-  "nlaReferees.*.indoorReferee.person.persistenceObjectIdentifier",
+  // Request person object first to ensure nested __identity is populated
+  "nlaReferees.*.indoorReferee.person",
+  "nlaReferees.*.indoorReferee.person.__identity",
   // NLA referee details
   "nlaReferees.*.indoorReferee.person.primaryEmailAddress",
   "nlaReferees.*.indoorReferee.person.primaryPhoneNumber",
   // NLB referee identity (required for filtering user's assignments)
-  "nlbReferees.*.indoorReferee.persistenceObjectIdentifier",
-  "nlbReferees.*.indoorReferee.person.persistenceObjectIdentifier",
+  // Request person object first to ensure nested __identity is populated
+  "nlbReferees.*.indoorReferee.person",
+  "nlbReferees.*.indoorReferee.person.__identity",
   // NLB referee details
   "nlbReferees.*.indoorReferee.person.primaryEmailAddress",
   "nlbReferees.*.indoorReferee.person.primaryPhoneNumber",

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.test.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.test.ts
@@ -16,17 +16,19 @@ const createTestAssignment = (
 describe("isUserAssignment", () => {
   const userId = "user-123";
 
-  it("returns true when persistenceObjectIdentifier matches", () => {
+  it("returns true when person.__identity matches", () => {
     const assignment = createTestAssignment({
       __identity: "assignment-1",
       indoorReferee: {
-        persistenceObjectIdentifier: userId,
+        person: {
+          __identity: userId,
+        },
       },
     });
     expect(isUserAssignment(assignment, userId)).toBe(true);
   });
 
-  it("returns true when person.persistenceObjectIdentifier matches", () => {
+  it("returns true when person.persistenceObjectIdentifier matches (fallback)", () => {
     const assignment = createTestAssignment({
       __identity: "assignment-1",
       indoorReferee: {
@@ -38,11 +40,13 @@ describe("isUserAssignment", () => {
     expect(isUserAssignment(assignment, userId)).toBe(true);
   });
 
-  it("returns false when neither ID matches", () => {
+  it("returns false when person ID does not match", () => {
     const assignment = createTestAssignment({
       __identity: "assignment-1",
       indoorReferee: {
-        persistenceObjectIdentifier: "other-user",
+        person: {
+          __identity: "other-user",
+        },
       },
     });
     expect(isUserAssignment(assignment, userId)).toBe(false);
@@ -55,12 +59,20 @@ describe("isUserAssignment", () => {
     expect(isUserAssignment(assignment, userId)).toBe(false);
   });
 
-  it("prefers persistenceObjectIdentifier over person.persistenceObjectIdentifier", () => {
+  it("returns false when person is missing", () => {
+    const assignment = createTestAssignment({
+      __identity: "assignment-1",
+      indoorReferee: {},
+    });
+    expect(isUserAssignment(assignment, userId)).toBe(false);
+  });
+
+  it("prefers __identity over persistenceObjectIdentifier on person", () => {
     const assignment = createTestAssignment({
       __identity: "assignment-1",
       indoorReferee: {
-        persistenceObjectIdentifier: userId,
         person: {
+          __identity: userId,
           persistenceObjectIdentifier: "other-user",
         },
       },
@@ -72,11 +84,13 @@ describe("isUserAssignment", () => {
 describe("extractUserOnCallAssignments", () => {
   const userId = "user-123";
 
-  const createAssignment = (id: string, refId: string) =>
+  const createAssignment = (id: string, personId: string) =>
     createTestAssignment({
       __identity: id,
       indoorReferee: {
-        persistenceObjectIdentifier: refId,
+        person: {
+          __identity: personId,
+        },
       },
     });
 

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
@@ -24,14 +24,21 @@ export interface OnCallAssignment {
 
 /**
  * Checks if a backup referee assignment belongs to the given user.
+ *
+ * The API returns person identity in two possible fields:
+ * - `person.__identity` - always returned by the API (the person's UUID)
+ * - `person.persistenceObjectIdentifier` - may not be included in responses
+ *
+ * The user ID from auth store is the person's `__identity`, so we need to
+ * check both fields to ensure matching works correctly.
  */
 export function isUserAssignment(
   assignment: BackupRefereeAssignment,
   userId: string,
 ): boolean {
+  const person = assignment.indoorReferee?.person;
   const refereeId =
-    assignment.indoorReferee?.persistenceObjectIdentifier ??
-    assignment.indoorReferee?.person?.persistenceObjectIdentifier;
+    person?.__identity ?? person?.persistenceObjectIdentifier;
   return refereeId === userId;
 }
 
@@ -114,8 +121,8 @@ function generateDemoOnCallAssignments(): OnCallAssignment[] {
       {
         __identity: generateDemoUuid("demo-backup-assignment-nla"),
         indoorReferee: {
-          persistenceObjectIdentifier: DEMO_USER_PERSON_IDENTITY,
           person: {
+            __identity: DEMO_USER_PERSON_IDENTITY,
             firstName: "Demo",
             lastName: "User",
             displayName: "Demo User",
@@ -149,8 +156,8 @@ function generateDemoOnCallAssignments(): OnCallAssignment[] {
       {
         __identity: generateDemoUuid("demo-backup-assignment-nlb"),
         indoorReferee: {
-          persistenceObjectIdentifier: DEMO_USER_PERSON_IDENTITY,
           person: {
+            __identity: DEMO_USER_PERSON_IDENTITY,
             firstName: "Demo",
             lastName: "User",
             displayName: "Demo User",


### PR DESCRIPTION
## Summary

- Fix on-call assignments not showing in production by checking `person.__identity` instead of `persistenceObjectIdentifier`
- The API returns the person's identity in the `__identity` field, which matches the user ID from the auth store
- Update property configs to explicitly request `person.__identity` to ensure the field is populated

## Test Plan

- [x] Unit tests updated and passing
- [x] Lint, knip, and build all pass
- [ ] Verify on-call assignments appear in production with real API