### PR TITLE
fix(ux): show error toast when compensation save fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Compensation update API now sends `__identity` nested inside `convocationCompensation` object, matching the format expected by the VolleyManager API - this fixes 500 errors when saving compensation edits
 - Compensation API calls now work correctly when editing from the Assignments tab - the hook was incorrectly using the global `api` object instead of the data-source-aware `getApiClient()`, which could cause issues in calendar mode
+- Compensation edits now show error toast when save fails - previously, failed API calls were silently swallowed and the modal closed without feedback (#714)
 
 ## [1.1.1] - 2026-01-11
 

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -401,6 +401,9 @@ export interface paths {
          * Update convocation compensation
          * @description Updates the compensation settings for a convocation.
          *     Used by the "Editer les frais et l'indemnité" dialog save action.
+         *
+         *     IMPORTANT: The `__identity` field must be nested inside `convocationCompensation`,
+         *     not at the root level. Example: `convocationCompensation[__identity]=uuid`
          */
         put: operations["updateConvocationCompensation"];
         post?: never;
@@ -4983,10 +4986,20 @@ export interface operations {
                 "application/x-www-form-urlencoded": {
                     /**
                      * Format: uuid
-                     * @description The compensation record identifier
+                     * @description The compensation record identifier (nested inside convocationCompensation)
                      * @example cccccccc-cccc-cccc-cccc-cccccccccccc
                      */
-                    __identity: string;
+                    "convocationCompensation[__identity]": string;
+                    /**
+                     * @description Distance in metres for travel expense calculation
+                     * @example 56000
+                     */
+                    "convocationCompensation[distanceInMetres]"?: number;
+                    /**
+                     * @description Reason for any correction to the compensation
+                     * @example Ich wohne in Oberengstringen
+                     */
+                    "convocationCompensation[correctionReason]"?: string;
                     /**
                      * @description Whether travel expenses should be paid
                      * @enum {string}

--- a/web-app/src/features/compensations/components/EditCompensationModal.test.tsx
+++ b/web-app/src/features/compensations/components/EditCompensationModal.test.tsx
@@ -93,8 +93,13 @@ async function waitForFormToLoad() {
 
 describe('EditCompensationModal', () => {
   const mockOnClose = vi.fn()
-  const mockMutate = vi.fn()
-  const mockAssignmentMutate = vi.fn()
+  // Mock mutate to call onSuccess callback immediately (simulates successful mutation)
+  const mockMutate = vi.fn((_, options) => {
+    options?.onSuccess?.()
+  })
+  const mockAssignmentMutate = vi.fn((_, options) => {
+    options?.onSuccess?.()
+  })
   const mockGetCompensationDetails = vi.fn()
   const mockSearchCompensations = vi.fn()
   const mockGetAssignmentCompensation = vi.fn()

--- a/web-app/src/features/compensations/components/EditCompensationModal.tsx
+++ b/web-app/src/features/compensations/components/EditCompensationModal.tsx
@@ -25,6 +25,7 @@ import { COMPENSATION_LOOKUP_LIMIT } from '@/shared/hooks/usePaginatedQuery'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useAuthStore } from '@/shared/stores/auth'
 import { useDemoStore } from '@/shared/stores/demo'
+import { toast } from '@/shared/stores/toast'
 import {
   DECIMAL_INPUT_PATTERN,
   formatDistanceKm,
@@ -81,6 +82,10 @@ function EditCompensationModalComponent({
 
   // Determine if we're editing an assignment or a compensation record
   const isAssignmentEdit = !!assignment && !compensation
+
+  // Track saving state to disable buttons during save
+  const isSaving =
+    updateCompensationMutation.isPending || updateAssignmentCompensationMutation.isPending
 
   // Get the compensation ID from the compensation record
   // Assignments don't have convocationCompensation, only CompensationRecord does
@@ -301,6 +306,15 @@ function EditCompensationModalComponent({
                   assignmentId: assignment.__identity,
                   ...updateData,
                 })
+                toast.success(t('compensations.saveSuccess'))
+                onClose()
+              },
+              onError: (error) => {
+                logger.error('[EditCompensationModal] Failed to update assignment compensation:', {
+                  assignmentId: assignment.__identity,
+                  error,
+                })
+                toast.error(t('compensations.saveError'))
               },
             }
           )
@@ -314,13 +328,23 @@ function EditCompensationModalComponent({
                   compensationId,
                   ...updateData,
                 })
+                toast.success(t('compensations.saveSuccess'))
+                onClose()
+              },
+              onError: (error) => {
+                logger.error('[EditCompensationModal] Failed to update compensation:', {
+                  compensationId,
+                  error,
+                })
+                toast.error(t('compensations.saveError'))
               },
             }
           )
         }
+      } else {
+        // No changes to save, just close
+        onClose()
       }
-
-      onClose()
     },
     [
       assignment,
@@ -426,10 +450,16 @@ function EditCompensationModalComponent({
             </div>
 
             <ModalFooter>
-              <Button variant="secondary" className="flex-1" onClick={onClose}>
+              <Button variant="secondary" className="flex-1" onClick={onClose} disabled={isSaving}>
                 {t('common.close')}
               </Button>
-              <Button variant="primary" className="flex-1" type="submit">
+              <Button
+                variant="primary"
+                className="flex-1"
+                type="submit"
+                disabled={isSaving}
+                loading={isSaving}
+              >
                 {t('common.save')}
               </Button>
             </ModalFooter>

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -298,6 +298,8 @@ const de: Translations = {
       'Entschädigungseintrag nicht gefunden. Das Spiel liegt möglicherweise zu weit in der Zukunft.',
     compensationMissingId:
       'Entschädigungseintrag hat keine Kennung. Bitte versuchen Sie es später erneut.',
+    saveError: 'Entschädigung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.',
+    saveSuccess: 'Entschädigung erfolgreich gespeichert.',
     unavailableInCalendarModeTitle: 'Im Kalender-Modus nicht verfügbar',
     unavailableInCalendarModeDescription:
       'Entschädigungsdaten sind im Kalender-Modus nicht verfügbar. Verwenden Sie die vollständige Anmeldung, um auf Entschädigungsdetails zuzugreifen.',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -292,6 +292,8 @@ const en: Translations = {
       'Assignment not found in cache. Please refresh the page and try again.',
     compensationNotFound: 'Compensation record not found. The game may be too far in the future.',
     compensationMissingId: 'Compensation record is missing an identifier. Please try again later.',
+    saveError: 'Failed to save compensation. Please try again.',
+    saveSuccess: 'Compensation saved successfully.',
     unavailableInCalendarModeTitle: 'Not available in Calendar Mode',
     unavailableInCalendarModeDescription:
       'Compensation data is not available in calendar mode. Use full login to access compensation details.',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -299,6 +299,8 @@ const fr: Translations = {
       "Enregistrement d'indemnité introuvable. Le match est peut-être trop éloigné dans le futur.",
     compensationMissingId:
       "L'enregistrement d'indemnité n'a pas d'identifiant. Veuillez réessayer plus tard.",
+    saveError: "Échec de l'enregistrement de l'indemnité. Veuillez réessayer.",
+    saveSuccess: 'Indemnité enregistrée avec succès.',
     unavailableInCalendarModeTitle: 'Non disponible en mode calendrier',
     unavailableInCalendarModeDescription:
       "Les données d'indemnités ne sont pas disponibles en mode calendrier. Utilisez la connexion complète pour accéder aux détails des indemnités.",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -297,6 +297,8 @@ const it: Translations = {
     compensationNotFound:
       'Record di compenso non trovato. La partita potrebbe essere troppo lontana nel futuro.',
     compensationMissingId: 'Il record di compenso non ha un identificatore. Riprova più tardi.',
+    saveError: 'Impossibile salvare il compenso. Riprova.',
+    saveSuccess: 'Compenso salvato con successo.',
     unavailableInCalendarModeTitle: 'Non disponibile in modalità calendario',
     unavailableInCalendarModeDescription:
       "I dati dei compensi non sono disponibili in modalità calendario. Usa l'accesso completo per accedere ai dettagli dei compensi.",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -184,6 +184,8 @@ export interface Translations {
     assignmentNotFoundInCache: string
     compensationNotFound: string
     compensationMissingId: string
+    saveError: string
+    saveSuccess: string
     unavailableInCalendarModeTitle: string
     unavailableInCalendarModeDescription: string
   }


### PR DESCRIPTION
## Summary

- When saving compensation edits, the modal now waits for the mutation to complete before closing
- Shows an error toast if the save fails
- Shows a success toast on successful save
- Disables the buttons during save to prevent double submission
- Regenerated API types from updated OpenAPI spec

Closes #714

## Test plan

- [ ] Edit compensation from the Compensations tab and verify save shows success toast
- [ ] Edit compensation from the Assignments tab and verify save shows success toast  
- [ ] Simulate API error and verify error toast is shown and modal stays open
- [ ] Verify buttons are disabled during save