### PR TITLE
fix(ci): use heredoc for release notes in dry run summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,9 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "### Release Notes Preview" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo '${{ steps.changelog.outputs.release-notes }}' >> "$GITHUB_STEP_SUMMARY"
+            cat << 'RELEASE_NOTES' >> "$GITHUB_STEP_SUMMARY"
+          ${{ steps.changelog.outputs.release-notes }}
+          RELEASE_NOTES
           else
             echo "## Release Complete" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Fixed bash syntax error in release workflow dry run mode
- Release notes containing parentheses (like `(#704)`) caused shell interpretation errors
- Using a heredoc with quoted delimiter prevents shell from parsing special characters

## Test Plan
- Run the release workflow in dry run mode
- Verify the summary step completes without syntax errors
- Check that release notes are displayed correctly in the step summary