### PR TITLE
feat(ci): add automated release workflow with semver auto-detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,14 +125,37 @@ jobs:
           keep-unreleased-section: true
           fail-on-empty-release-notes: true
 
-      - name: Update package.json version
+      - name: Update package.json and package-lock.json
         working-directory: web-app
+        env:
+          NEW_VERSION: ${{ steps.changelog.outputs.version }}
         run: |
-          npm version "${{ steps.changelog.outputs.version }}" --no-git-tag-version --allow-same-version
+          echo "Updating package.json to version $NEW_VERSION"
+          npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
+          npm install --package-lock-only
 
-      - name: Update package-lock.json
-        working-directory: web-app
-        run: npm install --package-lock-only
+      - name: Verify versions match
+        env:
+          CHANGELOG_VERSION: ${{ steps.changelog.outputs.version }}
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./web-app/package.json').version")
+          LOCK_VERSION=$(node -p "require('./web-app/package-lock.json').version")
+
+          echo "Changelog version: $CHANGELOG_VERSION"
+          echo "package.json version: $PACKAGE_VERSION"
+          echo "package-lock.json version: $LOCK_VERSION"
+
+          if [ "$CHANGELOG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "::error::Version mismatch: changelog=$CHANGELOG_VERSION, package.json=$PACKAGE_VERSION"
+            exit 1
+          fi
+
+          if [ "$CHANGELOG_VERSION" != "$LOCK_VERSION" ]; then
+            echo "::error::Version mismatch: changelog=$CHANGELOG_VERSION, package-lock.json=$LOCK_VERSION"
+            exit 1
+          fi
+
+          echo "All versions match: $CHANGELOG_VERSION"
 
       - name: Show changes (dry run)
         if: ${{ inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       version_type:
-        description: 'Version bump type'
+        description: 'Version bump type (leave as "auto" to detect from changelog)'
         required: true
         type: choice
+        default: auto
         options:
+          - auto
           - patch
           - minor
           - major
       dry_run:
-        description: 'Dry run (no commits or releases)'
+        description: 'Dry run (preview changes without committing)'
         required: false
         type: boolean
         default: false
@@ -83,11 +85,57 @@ jobs:
           echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
           echo "Current version: $CURRENT_VERSION"
 
+      - name: Extract unreleased changes
+        id: unreleased
+        run: |
+          # Extract content between [Unreleased] and the next version header
+          UNRELEASED=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | sed '1d;$d')
+
+          if [ -z "$(echo "$UNRELEASED" | sed '/^$/d')" ]; then
+            echo "::error::No unreleased changes found in CHANGELOG.md"
+            exit 1
+          fi
+
+          # Save to file for later use
+          echo "$UNRELEASED" > /tmp/unreleased.md
+          echo "Found unreleased changes"
+
+          # Detect version bump type from changelog content
+          # Priority: BREAKING > Added > everything else
+
+          # Check for breaking changes (BREAKING: or [BREAKING] markers)
+          if echo "$UNRELEASED" | grep -qiE '(BREAKING:|BREAKING CHANGE:|\[BREAKING\])'; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+            echo "Detected: MAJOR (breaking changes found)"
+          # Check for new features (### Added section with content)
+          elif echo "$UNRELEASED" | sed -n '/^### Added/,/^### /p' | grep -qE '^- '; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+            echo "Detected: MINOR (new features in Added section)"
+          # Default to patch (bug fixes, changes, etc.)
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+            echo "Detected: PATCH (bug fixes or minor changes)"
+          fi
+
+      - name: Determine version type
+        id: version_type
+        run: |
+          INPUT_TYPE="${{ inputs.version_type }}"
+          DETECTED_TYPE="${{ steps.unreleased.outputs.type }}"
+
+          if [ "$INPUT_TYPE" = "auto" ]; then
+            echo "type=$DETECTED_TYPE" >> "$GITHUB_OUTPUT"
+            echo "Using auto-detected version type: $DETECTED_TYPE"
+          else
+            echo "type=$INPUT_TYPE" >> "$GITHUB_OUTPUT"
+            echo "Using manually specified version type: $INPUT_TYPE"
+          fi
+
       - name: Calculate new version
         id: bump
         run: |
           CURRENT="${{ steps.current.outputs.version }}"
-          TYPE="${{ inputs.version_type }}"
+          TYPE="${{ steps.version_type.outputs.type }}"
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 
@@ -104,21 +152,8 @@ jobs:
           esac
 
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "New version: $NEW_VERSION"
-
-      - name: Check for unreleased changes
-        id: check_changes
-        run: |
-          # Extract content between [Unreleased] and the next version header
-          UNRELEASED=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
-
-          if [ -z "$UNRELEASED" ]; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No unreleased changes found in CHANGELOG.md"
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            echo "Found unreleased changes"
-          fi
+          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+          echo "Version bump: $CURRENT -> $NEW_VERSION ($TYPE)"
 
       - name: Update CHANGELOG.md
         id: changelog
@@ -128,22 +163,13 @@ jobs:
           DATE=$(date +%Y-%m-%d)
           REPO="${{ github.repository }}"
 
-          # Create temporary file for new changelog
-          TEMP_FILE=$(mktemp)
+          # Save release notes for GitHub release
+          cp /tmp/unreleased.md /tmp/release_notes.md
+          echo "notes_file=/tmp/release_notes.md" >> "$GITHUB_OUTPUT"
 
-          # Extract unreleased content for release notes
-          RELEASE_NOTES=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | sed '1d;$d')
-
-          # Save release notes to file for GitHub release (handle multiline)
-          NOTES_FILE=$(mktemp)
-          echo "$RELEASE_NOTES" > "$NOTES_FILE"
-          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
-
-          # Update the changelog:
-          # 1. Keep header and [Unreleased] section header
-          # 2. Add new version section after [Unreleased]
-          # 3. Keep rest of file
-
+          # Update the changelog using awk:
+          # 1. After [Unreleased] header, insert new version section
+          # 2. Update the comparison links at the bottom
           awk -v version="$VERSION" -v date="$DATE" -v repo="$REPO" -v current="$CURRENT" '
             /^## \[Unreleased\]/ {
               print $0
@@ -161,10 +187,9 @@ jobs:
               next
             }
             { print }
