### PR TITLE
fix(pwa): improve version detection and refresh on iOS login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- PWA version detection now properly triggers refresh on iOS - added fallback reload mechanism when service worker is not ready, visibility change handler for app resume from background, and login buttons are disabled until update is applied to prevent authentication with stale code
 - PWA login page now shows prominent update banner when a new version is available - previously users could attempt login with stale cached code, causing confusing username/password errors; the banner prompts users to update before logging in
 - Compensation update API now sends `__identity` nested inside `convocationCompensation` object, matching the format expected by the VolleyManager API - this fixes 500 errors when saving compensation edits
 - Compensation API calls now work correctly when editing from the Assignments tab - the hook was incorrectly using the global `api` object instead of the data-source-aware `getApiClient()`, which could cause issues in calendar mode

--- a/web-app/src/features/auth/LoginPage.tsx
+++ b/web-app/src/features/auth/LoginPage.tsx
@@ -375,7 +375,7 @@ export function LoginPage() {
                   variant="primary"
                   fullWidth
                   loading={isLoading}
-                  disabled={isLockedOut}
+                  disabled={isLockedOut || needRefresh}
                   onClick={performLogin}
                   data-testid="login-button"
                 >
@@ -459,6 +459,7 @@ export function LoginPage() {
                   variant="primary"
                   fullWidth
                   loading={isLoading}
+                  disabled={needRefresh}
                   onClick={performCalendarLogin}
                   data-testid="calendar-login-button"
                 >


### PR DESCRIPTION
## Summary

- Add fallback reload mechanism in `updateApp()` when service worker is not ready - clears caches and forces reload instead of silently failing
- Add visibility change handler to version check script for iOS PWA resume from background - ensures stale cached versions are detected when app is brought back to foreground
- Disable login buttons when `needRefresh` is true - forces user to click explicit "Update Now" button, preventing loss of entered credentials

## Test plan

- [ ] Install PWA on iOS, verify version detection works when resuming from background
- [ ] Test login page with update available - buttons should be disabled until update is clicked
- [ ] Verify fallback reload works when service worker is not ready