### PR TITLE
fix(pwa): clear session state and use cache-busting URLs on PWA update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - PDF download for compensation statements now works in PWA mode - the MIME type validation was case-sensitive and failed when servers returned `Application/PDF` or `application/pdf; charset=utf-8` instead of lowercase `application/pdf`
+- PWA auto-refresh after update now works correctly on iOS - previously users experienced "invalid login" errors after automatic updates because stale session tokens and auth state remained in localStorage; now the update process clears session data and uses cache-busting URLs to bypass Safari's aggressive memory cache
 
 ## [1.2.0] - 2026-01-11
 


### PR DESCRIPTION
## Summary

- Clear localStorage session tokens (volleykit-session-token, volleykit-auth) during PWA version mismatch updates to prevent stale auth state causing "invalid login" errors
- Use cache-busting URL parameter (?_pwa_update=<timestamp>) to bypass Safari's aggressive memory cache
- Add fallback to regular reload() if URL parsing fails in test environments

## Test plan

- [ ] Install PWA on iOS Safari
- [ ] Deploy a new version  
- [ ] Verify automatic update triggers reload
- [ ] Verify user is redirected to login page without errors
- [ ] Verify user can log in successfully after update