-          ' CHANGELOG.md > "$TEMP_FILE"
+          ' CHANGELOG.md > /tmp/changelog_updated.md
 
-          mv "$TEMP_FILE" CHANGELOG.md
-
+          mv /tmp/changelog_updated.md CHANGELOG.md
           echo "Updated CHANGELOG.md for version $VERSION"
 
       - name: Update package.json version
@@ -183,11 +208,18 @@ jobs:
       - name: Show changes (dry run)
         if: ${{ inputs.dry_run }}
         run: |
+          echo "=== Version bump ==="
+          echo "Type: ${{ steps.bump.outputs.type }}"
+          echo "New version: ${{ steps.bump.outputs.version }}"
+          echo ""
           echo "=== CHANGELOG.md changes ==="
           git diff CHANGELOG.md
           echo ""
           echo "=== package.json changes ==="
           git diff web-app/package.json
+          echo ""
+          echo "=== Release notes ==="
+          cat /tmp/release_notes.md
           echo ""
           echo "=== Would create tag: v${{ steps.bump.outputs.version }} ==="
 
@@ -222,27 +254,36 @@ jobs:
           NOTES_FILE="${{ steps.changelog.outputs.notes_file }}"
 
           # Create release with notes from changelog
-          if [ -s "$NOTES_FILE" ]; then
-            gh release create "v$VERSION" \
-              --title "v$VERSION" \
-              --notes-file "$NOTES_FILE"
-          else
-            gh release create "v$VERSION" \
-              --title "v$VERSION" \
-              --notes "Release v$VERSION"
-          fi
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file "$NOTES_FILE"
 
           echo "Created GitHub release v$VERSION"
 
       - name: Summary
         run: |
           VERSION="${{ steps.bump.outputs.version }}"
+          TYPE="${{ steps.bump.outputs.type }}"
+
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             echo "## Dry Run Complete" >> "$GITHUB_STEP_SUMMARY"
-            echo "Would have released version **v$VERSION**" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+            echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Version type | $TYPE |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| New version | v$VERSION |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Auto-detected | ${{ inputs.version_type == 'auto' && 'Yes' || 'No' }} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Release Notes Preview" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat /tmp/release_notes.md >> "$GITHUB_STEP_SUMMARY"
           else
             echo "## Release Complete" >> "$GITHUB_STEP_SUMMARY"
