### PR TITLE
feat(notifications): add unified notification system with automatic fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Notification settings section in Settings page - users can now enable/disable browser notifications and configure reminder time preferences
+- Unified notification system with automatic fallback - notifications use browser notifications when available and automatically fall back to in-app notifications when browser permissions are denied or unavailable
+- Notification settings section in Settings page with single toggle for enabling game reminders and reminder time selection
 
 ### Fixed
 

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -399,6 +399,10 @@ const de: Translations = {
       requesting: 'Anfrage läuft...',
       gameReminders: 'Spielerinnerungen',
       gameRemindersDescription: 'Erhalte Benachrichtigungen vor deinen geplanten Spielen.',
+      usingBrowser: 'Browser-Benachrichtigungen werden verwendet',
+      usingInApp: 'In-App-Benachrichtigungen werden verwendet',
+      browserDeniedUsingInApp:
+        'Browser-Benachrichtigungserlaubnis wurde verweigert. Stattdessen werden In-App-Benachrichtigungen verwendet.',
       reminderTimes: 'Erinnere mich',
       reminderTimesHint: 'Wähle, wann du vor jedem Spiel erinnert werden möchtest.',
       foregroundNote:

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -391,6 +391,10 @@ const en: Translations = {
       requesting: 'Requesting...',
       gameReminders: 'Game Reminders',
       gameRemindersDescription: 'Receive notifications before your scheduled games.',
+      usingBrowser: 'Using browser notifications',
+      usingInApp: 'Using in-app notifications',
+      browserDeniedUsingInApp:
+        'Browser notification permission was denied. Using in-app notifications instead.',
       reminderTimes: 'Remind me',
       reminderTimesHint: 'Select when you want to be reminded before each game.',
       foregroundNote:

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -400,6 +400,10 @@ const fr: Translations = {
       requesting: 'Demande en cours...',
       gameReminders: 'Rappels de matchs',
       gameRemindersDescription: 'Recevez des notifications avant vos matchs programmés.',
+      usingBrowser: 'Notifications du navigateur utilisées',
+      usingInApp: 'Notifications in-app utilisées',
+      browserDeniedUsingInApp:
+        "L'autorisation des notifications du navigateur a été refusée. Utilisation des notifications in-app.",
       reminderTimes: 'Me rappeler',
       reminderTimesHint: 'Choisissez quand vous souhaitez être rappelé avant chaque match.',
       foregroundNote:

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -398,6 +398,10 @@ const it: Translations = {
       requesting: 'Richiesta in corso...',
       gameReminders: 'Promemoria partite',
       gameRemindersDescription: 'Ricevi notifiche prima delle tue partite programmate.',
+      usingBrowser: 'Utilizzo delle notifiche del browser',
+      usingInApp: 'Utilizzo delle notifiche in-app',
+      browserDeniedUsingInApp:
+        "L'autorizzazione alle notifiche del browser è stata negata. Verranno utilizzate le notifiche in-app.",
       reminderTimes: 'Ricordami',
       reminderTimesHint: 'Scegli quando vuoi essere avvisato prima di ogni partita.',
       foregroundNote:

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -279,6 +279,9 @@ export interface Translations {
       requesting: string
       gameReminders: string
       gameRemindersDescription: string
+      usingBrowser: string
+      usingInApp: string
+      browserDeniedUsingInApp: string
       reminderTimes: string
       reminderTimesHint: string
       foregroundNote: string

--- a/web-app/src/shared/services/notifications/index.ts
+++ b/web-app/src/shared/services/notifications/index.ts
@@ -1,10 +1,25 @@
+// Native notification service (low-level)
 export { notificationService } from './notification-service'
+
+// Unified notification service (recommended)
+export { unifiedNotificationService } from './unified-notification-service'
+
+// Types
 export type {
+  // Native types
   NotificationPermission,
   NotificationResult,
   NotificationService,
   ReminderTime,
   ScheduledNotification,
   ShowNotificationOptions,
+  // Unified types
+  NotificationChannel,
+  NotificationPreference,
+  NotificationType,
+  UnifiedNotificationOptions,
+  UnifiedNotificationResult,
+  UnifiedNotificationService,
 } from './types'
+
 export { REMINDER_TIME_OPTIONS } from './types'

--- a/web-app/src/shared/services/notifications/types.ts
+++ b/web-app/src/shared/services/notifications/types.ts
@@ -1,12 +1,28 @@
 /**
  * Notification Service Types
  *
- * Types for the native notifications service that handles
- * permission requests and scheduled game reminders.
+ * Types for the unified notification system that supports both
+ * native browser notifications and in-app notifications.
  */
 
 /** Possible reminder times before a game */
 export type ReminderTime = '1h' | '2h' | '1d'
+
+/**
+ * Notification delivery channel.
+ * - 'native': Browser's native Notification API (requires permission)
+ * - 'in-app': In-app notification displayed within the UI
+ * - 'all': Both native and in-app
+ */
+export type NotificationChannel = 'native' | 'in-app' | 'all'
+
+/**
+ * User preference for notification delivery.
+ * - 'native': Prefer native, fall back to in-app if unavailable
+ * - 'in-app': Always use in-app only
+ * - 'both': Show both native and in-app
+ */
+export type NotificationPreference = 'native' | 'in-app' | 'both'
 
 // Time constants for scheduling limits
 const SECONDS_PER_MINUTE = 60
@@ -57,7 +73,7 @@ export interface ScheduledNotification {
   timeoutId: ReturnType<typeof setTimeout>
 }
 
-/** Notification service interface */
+/** Notification service interface (native notifications) */
 export interface NotificationService {
   /** Check if notifications are supported in this browser */
   isSupported: () => boolean
@@ -79,4 +95,105 @@ export interface NotificationService {
   cancelAllScheduledNotifications: () => void
   /** Get all currently scheduled notifications */
   getScheduledNotifications: () => ScheduledNotification[]
+}
+
+// ============================================================================
+// Unified Notification Types
+// ============================================================================
+
+/** Notification type/severity for in-app display */
+export type NotificationType = 'info' | 'success' | 'warning' | 'error'
+
+/** Options for showing a unified notification */
+export interface UnifiedNotificationOptions {
+  /** Notification title */
+  title: string
+  /** Notification body text */
+  body: string
+  /** Notification type/severity (for in-app styling) */
+  type?: NotificationType
+  /** Optional icon URL (for native notifications) */
+  icon?: string
+  /** Optional tag to replace existing notifications with same tag */
+  tag?: string
+  /** Whether to require user interaction to dismiss (native only) */
+  requireInteraction?: boolean
+  /** Duration in ms for in-app notifications (default: 8000ms for notifications) */
+  duration?: number
+  /** Optional data payload */
+  data?: Record<string, unknown>
+  /** Which channel to use (default: based on user preference) */
+  channel?: NotificationChannel
+}
+
+/** Result of a unified notification operation */
+export interface UnifiedNotificationResult {
+  /** Whether the notification was shown successfully */
+  success: boolean
+  /** Which channels successfully delivered the notification */
+  channels: {
+    native?: boolean
+    inApp?: boolean
+  }
+  /** Error message if both channels failed */
+  error?: string
+}
+
+/** Unified notification service interface */
+export interface UnifiedNotificationService {
+  /**
+   * Show a notification using the preferred channel(s).
+   * Falls back to in-app if native is unavailable.
+   */
+  notify: (options: UnifiedNotificationOptions) => Promise<UnifiedNotificationResult>
+
+  /**
+   * Check if native notifications are available (supported + permitted).
+   */
+  isNativeAvailable: () => boolean
+
+  /**
+   * Check if native notifications are supported (browser capability).
+   */
+  isNativeSupported: () => boolean
+
+  /**
+   * Get current native notification permission status.
+   */
+  getNativePermission: () => NotificationPermission
+
+  /**
+   * Request native notification permission.
+   */
+  requestNativePermission: () => Promise<NotificationPermission>
+
+  /**
+   * Show a notification via native channel only.
+   */
+  showNative: (options: ShowNotificationOptions) => Promise<NotificationResult>
+
+  /**
+   * Show a notification via in-app channel only.
+   */
+  showInApp: (options: UnifiedNotificationOptions) => string
+
+  /**
+   * Schedule a notification for a future time.
+   * Uses native notifications if available, otherwise schedules in-app.
+   */
+  schedule: (
+    id: string,
+    options: UnifiedNotificationOptions,
+    triggerTime: number,
+    preference?: NotificationPreference
+  ) => ScheduledNotification | null
+
+  /** Cancel a scheduled notification */
+  cancelScheduled: (id: string) => void
+
+  /** Cancel all scheduled notifications */
+  cancelAllScheduled: () => void
+
+  /** Get all currently scheduled notifications */
+  getScheduled: () => ScheduledNotification[]
 }

--- a/web-app/src/shared/services/notifications/unified-notification-service.test.ts
+++ b/web-app/src/shared/services/notifications/unified-notification-service.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { useToastStore } from '@/shared/stores/toast'
+
+import { notificationService } from './notification-service'
+import { unifiedNotificationService } from './unified-notification-service'
+
+// Mock the native notification service
+vi.mock('./notification-service', () => ({
+  notificationService: {
+    isSupported: vi.fn(),
+    getPermission: vi.fn(),
+    requestPermission: vi.fn(),
+    showNotification: vi.fn(),
+    scheduleNotification: vi.fn(),
+    cancelScheduledNotification: vi.fn(),
+    cancelAllScheduledNotifications: vi.fn(),
+    getScheduledNotifications: vi.fn(),
+  },
+}))
+
+describe('unifiedNotificationService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Reset all mocks
+    vi.mocked(notificationService.isSupported).mockReturnValue(true)
+    vi.mocked(notificationService.getPermission).mockReturnValue('granted')
+    vi.mocked(notificationService.requestPermission).mockResolvedValue('granted')
+    vi.mocked(notificationService.showNotification).mockResolvedValue({ success: true })
+    vi.mocked(notificationService.scheduleNotification).mockReturnValue(null)
+    vi.mocked(notificationService.getScheduledNotifications).mockReturnValue([])
+    // Clear toast store
+    useToastStore.getState().clearToasts()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+    useToastStore.getState().clearToasts()
+  })
+
+  describe('isNativeSupported', () => {
+    it('returns true when native notifications are supported', () => {
+      vi.mocked(notificationService.isSupported).mockReturnValue(true)
+      expect(unifiedNotificationService.isNativeSupported()).toBe(true)
+    })
+
+    it('returns false when native notifications are not supported', () => {
+      vi.mocked(notificationService.isSupported).mockReturnValue(false)
+      expect(unifiedNotificationService.isNativeSupported()).toBe(false)
+    })
+  })
+
+  describe('isNativeAvailable', () => {
+    it('returns true when native is supported and permission granted', () => {
+      vi.mocked(notificationService.isSupported).mockReturnValue(true)
+      vi.mocked(notificationService.getPermission).mockReturnValue('granted')
+      expect(unifiedNotificationService.isNativeAvailable()).toBe(true)
+    })
+
+    it('returns false when native is not supported', () => {
+      vi.mocked(notificationService.isSupported).mockReturnValue(false)
+      vi.mocked(notificationService.getPermission).mockReturnValue('granted')
+      expect(unifiedNotificationService.isNativeAvailable()).toBe(false)
+    })
+
+    it('returns false when permission not granted', () => {
+      vi.mocked(notificationService.isSupported).mockReturnValue(true)
+      vi.mocked(notificationService.getPermission).mockReturnValue('denied')
+      expect(unifiedNotificationService.isNativeAvailable()).toBe(false)
+    })
+  })
+
+  describe('getNativePermission', () => {
+    it('delegates to native notification service', () => {
+      vi.mocked(notificationService.getPermission).mockReturnValue('default')
+      expect(unifiedNotificationService.getNativePermission()).toBe('default')
+    })
+  })
+
+  describe('requestNativePermission', () => {
+    it('delegates to native notification service', async () => {
+      vi.mocked(notificationService.requestPermission).mockResolvedValue('granted')
+      const result = await unifiedNotificationService.requestNativePermission()
+      expect(result).toBe('granted')
+      expect(notificationService.requestPermission).toHaveBeenCalled()
+    })
+  })
+
+  describe('showNative', () => {
+    it('delegates to native notification service', async () => {
+      vi.mocked(notificationService.showNotification).mockResolvedValue({ success: true })
+      const result = await unifiedNotificationService.showNative({
+        title: 'Test',
+        body: 'Test body',
+      })
+      expect(result.success).toBe(true)
+      expect(notificationService.showNotification).toHaveBeenCalledWith({
+        title: 'Test',
+        body: 'Test body',
+      })
+    })
+  })
+
+  describe('showInApp', () => {
+    it('shows toast notification with title and body combined', () => {
+      const id = unifiedNotificationService.showInApp({
+        title: 'Test Title',
+        body: 'Test body',
+        type: 'info',
+      })
+      expect(id).toBeDefined()
+
+      const toasts = useToastStore.getState().toasts
+      expect(toasts).toHaveLength(1)
+      expect(toasts[0]?.message).toBe('Test Title: Test body')
+      expect(toasts[0]?.type).toBe('info')
+    })
+
+    it('shows toast with custom duration', () => {
+      unifiedNotificationService.showInApp({
+        title: 'Test',
+        body: 'Test body',
+        duration: 10000,
+      })
+
+      const toasts = useToastStore.getState().toasts
+      expect(toasts[0]?.duration).toBe(10000)
+    })
+
+    it('defaults to info type', () => {
+      unifiedNotificationService.showInApp({
+        title: 'Test',
+        body: 'Test body',
+      })
+
+      const toasts = useToastStore.getState().toasts
+      expect(toasts[0]?.type).toBe('info')
+    })
+  })
+
+  describe('notify', () => {
+    describe('with channel: native', () => {
+      it('only shows native notification', async () => {
+        vi.mocked(notificationService.showNotification).mockResolvedValue({ success: true })
+
+        const result = await unifiedNotificationService.notify({
+          title: 'Test',
+          body: 'Test body',
+          channel: 'native',
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.channels.native).toBe(true)
+        expect(result.channels.inApp).toBeUndefined()
+        expect(notificationService.showNotification).toHaveBeenCalled()
+        expect(useToastStore.getState().toasts).toHaveLength(0)
+      })
+    })
+
+    describe('with channel: in-app', () => {
+      it('only shows in-app notification', async () => {
+        const result = await unifiedNotificationService.notify({
+          title: 'Test',
+          body: 'Test body',
+          channel: 'in-app',
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.channels.inApp).toBe(true)
+        expect(result.channels.native).toBeUndefined()
+        expect(notificationService.showNotification).not.toHaveBeenCalled()
+        expect(useToastStore.getState().toasts).toHaveLength(1)
+      })
+    })
+
+    describe('with channel: all', () => {
+      it('shows both native and in-app notifications', async () => {
+        vi.mocked(notificationService.showNotification).mockResolvedValue({ success: true })
+
+        const result = await unifiedNotificationService.notify({
+          title: 'Test',
+          body: 'Test body',
+          channel: 'all',
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.channels.native).toBe(true)
+        expect(result.channels.inApp).toBe(true)
+        expect(notificationService.showNotification).toHaveBeenCalled()
+        expect(useToastStore.getState().toasts).toHaveLength(1)
+      })
+    })
+
+    describe('with default channel (no explicit channel)', () => {
+      it('uses native when available and falls back to in-app when not', async () => {
+        // Native available
+        vi.mocked(notificationService.isSupported).mockReturnValue(true)
+        vi.mocked(notificationService.getPermission).mockReturnValue('granted')
+        vi.mocked(notificationService.showNotification).mockResolvedValue({ success: true })
+
+        const result = await unifiedNotificationService.notify({
+          title: 'Test',
+          body: 'Test body',
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.channels.native).toBe(true)
+        // In-app should not be used when native is available
+        expect(result.channels.inApp).toBeUndefined()
+      })
+
+      it('uses in-app when native is not available', async () => {
+        // Native not available
+        vi.mocked(notificationService.isSupported).mockReturnValue(true)
+        vi.mocked(notificationService.getPermission).mockReturnValue('denied')
+
+        const result = await unifiedNotificationService.notify({
+          title: 'Test',
+          body: 'Test body',
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.channels.inApp).toBe(true)
+        expect(result.channels.native).toBeUndefined()
+      })
+    })
+  })
+
+  describe('schedule', () => {
+    it('schedules a notification for future time', () => {
+      const now = Date.now()
+      const triggerTime = now + 5000
+
+      const result = unifiedNotificationService.schedule(
+        'test-id',
+        { title: 'Test', body: 'Test body' },
+        triggerTime
+      )
+
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe('test-id')
+      expect(result?.scheduledTime).toBe(triggerTime)
+    })
+
+    it('returns null for past times', () => {
+      const pastTime = Date.now() - 1000
+
+      const result = unifiedNotificationService.schedule(
+        'test-past',
+        { title: 'Test', body: 'Test body' },
+        pastTime
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null for times more than 24 hours in advance', () => {
+      const farFuture = Date.now() + 25 * 60 * 60 * 1000
+
+      const result = unifiedNotificationService.schedule(
+        'test-far',
+        { title: 'Test', body: 'Test body' },
+        farFuture
+      )
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('cancelScheduled', () => {
+    it('cancels unified and native scheduled notifications', () => {
+      const now = Date.now()
+      unifiedNotificationService.schedule('test-id', { title: 'Test', body: 'Test' }, now + 5000)
+
+      unifiedNotificationService.cancelScheduled('test-id')
+
+      expect(notificationService.cancelScheduledNotification).toHaveBeenCalledWith('test-id')
+    })
+  })
+
+  describe('cancelAllScheduled', () => {
+    it('cancels all scheduled notifications', () => {
+      const now = Date.now()
+      unifiedNotificationService.schedule('test-1', { title: 'T1', body: 'B1' }, now + 5000)
+      unifiedNotificationService.schedule('test-2', { title: 'T2', body: 'B2' }, now + 10000)
+
+      unifiedNotificationService.cancelAllScheduled()
+
+      expect(notificationService.cancelAllScheduledNotifications).toHaveBeenCalled()
+    })
+  })
+
+  describe('getScheduled', () => {
+    it('returns combined unified and native scheduled notifications', () => {
+      vi.mocked(notificationService.getScheduledNotifications).mockReturnValue([
+        { id: 'native-1', assignmentId: 'a1', scheduledTime: 1000, timeoutId: 123 as unknown as ReturnType<typeof setTimeout> },
+      ])
+
+      const now = Date.now()
+      unifiedNotificationService.schedule('unified-1', { title: 'U1', body: 'B1' }, now + 5000)
+
+      const scheduled = unifiedNotificationService.getScheduled()
+
+      expect(scheduled.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+})

--- a/web-app/src/shared/services/notifications/unified-notification-service.ts
+++ b/web-app/src/shared/services/notifications/unified-notification-service.ts
@@ -1,0 +1,312 @@
+/**
+ * Unified Notification Service
+ *
+ * Provides a unified interface for both native browser notifications
+ * and in-app notifications. Automatically falls back to in-app when
+ * native notifications are unavailable or not permitted.
+ *
+ * Usage:
+ * ```typescript
+ * import { unifiedNotificationService } from '@/shared/services/notifications';
+ *
+ * // Show notification (auto-selects channel based on availability)
+ * await unifiedNotificationService.notify({
+ *   title: 'Game Reminder',
+ *   body: 'Your game starts in 1 hour',
+ *   type: 'info',
+ * });
+ *
+ * // Force specific channel
+ * await unifiedNotificationService.notify({
+ *   title: 'Game Reminder',
+ *   body: 'Your game starts in 1 hour',
+ *   channel: 'in-app', // or 'native', 'all'
+ * });
+ * ```
+ */
+
+import { useToastStore } from '@/shared/stores/toast'
+
+import { notificationService } from './notification-service'
+import {
+  ONE_DAY_MS,
+  type NotificationChannel,
+  type NotificationPermission,
+  type NotificationPreference,
+  type NotificationResult,
+  type ScheduledNotification,
+  type ShowNotificationOptions,
+  type UnifiedNotificationOptions,
+  type UnifiedNotificationResult,
+  type UnifiedNotificationService,
+} from './types'
+
+// Default duration for in-app notifications (longer than toasts for importance)
+const DEFAULT_NOTIFICATION_DURATION_MS = 8000
+
+// Store for scheduled unified notifications
+const scheduledNotifications = new Map<string, ScheduledNotification>()
+
+/**
+ * Check if native notifications are supported by the browser.
+ */
+function isNativeSupported(): boolean {
+  return notificationService.isSupported()
+}
+
+/**
+ * Check if native notifications are available (supported AND permitted).
+ */
+function isNativeAvailable(): boolean {
+  return isNativeSupported() && notificationService.getPermission() === 'granted'
+}
+
+/**
+ * Get current native notification permission status.
+ */
+function getNativePermission(): NotificationPermission {
+  return notificationService.getPermission()
+}
+
+/**
+ * Request native notification permission.
+ */
+async function requestNativePermission(): Promise<NotificationPermission> {
+  return notificationService.requestPermission()
+}
+
+/**
+ * Show a native notification.
+ */
+async function showNative(options: ShowNotificationOptions): Promise<NotificationResult> {
+  return notificationService.showNotification(options)
+}
+
+/**
+ * Show an in-app notification using the toast system.
+ * Returns the notification ID.
+ */
+function showInApp(options: UnifiedNotificationOptions): string {
+  const { addToast } = useToastStore.getState()
+
+  // Combine title and body for toast message
+  const message = options.title ? `${options.title}: ${options.body}` : options.body
+
+  return addToast({
+    message,
+    type: options.type ?? 'info',
+    duration: options.duration ?? DEFAULT_NOTIFICATION_DURATION_MS,
+  })
+}
+
+/**
+ * Determine which channels to use based on options and availability.
+ */
+function resolveChannels(
+  channel: NotificationChannel | undefined,
+  preference: NotificationPreference = 'native'
+): { native: boolean; inApp: boolean } {
+  // Explicit channel override
+  if (channel === 'native') {
+    return { native: true, inApp: false }
+  }
+  if (channel === 'in-app') {
+    return { native: false, inApp: true }
+  }
+  if (channel === 'all') {
+    return { native: true, inApp: true }
+  }
+
+  // Based on preference
+  const nativeAvailable = isNativeAvailable()
+
+  switch (preference) {
+    case 'both':
+      return { native: nativeAvailable, inApp: true }
+    case 'in-app':
+      return { native: false, inApp: true }
+    case 'native':
+    default:
+      // Prefer native, fall back to in-app
+      return {
+        native: nativeAvailable,
+        inApp: !nativeAvailable,
+      }
+  }
+}
+
+/**
+ * Show a notification using the preferred channel(s).
+ */
+async function notify(options: UnifiedNotificationOptions): Promise<UnifiedNotificationResult> {
+  const channels = resolveChannels(options.channel)
+  const result: UnifiedNotificationResult = {
+    success: false,
+    channels: {},
+  }
+
+  // Try native notification
+  if (channels.native) {
+    const nativeResult = await showNative({
+      title: options.title,
+      body: options.body,
+      icon: options.icon,
+      tag: options.tag,
+      requireInteraction: options.requireInteraction,
+      data: options.data,
+    })
+    result.channels.native = nativeResult.success
+    if (nativeResult.success) {
+      result.success = true
+    }
+  }
+
+  // Try in-app notification
+  if (channels.inApp) {
+    try {
+      showInApp(options)
+      result.channels.inApp = true
+      result.success = true
+    } catch (error) {
+      result.channels.inApp = false
+      if (!result.success) {
+        result.error = error instanceof Error ? error.message : 'Failed to show in-app notification'
+      }
+    }
+  }
+
+  // Set error if nothing succeeded
+  if (!result.success && !result.error) {
+    result.error = 'No notification channel available'
+  }
+
+  return result
+}
+
+/**
+ * Schedule a notification for a future time.
+ */
+function schedule(
+  id: string,
+  options: UnifiedNotificationOptions,
+  triggerTime: number,
+  preference: NotificationPreference = 'native'
+): ScheduledNotification | null {
+  // Cancel any existing notification with this ID
+  cancelScheduled(id)
+
+  const now = Date.now()
+  const delay = triggerTime - now
+
+  // Don't schedule if the time has already passed
+  if (delay <= 0) {
+    return null
+  }
+
+  // Don't schedule notifications more than 24 hours in advance
+  if (delay > ONE_DAY_MS) {
+    return null
+  }
+
+  const timeoutId = setTimeout(() => {
+    const channels = resolveChannels(options.channel, preference)
+
+    // Show notification through appropriate channels
+    if (channels.native && isNativeAvailable()) {
+      showNative({
+        title: options.title,
+        body: options.body,
+        icon: options.icon,
+        tag: options.tag,
+        requireInteraction: options.requireInteraction,
+        data: options.data,
+      })
+    }
+
+    if (channels.inApp) {
+      showInApp(options)
+    }
+
+    scheduledNotifications.delete(id)
+  }, delay)
+
+  const scheduled: ScheduledNotification = {
+    id,
+    assignmentId: (options.data?.assignmentId as string) ?? id,
+    scheduledTime: triggerTime,
+    timeoutId,
+  }
+
+  scheduledNotifications.set(id, scheduled)
+
+  return scheduled
+}
+
+/**
+ * Cancel a scheduled notification.
+ */
+function cancelScheduled(id: string): void {
+  const scheduled = scheduledNotifications.get(id)
+  if (scheduled) {
+    clearTimeout(scheduled.timeoutId)
+    scheduledNotifications.delete(id)
+  }
+
+  // Also cancel from native service
+  notificationService.cancelScheduledNotification(id)
+}
+
+/**
+ * Cancel all scheduled notifications.
+ */
+function cancelAllScheduled(): void {
+  for (const scheduled of scheduledNotifications.values()) {
+    clearTimeout(scheduled.timeoutId)
+  }
+  scheduledNotifications.clear()
+
+  // Also cancel from native service
+  notificationService.cancelAllScheduledNotifications()
+}
+
+/**
+ * Get all currently scheduled notifications.
+ */
+function getScheduled(): ScheduledNotification[] {
+  // Combine unified and native scheduled notifications
+  const unifiedScheduled = Array.from(scheduledNotifications.values())
+  const nativeScheduled = notificationService.getScheduledNotifications()
+
+  // Deduplicate by ID
+  const all = new Map<string, ScheduledNotification>()
+  for (const s of unifiedScheduled) {
+    all.set(s.id, s)
+  }
+  for (const s of nativeScheduled) {
+    if (!all.has(s.id)) {
+      all.set(s.id, s)
+    }
+  }
+
+  return Array.from(all.values())
+}
+
+/**
+ * Unified notification service singleton.
+ *
+ * Provides a single interface for both native and in-app notifications.
+ * Automatically handles fallback when native notifications are unavailable.
+ */
+export const unifiedNotificationService: UnifiedNotificationService = {
+  notify,
+  isNativeAvailable,
+  isNativeSupported,
+  getNativePermission,
+  requestNativePermission,
+  showNative,
+  showInApp,
+  schedule,
+  cancelScheduled,
+  cancelAllScheduled,
+  getScheduled,
+}

--- a/web-app/src/shared/stores/settings.test.ts
+++ b/web-app/src/shared/stores/settings.test.ts
@@ -31,6 +31,7 @@ const DEFAULT_MODE_SETTINGS: ModeSettings = {
   notificationSettings: {
     enabled: false,
     reminderTimes: ['1h'],
+    deliveryPreference: 'native',
   },
 }
 


### PR DESCRIPTION
## Summary

- Add unified notification service that combines native browser notifications and in-app toast notifications
- Automatically use native notifications when available, fallback to in-app when browser permissions denied
- Single toggle in settings to enable/disable notifications (app decides delivery method automatically)
- Show indicator of which notification type is being used when enabled

## Test plan

- [ ] Toggle notifications on when native permissions not yet requested - should prompt for permission
- [ ] Toggle notifications on after granting permission - should show "Using browser notifications"
- [ ] Toggle notifications on after denying permission - should show info message and use in-app
- [ ] Verify reminder time selection works when notifications enabled
- [ ] Run existing notification tests: `npm test -- NotificationsSection`