### PR TITLE
fix(auth): sync server-side active association after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Login success detection now checks for session cookie in redirect responses (fixes root path redirect)
 - OCR camera capture now auto-crops images to match the guide overlay, improving OCR accuracy by focusing on the scoresheet area
 - User now sees correct assignments after logging into a different association (#697)
+- Association dropdown now stays in sync with displayed data after logout and re-login
 
 ### Removed
 

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -764,6 +764,10 @@ export const api = {
 
 export type ApiClient = typeof api;
 
+// Export the API client directly for use in auth store
+// (auth store calls switchRoleAndAttribute after login to sync server state)
+export { api as apiClient };
+
 // Re-export DataSource from auth store for consumers that import from client
 export type { DataSource } from "@/shared/stores/auth";
 

--- a/web-app/src/shared/stores/auth.ts
+++ b/web-app/src/shared/stores/auth.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { setCsrfToken, clearSession, captureSessionToken, getSessionHeaders } from "@/api/client";
+import { setCsrfToken, clearSession, captureSessionToken, getSessionHeaders, apiClient } from "@/api/client";
 import {
   filterRefereeOccupations,
   parseOccupationsFromActiveParty,
@@ -320,6 +320,20 @@ export const useAuthStore = create<AuthState>()(
               activeOccupationId,
               _lastAuthTimestamp: Date.now(),
             });
+
+            // Sync server-side active association with client's selection.
+            // This ensures the API returns data for the correct association,
+            // especially after logout/re-login when the server's default
+            // may differ from the client's chosen occupation.
+            if (activeOccupationId) {
+              try {
+                await apiClient.switchRoleAndAttribute(activeOccupationId);
+              } catch (error) {
+                // Log but don't fail login - user can manually switch if needed
+                logger.warn("Failed to sync active association after login:", error);
+              }
+            }
+
             return true;
           }
 
@@ -357,6 +371,20 @@ export const useAuthStore = create<AuthState>()(
               activeOccupationId,
               _lastAuthTimestamp: Date.now(),
             });
+
+            // Sync server-side active association with client's selection.
+            // This ensures the API returns data for the correct association,
+            // especially after logout/re-login when the server's default
+            // may differ from the client's chosen occupation.
+            if (activeOccupationId) {
+              try {
+                await apiClient.switchRoleAndAttribute(activeOccupationId);
+              } catch (error) {
+                // Log but don't fail login - user can manually switch if needed
+                logger.warn("Failed to sync active association after login:", error);
+              }
+            }
+
             return true;
           }
 


### PR DESCRIPTION
## Summary
- After login, the client now calls `switchRoleAndAttribute` to ensure the server's active association matches the client's selection
- Fixes bug where association dropdown showed one association (e.g., SVRZ) but displayed data from another (e.g., SV) after logout/re-login

## Test plan
- [ ] Login with a user that has multiple associations
- [ ] Select a specific association (e.g., SV)
- [ ] Logout
- [ ] Login again
- [ ] Verify dropdown shows the first association and the displayed data matches