### PR TITLE
feat(ocr-poc): replace comparison with parsed roster display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Automated release workflow with semantic version auto-detection from changelog
 
+### Changed
+
+- OCR POC now displays parsed roster data instead of comparing against dummy data, for debugging OCR recognition issues
+
 ### Fixed
 
 - Login not working on iPhone when installed as PWA due to iOS Safari standalone mode limitations with response.url and response.redirected

--- a/ocr-poc/src/components/ParsedRosterDisplay.js
+++ b/ocr-poc/src/components/ParsedRosterDisplay.js
@@ -1,0 +1,483 @@
+/**
+ * Parsed Roster Display Component
+ *
+ * Displays the OCR-parsed roster data for both teams in a format similar
+ * to the validation modal. This is used for debugging OCR recognition
+ * issues - showing exactly what was parsed without comparison to reference data.
+ *
+ * Shows:
+ * - Team name
+ * - Players with shirt numbers
+ * - Officials with roles (C, AC, etc.)
+ * - Liberos (marked with L badge)
+ * - Parsing warnings
+ */
+
+import {
+  parseGameSheet,
+  getAllPlayers,
+  getAllOfficials,
+} from '../services/PlayerListParser.js';
+
+/**
+ * @typedef {import('@volleykit/ocr/types').ParsedPlayer} ParsedPlayer
+ * @typedef {import('@volleykit/ocr/types').ParsedOfficial} ParsedOfficial
+ * @typedef {import('@volleykit/ocr/types').ParsedTeam} ParsedTeam
+ * @typedef {import('../services/PlayerListParser.js').ParsedGameSheet} ParsedGameSheet
+ */
+
+/**
+ * Escape HTML to prevent XSS
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+/**
+ * Role display names for officials
+ */
+const OFFICIAL_ROLE_NAMES = {
+  C: 'Coach',
+  AC: 'Asst. Coach',
+  AC2: 'Asst. Coach 2',
+  AC3: 'Asst. Coach 3',
+  AC4: 'Asst. Coach 4',
+  M: 'Manager',
+};
+
+/**
+ * Render a player row
+ * @param {ParsedPlayer} player
+ * @param {boolean} isLibero
+ * @returns {string}
+ */
+function renderPlayerRow(player, isLibero = false) {
+  const numberDisplay = player.shirtNumber !== null
+    ? `<span class="roster-display__number">${escapeHtml(String(player.shirtNumber))}</span>`
+    : '<span class="roster-display__number roster-display__number--missing">?</span>';
+
+  const liberoTag = isLibero
+    ? '<span class="roster-display__libero-tag">L</span>'
+    : '';
+
+  const licenseStatus = player.licenseStatus && player.licenseStatus !== 'OK'
+    ? `<span class="roster-display__license roster-display__license--${player.licenseStatus.toLowerCase()}">${escapeHtml(player.licenseStatus)}</span>`
+    : '';
+
+  return `
+    <div class="roster-display__row">
+      ${numberDisplay}
+      ${liberoTag}
+      <span class="roster-display__name">${escapeHtml(player.displayName)}</span>
+      ${licenseStatus}
+    </div>
+  `;
+}
+
+/**
+ * Render an official row
+ * @param {ParsedOfficial} official
+ * @returns {string}
+ */
+function renderOfficialRow(official) {
+  const roleDisplay = official.role
+    ? `<span class="roster-display__role-badge">${escapeHtml(official.role)}</span>`
+    : '';
+
+  const roleName = official.role && OFFICIAL_ROLE_NAMES[official.role]
+    ? `<span class="roster-display__role-name">${escapeHtml(OFFICIAL_ROLE_NAMES[official.role])}</span>`
+    : '';
+
+  return `
+    <div class="roster-display__row roster-display__row--official">
+      ${roleDisplay}
+      <span class="roster-display__name">${escapeHtml(official.displayName)}</span>
+      ${roleName}
+    </div>
+  `;
+}
+
+/**
+ * Render a team panel
+ * @param {ParsedTeam} team
+ * @param {string} label
+ * @param {boolean} playersExpanded
+ * @param {boolean} officialsExpanded
+ * @param {string} panelId
+ * @returns {string}
+ */
+function renderTeamPanel(team, label, playersExpanded, officialsExpanded, panelId) {
+  const players = getAllPlayers(team);
+  const officials = getAllOfficials(team);
+
+  // Separate regular players and liberos
+  const regularPlayers = team.players || [];
+  const liberos = team.liberos || [];
+
+  const playerRows = regularPlayers.map((p) => renderPlayerRow(p, false)).join('');
+  const liberoRows = liberos.map((p) => renderPlayerRow(p, true)).join('');
+  const officialRows = officials.map((o) => renderOfficialRow(o)).join('');
+
+  const hasOfficials = officials.length > 0;
+  const teamName = team.name || 'Unknown Team';
+
+  return `
+    <div class="roster-display__panel" data-panel-id="${panelId}">
+      <div class="roster-display__panel-header">
+        <h3 class="roster-display__panel-title">${escapeHtml(label)}</h3>
+        <div class="roster-display__team-name">${escapeHtml(teamName)}</div>
+      </div>
+
+      <!-- Players Section -->
+      <div class="roster-display__section">
+        <button
+          type="button"
+          class="roster-display__section-header"
+          aria-expanded="${playersExpanded}"
+          aria-controls="${panelId}-players"
+          data-section="players"
+        >
+          <span class="roster-display__section-toggle">${playersExpanded ? '▼' : '▶'}</span>
+          <span class="roster-display__section-title">Players</span>
+          <span class="roster-display__section-count">${players.length} players</span>
+        </button>
+        <div
+          id="${panelId}-players"
+          class="roster-display__section-content"
+          ${playersExpanded ? '' : 'hidden'}
+        >
+          ${players.length > 0 ? `
+            <div class="roster-display__list">
+              ${playerRows}
+              ${liberoRows}
+            </div>
+          ` : `
+            <div class="roster-display__empty">No players detected</div>
+          `}
+        </div>
+      </div>
+
+      <!-- Officials Section -->
+      ${hasOfficials ? `
+        <div class="roster-display__section">
+          <button
+            type="button"
+            class="roster-display__section-header"
+            aria-expanded="${officialsExpanded}"
+            aria-controls="${panelId}-officials"
+            data-section="officials"
+          >
+            <span class="roster-display__section-toggle">${officialsExpanded ? '▼' : '▶'}</span>
+            <span class="roster-display__section-title">Officials</span>
+            <span class="roster-display__section-count">${officials.length} officials</span>
+          </button>
+          <div
+            id="${panelId}-officials"
+            class="roster-display__section-content"
+            ${officialsExpanded ? '' : 'hidden'}
+          >
+            <div class="roster-display__list">
+              ${officialRows}
+            </div>
+          </div>
+        </div>
+      ` : ''}
+    </div>
+  `;
+}
+
+/** Duration in ms to show copy success feedback before resetting button text */
+const COPY_FEEDBACK_DURATION_MS = 2000;
+
+/**
+ * Copy text to clipboard
+ * @param {string} text
+ * @returns {Promise<boolean>}
+ */
+async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copy text to clipboard and show feedback on a button
+ * @param {HTMLButtonElement} button - The button to update with feedback
+ * @param {string} text - The text to copy
+ * @param {string} originalLabel - The button's original text to restore
+ */
+async function copyWithFeedback(button, text, originalLabel) {
+  const success = await copyToClipboard(text);
+  if (success) {
+    button.textContent = '✓ Copied!';
+    setTimeout(() => {
+      button.textContent = originalLabel;
+    }, COPY_FEEDBACK_DURATION_MS);
+  }
+}
+
+/**
+ * ParsedRosterDisplay Component
+ */
+export class ParsedRosterDisplay {
+  /**
+   * @param {Object} options
+   * @param {HTMLElement} options.container - Container element
+   * @param {string} options.ocrText - Raw OCR text
+   * @param {import('../services/ocr/StubOCR.js').OCRResult} [options.ocrResult] - Full OCR result with metadata
+   * @param {'electronic' | 'manuscript'} [options.sheetType='electronic'] - Sheet type for export
+   * @param {boolean} [options.isManuscript=false] - Whether this is a manuscript scoresheet
+   * @param {Function} [options.onBack] - Callback when back button is clicked
+   */
+  constructor({ container, ocrText, ocrResult = null, sheetType = 'electronic', isManuscript = false, onBack }) {
+    this.container = container;
+    this.ocrText = ocrText;
+    this.ocrResult = ocrResult;
+    this.sheetType = sheetType;
+    this.isManuscript = isManuscript;
+    this.onBack = onBack;
+
+    /** @type {ParsedGameSheet | null} */
+    this.parsed = null;
+
+    /** @type {{ playersA: boolean, officialsA: boolean, playersB: boolean, officialsB: boolean }} */
+    this.expandedState = {
+      playersA: true,
+      officialsA: false,
+      playersB: true,
+      officialsB: false,
+    };
+
+    this.initialize();
+  }
+
+  /**
+   * Initialize the component
+   */
+  initialize() {
+    // Parse OCR text using appropriate parser based on scoresheet type
+    const parserType = this.isManuscript ? 'manuscript' : 'electronic';
+    this.parsed = parseGameSheet(this.ocrText, { type: parserType });
+
+    console.log('Parsed game sheet:', this.parsed);
+
+    this.render();
+    this.bindEvents();
+  }
+
+  /**
+   * Render the component
+   */
+  render() {
+    if (!this.parsed) {
+      this.container.innerHTML = `
+        <div class="roster-display__error">
+          <p>Failed to parse scoresheet</p>
+        </div>
+      `;
+      return;
+    }
+
+    // Render warnings if any
+    const warningsHtml = this.parsed.warnings.length > 0
+      ? `
+        <div class="roster-display__warnings">
+          ${this.parsed.warnings.map((w) => `<p class="roster-display__warning">⚠ ${escapeHtml(w)}</p>`).join('')}
+        </div>
+      `
+      : '';
+
+    // Get player counts for summary
+    const teamAPlayers = getAllPlayers(this.parsed.teamA);
+    const teamBPlayers = getAllPlayers(this.parsed.teamB);
+    const teamAOfficials = getAllOfficials(this.parsed.teamA);
+    const teamBOfficials = getAllOfficials(this.parsed.teamB);
+    const totalPlayers = teamAPlayers.length + teamBPlayers.length;
+    const totalOfficials = teamAOfficials.length + teamBOfficials.length;
+
+    this.container.innerHTML = `
+      <div class="roster-display">
+        <div class="roster-display__intro">
+          <p class="text-muted">
+            OCR parsed roster data. Use this to debug recognition issues.
+            ${this.isManuscript ? '<br><em>Manuscript parser with OCR error correction enabled.</em>' : ''}
+          </p>
+        </div>
+
+        <!-- Summary stats -->
+        <div class="roster-display__summary">
+          <div class="roster-display__stat">
+            <span class="roster-display__stat-value">${totalPlayers}</span>
+            <span class="roster-display__stat-label">Players</span>
+          </div>
+          <div class="roster-display__stat">
+            <span class="roster-display__stat-value">${totalOfficials}</span>
+            <span class="roster-display__stat-label">Officials</span>
+          </div>
+        </div>
+
+        ${warningsHtml}
+
+        <div class="roster-display__panels">
+          ${renderTeamPanel(
+            this.parsed.teamA,
+            'Team A (Left Column)',
+            this.expandedState.playersA,
+            this.expandedState.officialsA,
+            'team-a'
+          )}
+          ${renderTeamPanel(
+            this.parsed.teamB,
+            'Team B (Right Column)',
+            this.expandedState.playersB,
+            this.expandedState.officialsB,
+            'team-b'
+          )}
+        </div>
+
+        <!-- Debug Data Export Panel -->
+        <details class="roster-display__debug-panel">
+          <summary class="roster-display__debug-summary">📊 Debug Data Export</summary>
+          <div class="roster-display__debug-content">
+            <div class="flex flex-col gap-sm">
+              <button class="btn btn-outline btn-block" id="btn-copy-parsed-json" aria-label="Copy parsed roster JSON to clipboard">
+                Copy Parsed Roster (JSON)
+              </button>
+              <button class="btn btn-outline btn-block" id="btn-copy-ocr-text" aria-label="Copy raw OCR text to clipboard">
+                Copy Raw OCR Text
+              </button>
+              ${this.ocrResult ? `
+                <button class="btn btn-outline btn-block" id="btn-copy-full-json" aria-label="Copy full OCR result JSON to clipboard">
+                  Copy Full OCR Result (JSON)
+                </button>
+              ` : ''}
+              <button class="btn btn-outline btn-block" id="btn-log-to-console" aria-label="Log all data to browser console">
+                Log to Console
+              </button>
+            </div>
+            <details class="roster-display__raw-text-panel mt-md">
+              <summary class="roster-display__debug-summary">View Raw OCR Text</summary>
+              <pre class="roster-display__raw-text">${escapeHtml(this.ocrText)}</pre>
+            </details>
+          </div>
+        </details>
+
+        ${this.onBack ? `
+          <button class="btn btn-secondary btn-block mt-lg" id="btn-back-to-results">
+            Back to OCR Results
+          </button>
+        ` : ''}
+      </div>
+    `;
+  }
+
+  /**
+   * Bind event listeners
+   */
+  bindEvents() {
+    // Back button
+    if (this.onBack) {
+      const backBtn = this.container.querySelector('#btn-back-to-results');
+      backBtn?.addEventListener('click', () => this.onBack?.());
+    }
+
+    // Debug export buttons
+    const copyParsedBtn = this.container.querySelector('#btn-copy-parsed-json');
+    copyParsedBtn?.addEventListener('click', async () => {
+      const json = JSON.stringify(this.parsed, null, 2);
+      await copyWithFeedback(copyParsedBtn, json, 'Copy Parsed Roster (JSON)');
+    });
+
+    const copyOcrTextBtn = this.container.querySelector('#btn-copy-ocr-text');
+    copyOcrTextBtn?.addEventListener('click', async () => {
+      await copyWithFeedback(copyOcrTextBtn, this.ocrText, 'Copy Raw OCR Text');
+    });
+
+    const copyFullJsonBtn = this.container.querySelector('#btn-copy-full-json');
+    copyFullJsonBtn?.addEventListener('click', async () => {
+      if (this.ocrResult) {
+        const json = JSON.stringify(this.ocrResult, null, 2);
+        await copyWithFeedback(copyFullJsonBtn, json, 'Copy Full OCR Result (JSON)');
+      }
+    });
+
+    const logToConsoleBtn = this.container.querySelector('#btn-log-to-console');
+    logToConsoleBtn?.addEventListener('click', () => {
+      console.log('=== OCR Debug Data ===');
+      console.log('Sheet Type:', this.sheetType);
+      console.log('Is Manuscript:', this.isManuscript);
+      console.log('');
+      console.log('--- Raw OCR Text ---');
+      console.log(this.ocrText);
+      console.log('');
+      console.log('--- Parsed Roster ---');
+      console.log(this.parsed);
+      if (this.ocrResult) {
+        console.log('');
+        console.log('--- Full OCR Result ---');
+        console.log(this.ocrResult);
+      }
+      console.log('=== End OCR Debug Data ===');
+
+      // Show feedback
+      logToConsoleBtn.textContent = '✓ Logged!';
+      setTimeout(() => {
+        logToConsoleBtn.textContent = 'Log to Console';
+      }, COPY_FEEDBACK_DURATION_MS);
+    });
+
+    // Section toggles
+    this.container.querySelectorAll('.roster-display__section-header').forEach((header) => {
+      header.addEventListener('click', (e) => {
+        const button = e.currentTarget;
+        const section = button.dataset.section;
+        const panel = button.closest('.roster-display__panel');
+        const panelId = panel?.dataset.panelId;
+        const contentId = button.getAttribute('aria-controls');
+        const content = this.container.querySelector(`#${contentId}`);
+        const toggle = button.querySelector('.roster-display__section-toggle');
+
+        if (!content || !toggle) {
+          return;
+        }
+
+        const isExpanded = button.getAttribute('aria-expanded') === 'true';
+        const newExpanded = !isExpanded;
+
+        // Update state
+        if (panelId === 'team-a' && section === 'players') {
+          this.expandedState.playersA = newExpanded;
+        } else if (panelId === 'team-a' && section === 'officials') {
+          this.expandedState.officialsA = newExpanded;
+        } else if (panelId === 'team-b' && section === 'players') {
+          this.expandedState.playersB = newExpanded;
+        } else if (panelId === 'team-b' && section === 'officials') {
+          this.expandedState.officialsB = newExpanded;
+        }
+
+        // Update UI
+        button.setAttribute('aria-expanded', String(newExpanded));
+        toggle.textContent = newExpanded ? '▼' : '▶';
+        if (newExpanded) {
+          content.removeAttribute('hidden');
+        } else {
+          content.setAttribute('hidden', '');
+        }
+      });
+    });
+  }
+
+  /**
+   * Destroy the component
+   */
+  destroy() {
+    this.container.innerHTML = '';
+  }
+}

