### PR TITLE
fix(pwa): iOS Safari PWA login with encrypted session storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - iOS Safari PWA update detection - app now checks for updates when reopened after being suspended, ensuring users see the update prompt after quitting and reopening the PWA
-- iOS Safari PWA session persistence - session token now stored in localStorage to survive PWA restarts
+- iOS Safari PWA session persistence - session token now encrypted with Web Crypto API (AES-GCM) before storage in localStorage; encryption key stored as non-extractable CryptoKey in IndexedDB
 - iOS Safari PWA login now works reliably with multiple worker-side fixes (#687, #690):
   - Session cookies relayed via `X-Session-Token` header to bypass ITP third-party cookie blocking
   - Query parameters stripped from Referer header to prevent upstream server rejections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - iOS Safari PWA update detection - app now checks for updates when reopened after being suspended, ensuring users see the update prompt after quitting and reopening the PWA
+- iOS Safari PWA session persistence - session token now stored in localStorage to survive PWA restarts
 - iOS Safari PWA login now works reliably with multiple worker-side fixes (#687, #690):
   - Session cookies relayed via `X-Session-Token` header to bypass ITP third-party cookie blocking
   - Query parameters stripped from Referer header to prevent upstream server rejections
   - POST auth redirects converted to JSON responses, fixing `opaqueredirect` issue
   - Broadened successful login detection to match any dashboard redirect path
+  - Login success detection now checks for session cookie in redirect responses (fixes root path redirect)
 - OCR camera capture now auto-crops images to match the guide overlay, improving OCR accuracy by focusing on the scoresheet area
 - User now sees correct assignments after logging into a different association (#697)
 

--- a/web-app/src/api/form-serialization.ts
+++ b/web-app/src/api/form-serialization.ts
@@ -74,6 +74,9 @@ export function setSessionToken(token: string | null): void {
       })
       .catch(() => {
         // Fallback to plaintext on encryption failure
+        console.warn(
+          "[session-token] Encryption failed, falling back to plaintext storage",
+        );
         try {
           localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
         } catch {
@@ -82,6 +85,9 @@ export function setSessionToken(token: string | null): void {
       });
   } else {
     // Fallback to plaintext storage
+    console.warn(
+      "[session-token] Web Crypto not available, using plaintext storage",
+    );
     try {
       localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
     } catch {

--- a/web-app/src/api/form-serialization.ts
+++ b/web-app/src/api/form-serialization.ts
@@ -25,10 +25,18 @@ export function clearCsrfToken() {
  * The Cloudflare Worker extracts session cookies from Set-Cookie headers
  * and sends them as X-Session-Token header to bypass iOS Safari ITP.
  *
- * IMPORTANT: This token is persisted to localStorage to survive PWA restarts.
- * iOS Safari PWA mode loses cookies when the app is closed, so we need to
- * store the session token client-side and send it with each request.
+ * Security: Token is encrypted using Web Crypto API before storage.
+ * - Encryption key is stored in IndexedDB as a non-extractable CryptoKey
+ * - Encrypted token is stored in localStorage
+ * - Falls back to plaintext if Web Crypto is unavailable
  */
+import {
+  encryptToken,
+  decryptToken,
+  isSecureStorageAvailable,
+  clearEncryptionKey,
+} from "./session-crypto";
+
 const SESSION_TOKEN_STORAGE_KEY = "volleykit-session-token";
 
 /**
@@ -37,39 +45,113 @@ const SESSION_TOKEN_STORAGE_KEY = "volleykit-session-token";
  */
 let sessionTokenCache: string | null | undefined = undefined;
 
-export function setSessionToken(token: string | null) {
+/**
+ * Set the session token (encrypts and stores asynchronously).
+ * The in-memory cache is updated immediately for sync access.
+ */
+export function setSessionToken(token: string | null): void {
   sessionTokenCache = token;
-  try {
-    if (token) {
-      localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
-    } else {
-      localStorage.removeItem(SESSION_TOKEN_STORAGE_KEY);
-    }
-  } catch {
-    // localStorage may not be available (e.g., private browsing)
-  }
-}
 
-export function getSessionToken(): string | null {
-  // Lazy initialization from localStorage
-  if (sessionTokenCache === undefined) {
+  if (!token) {
+    // Clear storage synchronously
     try {
-      sessionTokenCache = localStorage.getItem(SESSION_TOKEN_STORAGE_KEY);
+      localStorage.removeItem(SESSION_TOKEN_STORAGE_KEY);
     } catch {
       // localStorage may not be available
-      sessionTokenCache = null;
+    }
+    return;
+  }
+
+  // Encrypt and store asynchronously
+  if (isSecureStorageAvailable()) {
+    encryptToken(token)
+      .then((encrypted) => {
+        try {
+          localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, encrypted);
+        } catch {
+          // localStorage may not be available
+        }
+      })
+      .catch(() => {
+        // Fallback to plaintext on encryption failure
+        try {
+          localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
+        } catch {
+          // localStorage may not be available
+        }
+      });
+  } else {
+    // Fallback to plaintext storage
+    try {
+      localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
+    } catch {
+      // localStorage may not be available
     }
   }
-  return sessionTokenCache;
 }
 
-export function clearSessionToken() {
+/**
+ * Get the session token synchronously from cache.
+ * Call initSessionToken() at app startup to load from encrypted storage.
+ */
+export function getSessionToken(): string | null {
+  return sessionTokenCache ?? null;
+}
+
+/**
+ * Initialize session token from encrypted storage.
+ * Should be called at app startup before any API requests.
+ */
+export async function initSessionToken(): Promise<void> {
+  if (sessionTokenCache !== undefined) {
+    return; // Already initialized
+  }
+
+  try {
+    const stored = localStorage.getItem(SESSION_TOKEN_STORAGE_KEY);
+    if (!stored) {
+      sessionTokenCache = null;
+      return;
+    }
+
+    if (isSecureStorageAvailable()) {
+      // Try to decrypt
+      const decrypted = await decryptToken(stored);
+      if (decrypted !== null) {
+        sessionTokenCache = decrypted;
+      } else {
+        // Decryption failed - token may be plaintext (migration) or corrupted
+        // Try using as-is if it looks like a valid token (base64)
+        if (/^[A-Za-z0-9+/=]+$/.test(stored)) {
+          sessionTokenCache = stored;
+        } else {
+          sessionTokenCache = null;
+          localStorage.removeItem(SESSION_TOKEN_STORAGE_KEY);
+        }
+      }
+    } else {
+      // No crypto available, use plaintext
+      sessionTokenCache = stored;
+    }
+  } catch {
+    sessionTokenCache = null;
+  }
+}
+
+/**
+ * Clear the session token and encryption key.
+ */
+export function clearSessionToken(): void {
   sessionTokenCache = null;
   try {
     localStorage.removeItem(SESSION_TOKEN_STORAGE_KEY);
   } catch {
     // localStorage may not be available
   }
+  // Clear encryption key asynchronously (don't wait)
+  clearEncryptionKey().catch(() => {
+    // Ignore errors during cleanup
+  });
 }
 
 export interface BuildFormDataOptions {

--- a/web-app/src/api/session-crypto.ts
+++ b/web-app/src/api/session-crypto.ts
@@ -1,0 +1,176 @@
+/**
+ * Session token encryption using Web Crypto API.
+ *
+ * Security model:
+ * - Encryption key is stored in IndexedDB as a non-extractable CryptoKey
+ * - Key cannot be read by JavaScript, only used for encrypt/decrypt operations
+ * - Encrypted token is stored in localStorage
+ * - AES-GCM provides both encryption and authentication
+ *
+ * This provides better protection than plaintext localStorage, though it's
+ * not equivalent to Secure Enclave (which requires native app access).
+ */
+
+const DB_NAME = "volleykit-security";
+const DB_VERSION = 1;
+const STORE_NAME = "keys";
+const KEY_ID = "session-encryption-key";
+/** AES-GCM uses 12-byte (96-bit) IV for optimal security */
+const AES_GCM_IV_LENGTH = 12;
+
+/**
+ * Open the IndexedDB database for key storage.
+ */
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+  });
+}
+
+/**
+ * Get or create the encryption key.
+ * Key is non-extractable, meaning it cannot be read by JavaScript.
+ */
+async function getOrCreateKey(): Promise<CryptoKey> {
+  const db = await openDatabase();
+
+  // Try to get existing key
+  const existingKey = await new Promise<CryptoKey | null>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(KEY_ID);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const result = request.result as { id: string; key: CryptoKey } | undefined;
+      resolve(result?.key ?? null);
+    };
+  });
+
+  if (existingKey) {
+    db.close();
+    return existingKey;
+  }
+
+  // Generate new key (non-extractable)
+  const newKey = await crypto.subtle.generateKey(
+    { name: "AES-GCM", length: 256 },
+    false, // non-extractable - cannot be read, only used
+    ["encrypt", "decrypt"],
+  );
+
+  // Store the key
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put({ id: KEY_ID, key: newKey });
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve();
+  });
+
+  db.close();
+  return newKey;
+}
+
+/**
+ * Encrypt a string using the stored key.
+ * Returns base64-encoded ciphertext with IV prepended.
+ */
+export async function encryptToken(plaintext: string): Promise<string> {
+  const key = await getOrCreateKey();
+
+  // Generate random IV
+  const iv = crypto.getRandomValues(new Uint8Array(AES_GCM_IV_LENGTH));
+
+  // Encode plaintext to bytes
+  const encoder = new TextEncoder();
+  const data = encoder.encode(plaintext);
+
+  // Encrypt
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    data,
+  );
+
+  // Combine IV + ciphertext and encode as base64
+  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ciphertext), iv.length);
+
+  return btoa(String.fromCharCode(...combined));
+}
+
+/**
+ * Decrypt a string using the stored key.
+ * Expects base64-encoded ciphertext with IV prepended.
+ */
+export async function decryptToken(encrypted: string): Promise<string | null> {
+  try {
+    const key = await getOrCreateKey();
+
+    // Decode from base64
+    const combined = Uint8Array.from(atob(encrypted), (c) => c.charCodeAt(0));
+
+    // Extract IV and ciphertext
+    const iv = combined.slice(0, AES_GCM_IV_LENGTH);
+    const ciphertext = combined.slice(AES_GCM_IV_LENGTH);
+
+    // Decrypt
+    const decrypted = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv },
+      key,
+      ciphertext,
+    );
+
+    // Decode bytes to string
+    const decoder = new TextDecoder();
+    return decoder.decode(decrypted);
+  } catch {
+    // Decryption failed (wrong key, tampered data, etc.)
+    return null;
+  }
+}
+
+/**
+ * Check if Web Crypto and IndexedDB are available.
+ */
+export function isSecureStorageAvailable(): boolean {
+  return (
+    typeof crypto !== "undefined" &&
+    typeof crypto.subtle !== "undefined" &&
+    typeof indexedDB !== "undefined"
+  );
+}
+
+/**
+ * Clear the encryption key (e.g., on logout).
+ * This invalidates all encrypted data.
+ */
+export async function clearEncryptionKey(): Promise<void> {
+  try {
+    const db = await openDatabase();
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, "readwrite");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.delete(KEY_ID);
+
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve();
+    });
+    db.close();
+  } catch {
+    // Ignore errors during cleanup
+  }
+}

