### PR TITLE
fix(pwa): convert all auth redirects to JSON for iOS Safari PWA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- iOS Safari PWA login - worker now converts all auth redirects to JSON responses, fixing `opaqueredirect` issue that prevented login detection
 - iOS Safari PWA login - broadened successful login detection to match any dashboard redirect (e.g., `/indoor/`), not just specific paths (#687)
 - Login not working on iPhone when installed as PWA - now uses manual redirect handling with `cache: no-store` to work around iOS Safari cookie and redirect handling issues in standalone mode
 - OCR camera capture now auto-crops images to match the guide overlay, improving OCR accuracy by focusing on the scoresheet area


### PR DESCRIPTION
## Summary

- Convert ALL auth redirects to 200 + JSON response (not just successful ones)
- Add diagnostic logging for auth redirect handling in worker
- Update client to handle both success: true and success: false JSON responses

When using `redirect: "manual"` with CORS, browsers return "opaqueredirect" for any redirect response, hiding all headers from JavaScript. This was causing iOS Safari PWA to fail login.

## Test Plan

- [ ] Test successful login on iOS Safari PWA - should get JSON response with success: true
- [ ] Test failed login on iOS Safari PWA - should show "Invalid username or password"
- [ ] Verify CSRF token is extracted after successful login