### PR TITLE
fix(pwa): convert auth redirect to 200 response for iOS Safari PWA

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -2172,8 +2172,13 @@ describe("Integration: Auth Lockout in Worker", () => {
 
     const response = await worker.fetch(request, mockEnv);
 
-    // Should proxy the response, not block
-    expect(response.status).toBe(302);
+    // iOS Safari PWA fix: Successful auth returns 200 + JSON instead of 302
+    // This allows iOS Safari PWA to properly process Set-Cookie headers
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    const body = await response.json();
+    expect(body).toHaveProperty("success", true);
+    expect(body).toHaveProperty("redirectUrl");
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
## Summary

iOS Safari PWA doesn't properly store cookies from redirect responses when using `redirect: "manual"`. The browser returns `opaqueredirect` which hides all headers including `Set-Cookie` from JavaScript.

## The Problem

1. Client sends auth request with `redirect: "manual"`
2. Server returns 303 redirect with `Set-Cookie` header
3. Browser returns `opaqueredirect` response type
4. JavaScript cannot access `Set-Cookie` header
5. iOS Safari PWA fails to store the session cookie

## The Solution

### Worker Changes
- For successful auth (303 redirect to dashboard), return `200 + JSON` with `{ success: true, redirectUrl: "..." }` instead of 303
- Browser can now properly process `Set-Cookie` header from the 200 response

### Client Changes
- Handle new JSON auth response format
- Fetch dashboard using `redirectUrl` from JSON body
- Existing `opaqueredirect` fallback still works as backup for non-updated workers

## Test Plan

- [ ] Deploy worker to Cloudflare
- [ ] Install PWA on iOS device
- [ ] Login and verify session persists
- [ ] Verify desktop browser login still works