### PR TITLE
fix(ocr-poc): add jsx-runtime path mappings for TypeScript build

### DIFF
--- a/ocr-poc/tsconfig.app.json
+++ b/ocr-poc/tsconfig.app.json
@@ -21,6 +21,8 @@
     "paths": {
       /* Redirect dependencies to ocr-poc's node_modules for web-app imports */
       "react": ["./node_modules/@types/react"],
+      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime"],
+      "react/jsx-dev-runtime": ["./node_modules/@types/react/jsx-dev-runtime"],
       "react-dom": ["./node_modules/@types/react-dom"],
       "react-easy-crop": ["./node_modules/react-easy-crop"],
       /* PoC and web-app path aliases */


### PR DESCRIPTION
## Summary
- Add `react/jsx-runtime` and `react/jsx-dev-runtime` path mappings to `tsconfig.app.json`
- Fixes CI build failure where TypeScript couldn't find `react/jsx-runtime` module

## Test Plan
- Build passes locally: `npm run build` in ocr-poc directory
- CI should now pass the TypeScript compilation step