### PR TITLE
fix(on-call): fix on-call assignments not appearing in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-01-10
+
+### Fixed
+
+- On-call assignments not appearing in production due to Zod validation rejecting null `originId` values (#675)
+- On-call assignment dates normalized to 12:00 noon for consistent display with game assignments (#675)
+
 ## [1.0.0] - 2025-01-10
 
 ### Added
@@ -56,5 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session-based authentication with CSRF protection
 - Content Security Policy headers
 
-[Unreleased]: https://github.com/Takishima/volleykit/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/Takishima/volleykit/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/Takishima/volleykit/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Takishima/volleykit/releases/tag/v1.0.0

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -2,7 +2,7 @@
   "name": "volleykit-web",
   "description": "VolleyKit - Swiss Volleyball Referee Management PWA",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -374,9 +374,9 @@ const backupRefereeAssignmentSchema = z
     hasFutureRefereeConvocations: z.boolean().optional(),
     hasResigned: z.boolean().optional(),
     unconfirmedFutureRefereeConvocations: z.boolean().optional(),
-    originId: z.number().optional(),
-    createdBy: z.string().optional(),
-    updatedBy: z.string().optional(),
+    originId: z.number().optional().nullable(),
+    createdBy: z.string().optional().nullable(),
+    updatedBy: z.string().optional().nullable(),
   })
   .passthrough();
 

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.test.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.test.ts
@@ -98,7 +98,7 @@ describe("extractUserOnCallAssignments", () => {
     const entries: RefereeBackupEntry[] = [
       {
         __identity: "entry-1",
-        date: "2026-01-15T00:00:00.000Z",
+        date: "2026-01-15T00:00:00.000Z", // API returns midnight
         weekday: "Mi",
         calendarWeek: 3,
         nlaReferees: [createAssignment("nla-1", userId)],
@@ -111,7 +111,7 @@ describe("extractUserOnCallAssignments", () => {
     expect(result[0]).toMatchObject({
       id: "entry-1-NLA",
       league: "NLA",
-      date: "2026-01-15T00:00:00.000Z",
+      date: "2026-01-15T12:00:00.000Z", // Normalized to noon
     });
   });
 
@@ -119,7 +119,7 @@ describe("extractUserOnCallAssignments", () => {
     const entries: RefereeBackupEntry[] = [
       {
         __identity: "entry-1",
-        date: "2026-01-15T00:00:00.000Z",
+        date: "2026-01-15T00:00:00.000Z", // API returns midnight
         weekday: "Mi",
         calendarWeek: 3,
         nlbReferees: [createAssignment("nlb-1", userId)],
@@ -139,7 +139,7 @@ describe("extractUserOnCallAssignments", () => {
     const entries: RefereeBackupEntry[] = [
       {
         __identity: "entry-1",
-        date: "2026-01-15T00:00:00.000Z",
+        date: "2026-01-15T00:00:00.000Z", // API returns midnight
         weekday: "Mi",
         calendarWeek: 3,
         nlaReferees: [createAssignment("nla-1", userId)],
@@ -157,7 +157,7 @@ describe("extractUserOnCallAssignments", () => {
     const entries: RefereeBackupEntry[] = [
       {
         __identity: "entry-1",
-        date: "2026-01-15T00:00:00.000Z",
+        date: "2026-01-15T00:00:00.000Z", // API returns midnight
         weekday: "Mi",
         calendarWeek: 3,
         nlaReferees: [
@@ -177,7 +177,7 @@ describe("extractUserOnCallAssignments", () => {
     const entries: RefereeBackupEntry[] = [
       {
         __identity: "entry-1",
-        date: "2026-01-15T00:00:00.000Z",
+        date: "2026-01-15T00:00:00.000Z", // API returns midnight
         weekday: "Mi",
         calendarWeek: 3,
         nlaReferees: [],
@@ -194,7 +194,7 @@ describe("extractUserOnCallAssignments", () => {
     const entries: RefereeBackupEntry[] = [
       {
         __identity: "entry-1",
-        date: "2026-01-15T00:00:00.000Z",
+        date: "2026-01-15T00:00:00.000Z", // API returns midnight
         weekday: "Mi",
         calendarWeek: 3,
       },
@@ -216,7 +216,7 @@ describe("extractUserOnCallAssignments", () => {
       },
       {
         __identity: "entry-1",
-        date: "2026-01-15T00:00:00.000Z",
+        date: "2026-01-15T00:00:00.000Z", // API returns midnight
         weekday: "Mi",
         calendarWeek: 3,
         nlaReferees: [createAssignment("nla-1", userId)],
@@ -226,8 +226,9 @@ describe("extractUserOnCallAssignments", () => {
     const result = extractUserOnCallAssignments(entries, userId);
 
     expect(result).toHaveLength(2);
-    expect(result[0]?.date).toBe("2026-01-15T00:00:00.000Z");
-    expect(result[1]?.date).toBe("2026-01-22T00:00:00.000Z");
+    // Both dates normalized to noon
+    expect(result[0]?.date).toBe("2026-01-15T12:00:00.000Z");
+    expect(result[1]?.date).toBe("2026-01-22T12:00:00.000Z");
   });
 
   it("returns empty array for empty entries", () => {

--- a/web-app/src/features/referee-backup/hooks/useRefereeBackups.ts
+++ b/web-app/src/features/referee-backup/hooks/useRefereeBackups.ts
@@ -90,7 +90,7 @@ export function useRefereeBackups(weeksAhead: number = DEFAULT_WEEKS_AHEAD) {
     };
   }, []);
 
-  return useQuery({
+  const query = useQuery({
     queryKey: queryKeys.refereeBackup.list(config, associationKey),
     queryFn: () => apiClient.searchRefereeBackups(config),
     select: selectBackups,
@@ -98,4 +98,9 @@ export function useRefereeBackups(weeksAhead: number = DEFAULT_WEEKS_AHEAD) {
     // Keep previous data while refetching
     placeholderData: (prev) => prev,
   });
+
+  // Debug: Log query state
+  console.log(`[VolleyKit] useRefereeBackups: status=${query.status}, error=${query.error?.message ?? "none"}, dataLength=${query.data?.length ?? "undefined"}`);
+
+  return query;
 }

--- a/web-app/src/features/referee-backup/hooks/useRefereeBackups.ts
+++ b/web-app/src/features/referee-backup/hooks/useRefereeBackups.ts
@@ -90,7 +90,7 @@ export function useRefereeBackups(weeksAhead: number = DEFAULT_WEEKS_AHEAD) {
     };
   }, []);
 
-  const query = useQuery({
+  return useQuery({
     queryKey: queryKeys.refereeBackup.list(config, associationKey),
     queryFn: () => apiClient.searchRefereeBackups(config),
     select: selectBackups,
@@ -98,9 +98,4 @@ export function useRefereeBackups(weeksAhead: number = DEFAULT_WEEKS_AHEAD) {
     // Keep previous data while refetching
     placeholderData: (prev) => prev,
   });
-
-  // Debug: Log query state
-  console.log(`[VolleyKit] useRefereeBackups: status=${query.status}, error=${query.error?.message ?? "none"}, dataLength=${query.data?.length ?? "undefined"}`);
-
-  return query;
 }

--- a/web-app/src/features/settings/SettingsPage.test.tsx
+++ b/web-app/src/features/settings/SettingsPage.test.tsx
@@ -148,7 +148,7 @@ describe("SettingsPage", () => {
   describe("About Section", () => {
     it("displays version info", () => {
       render(<SettingsPage />, { wrapper: createWrapper() });
-      expect(screen.getByText("1.0.0")).toBeInTheDocument();
+      expect(screen.getByText("1.0.1")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix on-call (Pikett) assignments not appearing when using the real API in production
- Root cause: Zod validation rejected API responses where `originId` was `null` (for manually-added referees)
- Normalize on-call dates to 12:00 noon for consistent display with game assignments

## Changes

1. **Schema fix** (`src/api/validation.ts`): Allow `null` values for `originId`, `createdBy`, and `updatedBy` fields in the backup referee assignment schema
2. **Date normalization** (`useMyOnCallAssignments.ts`): On-call assignments now display at 12:00 noon instead of midnight for better visual alignment in the timeline
3. **Cleanup**: Removed temporary debug logging that was added to diagnose the issue

## Root Cause

The API returns `"originId": null` for referees that were manually added (not imported from an external system). The Zod schema only allowed `z.number().optional()` which doesn't accept `null`. This caused the entire API response validation to fail silently.

## Test Plan

- [x] Unit tests updated for date normalization
- [x] Verify on-call assignments appear in production with real API
- [x] Confirm dates display as 12:00 in the UI