### PR TITLE
fix(auth): proactively establish session before login form extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Favicon now matches PWA icon for consistent branding across browser tabs and installed app
 - iOS Safari PWA update detection - app now checks for updates when reopened after being suspended, ensuring users see the update prompt after quitting and reopening the PWA
 - iOS Safari PWA session persistence - session token now encrypted with Web Crypto API (AES-GCM) before storage in localStorage; encryption key stored as non-extractable CryptoKey in IndexedDB
-- iOS Safari PWA login after logout - first login attempt no longer fails; login flow now re-fetches the login page with the captured session token to ensure form fields are generated for an established session (#701)
+- iOS Safari PWA first login failure - login now proactively establishes a session before fetching the login page form, ensuring the form's CSRF token matches the session state when credentials are submitted (#703)
 - iOS Safari PWA login now works reliably with multiple worker-side fixes (#687, #690):
   - Session cookies relayed via `X-Session-Token` header to bypass ITP third-party cookie blocking
   - Query parameters stripped from Referer header to prevent upstream server rejections


### PR DESCRIPTION
## Summary

- Fix iOS Safari PWA first login failure by proactively establishing a session before fetching the login page
- The Neos Flow framework's `__trustedProperties` HMAC is tied to session state; if no session exists when the form is generated but one is created during authentication, validation fails
- Add `ensureSessionEstablished()` function that fetches the dashboard endpoint to trigger session creation before extracting login form fields
- Extract `handleSuccessfulLoginResult()` helper to reduce code duplication

Fixes #703

## Test Plan

- [x] All 55 auth store tests pass
- [x] All 590 tests pass
- [x] Lint, knip, and build pass
- [ ] Fresh install login succeeds on first attempt in iOS Safari PWA
- [ ] Login after logout succeeds on first attempt in iOS Safari PWA
- [ ] Regular browser login continues to work