--- a/ocr-poc/src/components/ParsedRosterDisplay.js
+++ b/ocr-poc/src/components/ParsedRosterDisplay.js
@@ -102,15 +102,20 @@ function renderOfficialRow(official) {
 }
 
 /**
+ * @typedef {Object} TeamPanelOptions
+ * @property {ParsedTeam} team - The parsed team data
+ * @property {string} label - Display label for the panel
+ * @property {boolean} playersExpanded - Whether players section is expanded
+ * @property {boolean} officialsExpanded - Whether officials section is expanded
+ * @property {string} panelId - Unique ID for the panel
+ */
+
+/**
  * Render a team panel
- * @param {ParsedTeam} team
- * @param {string} label
- * @param {boolean} playersExpanded
- * @param {boolean} officialsExpanded
- * @param {string} panelId
+ * @param {TeamPanelOptions} options
  * @returns {string}
  */
-function renderTeamPanel(team, label, playersExpanded, officialsExpanded, panelId) {
+function renderTeamPanel({ team, label, playersExpanded, officialsExpanded, panelId }) {
   const players = getAllPlayers(team);
   const officials = getAllOfficials(team);
 
@@ -266,8 +271,6 @@ export class ParsedRosterDisplay {
     const parserType = this.isManuscript ? 'manuscript' : 'electronic';
     this.parsed = parseGameSheet(this.ocrText, { type: parserType });
 
-    console.log('Parsed game sheet:', this.parsed);
-
     this.render();
     this.bindEvents();
   }
@@ -326,20 +329,20 @@ export class ParsedRosterDisplay {
         ${warningsHtml}
 
         <div class="roster-display__panels">
-          ${renderTeamPanel(
-            this.parsed.teamA,
-            'Team A (Left Column)',
-            this.expandedState.playersA,
-            this.expandedState.officialsA,
-            'team-a'
-          )}
-          ${renderTeamPanel(
-            this.parsed.teamB,
-            'Team B (Right Column)',
-            this.expandedState.playersB,
-            this.expandedState.officialsB,
-            'team-b'
-          )}
+          ${renderTeamPanel({
+            team: this.parsed.teamA,
+            label: 'Team A (Left Column)',
+            playersExpanded: this.expandedState.playersA,
+            officialsExpanded: this.expandedState.officialsA,
+            panelId: 'team-a',
+          })}
+          ${renderTeamPanel({
+            team: this.parsed.teamB,
+            label: 'Team B (Right Column)',
+            playersExpanded: this.expandedState.playersB,
+            officialsExpanded: this.expandedState.officialsB,
+            panelId: 'team-b',
+          })}
         </div>
 
         <!-- Debug Data Export Panel -->

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -1643,3 +1643,320 @@ body {
     }
   }
 }
+
+/* ==============================================
+ * PARSED ROSTER DISPLAY COMPONENT
+ * ============================================== */
+
+.roster-display {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.roster-display__intro {
+  text-align: center;
+}
+
+.roster-display__intro em {
+  color: var(--color-primary-600);
+}
+
+.roster-display__summary {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-lg);
+}
+
+.roster-display__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--spacing-md);
+  background-color: var(--color-surface-subtle);
+  border-radius: var(--radius-lg);
+  min-width: 80px;
+}
+
+.roster-display__stat-value {
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  color: var(--color-primary-700);
+}
+
+.roster-display__stat-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.roster-display__warnings {
+  background-color: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md);
+}
+
+.roster-display__warning {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: #92400e;
+}
+
+.roster-display__warning + .roster-display__warning {
+  margin-top: var(--spacing-xs);
+}
+
+.roster-display__panels {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+@media (min-width: 768px) {
+  .roster-display__panels {
+    flex-direction: row;
+  }
+
+  .roster-display__panel {
+    flex: 1;
+  }
+}
+
+.roster-display__panel {
+  background-color: var(--color-surface-card);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.roster-display__panel-header {
+  background-color: var(--color-primary-50);
+  padding: var(--spacing-md);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.roster-display__panel-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.roster-display__team-name {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Section headers (collapsible) */
+.roster-display__section {
+  border-top: 1px solid var(--color-border-default);
+}
+
+.roster-display__section:first-of-type {
+  border-top: none;
+}
+
+.roster-display__section-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface-subtle);
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition: background-color 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.roster-display__section-header:hover {
+  background-color: var(--color-gray-200);
+}
+
+.roster-display__section-header:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: -2px;
+}
+
+.roster-display__section-toggle {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  width: 12px;
+}
+
+.roster-display__section-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.roster-display__section-count {
+  margin-left: auto;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-weight: normal;
+}
+
+.roster-display__section-content {
+  padding: var(--spacing-sm);
+}
+
+.roster-display__section-content[hidden] {
+  display: none;
+}
+
+.roster-display__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.roster-display__empty {
+  text-align: center;
+  padding: var(--spacing-md);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-style: italic;
+}
+
+/* Player/Official rows */
+.roster-display__row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-surface-subtle);
+  border-radius: var(--radius-md);
+}
+
+.roster-display__row--official {
+  background-color: var(--color-primary-50);
+}
+
+.roster-display__number {
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--color-primary-700);
+  min-width: 24px;
+  text-align: right;
+}
+
+.roster-display__number--missing {
+  color: var(--color-text-muted);
+}
+
+.roster-display__libero-tag {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  background-color: var(--color-warning-500);
+  color: white;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+}
+
+.roster-display__role-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-gray-600);
+  color: white;
+  min-width: 28px;
+  text-align: center;
+}
+
+.roster-display__role-name {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin-left: auto;
+}
+
+.roster-display__name {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.roster-display__license {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  margin-left: auto;
+}
+
+.roster-display__license--not,
+.roster-display__license--lfp {
+  background-color: var(--color-warning-500);
+  color: white;
+}
+
+.roster-display__license--ne,
+.roster-display__license--pen {
+  background-color: var(--color-danger-500);
+  color: white;
+}
+
+/* Debug panel */
+.roster-display__debug-panel {
+  background-color: var(--color-surface-subtle);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-default);
+}
+
+.roster-display__debug-summary {
+  padding: var(--spacing-md);
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  user-select: none;
+}
+
+.roster-display__debug-summary:hover {
+  color: var(--color-text-primary);
+}
+
+.roster-display__debug-content {
+  padding: 0 var(--spacing-md) var(--spacing-md) var(--spacing-md);
+}
+
+.roster-display__raw-text-panel {
+  background-color: var(--color-surface-card);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-default);
+}
+
+.roster-display__raw-text {
+  margin: 0;
+  padding: var(--spacing-md);
+  padding-top: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 300px;
+  overflow-y: auto;
+  color: var(--color-text-secondary);
+}
+
+.roster-display__error {
+  text-align: center;
+  padding: var(--spacing-xl);
+  color: var(--color-danger-600);
+}
+
+/* Gap utility for flex */
+.gap-sm {
+  gap: var(--spacing-sm);
+}