--- a/web-app/src/main.tsx
+++ b/web-app/src/main.tsx
@@ -2,9 +2,18 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { initSessionToken } from "./api/form-serialization";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+// Initialize encrypted session token from storage before rendering
+// This ensures the token is available for any API requests during app startup
+initSessionToken()
+  .catch(() => {
+    // Ignore initialization errors - app will work without persisted session
+  })
+  .finally(() => {
+    createRoot(document.getElementById("root")!).render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+  });

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -2098,12 +2098,24 @@ describe("Auth Lockout", () => {
       ).toBe(false);
     });
 
-    it("returns false for redirect to root path", () => {
+    it("returns false for redirect to root path without session cookie", () => {
       expect(
         isSuccessfulLoginResponse(
           mockResponse(302, { Location: "https://volleymanager.volleyball.ch/" }),
         ),
       ).toBe(false);
+    });
+
+    it("detects redirect to root with session cookie", () => {
+      // If session cookie is set, login succeeded even if redirecting to root
+      expect(
+        isSuccessfulLoginResponse(
+          mockResponse(302, {
+            Location: "https://volleymanager.volleyball.ch/",
+            "Set-Cookie": "Neos_Session=abc123; Path=/",
+          }),
+        ),
+      ).toBe(true);
     });
 
     it("returns false for redirect to authentication endpoint", () => {


### PR DESCRIPTION
## Summary
- **Worker fix**: Detect successful login by presence of `Neos_Session` cookie in response headers, not just redirect URL
- **Session persistence**: Session token now persisted to localStorage to survive PWA restarts
- **Encrypted storage**: Session token encrypted with AES-GCM (256-bit) using Web Crypto API
- **Non-extractable key**: Encryption key stored in IndexedDB as non-extractable CryptoKey (cannot be read by JavaScript, only used for encrypt/decrypt)

## Problem
iOS Safari PWA was showing "Invalid username or password" because:
1. The worker incorrectly detected redirects to root path as failed logins, even when session cookie was set
2. Session token was only stored in memory, lost when PWA was closed

## Security Model
- Encryption key is stored in IndexedDB as a non-extractable CryptoKey
- Key cannot be read by JavaScript, only used for encrypt/decrypt operations
- Encrypted token is stored in localStorage
- AES-GCM provides both encryption and authentication
- Falls back to plaintext storage if Web Crypto is unavailable

## Test Plan
- [ ] Login works in browser (regression test)
- [ ] Login works in iOS Safari PWA
- [ ] Close and reopen iOS PWA - session persists
- [ ] Logout clears session token and encryption key