-            echo "Released version **v$VERSION**" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+            echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Version type | $TYPE |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| New version | v$VERSION |" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "[View Release](https://github.com/${{ github.repository }}/releases/tag/v$VERSION)" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,248 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: 'Dry run (no commits or releases)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+# Prevent concurrent releases
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  # Validate before release
+  validate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          working-directory: web-app
+
+      - name: Generate API types
+        run: npm run generate:api
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  release:
+    needs: validate
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      release_notes: ${{ steps.changelog.outputs.release_notes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Get current version
+        id: current
+        run: |
+          CURRENT_VERSION=$(node -p "require('./web-app/package.json').version")
+          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $CURRENT_VERSION"
+
+      - name: Calculate new version
+        id: bump
+        run: |
+          CURRENT="${{ steps.current.outputs.version }}"
+          TYPE="${{ inputs.version_type }}"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+          case "$TYPE" in
+            major)
+              NEW_VERSION="$((MAJOR + 1)).0.0"
+              ;;
+            minor)
+              NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+              ;;
+            patch)
+              NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+              ;;
+          esac
+
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "New version: $NEW_VERSION"
+
+      - name: Check for unreleased changes
+        id: check_changes
+        run: |
+          # Extract content between [Unreleased] and the next version header
+          UNRELEASED=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
+
+          if [ -z "$UNRELEASED" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No unreleased changes found in CHANGELOG.md"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Found unreleased changes"
+          fi
+
+      - name: Update CHANGELOG.md
+        id: changelog
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          CURRENT="${{ steps.current.outputs.version }}"
+          DATE=$(date +%Y-%m-%d)
+          REPO="${{ github.repository }}"
+
+          # Create temporary file for new changelog
+          TEMP_FILE=$(mktemp)
+
+          # Extract unreleased content for release notes
+          RELEASE_NOTES=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | sed '1d;$d')
+
+          # Save release notes to file for GitHub release (handle multiline)
+          NOTES_FILE=$(mktemp)
+          echo "$RELEASE_NOTES" > "$NOTES_FILE"
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
+          # Update the changelog:
+          # 1. Keep header and [Unreleased] section header
+          # 2. Add new version section after [Unreleased]
+          # 3. Keep rest of file
+
+          awk -v version="$VERSION" -v date="$DATE" -v repo="$REPO" -v current="$CURRENT" '
+            /^## \[Unreleased\]/ {
+              print $0
+              print ""
+              print "## [" version "] - " date
+              in_unreleased = 1
+              next
+            }
+            /^## \[/ && in_unreleased {
+              in_unreleased = 0
+            }
+            /^\[Unreleased\]:/ {
+              print "[Unreleased]: https://github.com/" repo "/compare/v" version "...HEAD"
+              print "[" version "]: https://github.com/" repo "/compare/v" current "...v" version
+              next
+            }
+            { print }
+          ' CHANGELOG.md > "$TEMP_FILE"
+
+          mv "$TEMP_FILE" CHANGELOG.md
+
+          echo "Updated CHANGELOG.md for version $VERSION"
+
+      - name: Update package.json version
+        working-directory: web-app
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          echo "Updated package.json to version $VERSION"
+
+      - name: Update package-lock.json
+        working-directory: web-app
+        run: |
+          npm install --package-lock-only
+          echo "Updated package-lock.json"
+
+      - name: Show changes (dry run)
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "=== CHANGELOG.md changes ==="
+          git diff CHANGELOG.md
+          echo ""
+          echo "=== package.json changes ==="
+          git diff web-app/package.json
+          echo ""
+          echo "=== Would create tag: v${{ steps.bump.outputs.version }} ==="
+
+      - name: Commit changes
+        if: ${{ !inputs.dry_run }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          git add CHANGELOG.md web-app/package.json web-app/package-lock.json
+          git commit -m "$(cat <<'EOF'
+          chore(release): prepare v${{ steps.bump.outputs.version }} release
+          EOF
+          )"
+
+      - name: Create tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+
+      - name: Push changes
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git push origin main
+          git push origin "v${{ steps.bump.outputs.version }}"
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          NOTES_FILE="${{ steps.changelog.outputs.notes_file }}"
+
+          # Create release with notes from changelog
+          if [ -s "$NOTES_FILE" ]; then
+            gh release create "v$VERSION" \
+              --title "v$VERSION" \
+              --notes-file "$NOTES_FILE"
+          else
+            gh release create "v$VERSION" \
+              --title "v$VERSION" \
+              --notes "Release v$VERSION"
+          fi
+
+          echo "Created GitHub release v$VERSION"
+
+      - name: Summary
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "## Dry Run Complete" >> "$GITHUB_STEP_SUMMARY"
+            echo "Would have released version **v$VERSION**" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Release Complete" >> "$GITHUB_STEP_SUMMARY"
+            echo "Released version **v$VERSION**" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "[View Release](https://github.com/${{ github.repository }}/releases/tag/v$VERSION)" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,7 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.bump.outputs.version }}
-      release_notes: ${{ steps.changelog.outputs.release_notes }}
+      version: ${{ steps.changelog.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -78,15 +77,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Get current version
-        id: current
-        run: |
-          CURRENT_VERSION=$(node -p "require('./web-app/package.json').version")
-          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Current version: $CURRENT_VERSION"
-
-      - name: Extract unreleased changes
-        id: unreleased
+      - name: Detect version type from changelog
+        id: detect
+        if: ${{ inputs.version_type == 'auto' }}
         run: |
           # Extract content between [Unreleased] and the next version header
           UNRELEASED=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | sed '1d;$d')
@@ -95,10 +88,6 @@ jobs:
             echo "::error::No unreleased changes found in CHANGELOG.md"
             exit 1
           fi
-
-          # Save to file for later use
-          echo "$UNRELEASED" > /tmp/unreleased.md
-          echo "Found unreleased changes"
 
           # Detect version bump type from changelog content
           # Priority: BREAKING > Added > everything else
@@ -120,97 +109,37 @@ jobs:
       - name: Determine version type
         id: version_type
         run: |
-          INPUT_TYPE="${{ inputs.version_type }}"
-          DETECTED_TYPE="${{ steps.unreleased.outputs.type }}"
-
-          if [ "$INPUT_TYPE" = "auto" ]; then
-            echo "type=$DETECTED_TYPE" >> "$GITHUB_OUTPUT"
-            echo "Using auto-detected version type: $DETECTED_TYPE"
+          if [ "${{ inputs.version_type }}" = "auto" ]; then
+            echo "type=${{ steps.detect.outputs.type }}" >> "$GITHUB_OUTPUT"
           else
-            echo "type=$INPUT_TYPE" >> "$GITHUB_OUTPUT"
-            echo "Using manually specified version type: $INPUT_TYPE"
+            echo "type=${{ inputs.version_type }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Calculate new version
-        id: bump
-        run: |
-          CURRENT="${{ steps.current.outputs.version }}"
-          TYPE="${{ steps.version_type.outputs.type }}"
-
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-
-          case "$TYPE" in
-            major)
-              NEW_VERSION="$((MAJOR + 1)).0.0"
-              ;;
-            minor)
-              NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
-              ;;
-            patch)
-              NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
-              ;;
-          esac
-
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
-          echo "Version bump: $CURRENT -> $NEW_VERSION ($TYPE)"
-
-      - name: Update CHANGELOG.md
+      - name: Update changelog
         id: changelog