--- a/ocr-poc/src/style.css
+++ b/ocr-poc/src/style.css
@@ -38,8 +38,10 @@
   /* Semantic colors */
   --color-success-500: #22c55e;
   --color-success-600: #16a34a;
+  --color-warning-100: #fef3c7;
   --color-warning-500: #f59e0b;
   --color-warning-600: #d97706;
+  --color-warning-800: #92400e;
   --color-danger-500: #ef4444;
   --color-danger-600: #dc2626;
 
@@ -1690,8 +1692,8 @@ body {
 }
 
 .roster-display__warnings {
-  background-color: #fef3c7;
-  border: 1px solid #f59e0b;
+  background-color: var(--color-warning-100);
+  border: 1px solid var(--color-warning-500);
   border-radius: var(--radius-lg);
   padding: var(--spacing-md);
 }
@@ -1699,7 +1701,7 @@ body {
 .roster-display__warning {
   margin: 0;
   font-size: var(--font-size-sm);
-  color: #92400e;
+  color: var(--color-warning-800);
 }
 
 .roster-display__warning + .roster-display__warning {


### PR DESCRIPTION
## Summary

- Replace player comparison against dummy data with new ParsedRosterDisplay component
- Display OCR-parsed roster for both teams with players, officials, and liberos
- Show shirt numbers, official roles (C, AC), and license status
- Include collapsible sections matching validation modal format
- Keep debug panel with copy JSON/text and log to console features
- Add changelog entry

## Test Plan

- [ ] Open OCR POC and scan a scoresheet
- [ ] Click "View Parsed Roster" to see the parsed data
- [ ] Verify both teams display with players and officials
- [ ] Test collapsible sections for players/officials
- [ ] Test debug panel copy buttons and console logging