### PR TITLE
chore(release): prepare v1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session-based authentication with CSRF protection
 - Content Security Policy headers
 
-[Unreleased]: https://github.com/Takishima/volleykit/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/Takishima/volleykit/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/Takishima/volleykit/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Takishima/volleykit/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Takishima/volleykit/releases/tag/v1.0.0

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "volleykit-web",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "volleykit-web",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
## Summary

- Update changelog comparison links for v1.0.2
- Regenerate package-lock.json

## Test Plan

- [ ] Verify changelog links resolve correctly on GitHub