### PR TITLE
fix(pwa): only convert POST auth redirects to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- iOS Safari PWA login - worker now converts all auth redirects to JSON responses, fixing `opaqueredirect` issue that prevented login detection
+- iOS Safari PWA login - worker now converts POST auth redirects to JSON responses, fixing `opaqueredirect` issue that prevented login detection (#690)
 - iOS Safari PWA login - broadened successful login detection to match any dashboard redirect (e.g., `/indoor/`), not just specific paths (#687)
 - Login not working on iPhone when installed as PWA - now uses manual redirect handling with `cache: no-store` to work around iOS Safari cookie and redirect handling issues in standalone mode
 - OCR camera capture now auto-crops images to match the guide overlay, improving OCR accuracy by focusing on the scoresheet area

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -931,17 +931,20 @@ export default {
             proxyRedirect.pathname = redirectUrl.pathname;
             proxyRedirect.search = redirectUrl.search;
 
-            // iOS Safari PWA fix: Convert ALL auth redirects to 200 + JSON response
+            // iOS Safari PWA fix: Convert POST auth redirects to 200 + JSON response
             // When using redirect: "manual", browsers return "opaqueredirect" which hides
             // all headers including Set-Cookie from JavaScript. iOS Safari PWA doesn't
             // properly store cookies from redirect responses. By returning 200 with JSON,
             // the browser processes Set-Cookie normally and the client handles navigation.
             //
-            // We convert ALL auth redirects (not just successful ones) because:
+            // We convert ALL auth POST redirects (not just successful ones) because:
             // 1. opaqueredirect hides all response details, making debugging impossible
             // 2. The client can determine success/failure by fetching the redirect URL
             // 3. This is more robust than trying to detect success server-side
-            if (isAuthReq) {
+            //
+            // NOTE: Only convert POST requests - GET to /login should return the HTML
+            // login page, even when the server redirects (e.g., user already logged in).
+            if (isAuthReq && request.method === "POST") {
               const isSuccess = isSuccessfulLoginResponse(response);
               console.log("[iOS PWA Auth] Converting redirect to JSON:", {
                 originalStatus: response.status,


### PR DESCRIPTION
## Summary

- Fix login failing on regular browsers with "Could not extract form fields from login page"
- Only convert POST auth requests to JSON redirect responses (for iOS Safari PWA)
- GET requests to /login now correctly return HTML even when server redirects

The previous commit (7e3726d) broke login on regular browsers by converting GET /login redirects to JSON. When a user was already logged in, fetching the login page would result in JSON being returned instead of HTML, causing the form field extraction to fail.

## Test Plan

- [ ] Login on regular browser works (no form extraction error)
- [ ] Login on iOS Safari PWA still works
- [ ] Login when already authenticated correctly detects existing session