### PR TITLE
fix(on-call): display date and time like regular assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-01-10
+
+### Changed
+
+- On-call card now displays date and time (12:00) in the same format as regular assignment cards (#676)
+
 ## [1.0.1] - 2026-01-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- On-call card now displays date and time (12:00) in the same format as regular assignment cards (#676)
+- On-call card now displays date and time (16:00 weekdays, 12:00 weekends) in the same format as regular assignment cards (#676)
 
 ## [1.0.1] - 2026-01-10
 

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -2,7 +2,7 @@
   "name": "volleykit-web",
   "description": "VolleyKit - Swiss Volleyball Referee Management PWA",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/web-app/src/features/referee-backup/components/OnCallCard.tsx
+++ b/web-app/src/features/referee-backup/components/OnCallCard.tsx
@@ -19,7 +19,7 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
       className="bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/50"
       aria-label={ariaLabel}
     >
-      <CardContent className="p-3">
+      <CardContent className="px-2 py-2">
         <div className="flex items-center gap-3">
           {/* Date and time */}
           <div className="flex flex-col items-end w-14 shrink-0">

--- a/web-app/src/features/referee-backup/components/OnCallCard.tsx
+++ b/web-app/src/features/referee-backup/components/OnCallCard.tsx
@@ -22,7 +22,7 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
       <CardContent className="p-3">
         <div className="flex items-center gap-3">
           {/* Date and time */}
-          <div className="flex flex-col items-start">
+          <div className="flex flex-col items-end w-14 shrink-0">
             <span
               className={`text-xs font-medium ${
                 isToday

--- a/web-app/src/features/referee-backup/components/OnCallCard.tsx
+++ b/web-app/src/features/referee-backup/components/OnCallCard.tsx
@@ -11,7 +11,7 @@ interface OnCallCardProps {
 
 function OnCallCardComponent({ assignment }: OnCallCardProps) {
   const { t } = useTranslation();
-  const { dateLabel, isToday } = useDateFormat(assignment.date);
+  const { dateLabel, timeLabel, isToday } = useDateFormat(assignment.date);
 
   const ariaLabel = `${t("onCall.duty")} ${assignment.league} - ${dateLabel}`;
 
@@ -30,25 +30,25 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
             />
           </div>
 
-          {/* Date and label */}
+          {/* Date and time */}
+          <div className="flex flex-col items-start">
+            <span
+              className={`text-xs font-medium ${
+                isToday
+                  ? "text-amber-700 dark:text-amber-300"
+                  : "text-amber-600 dark:text-amber-400"
+              }`}
+            >
+              {dateLabel}
+            </span>
+            <span className="text-lg font-bold text-amber-900 dark:text-amber-100">
+              {timeLabel}
+            </span>
+          </div>
+
+          {/* Label */}
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <span
-                className={`text-sm font-medium ${
-                  isToday
-                    ? "text-amber-700 dark:text-amber-300"
-                    : "text-amber-900 dark:text-amber-100"
-                }`}
-              >
-                {dateLabel}
-              </span>
-              {isToday && (
-                <span className="px-1.5 py-0.5 text-xs font-medium bg-amber-200 dark:bg-amber-800 text-amber-800 dark:text-amber-200 rounded">
-                  {t("common.today")}
-                </span>
-              )}
-            </div>
-            <p className="text-xs text-amber-700 dark:text-amber-400">
+            <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
               {t("onCall.duty")}
             </p>
           </div>

--- a/web-app/src/features/referee-backup/components/OnCallCard.tsx
+++ b/web-app/src/features/referee-backup/components/OnCallCard.tsx
@@ -1,5 +1,4 @@
 import { memo } from "react";
-import { Phone } from "lucide-react";
 import { Card, CardContent } from "@/shared/components/Card";
 import { useDateFormat } from "@/shared/hooks/useDateFormat";
 import { useTranslation } from "@/shared/hooks/useTranslation";
@@ -22,14 +21,6 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
     >
       <CardContent className="p-3">
         <div className="flex items-center gap-3">
-          {/* Icon */}
-          <div className="flex-shrink-0 w-10 h-10 rounded-full bg-amber-100 dark:bg-amber-900/50 flex items-center justify-center">
-            <Phone
-              className="w-5 h-5 text-amber-600 dark:text-amber-400"
-              aria-hidden="true"
-            />
-          </div>
-
           {/* Date and time */}
           <div className="flex flex-col items-start">
             <span

--- a/web-app/src/features/referee-backup/components/OnCallCard.tsx
+++ b/web-app/src/features/referee-backup/components/OnCallCard.tsx
@@ -19,8 +19,9 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
       className="bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/50"
       aria-label={ariaLabel}
     >
-      <CardContent className="px-2 py-2">
-        <div className="flex items-center gap-3">
+      <CardContent className="p-0">
+        <div className="px-2 py-2">
+          <div className="flex items-center gap-3">
           {/* Date and time */}
           <div className="flex flex-col items-end w-14 shrink-0">
             <span
@@ -53,6 +54,7 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
             }`}
           >
             {assignment.league}
+          </div>
           </div>
         </div>
       </CardContent>

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.test.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.test.ts
@@ -111,7 +111,7 @@ describe("extractUserOnCallAssignments", () => {
     expect(result[0]).toMatchObject({
       id: "entry-1-NLA",
       league: "NLA",
-      date: "2026-01-15T12:00:00.000Z", // Normalized to noon
+      date: "2026-01-15T16:00:00.000Z", // Normalized to 16:00 (weekday)
     });
   });
 
@@ -226,9 +226,9 @@ describe("extractUserOnCallAssignments", () => {
     const result = extractUserOnCallAssignments(entries, userId);
 
     expect(result).toHaveLength(2);
-    // Both dates normalized to noon
-    expect(result[0]?.date).toBe("2026-01-15T12:00:00.000Z");
-    expect(result[1]?.date).toBe("2026-01-22T12:00:00.000Z");
+    // Both dates normalized to 16:00 (weekdays)
+    expect(result[0]?.date).toBe("2026-01-15T16:00:00.000Z");
+    expect(result[1]?.date).toBe("2026-01-22T16:00:00.000Z");
   });
 
   it("returns empty array for empty entries", () => {

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
@@ -77,7 +77,7 @@ export function extractUserOnCallAssignments(
   const assignments: OnCallAssignment[] = [];
 
   for (const entry of entries) {
-    // Normalize date to 12:00 for consistent display
+    // Normalize date to appropriate display hour (16:00 weekdays, 12:00 weekends)
     const normalizedDate = normalizeOnCallDate(entry.date);
 
     // Check NLA referees

--- a/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
+++ b/web-app/src/features/referee-backup/hooks/useMyOnCallAssignments.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { addDays, getISOWeek, setHours } from "date-fns";
+import { addDays, getISOWeek, isWeekend, setHours } from "date-fns";
 import { useRefereeBackups } from "./useRefereeBackups";
 import { useAuthStore } from "@/shared/stores/auth";
 import { generateDemoUuid } from "@/shared/utils/demo-uuid";
@@ -9,17 +9,29 @@ import type { RefereeBackupEntry, BackupRefereeAssignment } from "@/api/client";
 /** Default number of weeks ahead to fetch on-call assignments */
 const DEFAULT_WEEKS_AHEAD = 2;
 
-/** On-call assignments display at noon for consistent sorting with game assignments */
-const ON_CALL_DISPLAY_HOUR = 12;
+/** On-call display hours: 16:00 on weekdays, 12:00 on weekends */
+const ON_CALL_WEEKDAY_HOUR = 16;
+const ON_CALL_WEEKEND_HOUR = 12;
 
 /**
- * Normalizes the on-call date to display at 12:00 (noon).
- * API returns dates at midnight, but we show them at noon for better
- * visual alignment with game assignments in the timeline.
+ * Returns the appropriate display hour for an on-call assignment based on the day.
+ * Weekdays (Mon-Fri): 16:00
+ * Weekends (Sat-Sun): 12:00
+ */
+function getOnCallDisplayHour(date: Date): number {
+  return isWeekend(date) ? ON_CALL_WEEKEND_HOUR : ON_CALL_WEEKDAY_HOUR;
+}
+
+/**
+ * Normalizes the on-call date to display at the appropriate time.
+ * API returns dates at midnight, but we show them at:
+ * - 16:00 on weekdays (Mon-Fri)
+ * - 12:00 on weekends (Sat-Sun)
  */
 function normalizeOnCallDate(dateString: string): string {
   const date = new Date(dateString);
-  return setHours(date, ON_CALL_DISPLAY_HOUR).toISOString();
+  const displayHour = getOnCallDisplayHour(date);
+  return setHours(date, displayHour).toISOString();
 }
 
 /**
@@ -123,7 +135,7 @@ function generateDemoOnCallAssignments(): OnCallAssignment[] {
   // Find the next Saturday (on-call duties typically on weekends)
   const daysUntilSaturday =
     (SATURDAY - now.getDay() + DAYS_IN_WEEK) % DAYS_IN_WEEK || DAYS_IN_WEEK;
-  const nextSaturday = setHours(addDays(now, daysUntilSaturday), ON_CALL_DISPLAY_HOUR);
+  const nextSaturday = setHours(addDays(now, daysUntilSaturday), ON_CALL_WEEKEND_HOUR);
 
   // Create a demo backup entry for NLA duty this weekend
   const nlaEntry: RefereeBackupEntry = {

--- a/web-app/src/features/settings/SettingsPage.test.tsx
+++ b/web-app/src/features/settings/SettingsPage.test.tsx
@@ -148,7 +148,7 @@ describe("SettingsPage", () => {
   describe("About Section", () => {
     it("displays version info", () => {
       render(<SettingsPage />, { wrapper: createWrapper() });
-      expect(screen.getByText("1.0.1")).toBeInTheDocument();
+      expect(screen.getByText("1.0.2")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Update OnCallCard to display date and time in the same format as regular assignment cards
- Remove phone icon for cleaner layout
- Align date/time column width with regular assignments (w-14, right-aligned)
- Match exact card structure with ExpandableCard (p-0 on CardContent, inner div with px-2 py-2)
- Different display times based on day of week:
  - **Weekdays (Mon-Fri)**: 16:00
  - **Weekends (Sat-Sun)**: 12:00
- Bump version to 1.0.2

## Test Plan
- Verify on-call cards display date label and time like regular assignments
- Confirm weekday on-call shows 16:00, weekend on-call shows 12:00
- Confirm text alignment matches regular assignment cards
- Check both light and dark mode rendering