### PR TITLE
fix(test): stub __APP_VERSION__ in SettingsPage test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Release workflow test failures - SettingsPage test now stubs `__APP_VERSION__` instead of hardcoding version (#710)
+
 ## [1.1.0] - 2026-01-11
 
 ### Added

--- a/web-app/src/features/settings/SettingsPage.test.tsx
+++ b/web-app/src/features/settings/SettingsPage.test.tsx
@@ -35,6 +35,9 @@ function createWrapper() {
 // Disable PWA for tests by default
 vi.stubGlobal('__PWA_ENABLED__', false)
 
+// Stub app version to avoid test failures on version bumps
+vi.stubGlobal('__APP_VERSION__', '1.0.0-test')
+
 const mockUser = {
   id: 'user-1',
   firstName: 'John',
@@ -147,7 +150,7 @@ describe('SettingsPage', () => {
   describe('About Section', () => {
     it('displays version info', () => {
       render(<SettingsPage />, { wrapper: createWrapper() })
-      expect(screen.getByText('1.0.2')).toBeInTheDocument()
+      expect(screen.getByText('1.0.0-test')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary

- Fixed SettingsPage test that was failing after version bumps
- The test was hardcoding version `1.0.2` but the release workflow updated it to `1.1.0`
- Now uses `vi.stubGlobal("__APP_VERSION__", "1.0.0-test")` for a consistent test value

## Test plan

- [x] Verified all 3297 tests pass
- [x] Verified lint passes
- [x] Verified knip passes
- [x] Verified build succeeds