### PR TITLE
feat(pwa): enable login debug panel and real login for PR previews

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Build for PR Preview
         run: npm run build
         env:
-          VITE_DEMO_MODE_ONLY: 'true'
+          # Real login enabled for iOS PWA debugging (VITE_DEMO_MODE_ONLY not set)
           VITE_API_PROXY_URL: ${{ vars.VITE_API_PROXY_URL }}
           VITE_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
           VITE_OJP_API_KEY: ${{ secrets.VITE_OJP_API_KEY }}
@@ -265,7 +265,7 @@ jobs:
               `**OCR POC:** ${ocrPocUrl}\n\n` +
               `**Help Site:** ${helpUrl}\n\n` +
               `> This preview will be updated on each push to this PR.\n\n` +
-              `**Preview Mode:** Calendar mode login (read-only) and demo mode are available. Full login is disabled for security.`;
+              `**Login:** All login modes available (full, calendar, demo). Debug panel auto-shows for installed PWAs.`;
 
             // Check if comment already exists
             const { data: comments } = await github.rest.issues.listComments({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/pr-review` command for Claude Code - creates PR and automatically addresses Claude Code Review comments after 2-minute wait
 - Automated release workflow with semantic version auto-detection from changelog
 - PWA standalone mode detection - Settings now displays "PWA" instead of "Web" when running as installed app (#687)
+- Login debug panel now auto-shows for installed PWAs with copy button for sharing logs (#700)
+- Enhanced auth logging throughout login and session check flows for easier debugging (#700)
 
 ### Changed
 
+- PR previews now enable real login for iOS PWA debugging (VITE_DEMO_MODE_ONLY removed) (#700)
 - OCR POC now displays parsed roster data instead of comparing against dummy data, for debugging OCR recognition issues
 - Claude Code `/review` command now includes changelog status check
 - CLAUDE.md workflow now explicitly lists changelog update as step 2 before commit

--- a/web-app/src/shared/stores/auth.test.ts
+++ b/web-app/src/shared/stores/auth.test.ts
@@ -899,10 +899,11 @@ describe("useAuthStore", () => {
       const result = await useAuthStore.getState().checkSession();
 
       expect(result).toBe(false);
+      // authLogger logs with [Auth] prefix and passes error as object
       expect(consoleSpy).toHaveBeenCalledWith(
-        "[VolleyKit][App]",
-        "Session check failed:",
-        expect.any(Error),
+        "[Auth]",
+        "Session check failed",
+        expect.objectContaining({ error: expect.any(String) }),
       );
       consoleSpy.mockRestore();
     });
@@ -995,9 +996,11 @@ describe("useAuthStore", () => {
       expect(result).toBe(false);
       expect(useAuthStore.getState().status).toBe("idle");
       expect(useAuthStore.getState().user).toBeNull();
+      // authLogger logs with [Auth] prefix and empty string for no data
       expect(consoleSpy).toHaveBeenCalledWith(
-        "[VolleyKit][App]",
+        "[Auth]",
         "Session check timed out",
+        "",
       );
 
       consoleSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Auto-show login debug panel for installed PWAs (standalone mode detection)
- Add Copy button to export auth logs with version/platform info
- Enable real login in PR previews (remove VITE_DEMO_MODE_ONLY)
- Add comprehensive auth logging throughout login and session flows
- Update PR preview comment to reflect all login modes available

## Test Plan
- [ ] Install PWA on iOS Safari and verify debug panel auto-shows on login page
- [ ] Test Copy button exports logs with version, platform, and PWA mode info
- [ ] Deploy PR preview and verify real login works (not just demo/calendar mode)
- [ ] Verify auth logs capture login flow details for debugging