### PR TITLE
feat(settings): add notification settings UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Notification settings section in Settings page - users can now enable/disable browser notifications and configure reminder time preferences
+
 ### Fixed
 
 - PWA login page now shows prominent update banner when a new version is available - previously users could attempt login with stale cached code, causing confusing username/password errors; the banner prompts users to update before logging in

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -73,7 +73,7 @@
     {
       "name": "Total JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "510 kB",
+      "limit": "515 kB",
       "gzip": true
     }
   ],

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -271,11 +271,9 @@ export const api = {
       convocationCompensation.correctionReason = data.correctionReason
     }
 
-    return apiRequest(
-      '/indoorvolleyball.refadmin/api%5cconvocationcompensation',
-      'PUT',
-      { convocationCompensation }
-    )
+    return apiRequest('/indoorvolleyball.refadmin/api%5cconvocationcompensation', 'PUT', {
+      convocationCompensation,
+    })
   },
 
   // Game Exchanges

--- a/web-app/src/features/auth/components/LoginUpdateBanner.tsx
+++ b/web-app/src/features/auth/components/LoginUpdateBanner.tsx
@@ -55,9 +55,7 @@ export function LoginUpdateBanner({ onUpdate }: LoginUpdateBannerProps) {
           aria-busy={isUpdating}
           className="inline-flex items-center gap-2 rounded-md bg-warning-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-warning-700 focus:outline-none focus:ring-2 focus:ring-warning-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-warning-500 dark:hover:bg-warning-600"
         >
-          {isUpdating && (
-            <RefreshCw className="h-4 w-4 animate-spin" aria-hidden="true" />
-          )}
+          {isUpdating && <RefreshCw className="h-4 w-4 animate-spin" aria-hidden="true" />}
           {isUpdating ? t('auth.updating') : t('auth.updateNow')}
         </button>
       </div>

--- a/web-app/src/features/settings/SettingsPage.test.tsx
+++ b/web-app/src/features/settings/SettingsPage.test.tsx
@@ -70,6 +70,12 @@ function mockSettingsStore(overrides = {}) {
   const state = {
     isSafeModeEnabled: true,
     setSafeMode: mockSetSafeMode,
+    notificationSettings: {
+      enabled: false,
+      reminderTimes: ['1h'] as const,
+    },
+    setNotificationsEnabled: vi.fn(),
+    setNotificationReminderTimes: vi.fn(),
     ...overrides,
   }
   vi.mocked(settingsStore.useSettingsStore).mockReturnValue(

--- a/web-app/src/features/settings/SettingsPage.tsx
+++ b/web-app/src/features/settings/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { useSettingsStore } from '@/shared/stores/settings'
 import {
   ProfileSection,
   PreferencesSection,
+  NotificationsSection,
   HomeLocationSection,
   TravelSettingsSection,
   DataProtectionSection,
@@ -42,6 +43,9 @@ export function SettingsPage() {
     setSafeValidation,
     preventZoom,
     setPreventZoom,
+    notificationSettings,
+    setNotificationsEnabled,
+    setNotificationReminderTimes,
   } = useSettingsStore(
     useShallow((state) => ({
       isSafeModeEnabled: state.isSafeModeEnabled,
@@ -50,6 +54,9 @@ export function SettingsPage() {
       setSafeValidation: state.setSafeValidation,
       preventZoom: state.preventZoom,
       setPreventZoom: state.setPreventZoom,
+      notificationSettings: state.notificationSettings,
+      setNotificationsEnabled: state.setNotificationsEnabled,
+      setNotificationReminderTimes: state.setNotificationReminderTimes,
     }))
   )
   const { t } = useTranslation()
@@ -66,6 +73,13 @@ export function SettingsPage() {
       {user && <ProfileSection user={user} />}
 
       <PreferencesSection preventZoom={preventZoom} onSetPreventZoom={setPreventZoom} />
+
+      <NotificationsSection
+        notificationsEnabled={notificationSettings.enabled}
+        reminderTimes={notificationSettings.reminderTimes}
+        onSetNotificationsEnabled={setNotificationsEnabled}
+        onSetReminderTimes={setNotificationReminderTimes}
+      />
 
       <HomeLocationSection />
 

--- a/web-app/src/features/settings/components/NotificationsSection.test.tsx
+++ b/web-app/src/features/settings/components/NotificationsSection.test.tsx
@@ -1,0 +1,228 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import * as notificationService from '@/shared/services/notifications'
+
+import { NotificationsSection } from './NotificationsSection'
+
+vi.mock('@/shared/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/shared/services/notifications', () => ({
+  notificationService: {
+    isSupported: vi.fn(() => true),
+    getPermission: vi.fn(() => 'default'),
+    requestPermission: vi.fn(),
+  },
+  REMINDER_TIME_OPTIONS: ['1h', '2h', '1d'],
+}))
+
+const defaultProps = {
+  notificationsEnabled: false,
+  reminderTimes: ['1h'] as ('1h' | '2h' | '1d')[],
+  onSetNotificationsEnabled: vi.fn(),
+  onSetReminderTimes: vi.fn(),
+}
+
+describe('NotificationsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(notificationService.notificationService.isSupported).mockReturnValue(true)
+    vi.mocked(notificationService.notificationService.getPermission).mockReturnValue('default')
+  })
+
+  describe('when notifications not supported', () => {
+    it('shows not supported message', () => {
+      vi.mocked(notificationService.notificationService.isSupported).mockReturnValue(false)
+
+      render(<NotificationsSection {...defaultProps} />)
+
+      expect(screen.getByText('settings.notifications.notSupported')).toBeInTheDocument()
+    })
+  })
+
+  describe('when permission not yet requested', () => {
+    it('shows enable notifications button', () => {
+      render(<NotificationsSection {...defaultProps} />)
+
+      expect(screen.getByText('settings.notifications.enableNotifications')).toBeInTheDocument()
+    })
+
+    it('requests permission when button clicked', async () => {
+      vi.mocked(notificationService.notificationService.requestPermission).mockResolvedValue(
+        'granted'
+      )
+
+      render(<NotificationsSection {...defaultProps} />)
+
+      const button = screen.getByText('settings.notifications.enableNotifications')
+      fireEvent.click(button)
+
+      expect(notificationService.notificationService.requestPermission).toHaveBeenCalled()
+    })
+
+    it('enables notifications after permission granted', async () => {
+      vi.mocked(notificationService.notificationService.requestPermission).mockResolvedValue(
+        'granted'
+      )
+      const onSetNotificationsEnabled = vi.fn()
+
+      render(
+        <NotificationsSection {...defaultProps} onSetNotificationsEnabled={onSetNotificationsEnabled} />
+      )
+
+      const button = screen.getByText('settings.notifications.enableNotifications')
+      await fireEvent.click(button)
+
+      // Wait for async permission request to complete
+      await vi.waitFor(() => {
+        expect(onSetNotificationsEnabled).toHaveBeenCalledWith(true)
+      })
+    })
+  })
+
+  describe('when permission denied', () => {
+    it('shows permission denied warning', () => {
+      vi.mocked(notificationService.notificationService.getPermission).mockReturnValue('denied')
+
+      render(<NotificationsSection {...defaultProps} />)
+
+      expect(screen.getByText('settings.notifications.permissionDenied')).toBeInTheDocument()
+    })
+
+    it('does not show enable button', () => {
+      vi.mocked(notificationService.notificationService.getPermission).mockReturnValue('denied')
+
+      render(<NotificationsSection {...defaultProps} />)
+
+      expect(
+        screen.queryByText('settings.notifications.enableNotifications')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when permission granted', () => {
+    beforeEach(() => {
+      vi.mocked(notificationService.notificationService.getPermission).mockReturnValue('granted')
+    })
+
+    it('shows toggle switch for game reminders', () => {
+      render(<NotificationsSection {...defaultProps} />)
+
+      expect(screen.getByText('settings.notifications.gameReminders')).toBeInTheDocument()
+      expect(screen.getByRole('switch')).toBeInTheDocument()
+    })
+
+    it('toggles notifications on switch click', () => {
+      const onSetNotificationsEnabled = vi.fn()
+
+      render(
+        <NotificationsSection
+          {...defaultProps}
+          notificationsEnabled={false}
+          onSetNotificationsEnabled={onSetNotificationsEnabled}
+        />
+      )
+
+      const toggle = screen.getByRole('switch')
+      fireEvent.click(toggle)
+
+      expect(onSetNotificationsEnabled).toHaveBeenCalledWith(true)
+    })
+
+    describe('when notifications enabled', () => {
+      it('shows reminder time options', () => {
+        render(<NotificationsSection {...defaultProps} notificationsEnabled={true} />)
+
+        expect(screen.getByText('settings.notifications.reminderTimes')).toBeInTheDocument()
+        expect(screen.getByText('settings.notifications.reminderTime.1h')).toBeInTheDocument()
+        expect(screen.getByText('settings.notifications.reminderTime.2h')).toBeInTheDocument()
+        expect(screen.getByText('settings.notifications.reminderTime.1d')).toBeInTheDocument()
+      })
+
+      it('shows selected reminder times as pressed', () => {
+        render(
+          <NotificationsSection
+            {...defaultProps}
+            notificationsEnabled={true}
+            reminderTimes={['1h', '1d']}
+          />
+        )
+
+        const button1h = screen.getByText('settings.notifications.reminderTime.1h').closest('button')
+        const button2h = screen.getByText('settings.notifications.reminderTime.2h').closest('button')
+        const button1d = screen.getByText('settings.notifications.reminderTime.1d').closest('button')
+
+        expect(button1h).toHaveAttribute('aria-pressed', 'true')
+        expect(button2h).toHaveAttribute('aria-pressed', 'false')
+        expect(button1d).toHaveAttribute('aria-pressed', 'true')
+      })
+
+      it('adds reminder time when unselected time clicked', () => {
+        const onSetReminderTimes = vi.fn()
+
+        render(
+          <NotificationsSection
+            {...defaultProps}
+            notificationsEnabled={true}
+            reminderTimes={['1h']}
+            onSetReminderTimes={onSetReminderTimes}
+          />
+        )
+
+        const button2h = screen.getByText('settings.notifications.reminderTime.2h')
+        fireEvent.click(button2h)
+
+        expect(onSetReminderTimes).toHaveBeenCalledWith(['1h', '2h'])
+      })
+
+      it('removes reminder time when selected time clicked', () => {
+        const onSetReminderTimes = vi.fn()
+
+        render(
+          <NotificationsSection
+            {...defaultProps}
+            notificationsEnabled={true}
+            reminderTimes={['1h', '2h']}
+            onSetReminderTimes={onSetReminderTimes}
+          />
+        )
+
+        const button1h = screen.getByText('settings.notifications.reminderTime.1h')
+        fireEvent.click(button1h)
+
+        expect(onSetReminderTimes).toHaveBeenCalledWith(['2h'])
+      })
+
+      it('does not remove last reminder time', () => {
+        const onSetReminderTimes = vi.fn()
+
+        render(
+          <NotificationsSection
+            {...defaultProps}
+            notificationsEnabled={true}
+            reminderTimes={['1h']}
+            onSetReminderTimes={onSetReminderTimes}
+          />
+        )
+
+        const button1h = screen.getByText('settings.notifications.reminderTime.1h')
+        fireEvent.click(button1h)
+
+        // Should not be called since it would result in empty array
+        expect(onSetReminderTimes).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  it('shows foreground note in all states', () => {
+    vi.mocked(notificationService.notificationService.getPermission).mockReturnValue('granted')
+
+    render(<NotificationsSection {...defaultProps} />)
+
+    expect(screen.getByText('settings.notifications.foregroundNote')).toBeInTheDocument()
+  })
+})

--- a/web-app/src/features/settings/components/NotificationsSection.tsx
+++ b/web-app/src/features/settings/components/NotificationsSection.tsx
@@ -75,7 +75,7 @@ function NotificationsSectionComponent({
       <Card>
         <CardHeader>
           <h2 className="font-semibold text-text-primary dark:text-text-primary-dark flex items-center gap-2">
-            <BellOff className="h-5 w-5" />
+            <BellOff className="h-5 w-5" aria-hidden="true" />
             {t('settings.notifications.title')}
           </h2>
         </CardHeader>
@@ -92,7 +92,7 @@ function NotificationsSectionComponent({
     <Card>
       <CardHeader>
         <h2 className="font-semibold text-text-primary dark:text-text-primary-dark flex items-center gap-2">
-          <Bell className="h-5 w-5" />
+          <Bell className="h-5 w-5" aria-hidden="true" />
           {t('settings.notifications.title')}
         </h2>
       </CardHeader>
@@ -164,7 +164,7 @@ function NotificationsSectionComponent({
                         `}
                         aria-pressed={isSelected}
                       >
-                        {isSelected && <Check className="h-3.5 w-3.5" />}
+                        {isSelected && <Check className="h-3.5 w-3.5" aria-hidden="true" />}
                         {t(`settings.notifications.reminderTime.${time}`)}
                       </button>
                     )

--- a/web-app/src/features/settings/components/NotificationsSection.tsx
+++ b/web-app/src/features/settings/components/NotificationsSection.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useState, memo } from 'react'
+
+import { Bell, BellOff, Check } from 'lucide-react'
+
+import { Button } from '@/shared/components/Button'
+import { Card, CardContent, CardHeader } from '@/shared/components/Card'
+import { ToggleSwitch } from '@/shared/components/ToggleSwitch'
+import { useTranslation } from '@/shared/hooks/useTranslation'
+import {
+  notificationService,
+  REMINDER_TIME_OPTIONS,
+  type ReminderTime,
+} from '@/shared/services/notifications'
+
+interface NotificationsSectionProps {
+  notificationsEnabled: boolean
+  reminderTimes: ReminderTime[]
+  onSetNotificationsEnabled: (enabled: boolean) => void
+  onSetReminderTimes: (times: ReminderTime[]) => void
+}
+
+function NotificationsSectionComponent({
+  notificationsEnabled,
+  reminderTimes,
+  onSetNotificationsEnabled,
+  onSetReminderTimes,
+}: NotificationsSectionProps) {
+  const { t } = useTranslation()
+  const [permissionStatus, setPermissionStatus] = useState<NotificationPermission>(
+    notificationService.getPermission()
+  )
+  const [isRequesting, setIsRequesting] = useState(false)
+
+  const isSupported = notificationService.isSupported()
+  const isGranted = permissionStatus === 'granted'
+  const isDenied = permissionStatus === 'denied'
+
+  const handleRequestPermission = useCallback(async () => {
+    setIsRequesting(true)
+    try {
+      const result = await notificationService.requestPermission()
+      setPermissionStatus(result)
+      if (result === 'granted') {
+        onSetNotificationsEnabled(true)
+      }
+    } finally {
+      setIsRequesting(false)
+    }
+  }, [onSetNotificationsEnabled])
+
+  const handleToggleNotifications = useCallback(() => {
+    if (!isGranted) {
+      handleRequestPermission()
+    } else {
+      onSetNotificationsEnabled(!notificationsEnabled)
+    }
+  }, [isGranted, notificationsEnabled, onSetNotificationsEnabled, handleRequestPermission])
+
+  const handleToggleReminderTime = useCallback(
+    (time: ReminderTime) => {
+      const newTimes = reminderTimes.includes(time)
+        ? reminderTimes.filter((t) => t !== time)
+        : [...reminderTimes, time]
+      // Ensure at least one time is selected
+      if (newTimes.length > 0) {
+        onSetReminderTimes(newTimes)
+      }
+    },
+    [reminderTimes, onSetReminderTimes]
+  )
+
+  // Show unsupported message if browser doesn't support notifications
+  if (!isSupported) {
+    return (
+      <Card>
+        <CardHeader>
+          <h2 className="font-semibold text-text-primary dark:text-text-primary-dark flex items-center gap-2">
+            <BellOff className="h-5 w-5" />
+            {t('settings.notifications.title')}
+          </h2>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-text-muted dark:text-text-muted-dark">
+            {t('settings.notifications.notSupported')}
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="font-semibold text-text-primary dark:text-text-primary-dark flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          {t('settings.notifications.title')}
+        </h2>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t('settings.notifications.description')}
+        </p>
+
+        {/* Permission denied warning */}
+        {isDenied && (
+          <div className="rounded-md bg-warning-50 dark:bg-warning-900/20 p-3">
+            <p className="text-sm text-warning-700 dark:text-warning-300">
+              {t('settings.notifications.permissionDenied')}
+            </p>
+          </div>
+        )}
+
+        {/* Request permission button (when not granted) */}
+        {!isGranted && !isDenied && (
+          <Button onClick={handleRequestPermission} disabled={isRequesting} variant="secondary">
+            {isRequesting
+              ? t('settings.notifications.requesting')
+              : t('settings.notifications.enableNotifications')}
+          </Button>
+        )}
+
+        {/* Notification toggle (when permission granted) */}
+        {isGranted && (
+          <>
+            <div className="flex items-center justify-between py-2">
+              <div className="flex-1">
+                <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                  {t('settings.notifications.gameReminders')}
+                </div>
+                <div className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+                  {t('settings.notifications.gameRemindersDescription')}
+                </div>
+              </div>
+
+              <ToggleSwitch
+                checked={notificationsEnabled}
+                onChange={handleToggleNotifications}
+                label={t('settings.notifications.gameReminders')}
+              />
+            </div>
+
+            {/* Reminder time selection */}
+            {notificationsEnabled && (
+              <div className="space-y-3 pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+                <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                  {t('settings.notifications.reminderTimes')}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {REMINDER_TIME_OPTIONS.map((time) => {
+                    const isSelected = reminderTimes.includes(time)
+                    return (
+                      <button
+                        key={time}
+                        type="button"
+                        onClick={() => handleToggleReminderTime(time)}
+                        className={`
+                          inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium
+                          transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2
+                          ${
+                            isSelected
+                              ? 'bg-primary-600 text-white'
+                              : 'bg-surface-muted dark:bg-surface-subtle-dark text-text-secondary dark:text-text-secondary-dark hover:bg-surface-subtle dark:hover:bg-surface-muted-dark'
+                          }
+                        `}
+                        aria-pressed={isSelected}
+                      >
+                        {isSelected && <Check className="h-3.5 w-3.5" />}
+                        {t(`settings.notifications.reminderTime.${time}`)}
+                      </button>
+                    )
+                  })}
+                </div>
+                <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                  {t('settings.notifications.reminderTimesHint')}
+                </p>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Foreground-only note */}
+        <div className="text-xs text-text-muted dark:text-text-muted-dark pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+          {t('settings.notifications.foregroundNote')}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export const NotificationsSection = memo(NotificationsSectionComponent)

--- a/web-app/src/features/settings/components/index.ts
+++ b/web-app/src/features/settings/components/index.ts
@@ -1,5 +1,6 @@
 export { ProfileSection } from './ProfileSection'
 export { PreferencesSection } from './PreferencesSection'
+export { NotificationsSection } from './NotificationsSection'
 export { HomeLocationSection } from './HomeLocationSection'
 export { TravelSettingsSection } from './TravelSettingsSection'
 export { DataProtectionSection } from './DataProtectionSection'

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -377,6 +377,10 @@ const de: Translations = {
     exchange: 'Tauschbörse',
     settings: 'Einstellungen',
   },
+  notifications: {
+    gameReminder: 'Spielerinnerung',
+    gameReminderBody: 'Dein Spiel {game} beginnt {time} um {gameTime}',
+  },
   settings: {
     title: 'Einstellungen',
     profile: 'Profil',
@@ -384,6 +388,26 @@ const de: Translations = {
     language: 'Sprache',
     preferences: {
       title: 'Einstellungen',
+    },
+    notifications: {
+      title: 'Benachrichtigungen',
+      description: 'Erhalte Erinnerungen vor deinen Spielen.',
+      notSupported: 'Benachrichtigungen werden in diesem Browser nicht unterstützt.',
+      permissionDenied:
+        'Benachrichtigungserlaubnis wurde verweigert. Bitte aktiviere Benachrichtigungen in deinen Browsereinstellungen.',
+      enableNotifications: 'Benachrichtigungen aktivieren',
+      requesting: 'Anfrage läuft...',
+      gameReminders: 'Spielerinnerungen',
+      gameRemindersDescription: 'Erhalte Benachrichtigungen vor deinen geplanten Spielen.',
+      reminderTimes: 'Erinnere mich',
+      reminderTimesHint: 'Wähle, wann du vor jedem Spiel erinnert werden möchtest.',
+      foregroundNote:
+        'Hinweis: Benachrichtigungen werden nur gesendet, während die App geöffnet ist. Für Offline-Erinnerungen füge Spiele deinem Kalender hinzu.',
+      reminderTime: {
+        '1h': '1 Stunde vorher',
+        '2h': '2 Stunden vorher',
+        '1d': '1 Tag vorher',
+      },
     },
     locationTravel: {
       title: 'Standort & Anreise',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -369,6 +369,10 @@ const en: Translations = {
     exchange: 'Exchange',
     settings: 'Settings',
   },
+  notifications: {
+    gameReminder: 'Game Reminder',
+    gameReminderBody: 'Your game {game} starts {time} at {gameTime}',
+  },
   settings: {
     title: 'Settings',
     profile: 'Profile',
@@ -376,6 +380,26 @@ const en: Translations = {
     language: 'Language',
     preferences: {
       title: 'Preferences',
+    },
+    notifications: {
+      title: 'Notifications',
+      description: 'Get reminders before your games start.',
+      notSupported: 'Notifications are not supported in this browser.',
+      permissionDenied:
+        'Notification permission was denied. Please enable notifications in your browser settings.',
+      enableNotifications: 'Enable Notifications',
+      requesting: 'Requesting...',
+      gameReminders: 'Game Reminders',
+      gameRemindersDescription: 'Receive notifications before your scheduled games.',
+      reminderTimes: 'Remind me',
+      reminderTimesHint: 'Select when you want to be reminded before each game.',
+      foregroundNote:
+        'Note: Notifications are only sent while the app is open. For offline reminders, add games to your calendar.',
+      reminderTime: {
+        '1h': '1 hour before',
+        '2h': '2 hours before',
+        '1d': '1 day before',
+      },
     },
     locationTravel: {
       title: 'Location & Travel',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -378,6 +378,10 @@ const fr: Translations = {
     exchange: 'Échanges',
     settings: 'Paramètres',
   },
+  notifications: {
+    gameReminder: 'Rappel de match',
+    gameReminderBody: 'Votre match {game} commence {time} à {gameTime}',
+  },
   settings: {
     title: 'Paramètres',
     profile: 'Profil',
@@ -385,6 +389,26 @@ const fr: Translations = {
     language: 'Langue',
     preferences: {
       title: 'Préférences',
+    },
+    notifications: {
+      title: 'Notifications',
+      description: 'Recevez des rappels avant vos matchs.',
+      notSupported: 'Les notifications ne sont pas prises en charge dans ce navigateur.',
+      permissionDenied:
+        "L'autorisation de notification a été refusée. Veuillez activer les notifications dans les paramètres de votre navigateur.",
+      enableNotifications: 'Activer les notifications',
+      requesting: 'Demande en cours...',
+      gameReminders: 'Rappels de matchs',
+      gameRemindersDescription: 'Recevez des notifications avant vos matchs programmés.',
+      reminderTimes: 'Me rappeler',
+      reminderTimesHint: 'Choisissez quand vous souhaitez être rappelé avant chaque match.',
+      foregroundNote:
+        "Note : Les notifications ne sont envoyées que lorsque l'application est ouverte. Pour les rappels hors ligne, ajoutez les matchs à votre calendrier.",
+      reminderTime: {
+        '1h': '1 heure avant',
+        '2h': '2 heures avant',
+        '1d': '1 jour avant',
+      },
     },
     locationTravel: {
       title: 'Localisation & Déplacement',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -376,6 +376,10 @@ const it: Translations = {
     exchange: 'Scambi',
     settings: 'Impostazioni',
   },
+  notifications: {
+    gameReminder: 'Promemoria partita',
+    gameReminderBody: 'La tua partita {game} inizia {time} alle {gameTime}',
+  },
   settings: {
     title: 'Impostazioni',
     profile: 'Profilo',
@@ -383,6 +387,26 @@ const it: Translations = {
     language: 'Lingua',
     preferences: {
       title: 'Preferenze',
+    },
+    notifications: {
+      title: 'Notifiche',
+      description: 'Ricevi promemoria prima delle tue partite.',
+      notSupported: 'Le notifiche non sono supportate in questo browser.',
+      permissionDenied:
+        "L'autorizzazione alle notifiche è stata negata. Abilita le notifiche nelle impostazioni del browser.",
+      enableNotifications: 'Abilita notifiche',
+      requesting: 'Richiesta in corso...',
+      gameReminders: 'Promemoria partite',
+      gameRemindersDescription: 'Ricevi notifiche prima delle tue partite programmate.',
+      reminderTimes: 'Ricordami',
+      reminderTimesHint: 'Scegli quando vuoi essere avvisato prima di ogni partita.',
+      foregroundNote:
+        "Nota: Le notifiche vengono inviate solo quando l'app è aperta. Per i promemoria offline, aggiungi le partite al tuo calendario.",
+      reminderTime: {
+        '1h': '1 ora prima',
+        '2h': '2 ore prima',
+        '1d': '1 giorno prima',
+      },
     },
     locationTravel: {
       title: 'Posizione & Viaggio',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -258,6 +258,10 @@ export interface Translations {
     exchange: string
     settings: string
   }
+  notifications: {
+    gameReminder: string
+    gameReminderBody: string
+  }
   settings: {
     title: string
     profile: string
@@ -265,6 +269,24 @@ export interface Translations {
     language: string
     preferences: {
       title: string
+    }
+    notifications: {
+      title: string
+      description: string
+      notSupported: string
+      permissionDenied: string
+      enableNotifications: string
+      requesting: string
+      gameReminders: string
+      gameRemindersDescription: string
+      reminderTimes: string
+      reminderTimesHint: string
+      foregroundNote: string
+      reminderTime: {
+        '1h': string
+        '2h': string
+        '1d': string
+      }
     }
     locationTravel: {
       title: string

--- a/web-app/src/shared/components/PullToRefresh.tsx
+++ b/web-app/src/shared/components/PullToRefresh.tsx
@@ -46,11 +46,7 @@ export function PullToRefresh({ onRefresh, children }: PullToRefreshProps) {
   // When refreshing, show full-page loading state overlay
   if (isRefreshing) {
     return (
-      <div
-        {...containerProps}
-        className="relative"
-        style={{ overscrollBehavior: 'none' }}
-      >
+      <div {...containerProps} className="relative" style={{ overscrollBehavior: 'none' }}>
         <LoadingState message={t('common.refreshing')} />
       </div>
     )

--- a/web-app/src/shared/services/notifications/index.ts
+++ b/web-app/src/shared/services/notifications/index.ts
@@ -1,0 +1,10 @@
+export { notificationService } from './notification-service'
+export type {
+  NotificationPermission,
+  NotificationResult,
+  NotificationService,
+  ReminderTime,
+  ScheduledNotification,
+  ShowNotificationOptions,
+} from './types'
+export { REMINDER_TIME_OPTIONS } from './types'

--- a/web-app/src/shared/services/notifications/notification-service.test.ts
+++ b/web-app/src/shared/services/notifications/notification-service.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { notificationService } from './notification-service'
+
+// Helper to create a mock Notification class with configurable permission
+function createMockNotification(permission: NotificationPermission = 'default') {
+  // Use a proper class for the mock to work with `new` operator
+  class MockNotification {
+    title: string
+    options: NotificationOptions
+    close = vi.fn()
+
+    constructor(title: string, options?: NotificationOptions) {
+      this.title = title
+      this.options = options ?? {}
+    }
+
+    static permission: NotificationPermission = permission
+    static requestPermission = vi.fn().mockResolvedValue(permission)
+  }
+
+  // Create a spy wrapper around the class to track calls
+  const MockNotificationSpy = vi.fn().mockImplementation(function (
+    this: MockNotification,
+    title: string,
+    options?: NotificationOptions
+  ) {
+    return new MockNotification(title, options)
+  }) as unknown as typeof Notification
+
+  Object.defineProperty(MockNotificationSpy, 'permission', {
+    value: permission,
+    configurable: true,
+    writable: true,
+  })
+
+  MockNotificationSpy.requestPermission = vi.fn().mockResolvedValue(permission)
+
+  return MockNotificationSpy
+}
+
+describe('notificationService', () => {
+  let originalNotification: typeof Notification | undefined
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    notificationService.cancelAllScheduledNotifications()
+    // Store original Notification
+    originalNotification = window.Notification
+    // Set up a default mock Notification
+    window.Notification = createMockNotification('default')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    notificationService.cancelAllScheduledNotifications()
+    // Restore original Notification
+    if (originalNotification) {
+      window.Notification = originalNotification
+    }
+  })
+
+  describe('isSupported', () => {
+    it('returns true when Notification API is available', () => {
+      expect(notificationService.isSupported()).toBe(true)
+    })
+
+    it('returns false when Notification API is not available', () => {
+      // @ts-expect-error - Temporarily remove Notification
+      delete window.Notification
+
+      expect(notificationService.isSupported()).toBe(false)
+    })
+  })
+
+  describe('getPermission', () => {
+    it('returns current notification permission', () => {
+      const permission = notificationService.getPermission()
+      expect(['granted', 'denied', 'default']).toContain(permission)
+    })
+
+    it('returns denied when notifications not supported', () => {
+      // @ts-expect-error - Temporarily remove Notification
+      delete window.Notification
+
+      expect(notificationService.getPermission()).toBe('denied')
+    })
+  })
+
+  describe('requestPermission', () => {
+    it('returns denied when notifications not supported', async () => {
+      // @ts-expect-error - Temporarily remove Notification
+      delete window.Notification
+
+      const result = await notificationService.requestPermission()
+      expect(result).toBe('denied')
+    })
+
+    it('returns current permission without re-prompting if already granted', async () => {
+      window.Notification = createMockNotification('granted')
+
+      const result = await notificationService.requestPermission()
+      expect(result).toBe('granted')
+    })
+
+    it('returns current permission without re-prompting if already denied', async () => {
+      window.Notification = createMockNotification('denied')
+
+      const result = await notificationService.requestPermission()
+      expect(result).toBe('denied')
+    })
+  })
+
+  describe('scheduleNotification', () => {
+    it('schedules a notification for future time', () => {
+      const now = Date.now()
+      const futureTime = now + 5000 // 5 seconds from now
+
+      const scheduled = notificationService.scheduleNotification(
+        'test-1',
+        { title: 'Test', body: 'Test body' },
+        futureTime
+      )
+
+      expect(scheduled).not.toBeNull()
+      expect(scheduled?.id).toBe('test-1')
+      expect(scheduled?.scheduledTime).toBe(futureTime)
+
+      const all = notificationService.getScheduledNotifications()
+      expect(all).toHaveLength(1)
+    })
+
+    it('returns null for past times', () => {
+      const pastTime = Date.now() - 1000
+
+      const scheduled = notificationService.scheduleNotification(
+        'test-past',
+        { title: 'Test', body: 'Test body' },
+        pastTime
+      )
+
+      expect(scheduled).toBeNull()
+    })
+
+    it('returns null for times more than 24 hours in advance', () => {
+      const farFuture = Date.now() + 25 * 60 * 60 * 1000 // 25 hours
+
+      const scheduled = notificationService.scheduleNotification(
+        'test-far',
+        { title: 'Test', body: 'Test body' },
+        farFuture
+      )
+
+      expect(scheduled).toBeNull()
+    })
+
+    it('cancels existing notification with same ID before scheduling new one', () => {
+      const now = Date.now()
+
+      notificationService.scheduleNotification(
+        'test-id',
+        { title: 'First', body: 'First body' },
+        now + 5000
+      )
+
+      notificationService.scheduleNotification(
+        'test-id',
+        { title: 'Second', body: 'Second body' },
+        now + 10000
+      )
+
+      const all = notificationService.getScheduledNotifications()
+      expect(all).toHaveLength(1)
+      expect(all[0]?.scheduledTime).toBe(now + 10000)
+    })
+  })
+
+  describe('cancelScheduledNotification', () => {
+    it('cancels a specific scheduled notification', () => {
+      const now = Date.now()
+
+      notificationService.scheduleNotification('test-1', { title: 'Test 1', body: 'Body 1' }, now + 5000)
+      notificationService.scheduleNotification('test-2', { title: 'Test 2', body: 'Body 2' }, now + 10000)
+
+      expect(notificationService.getScheduledNotifications()).toHaveLength(2)
+
+      notificationService.cancelScheduledNotification('test-1')
+
+      const remaining = notificationService.getScheduledNotifications()
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.id).toBe('test-2')
+    })
+
+    it('does nothing for non-existent ID', () => {
+      const now = Date.now()
+
+      notificationService.scheduleNotification('test-1', { title: 'Test', body: 'Body' }, now + 5000)
+
+      notificationService.cancelScheduledNotification('non-existent')
+
+      expect(notificationService.getScheduledNotifications()).toHaveLength(1)
+    })
+  })
+
+  describe('cancelAllScheduledNotifications', () => {
+    it('cancels all scheduled notifications', () => {
+      const now = Date.now()
+
+      notificationService.scheduleNotification('test-1', { title: 'T1', body: 'B1' }, now + 5000)
+      notificationService.scheduleNotification('test-2', { title: 'T2', body: 'B2' }, now + 10000)
+      notificationService.scheduleNotification('test-3', { title: 'T3', body: 'B3' }, now + 15000)
+
+      expect(notificationService.getScheduledNotifications()).toHaveLength(3)
+
+      notificationService.cancelAllScheduledNotifications()
+
+      expect(notificationService.getScheduledNotifications()).toHaveLength(0)
+    })
+  })
+
+  describe('getScheduledNotifications', () => {
+    it('returns empty array when no notifications scheduled', () => {
+      expect(notificationService.getScheduledNotifications()).toEqual([])
+    })
+
+    it('returns all scheduled notifications', () => {
+      const now = Date.now()
+
+      notificationService.scheduleNotification('a', { title: 'A', body: 'A' }, now + 1000)
+      notificationService.scheduleNotification('b', { title: 'B', body: 'B' }, now + 2000)
+
+      const notifications = notificationService.getScheduledNotifications()
+      expect(notifications).toHaveLength(2)
+      expect(notifications.map((n) => n.id)).toContain('a')
+      expect(notifications.map((n) => n.id)).toContain('b')
+    })
+  })
+
+  describe('showNotification', () => {
+    it('returns error when notifications not supported', async () => {
+      // @ts-expect-error - Temporarily remove Notification
+      delete window.Notification
+
+      const result = await notificationService.showNotification({
+        title: 'Test',
+        body: 'Test body',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('not supported')
+    })
+
+    it('returns error when permission not granted', async () => {
+      window.Notification = createMockNotification('denied')
+
+      const result = await notificationService.showNotification({
+        title: 'Test',
+        body: 'Test body',
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('not granted')
+    })
+
+    it('shows notification when permission granted', async () => {
+      window.Notification = createMockNotification('granted')
+
+      // Mock service worker to ensure fallback to Notification constructor is used
+      const originalServiceWorker = navigator.serviceWorker
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: { controller: null },
+        configurable: true,
+      })
+
+      const result = await notificationService.showNotification({
+        title: 'Test',
+        body: 'Test body',
+      })
+
+      expect(result.success).toBe(true)
+      expect(window.Notification).toHaveBeenCalledWith('Test', expect.objectContaining({ body: 'Test body' }))
+
+      // Restore service worker
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: originalServiceWorker,
+        configurable: true,
+      })
+    })
+  })
+})

--- a/web-app/src/shared/services/notifications/notification-service.ts
+++ b/web-app/src/shared/services/notifications/notification-service.ts
@@ -1,0 +1,235 @@
+/**
+ * Notification Service
+ *
+ * Abstraction layer for the Web Notifications API.
+ * Handles permission requests and scheduled notifications for game reminders.
+ *
+ * Browser Support:
+ * - Desktop: All modern browsers (Chrome, Firefox, Safari, Edge)
+ * - iOS/iPadOS: Safari 16.4+ (requires PWA installed)
+ * - Android: All modern browsers
+ *
+ * Limitations:
+ * - Scheduled notifications only work while the app is open/in background
+ * - For true background notifications, a push notification server is required
+ */
+
+import {
+  ONE_DAY_MS,
+  type NotificationPermission,
+  type NotificationResult,
+  type NotificationService,
+  type ScheduledNotification,
+  type ShowNotificationOptions,
+} from './types'
+
+// Store scheduled notifications for management
+const scheduledNotifications = new Map<string, ScheduledNotification>()
+
+/**
+ * Check if the Notifications API is available
+ */
+function isSupported(): boolean {
+  return typeof window !== 'undefined' && 'Notification' in window
+}
+
+/**
+ * Get current notification permission status
+ */
+function getPermission(): NotificationPermission {
+  if (!isSupported()) {
+    return 'denied'
+  }
+  return Notification.permission as NotificationPermission
+}
+
+/**
+ * Request notification permission from the user
+ *
+ * @returns The resulting permission status
+ */
+async function requestPermission(): Promise<NotificationPermission> {
+  if (!isSupported()) {
+    return 'denied'
+  }
+
+  // Already granted or denied - don't re-request
+  if (Notification.permission !== 'default') {
+    return Notification.permission as NotificationPermission
+  }
+
+  try {
+    const result = await Notification.requestPermission()
+    return result as NotificationPermission
+  } catch {
+    // Some browsers (older Safari) use callback-based API
+    return new Promise((resolve) => {
+      Notification.requestPermission((result) => {
+        resolve(result as NotificationPermission)
+      })
+    })
+  }
+}
+
+/**
+ * Show a notification immediately
+ *
+ * @param options - Notification options
+ * @returns Result indicating success or failure
+ */
+async function showNotification(options: ShowNotificationOptions): Promise<NotificationResult> {
+  if (!isSupported()) {
+    return {
+      success: false,
+      error: 'Notifications not supported in this browser',
+    }
+  }
+
+  if (Notification.permission !== 'granted') {
+    return {
+      success: false,
+      error: 'Notification permission not granted',
+    }
+  }
+
+  try {
+    // Try to use service worker for better notification experience
+    if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+      const registration = await navigator.serviceWorker.ready
+      await registration.showNotification(options.title, {
+        body: options.body,
+        icon: options.icon ?? '/icons/icon-192x192.png',
+        tag: options.tag,
+        requireInteraction: options.requireInteraction ?? false,
+        data: options.data,
+      })
+    } else {
+      // Fallback to regular Notification API
+      new Notification(options.title, {
+        body: options.body,
+        icon: options.icon ?? '/icons/icon-192x192.png',
+        tag: options.tag,
+        requireInteraction: options.requireInteraction ?? false,
+        data: options.data,
+      })
+    }
+
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return {
+      success: false,
+      error: `Failed to show notification: ${message}`,
+    }
+  }
+}
+
+/**
+ * Schedule a notification for a future time
+ *
+ * @param id - Unique identifier for this scheduled notification
+ * @param options - Notification options
+ * @param triggerTime - Unix timestamp (ms) when to show the notification
+ * @returns The scheduled notification info, or null if scheduling failed
+ */
+function scheduleNotification(
+  id: string,
+  options: ShowNotificationOptions,
+  triggerTime: number
+): ScheduledNotification | null {
+  if (!isSupported()) {
+    return null
+  }
+
+  // Cancel any existing notification with this ID
+  cancelScheduledNotification(id)
+
+  const now = Date.now()
+  const delay = triggerTime - now
+
+  // Don't schedule if the time has already passed
+  if (delay <= 0) {
+    return null
+  }
+
+  // Don't schedule notifications more than 24 hours in advance
+  // (browser may not keep timers alive that long)
+  if (delay > ONE_DAY_MS) {
+    return null
+  }
+
+  const timeoutId = setTimeout(() => {
+    showNotification(options)
+    scheduledNotifications.delete(id)
+  }, delay)
+
+  const scheduled: ScheduledNotification = {
+    id,
+    assignmentId: (options.data?.assignmentId as string) ?? id,
+    scheduledTime: triggerTime,
+    timeoutId,
+  }
+
+  scheduledNotifications.set(id, scheduled)
+
+  return scheduled
+}
+
+/**
+ * Cancel a scheduled notification
+ *
+ * @param id - The notification ID to cancel
+ */
+function cancelScheduledNotification(id: string): void {
+  const scheduled = scheduledNotifications.get(id)
+  if (scheduled) {
+    clearTimeout(scheduled.timeoutId)
+    scheduledNotifications.delete(id)
+  }
+}
+
+/**
+ * Cancel all scheduled notifications
+ */
+function cancelAllScheduledNotifications(): void {
+  for (const scheduled of scheduledNotifications.values()) {
+    clearTimeout(scheduled.timeoutId)
+  }
+  scheduledNotifications.clear()
+}
+
+/**
+ * Get all currently scheduled notifications
+ */
+function getScheduledNotifications(): ScheduledNotification[] {
+  return Array.from(scheduledNotifications.values())
+}
+
+/**
+ * Notification service singleton
+ *
+ * Usage:
+ * ```typescript
+ * import { notificationService } from '@/shared/services/notifications';
+ *
+ * if (notificationService.isSupported()) {
+ *   const permission = await notificationService.requestPermission();
+ *   if (permission === 'granted') {
+ *     await notificationService.showNotification({
+ *       title: 'Game Reminder',
+ *       body: 'Your game starts in 1 hour',
+ *     });
+ *   }
+ * }
+ * ```
+ */
+export const notificationService: NotificationService = {
+  isSupported,
+  getPermission,
+  requestPermission,
+  showNotification,
+  scheduleNotification,
+  cancelScheduledNotification,
+  cancelAllScheduledNotifications,
+  getScheduledNotifications,
+}

--- a/web-app/src/shared/services/notifications/types.ts
+++ b/web-app/src/shared/services/notifications/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Notification Service Types
+ *
+ * Types for the native notifications service that handles
+ * permission requests and scheduled game reminders.
+ */
+
+/** Possible reminder times before a game */
+export type ReminderTime = '1h' | '2h' | '1d'
+
+// Time constants for scheduling limits
+const SECONDS_PER_MINUTE = 60
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const MS_PER_SECOND = 1000
+
+/** One day in milliseconds - used for max scheduling limit */
+export const ONE_DAY_MS = HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MS_PER_SECOND
+
+/** Available reminder time options */
+export const REMINDER_TIME_OPTIONS: ReminderTime[] = ['1h', '2h', '1d']
+
+/** Notification permission status */
+export type NotificationPermission = 'granted' | 'denied' | 'default'
+
+/** Result of a notification operation */
+export interface NotificationResult {
+  success: boolean
+  error?: string
+}
+
+/** Options for showing a notification */
+export interface ShowNotificationOptions {
+  /** Notification title */
+  title: string
+  /** Notification body text */
+  body: string
+  /** Optional icon URL */
+  icon?: string
+  /** Optional tag to replace existing notifications */
+  tag?: string
+  /** Whether to require interaction to dismiss */
+  requireInteraction?: boolean
+  /** Optional data payload */
+  data?: Record<string, unknown>
+}
+
+/** Scheduled notification info */
+export interface ScheduledNotification {
+  /** Unique identifier for this scheduled notification */
+  id: string
+  /** Assignment ID this notification is for */
+  assignmentId: string
+  /** When the notification should fire */
+  scheduledTime: number
+  /** The timeout ID for cancellation */
+  timeoutId: ReturnType<typeof setTimeout>
+}
+
+/** Notification service interface */
+export interface NotificationService {
+  /** Check if notifications are supported in this browser */
+  isSupported: () => boolean
+  /** Get current permission status */
+  getPermission: () => NotificationPermission
+  /** Request permission from the user */
+  requestPermission: () => Promise<NotificationPermission>
+  /** Show a notification immediately */
+  showNotification: (options: ShowNotificationOptions) => Promise<NotificationResult>
+  /** Schedule a notification for a future time */
+  scheduleNotification: (
+    id: string,
+    options: ShowNotificationOptions,
+    triggerTime: number
+  ) => ScheduledNotification | null
+  /** Cancel a scheduled notification */
+  cancelScheduledNotification: (id: string) => void
+  /** Cancel all scheduled notifications */
+  cancelAllScheduledNotifications: () => void
+  /** Get all currently scheduled notifications */
+  getScheduledNotifications: () => ScheduledNotification[]
+}

--- a/web-app/src/shared/stores/settings.test.ts
+++ b/web-app/src/shared/stores/settings.test.ts
@@ -28,6 +28,10 @@ const DEFAULT_MODE_SETTINGS: ModeSettings = {
     sbbDestinationType: 'address',
   },
   levelFilterEnabled: false,
+  notificationSettings: {
+    enabled: false,
+    reminderTimes: ['1h'],
+  },
 }
 
 /** Helper to reset store to clean state */
@@ -52,6 +56,7 @@ function resetStore(mode: DataSource = 'api') {
     transportEnabledByAssociation: { ...DEFAULT_MODE_SETTINGS.transportEnabledByAssociation },
     travelTimeFilter: { ...DEFAULT_MODE_SETTINGS.travelTimeFilter },
     levelFilterEnabled: DEFAULT_MODE_SETTINGS.levelFilterEnabled,
+    notificationSettings: { ...DEFAULT_MODE_SETTINGS.notificationSettings },
   })
 }
 


### PR DESCRIPTION
## Summary

- Add Notifications section to Settings page with permission request flow
- Implement notification service with browser API abstraction
- Add reminder time preferences (1h, 2h, 1d before games)
- Include translations for all 4 languages (de, en, fr, it)
- Add settings store persistence with v5 migration

This is the infrastructure foundation for native notifications; actual game reminder scheduling will be added in a future update.

## Test plan

- [ ] Verify Notifications section appears in Settings page
- [ ] Test permission request flow in supported browsers
- [ ] Verify reminder time toggle buttons work correctly
- [ ] Check translations display correctly for each language
- [ ] Confirm settings persist across page reloads