-        run: |
-          VERSION="${{ steps.bump.outputs.version }}"
-          CURRENT="${{ steps.current.outputs.version }}"
-          DATE=$(date +%Y-%m-%d)
-          REPO="${{ github.repository }}"
-
-          # Save release notes for GitHub release
-          cp /tmp/unreleased.md /tmp/release_notes.md
-          echo "notes_file=/tmp/release_notes.md" >> "$GITHUB_OUTPUT"
-
-          # Update the changelog using awk:
-          # 1. After [Unreleased] header, insert new version section
-          # 2. Update the comparison links at the bottom
-          awk -v version="$VERSION" -v date="$DATE" -v repo="$REPO" -v current="$CURRENT" '
-            /^## \[Unreleased\]/ {
-              print $0
-              print ""
-              print "## [" version "] - " date
-              in_unreleased = 1
-              next
-            }
-            /^## \[/ && in_unreleased {
-              in_unreleased = 0
-            }
-            /^\[Unreleased\]:/ {
-              print "[Unreleased]: https://github.com/" repo "/compare/v" version "...HEAD"
-              print "[" version "]: https://github.com/" repo "/compare/v" current "...v" version
-              next
-            }
-            { print }
-          ' CHANGELOG.md > /tmp/changelog_updated.md
-
-          mv /tmp/changelog_updated.md CHANGELOG.md
-          echo "Updated CHANGELOG.md for version $VERSION"
+        uses: release-flow/keep-a-changelog-action@v3
+        with:
+          command: bump
+          version: ${{ steps.version_type.outputs.type }}
+          tag-prefix: v
+          keep-unreleased-section: true
+          fail-on-empty-release-notes: true
 
       - name: Update package.json version
         working-directory: web-app
         run: |
