### PR TITLE
fix(pwa): fix login not working on iPhone when installed as PWA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Login not working on iPhone when installed as PWA due to iOS Safari standalone mode limitations with response.url and response.redirected
+
 ## [1.0.2] - 2026-01-10
 
 ### Changed


### PR DESCRIPTION
## Summary

- Fix login failing on iPhone when app is installed as PWA (standalone mode)
- Add content-based detection as fallback when response.url and response.redirected are unreliable
- iOS Safari PWA standalone mode has known limitations with fetch redirect tracking

## Test Plan

- [ ] Install the app as PWA on iPhone (Add to Home Screen)
- [ ] Open the PWA and attempt to login with valid credentials
- [ ] Verify login succeeds and redirects to dashboard
- [ ] Verify session persists after closing and reopening the PWA
- [ ] Test login still works in regular Safari browser