### PR TITLE
fix(auth): clear activeOccupationId and query cache on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Login not working on iPhone when installed as PWA due to iOS Safari standalone mode limitations with response.url and response.redirected
 - OCR camera capture now auto-crops images to match the guide overlay, improving OCR accuracy by focusing on the scoresheet area
+- User now sees correct assignments after logging into a different association (#682)
 
 ## [1.0.2] - 2026-01-10
 

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -284,6 +284,28 @@ export default function App() {
     return unsubscribe;
   }, []);
 
+  // Clear query cache on logout to prevent stale data from previous sessions.
+  // This ensures users don't see assignments from a previously logged-in association.
+  useEffect(() => {
+    // Track whether user was previously authenticated
+    let wasAuthenticated = useAuthStore.getState().user !== null;
+
+    const unsubscribe = useAuthStore.subscribe((state) => {
+      const isAuthenticated = state.user !== null;
+
+      // User just logged out (was authenticated, now is not)
+      if (wasAuthenticated && !isAuthenticated) {
+        // Reset all queries to clear cached data from previous session
+        queryClient.resetQueries();
+        logger.info("Query cache cleared on logout");
+      }
+
+      wasAuthenticated = isAuthenticated;
+    });
+
+    return unsubscribe;
+  }, []);
+
   return (
     <ErrorBoundary>
       <PWAProvider>

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -263,43 +263,31 @@ export default function App() {
   useViewportZoom();
   useCalendarTheme();
 
-  // Sync settings store's currentMode with auth store's dataSource
-  // This ensures mode-specific settings are loaded for the correct mode
+  // Sync settings store with auth store and handle logout cache clearing.
+  // Uses a single subscription for better performance.
   useEffect(() => {
     // Set initial mode from auth store
     const initialDataSource = useAuthStore.getState().dataSource;
     useSettingsStore.getState()._setCurrentMode(initialDataSource);
 
-    // Track previous dataSource to detect changes
+    // Track state to detect changes
     let previousDataSource = initialDataSource;
+    let wasAuthenticated = useAuthStore.getState().user !== null;
 
-    // Subscribe to auth store changes
     const unsubscribe = useAuthStore.subscribe((state) => {
+      // Sync dataSource changes to settings store
       if (state.dataSource !== previousDataSource) {
         previousDataSource = state.dataSource;
         useSettingsStore.getState()._setCurrentMode(state.dataSource);
       }
-    });
 
-    return unsubscribe;
-  }, []);
-
-  // Clear query cache on logout to prevent stale data from previous sessions.
-  // This ensures users don't see assignments from a previously logged-in association.
-  useEffect(() => {
-    // Track whether user was previously authenticated
-    let wasAuthenticated = useAuthStore.getState().user !== null;
-
-    const unsubscribe = useAuthStore.subscribe((state) => {
+      // Clear query cache on logout to prevent stale data from previous sessions.
+      // This ensures users don't see assignments from a previously logged-in association.
       const isAuthenticated = state.user !== null;
-
-      // User just logged out (was authenticated, now is not)
       if (wasAuthenticated && !isAuthenticated) {
-        // Reset all queries to clear cached data from previous session
         queryClient.resetQueries();
         logger.info("Query cache cleared on logout");
       }
-
       wasAuthenticated = isAuthenticated;
     });
 

--- a/web-app/src/shared/stores/auth.ts
+++ b/web-app/src/shared/stores/auth.ts
@@ -386,6 +386,7 @@ export const useAuthStore = create<AuthState>()(
           groupedEligibleAttributeValues: null,
           eligibleRoles: null,
           _lastAuthTimestamp: null,
+          activeOccupationId: null,
         });
       },
 


### PR DESCRIPTION
## Summary

- Clear `activeOccupationId` during logout to prevent stale association data from being restored on next login
- Add query cache reset on logout to ensure old assignment data from previous sessions is cleared

## Test Plan

- [ ] Log in to Association A and load assignments
- [ ] Log out
- [ ] Log in to Association B
- [ ] Verify assignments shown are for Association B, not Association A
- [ ] Refresh page and verify correct assignments persist