### PR TITLE
fix(pwa): improve iOS Safari PWA login detection and add standalone mode display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Automated release workflow with semantic version auto-detection from changelog
+- PWA standalone mode detection - Settings now displays "PWA" instead of "Web" when running as installed app (#687)
 
 ### Changed
 
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- iOS Safari PWA login - broadened successful login detection to match any dashboard redirect (e.g., `/indoor/`), not just specific paths (#687)
 - Login not working on iPhone when installed as PWA - now uses manual redirect handling with `cache: no-store` to work around iOS Safari cookie and redirect handling issues in standalone mode
 - OCR camera capture now auto-crops images to match the guide overlay, improving OCR accuracy by focusing on the scoresheet area
 - User now sees correct assignments after logging into a different association (#682)

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -2078,9 +2078,39 @@ describe("Auth Lockout", () => {
       ).toBe(true);
     });
 
+    it("detects redirect to /indoor/ path", () => {
+      expect(
+        isSuccessfulLoginResponse(
+          mockResponse(302, { Location: "https://volleymanager.volleyball.ch/indoor/start" }),
+        ),
+      ).toBe(true);
+    });
+
     it("returns false for redirect to login", () => {
       expect(
         isSuccessfulLoginResponse(mockResponse(302, { Location: "/login" })),
+      ).toBe(false);
+    });
+
+    it("returns false for redirect to login with query params", () => {
+      expect(
+        isSuccessfulLoginResponse(mockResponse(302, { Location: "/login?error=invalid" })),
+      ).toBe(false);
+    });
+
+    it("returns false for redirect to root path", () => {
+      expect(
+        isSuccessfulLoginResponse(
+          mockResponse(302, { Location: "https://volleymanager.volleyball.ch/" }),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false for redirect to authentication endpoint", () => {
+      expect(
+        isSuccessfulLoginResponse(
+          mockResponse(302, { Location: "/sportmanager.security/authentication" }),
+        ),
       ).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

- **Worker fix**: Broadened `isSuccessfulLoginResponse` to detect successful logins by exclusion instead of inclusion. Any 3xx redirect that does NOT go back to `/login`, `/authentication`, or root path is now considered successful. This fixes login on iOS Safari PWA where volleymanager redirects to `/indoor/` paths.
- **PWA detection**: Added reliable detection of PWA standalone mode using `navigator.standalone` (iOS Safari) and `display-mode: standalone` media query (Chrome/Android). Settings page now shows "PWA" instead of "Web" when running as installed app.

## Changes

### Worker (`worker/src/utils.ts`)
- Changed `isSuccessfulLoginResponse` to use exclusion logic
- Now matches any redirect except failed login patterns
- Added tests for `/indoor/` path, login with query params, root path, and auth endpoints

### Web App (`AppInfoSection.tsx`)
- Added `isPwaStandalone()` function with multiple detection methods
- Platform display now correctly shows "PWA" in standalone mode

## Test Plan

- [ ] Login works in iOS Safari PWA (no more "session cookie failed" error)
- [ ] Settings shows "PWA" when running as installed app on iOS
- [ ] Settings shows "Web" when running in browser
- [ ] Worker tests pass (225 tests)