-          VERSION="${{ steps.bump.outputs.version }}"
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
-          echo "Updated package.json to version $VERSION"
+          npm version "${{ steps.changelog.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Update package-lock.json
         working-directory: web-app
-        run: |
-          npm install --package-lock-only
-          echo "Updated package-lock.json"
+        run: npm install --package-lock-only
 
       - name: Show changes (dry run)
         if: ${{ inputs.dry_run }}
         run: |
           echo "=== Version bump ==="
-          echo "Type: ${{ steps.bump.outputs.type }}"
-          echo "New version: ${{ steps.bump.outputs.version }}"
+          echo "Type: ${{ steps.version_type.outputs.type }}"
+          echo "New version: ${{ steps.changelog.outputs.version }}"
           echo ""
           echo "=== CHANGELOG.md changes ==="
           git diff CHANGELOG.md
@@ -219,51 +148,48 @@ jobs:
           git diff web-app/package.json
           echo ""
           echo "=== Release notes ==="
-          cat /tmp/release_notes.md
+          cat << 'RELEASE_NOTES'
+          ${{ steps.changelog.outputs.release-notes }}
+          RELEASE_NOTES
           echo ""
-          echo "=== Would create tag: v${{ steps.bump.outputs.version }} ==="
+          echo "=== Would create tag: v${{ steps.changelog.outputs.version }} ==="
 
       - name: Commit changes
         if: ${{ !inputs.dry_run }}
         run: |
-          VERSION="${{ steps.bump.outputs.version }}"
           git add CHANGELOG.md web-app/package.json web-app/package-lock.json
           git commit -m "$(cat <<'EOF'
-          chore(release): prepare v${{ steps.bump.outputs.version }} release
+          chore(release): prepare v${{ steps.changelog.outputs.version }} release
           EOF
           )"
 
       - name: Create tag
         if: ${{ !inputs.dry_run }}
-        run: |
-          VERSION="${{ steps.bump.outputs.version }}"
-          git tag -a "v$VERSION" -m "Release v$VERSION"
+        run: git tag -a "v${{ steps.changelog.outputs.version }}" -m "Release v${{ steps.changelog.outputs.version }}"
 
       - name: Push changes
         if: ${{ !inputs.dry_run }}
         run: |
           git push origin main
-          git push origin "v${{ steps.bump.outputs.version }}"
+          git push origin "v${{ steps.changelog.outputs.version }}"
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ steps.bump.outputs.version }}"
-          NOTES_FILE="${{ steps.changelog.outputs.notes_file }}"
+          cat << 'RELEASE_NOTES' > /tmp/release_notes.md
+          ${{ steps.changelog.outputs.release-notes }}
+          RELEASE_NOTES
 
-          # Create release with notes from changelog
-          gh release create "v$VERSION" \
-            --title "v$VERSION" \
-            --notes-file "$NOTES_FILE"
-
-          echo "Created GitHub release v$VERSION"
+          gh release create "v${{ steps.changelog.outputs.version }}" \
+            --title "v${{ steps.changelog.outputs.version }}" \
+            --notes-file /tmp/release_notes.md
 
       - name: Summary
         run: |
-          VERSION="${{ steps.bump.outputs.version }}"
-          TYPE="${{ steps.bump.outputs.type }}"
+          VERSION="${{ steps.changelog.outputs.version }}"
+          TYPE="${{ steps.version_type.outputs.type }}"
 
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             echo "## Dry Run Complete" >> "$GITHUB_STEP_SUMMARY"
@@ -276,7 +202,7 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "### Release Notes Preview" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            cat /tmp/release_notes.md >> "$GITHUB_STEP_SUMMARY"
+            echo '${{ steps.changelog.outputs.release-notes }}' >> "$GITHUB_STEP_SUMMARY"
           else
             echo "## Release Complete" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Push changes
         if: ${{ !inputs.dry_run }}
         run: |
