### PR TITLE
fix(ocr-poc): add TypeScript path mappings for react dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- OCR POC TypeScript build now resolves React dependencies correctly when importing web-app components (#724)
 - Profile picture now displays correctly in PWA Settings page - image URLs are now proxied through the worker to bypass iOS Safari's cross-origin restrictions that blocked images from volleymanager.volleyball.ch in standalone PWA mode
 - PWA version detection now properly triggers refresh on iOS - added fallback reload mechanism when service worker is not ready, visibility change handler for app resume from background, and login buttons are disabled until update is applied to prevent authentication with stale code
 - PWA login page now shows prominent update banner when a new version is available - previously users could attempt login with stale cached code, causing confusing username/password errors; the banner prompts users to update before logging in

--- a/ocr-poc/tsconfig.app.json
+++ b/ocr-poc/tsconfig.app.json
@@ -19,6 +19,11 @@
     /* Path aliases */
     "baseUrl": ".",
     "paths": {
+      /* Redirect dependencies to ocr-poc's node_modules for web-app imports */
+      "react": ["./node_modules/@types/react"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react-easy-crop": ["./node_modules/react-easy-crop"],
+      /* PoC and web-app path aliases */
       "@/*": ["./src/*"],
       "@/shared/*": ["./src/shared/*"],
       "@/features/*": ["../web-app/src/features/*"],


### PR DESCRIPTION
## Summary

- Add TypeScript path mappings for `react`, `react-dom`, and `react-easy-crop` to ocr-poc's tsconfig.app.json
- Fixes CI build failure when ocr-poc imports components from web-app that depend on React
- Mirrors the Vite alias configuration that already handles this at build time

## Test Plan

- [ ] Verify `npm run build` succeeds in ocr-poc
- [ ] Verify CI build passes for ocr-poc deployment