### PR TITLE
fix(compensations): nest __identity inside convocationCompensation for API updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Compensation update API now sends `__identity` nested inside `convocationCompensation` object, matching the format expected by the VolleyManager API - this fixes 500 errors when saving compensation edits
 - Compensation API calls now work correctly when editing from the Assignments tab - the hook was incorrectly using the global `api` object instead of the data-source-aware `getApiClient()`, which could cause issues in calendar mode
 
 ## [1.1.1] - 2026-01-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Compensation API calls now work correctly when editing from the Assignments tab - the hook was incorrectly using the global `api` object instead of the data-source-aware `getApiClient()`, which could cause issues in calendar mode
+
 ## [1.1.1] - 2026-01-11
 
 ### Fixed

--- a/docs/api/captures/assignment_actions.md
+++ b/docs/api/captures/assignment_actions.md
@@ -36,19 +36,22 @@ Likely uses the same 3 endpoints as match details:
 
 Opens compensation editing form.
 
-**Endpoint (hypothesized):**
+**Endpoint (confirmed):**
 
 ```
-PUT /api/indoorvolleyball.refadmin/api\refereeconvocationcompensation
+PUT /api/indoorvolleyball.refadmin/api\convocationcompensation
 ```
 
 **Request format:**
 
+IMPORTANT: The `__identity` must be nested inside `convocationCompensation`, not at root level!
+
 ```
-__identity=<compensation-uuid>
-&convocationCompensation[transportationMode]=car
-&convocationCompensation[distanceInMetres]=96317
-&convocationCompensation[travelExpenses]=20
+convocationCompensation[__identity]=<compensation-uuid>
+&convocationCompensation[distanceInMetres]=56000
+&convocationCompensation[correctionReason]=<reason-text>
+&convocationCompensation[payTravelExpenses]=1
+&convocationCompensation[travelExpensesPercentageWeighting]=1
 &__csrfToken=<token>
 ```
 

--- a/docs/api/captures/compensation_edit_endpoints.md
+++ b/docs/api/captures/compensation_edit_endpoints.md
@@ -134,16 +134,20 @@ PUT /api/indoorvolleyball.refadmin/api\convocationcompensation
 
 **Request Format:**
 
-```
-Content-Type: application/x-www-form-urlencoded
+IMPORTANT: The `__identity` must be nested inside `convocationCompensation`, not at root level!
 
-__identity=<compensation-uuid>
+```
+Content-Type: text/plain;charset=UTF-8
+
+convocationCompensation[__identity]=<compensation-uuid>
+&convocationCompensation[distanceInMetres]=56000
+&convocationCompensation[correctionReason]=<reason-text>
 &convocationCompensation[payTravelExpenses]=1
 &convocationCompensation[travelExpensesPercentageWeighting]=1
 &__csrfToken=<token>
 ```
 
-**Response:** 200 OK on success
+**Response:** 200 OK on success with updated compensation record as JSON
 
 After saving, the assignments list is automatically refreshed via `searchMyRefereeConvocations`.
 

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -623,6 +623,9 @@ paths:
       description: |
         Updates the compensation settings for a convocation.
         Used by the "Editer les frais et l'indemnité" dialog save action.
+
+        IMPORTANT: The `__identity` field must be nested inside `convocationCompensation`,
+        not at the root level. Example: `convocationCompensation[__identity]=uuid`
       operationId: updateConvocationCompensation
       requestBody:
         required: true
@@ -630,13 +633,21 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               type: object
-              required: [__identity, __csrfToken]
+              required: [convocationCompensation[__identity], __csrfToken]
               properties:
-                __identity:
+                convocationCompensation[__identity]:
                   type: string
                   format: uuid
-                  description: The compensation record identifier
+                  description: The compensation record identifier (nested inside convocationCompensation)
                   example: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+                convocationCompensation[distanceInMetres]:
+                  type: integer
+                  description: Distance in metres for travel expense calculation
+                  example: 56000
+                convocationCompensation[correctionReason]:
+                  type: string
+                  description: Reason for any correction to the compensation
+                  example: "Ich wohne in Oberengstringen"
                 convocationCompensation[payTravelExpenses]:
                   type: string
                   enum: ["0", "1"]

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -633,7 +633,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               type: object
-              required: [convocationCompensation[__identity], __csrfToken]
+              required: ["convocationCompensation[__identity]", __csrfToken]
               properties:
                 convocationCompensation[__identity]:
                   type: string

--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -380,14 +380,15 @@ describe('API Client', () => {
       )
     })
 
-    it('includes compensation ID in request body', async () => {
+    it('includes compensation ID nested in convocationCompensation', async () => {
       mockFetch.mockResolvedValueOnce(createMockResponse({}))
 
       await api.updateCompensation('comp-456', { distanceInMetres: 60000 })
 
       const [, options] = mockFetch.mock.calls[0]!
       const body = options.body as URLSearchParams
-      expect(body.get('__identity')).toBe('comp-456')
+      // __identity must be nested inside convocationCompensation per API requirements
+      expect(body.get('convocationCompensation[__identity]')).toBe('comp-456')
     })
 
     it('includes distanceInMetres in nested convocationCompensation object', async () => {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -258,28 +258,23 @@ export const api = {
     compensationId: string,
     data: { distanceInMetres?: number; correctionReason?: string }
   ): Promise<void> {
-    const requestBody: Record<string, unknown> = {
+    // The __identity must be nested inside convocationCompensation, not at root level
+    const convocationCompensation: Record<string, unknown> = {
       __identity: compensationId,
     }
 
     if (data.distanceInMetres !== undefined) {
-      requestBody['convocationCompensation'] = {
-        ...(requestBody['convocationCompensation'] as object),
-        distanceInMetres: data.distanceInMetres,
-      }
+      convocationCompensation.distanceInMetres = data.distanceInMetres
     }
 
     if (data.correctionReason !== undefined) {
-      requestBody['convocationCompensation'] = {
-        ...(requestBody['convocationCompensation'] as object),
-        correctionReason: data.correctionReason,
-      }
+      convocationCompensation.correctionReason = data.correctionReason
     }
 
     return apiRequest(
       '/indoorvolleyball.refadmin/api%5cconvocationcompensation',
       'PUT',
-      requestBody
+      { convocationCompensation }
     )
   },
 


### PR DESCRIPTION
## Summary

- Fixed the compensation update API to send `__identity` nested inside `convocationCompensation` object
- This matches the format expected by the VolleyManager API and fixes 500 errors when saving compensation edits
- Also includes the earlier fix for using `getApiClient(dataSource)` instead of the global `api` object
- Updated OpenAPI spec and API documentation with the correct request format

**Root cause:** The API requires `convocationCompensation[__identity]=uuid`, not `__identity=uuid` at root level.

## Test plan

- [x] All 160 test files pass (3326 tests)
- [x] Build succeeds
- [ ] Test saving compensation edits in production with real API