-          git push origin main
+          git push origin ${{ github.event.repository.default_branch }}
           git push origin "v${{ steps.changelog.outputs.version }}"
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Knip (dead code detection)
+        run: npm run knip
+
       - name: Test
         run: npm test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Automated release workflow with semantic version auto-detection from changelog
+
 ### Fixed
 
 - Login not working on iPhone when installed as PWA due to iOS Safari standalone mode limitations with response.url and response.redirected

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,12 +490,16 @@ Releases are fully automated via the **Release workflow** (`.github/workflows/re
 **What the workflow does**:
 1. Validates the codebase (lint, test, build)
 2. Auto-detects version bump type from changelog (or uses manual selection)
-3. Moves `[Unreleased]` entries in CHANGELOG.md to new version section
-4. Updates version in `web-app/package.json` and `package-lock.json`
-5. Creates commit: `chore(release): prepare vX.Y.Z release`
-6. Creates git tag: `vX.Y.Z`
-7. Creates GitHub Release with changelog excerpt
-8. Deployment triggers automatically via `deploy-web.yml`
+3. Updates CHANGELOG.md using [keep-a-changelog-action](https://github.com/release-flow/keep-a-changelog-action):
+   - Moves `[Unreleased]` entries to new version section
+   - Updates comparison links
+   - Outputs the new version number
+4. Updates `web-app/package.json` and `package-lock.json` with the **same version**
+5. Verifies all three files have matching versions (fails if mismatch)
+6. Creates commit: `chore(release): prepare vX.Y.Z release`
+7. Creates git tag: `vX.Y.Z`
+8. Creates GitHub Release with changelog excerpt
+9. Deployment triggers automatically via `deploy-web.yml`
 
 **Manual release** (if needed):
 1. Move `[Unreleased]` entries to a new version section with date

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,13 @@ This project uses [Semantic Versioning](https://semver.org/) and maintains a [Ch
 - `BREAKING CHANGE:` - Alternative prefix
 - `[BREAKING]` - Inline marker
 
+**What counts as a breaking change** (use `BREAKING:` prefix):
+- Removing or renaming public APIs, components, or props
+- Changing authentication or authorization flows
+- Removing features users depend on
+- Changing data formats that affect stored data
+- Requiring user action after update (re-login, clear cache, etc.)
+
 The release workflow auto-detects the version bump type:
 - **MAJOR**: Any entry contains `BREAKING:`, `BREAKING CHANGE:`, or `[BREAKING]`
 - **MINOR**: `### Added` section has entries (new features)
@@ -604,7 +611,7 @@ ESLint plugin `jsx-a11y` enforces many accessibility rules.
 1. Unit tests cover business logic and interactions
 1. E2E tests added for critical user flows (if applicable)
 1. Translations added for all 4 languages (de, en, fr, it)
-1. **Changelog updated** for new features and bug fixes (see [Semantic Versioning & Changelog](#semantic-versioning--changelog))
+1. **Changelog updated** with `BREAKING:` prefix for breaking changes (see [Semantic Versioning & Changelog](#semantic-versioning--changelog))
 1. **All validation phases pass before push** (lint, knip, test, build - see [AI Development Workflow](#ai-development-workflow))
 1. Bundle size limits not exceeded
 1. Works across modern browsers (Chrome, Firefox, Safari)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,7 @@ This project uses [Semantic Versioning](https://semver.org/) and maintains a [Ch
 2. Use the appropriate subsection: Added, Changed, Deprecated, Removed, Fixed, Security
 3. Include the PR/issue number: `- Description of change (#123)`
 4. Write user-facing descriptions (what users will notice, not implementation details)
+5. **For breaking changes**: Prefix the entry with `BREAKING:` (see below)
 
 **Entry format**:
 ```markdown
@@ -444,7 +445,20 @@ This project uses [Semantic Versioning](https://semver.org/) and maintains a [Ch
 
 ### Fixed
 - Assignment dates now display correctly in all timezones (#126)
+
+### Changed
+- BREAKING: Authentication now requires email instead of username (#130)
 ```
+
+**Breaking change markers** (triggers MAJOR version bump):
+- `BREAKING:` - Prefix for breaking changes
+- `BREAKING CHANGE:` - Alternative prefix
+- `[BREAKING]` - Inline marker
+
+The release workflow auto-detects the version bump type:
+- **MAJOR**: Any entry contains `BREAKING:`, `BREAKING CHANGE:`, or `[BREAKING]`
+- **MINOR**: `### Added` section has entries (new features)
+- **PATCH**: Only `### Fixed`, `### Changed`, etc. without breaking markers
 
 ### PWA Version Display
 
@@ -456,25 +470,32 @@ The PWA automatically checks for updates and prompts users when a new version is
 
 ### Releasing a New Version
 
-Releases are automated via the **Release workflow** (`.github/workflows/release.yml`).
+Releases are fully automated via the **Release workflow** (`.github/workflows/release.yml`).
 
 **To create a release**:
 1. Go to **Actions** > **Release** workflow in GitHub
 2. Click **Run workflow**
-3. Select version bump type:
+3. Leave version type as `auto` (recommended) or manually select:
+   - `auto` - **Automatically detects** from changelog content (default)
    - `patch` - Bug fixes (1.0.0 -> 1.0.1)
    - `minor` - New features (1.0.0 -> 1.1.0)
    - `major` - Breaking changes (1.0.0 -> 2.0.0)
 4. Optionally enable **Dry run** to preview changes without committing
 
+**Auto-detection rules** (from changelog content):
+- **MAJOR**: Entry contains `BREAKING:`, `BREAKING CHANGE:`, or `[BREAKING]`
+- **MINOR**: `### Added` section has entries
+- **PATCH**: Only fixes, changes, or other non-breaking updates
+
 **What the workflow does**:
 1. Validates the codebase (lint, test, build)
-2. Moves `[Unreleased]` entries in CHANGELOG.md to new version section
-3. Updates version in `web-app/package.json` and `package-lock.json`
-4. Creates commit: `chore(release): prepare vX.Y.Z release`
-5. Creates git tag: `vX.Y.Z`
-6. Creates GitHub Release with changelog excerpt
-7. Deployment triggers automatically via `deploy-web.yml`
+2. Auto-detects version bump type from changelog (or uses manual selection)
+3. Moves `[Unreleased]` entries in CHANGELOG.md to new version section
+4. Updates version in `web-app/package.json` and `package-lock.json`
+5. Creates commit: `chore(release): prepare vX.Y.Z release`
+6. Creates git tag: `vX.Y.Z`
+7. Creates GitHub Release with changelog excerpt
+8. Deployment triggers automatically via `deploy-web.yml`
 
 **Manual release** (if needed):
 1. Move `[Unreleased]` entries to a new version section with date

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,7 +456,27 @@ The PWA automatically checks for updates and prompts users when a new version is
 
 ### Releasing a New Version
 
-When ready to release (typically done by maintainers):
+Releases are automated via the **Release workflow** (`.github/workflows/release.yml`).
+
+**To create a release**:
+1. Go to **Actions** > **Release** workflow in GitHub
+2. Click **Run workflow**
+3. Select version bump type:
+   - `patch` - Bug fixes (1.0.0 -> 1.0.1)
+   - `minor` - New features (1.0.0 -> 1.1.0)
+   - `major` - Breaking changes (1.0.0 -> 2.0.0)
+4. Optionally enable **Dry run** to preview changes without committing
+
+**What the workflow does**:
+1. Validates the codebase (lint, test, build)
+2. Moves `[Unreleased]` entries in CHANGELOG.md to new version section
+3. Updates version in `web-app/package.json` and `package-lock.json`
+4. Creates commit: `chore(release): prepare vX.Y.Z release`
+5. Creates git tag: `vX.Y.Z`
+6. Creates GitHub Release with changelog excerpt
+7. Deployment triggers automatically via `deploy-web.yml`
+
+**Manual release** (if needed):
 1. Move `[Unreleased]` entries to a new version section with date
 2. Update version in `web-app/package.json`
 3. Update comparison links at the bottom of `CHANGELOG.md`


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for fully automated releases
- Use `release-flow/keep-a-changelog-action` for changelog manipulation
- Auto-detect version bump type from changelog content
- Verify all versions match (CHANGELOG, package.json, package-lock.json)
- Update CLAUDE.md with breaking change guidelines and Definition of Done

## Test Plan

- [ ] Run workflow with dry run to preview changes
- [ ] Verify version verification step
- [ ] Test auto-detection with BREAKING: marker