### PR TITLE
fix(pwa): proxy profile picture URL to fix display in PWA mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Profile picture now displays correctly in PWA Settings page - image URLs are now proxied through the worker to bypass iOS Safari's cross-origin restrictions that blocked images from volleymanager.volleyball.ch in standalone PWA mode
 - PWA version detection now properly triggers refresh on iOS - added fallback reload mechanism when service worker is not ready, visibility change handler for app resume from background, and login buttons are disabled until update is applied to prevent authentication with stale code
 - PWA login page now shows prominent update banner when a new version is available - previously users could attempt login with stale cached code, causing confusing username/password errors; the banner prompts users to update before logging in
 - Compensation update API now sends `__identity` nested inside `convocationCompensation` object, matching the format expected by the VolleyManager API - this fixes 500 errors when saving compensation edits

--- a/web-app/src/features/settings/components/ProfileSection.tsx
+++ b/web-app/src/features/settings/components/ProfileSection.tsx
@@ -79,7 +79,19 @@ function ProfileSectionComponent({ user }: ProfileSectionProps) {
           const data: PersonProfileResponse = await response.json()
           const person = data.person
           if (person?.profilePicture?.publicResourceUri) {
-            setProfilePictureUrl(person.profilePicture.publicResourceUri)
+            // Rewrite the full volleymanager URL to go through our proxy.
+            // This is necessary for PWA mode where cross-origin images from
+            // volleymanager.volleyball.ch are blocked by iOS Safari's ITP.
+            const fullUrl = person.profilePicture.publicResourceUri
+            try {
+              const url = new URL(fullUrl)
+              // Extract just the path (e.g., /_Resources/Persistent/<hash>/image.jpg)
+              // and prepend our API proxy base URL
+              setProfilePictureUrl(`${API_BASE}${url.pathname}`)
+            } catch {
+              // If URL parsing fails, use the original URL
+              setProfilePictureUrl(fullUrl)
+            }
           }
           // Check for svNumber first, fall back to associationId (same value, different property names)
           const svNum = person?.svNumber ?? person?.associationId

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -204,6 +204,15 @@ describe("Path Filtering", () => {
         isAllowedPath("/sportmanager.notificationcenter/api/notifications"),
       ).toBe(true);
     });
+
+    it("allows static resource paths (profile pictures, uploads)", () => {
+      expect(
+        isAllowedPath("/_Resources/Persistent/abc123/profile.jpg"),
+      ).toBe(true);
+      expect(
+        isAllowedPath("/_Resources/Static/Packages/some-asset.png"),
+      ).toBe(true);
+    });
   });
 
   describe("requiresApiPrefix", () => {
@@ -275,6 +284,12 @@ describe("Path Filtering", () => {
           "/indoorvolleyball.refadmin/refereestatementofexpenses/downloadrefereestatementofexpenses?refereeConvocation=abc-123",
         ),
       ).toBe(false);
+    });
+
+    it("returns false for static resource paths", () => {
+      expect(requiresApiPrefix("/_Resources/Persistent/abc123/image.jpg")).toBe(
+        false,
+      );
     });
   });
 });

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -14,6 +14,8 @@ export const ALLOWED_EXACT_PATHS = ["/", "/login", "/logout"];
 export const ALLOWED_PREFIX_PATHS_NO_API = [
   "/sportmanager.security/",
   "/sportmanager.volleyball/",
+  // Static resources (profile pictures, uploaded files) served by Neos Flow
+  "/_Resources/",
 ];
 
 /** Prefix match paths that ARE prefixed with /api/ (API endpoints) */


### PR DESCRIPTION
## Summary
- Profile pictures were not displaying in the Settings page when running as an installed PWA on iOS
- The issue was caused by iOS Safari's Intelligent Tracking Prevention (ITP) blocking cross-origin images from volleymanager.volleyball.ch
- Added `/_Resources/` to the worker's allowed paths to proxy static resources (profile pictures, uploaded files)
- Updated ProfileSection to rewrite the volleymanager.volleyball.ch URL to go through the proxy

## Test plan
- [ ] Install PWA on iOS Safari
- [ ] Log in and navigate to Settings page
- [ ] Verify profile picture displays correctly
- [ ] Test in browser mode to ensure no regression