### PR TITLE
fix(pwa): show update banner on login page when new version available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- PWA login page now shows prominent update banner when a new version is available - previously users could attempt login with stale cached code, causing confusing username/password errors; the banner prompts users to update before logging in
 - Compensation update API now sends `__identity` nested inside `convocationCompensation` object, matching the format expected by the VolleyManager API - this fixes 500 errors when saving compensation edits
 - Compensation API calls now work correctly when editing from the Assignments tab - the hook was incorrectly using the global `api` object instead of the data-source-aware `getApiClient()`, which could cause issues in calendar mode
 - Compensation edits now show error toast when save fails - previously, failed API calls were silently swallowed and the modal closed without feedback (#714)

--- a/web-app/src/features/auth/LoginPage.tsx
+++ b/web-app/src/features/auth/LoginPage.tsx
@@ -3,10 +3,12 @@ import { useState, useRef, useEffect, useCallback, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useShallow } from 'zustand/react/shallow'
 
+import { usePWA } from '@/contexts/PWAContext'
 import {
   extractCalendarCode,
   validateCalendarCode,
 } from '@/features/assignments/utils/calendar-helpers'
+import { LoginUpdateBanner } from '@/features/auth/components/LoginUpdateBanner'
 import { Button } from '@/shared/components/Button'
 import { Volleyball } from '@/shared/components/icons'
 import { LanguageSwitcher } from '@/shared/components/LanguageSwitcher'
@@ -38,6 +40,7 @@ export function LoginPage() {
     )
   const initializeDemoData = useDemoStore((state) => state.initializeDemoData)
   const { t } = useTranslation()
+  const { needRefresh, updateApp } = usePWA()
 
   const [loginMode, setLoginMode] = useState<LoginMode>('calendar')
   const [username, setUsername] = useState('')
@@ -266,6 +269,9 @@ export function LoginPage() {
           </h1>
           <p className="mt-2 text-text-muted dark:text-text-muted-dark">{t('auth.subtitle')}</p>
         </div>
+
+        {/* Update banner - shown when PWA needs update to prevent login errors */}
+        {needRefresh && <LoginUpdateBanner onUpdate={updateApp} />}
 
         {/* Login form */}
         <div className="card p-6">

--- a/web-app/src/features/auth/components/LoginUpdateBanner.tsx
+++ b/web-app/src/features/auth/components/LoginUpdateBanner.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+
+import { RefreshCw } from '@/shared/components/icons'
+import { useTranslation } from '@/shared/hooks/useTranslation'
+
+interface LoginUpdateBannerProps {
+  onUpdate: () => Promise<void>
+}
+
+/**
+ * Prominent update banner for the login page.
+ * Shown when PWA needs a refresh to ensure users update before logging in,
+ * preventing authentication errors from stale cached code.
+ */
+export function LoginUpdateBanner({ onUpdate }: LoginUpdateBannerProps) {
+  const [isUpdating, setIsUpdating] = useState(false)
+  const { t } = useTranslation()
+
+  const handleUpdate = async () => {
+    if (isUpdating) return
+    setIsUpdating(true)
+    try {
+      await onUpdate()
+    } finally {
+      // Note: updateApp() typically reloads, so this may not execute
+      setIsUpdating(false)
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="mb-6 rounded-lg border border-warning-300 bg-warning-50 p-4 dark:border-warning-700 dark:bg-warning-900/30"
+    >
+      <div className="flex items-start gap-3">
+        <RefreshCw
+          className="mt-0.5 h-5 w-5 flex-shrink-0 text-warning-600 dark:text-warning-400"
+          aria-hidden="true"
+        />
+        <div className="flex-1">
+          <p className="text-sm font-medium text-warning-800 dark:text-warning-200">
+            {t('auth.updateRequired')}
+          </p>
+          <p className="mt-1 text-sm text-warning-700 dark:text-warning-300">
+            {t('auth.updateRequiredDescription')}
+          </p>
+        </div>
+      </div>
+      <div className="mt-3 flex justify-end">
+        <button
+          type="button"
+          onClick={handleUpdate}
+          disabled={isUpdating}
+          aria-busy={isUpdating}
+          className="inline-flex items-center gap-2 rounded-md bg-warning-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-warning-700 focus:outline-none focus:ring-2 focus:ring-warning-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-warning-500 dark:hover:bg-warning-600"
+        >
+          {isUpdating && (
+            <RefreshCw className="h-4 w-4 animate-spin" aria-hidden="true" />
+          )}
+          {isUpdating ? t('auth.updating') : t('auth.updateNow')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -187,6 +187,11 @@ const de: Translations = {
     accountLocked: 'Konto vorübergehend gesperrt',
     lockoutRemainingTime: 'Versuchen Sie es in',
     lockoutSeconds: 'Sekunden erneut',
+    updateRequired: 'App-Update erforderlich',
+    updateRequiredDescription:
+      'Eine neue Version ist verfügbar. Bitte aktualisieren Sie vor der Anmeldung, um Fehler zu vermeiden.',
+    updateNow: 'Jetzt aktualisieren',
+    updating: 'Aktualisierung...',
   },
   calendarError: {
     title: 'Kalenderfehler',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -185,6 +185,11 @@ const en: Translations = {
     accountLocked: 'Account temporarily locked',
     lockoutRemainingTime: 'Try again in',
     lockoutSeconds: 'seconds',
+    updateRequired: 'App Update Required',
+    updateRequiredDescription:
+      'A new version is available. Please update before logging in to avoid errors.',
+    updateNow: 'Update Now',
+    updating: 'Updating...',
   },
   calendarError: {
     title: 'Calendar Error',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -188,6 +188,11 @@ const fr: Translations = {
     accountLocked: 'Compte temporairement verrouillé',
     lockoutRemainingTime: 'Réessayez dans',
     lockoutSeconds: 'secondes',
+    updateRequired: 'Mise à jour requise',
+    updateRequiredDescription:
+      'Une nouvelle version est disponible. Veuillez mettre à jour avant de vous connecter pour éviter les erreurs.',
+    updateNow: 'Mettre à jour',
+    updating: 'Mise à jour...',
   },
   calendarError: {
     title: 'Erreur de calendrier',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -187,6 +187,11 @@ const it: Translations = {
     accountLocked: 'Account temporaneamente bloccato',
     lockoutRemainingTime: 'Riprova tra',
     lockoutSeconds: 'secondi',
+    updateRequired: 'Aggiornamento richiesto',
+    updateRequiredDescription:
+      'È disponibile una nuova versione. Aggiorna prima di accedere per evitare errori.',
+    updateNow: 'Aggiorna ora',
+    updating: 'Aggiornamento...',
   },
   calendarError: {
     title: 'Errore calendario',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -84,6 +84,10 @@ export interface Translations {
     accountLocked: string
     lockoutRemainingTime: string
     lockoutSeconds: string
+    updateRequired: string
+    updateRequiredDescription: string
+    updateNow: string
+    updating: string
   }
   calendarError: {
     title: string


### PR DESCRIPTION
## Summary
- Add prominent update banner on login page when PWA update is pending
- Prevents users from attempting login with stale cached code, which caused confusing username/password errors
- Banner prompts users to update before logging in

## Test plan
- [ ] Build and install PWA
- [ ] Deploy a new version while having the old version cached
- [ ] Open the login page and verify the update banner appears
- [ ] Click "Update Now" and verify the app reloads with the new version
- [ ] Verify login works after updating