### PR TITLE
feat(auth): add client-side session token handling for iOS Safari PWA

### DIFF
--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -103,11 +103,9 @@ describe("API Client", () => {
     it("clears session and throws on 401 response", async () => {
       setCsrfToken("some-token");
 
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 401,
-        statusText: "Unauthorized",
-      });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({}, { ok: false, status: 401, statusText: "Unauthorized" }),
+      );
 
       await expect(api.searchAssignments({})).rejects.toThrow(
         "Session expired. Please log in again.",
@@ -117,11 +115,9 @@ describe("API Client", () => {
     it("clears session and throws on 403 response", async () => {
       setCsrfToken("some-token");
 
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 403,
-        statusText: "Forbidden",
-      });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({}, { ok: false, status: 403, statusText: "Forbidden" }),
+      );
 
       await expect(api.searchAssignments({})).rejects.toThrow(
         "Session expired. Please log in again.",
@@ -131,11 +127,9 @@ describe("API Client", () => {
     it("clears session and throws on 406 response", async () => {
       setCsrfToken("some-token");
 
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 406,
-        statusText: "Not Acceptable",
-      });
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({}, { ok: false, status: 406, statusText: "Not Acceptable" }),
+      );
 
       await expect(api.searchAssignments({})).rejects.toThrow(
         "Session expired. Please log in again.",

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -13,6 +13,9 @@ import {
   setCsrfToken as setToken,
   clearCsrfToken,
   getCsrfToken,
+  setSessionToken,
+  getSessionToken,
+  clearSessionToken,
 } from "./form-serialization";
 import { parseErrorResponse } from "./error-handling";
 import {
@@ -94,8 +97,36 @@ export function setCsrfToken(token: string | null) {
   setToken(token);
 }
 
+/**
+ * Session token header name used by the Cloudflare Worker for iOS Safari PWA.
+ * The worker sends session cookies via this header to bypass ITP cookie blocking.
+ */
+const SESSION_TOKEN_HEADER = "X-Session-Token";
+
+/**
+ * Capture session token from response headers.
+ * The Cloudflare Worker sends session cookies as X-Session-Token header
+ * to bypass iOS Safari ITP blocking third-party cookies in PWA mode.
+ */
+export function captureSessionToken(response: Response): void {
+  const token = response.headers.get(SESSION_TOKEN_HEADER);
+  if (token) {
+    setSessionToken(token);
+  }
+}
+
+/**
+ * Get headers for sending session token with requests.
+ * Returns the X-Session-Token header if a token is stored.
+ */
+export function getSessionHeaders(): HeadersInit {
+  const token = getSessionToken();
+  return token ? { [SESSION_TOKEN_HEADER]: token } : {};
+}
+
 export function clearSession() {
   clearCsrfToken();
+  clearSessionToken();
 }
 
 // Generic fetch wrapper

--- a/web-app/src/api/form-serialization.ts
+++ b/web-app/src/api/form-serialization.ts
@@ -20,6 +20,25 @@ export function clearCsrfToken() {
   csrfToken = null;
 }
 
+/**
+ * Session token for iOS Safari PWA mode.
+ * The Cloudflare Worker extracts session cookies from Set-Cookie headers
+ * and sends them as X-Session-Token header to bypass iOS Safari ITP.
+ */
+let sessionToken: string | null = null;
+
+export function setSessionToken(token: string | null) {
+  sessionToken = token;
+}
+
+export function getSessionToken(): string | null {
+  return sessionToken;
+}
+
+export function clearSessionToken() {
+  sessionToken = null;
+}
+
 export interface BuildFormDataOptions {
   /** Include CSRF token in params. Default true. Set false for GET requests. */
   includeCsrfToken?: boolean;

--- a/web-app/src/features/auth/utils/auth-parsers.ts
+++ b/web-app/src/features/auth/utils/auth-parsers.ts
@@ -4,6 +4,7 @@
  */
 
 import { authLogger as logger } from "@/shared/utils/auth-log-buffer";
+import { captureSessionToken, getSessionHeaders } from "@/api/client";
 
 /**
  * URL path pattern that indicates successful login redirect to dashboard.
@@ -183,7 +184,11 @@ async function fetchDashboardAfterLogin(dashboardUrl: string): Promise<LoginResu
     credentials: "include",
     redirect: "follow",
     cache: "no-store",
+    headers: getSessionHeaders(),
   });
+
+  // Capture session token from response headers (iOS Safari PWA)
+  captureSessionToken(dashboardResponse);
 
   if (!dashboardResponse.ok) {
     logger.warn("iOS PWA: Dashboard fetch failed after successful login redirect", {
@@ -343,9 +348,13 @@ export async function submitLoginCredentials(
     cache: "no-store",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
+      ...getSessionHeaders(),
     },
     body: formData,
   });
+
+  // Capture session token from response headers (iOS Safari PWA)
+  captureSessionToken(response);
 
   // Handle lockout response from proxy (auth brute-force protection)
   if (response.status === HTTP_STATUS_LOCKED) {

--- a/web-app/src/shared/stores/auth.test.ts
+++ b/web-app/src/shared/stores/auth.test.ts
@@ -6,6 +6,8 @@ import { setCsrfToken, clearSession } from "@/api/client";
 vi.mock("@/api/client", () => ({
   setCsrfToken: vi.fn(),
   clearSession: vi.fn(),
+  captureSessionToken: vi.fn(),
+  getSessionHeaders: vi.fn(() => ({})),
 }));
 
 


### PR DESCRIPTION
## Summary

- Add client-side handling for X-Session-Token header to bypass iOS Safari ITP blocking third-party cookies in PWA standalone mode
- Capture session tokens from response headers and send them with subsequent requests
- Update all auth-related fetch calls to include session headers

## Test Plan

- [ ] Verify login still works in regular browsers (Chrome, Firefox, Safari browser)
- [ ] Test on iOS Safari PWA to confirm session token is captured and sent
- [ ] Check debug panel shows `hasSessionToken: true` after login page fetch