### PR TITLE
fix(release): extract changelog entries and sync package-lock.json

### DIFF
--- a/.changeset/fix-release-notes-extraction.md
+++ b/.changeset/fix-release-notes-extraction.md
@@ -2,4 +2,4 @@
 "volleykit-web": patch
 ---
 
-Fixed release workflow not extracting changelog entries for GitHub release notes - the sed pattern expected `## [1.3.0]` format but Changesets generates `## 1.3.0` without brackets
+Fixed release workflow not extracting changelog entries for GitHub release notes - the sed pattern expected `## [1.3.0]` format but Changesets generates `## 1.3.0` without brackets. Also fixed package-lock.json not being updated during releases by adding `npm install --package-lock-only` after version bump

--- a/.changeset/fix-release-notes-extraction.md
+++ b/.changeset/fix-release-notes-extraction.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": patch
+---
+
+Fixed release workflow not extracting changelog entries for GitHub release notes - the sed pattern expected `## [1.3.0]` format but Changesets generates `## 1.3.0` without brackets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,9 @@ jobs:
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
 
+          # Sync package-lock.json with the new version in package.json
+          cd web-app && npm install --package-lock-only
+
       - name: Get new version
         id: get_version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,21 @@ jobs:
 
           # Extract content between the new version header and the next version header
           # This gets the release notes for the version we're releasing
-          NOTES=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '1d;$d')
+          # Supports both formats:
+          #   - Changesets format: "## 1.3.0" (no brackets)
+          #   - Keep a Changelog format: "## [1.2.0] - date" (with brackets and date)
+          NOTES=$(awk -v ver="$VERSION" '
+            BEGIN { printing=0 }
+            /^## / {
+              if (printing) { exit }
+              # Match: "## 1.3.0" or "## [1.3.0]" (with optional date suffix)
+              if (index($0, "## " ver) == 1 || index($0, "## [" ver "]") == 1) {
+                printing=1
+                next
+              }
+            }
+            printing { print }
+          ' CHANGELOG.md)
 
           # Write to file for GitHub release
           echo "$NOTES" > /tmp/release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,6 @@
 
 - [#729](https://github.com/Takishima/volleykit/pull/729) [`166bf02`](https://github.com/Takishima/volleykit/commit/166bf0291d5afffd6ef59249226bc17b40c9ac10) Thanks [@Takishima](https://github.com/Takishima)! - Removed notification settings section from Settings page - notifications can only be generated when the app is open, making them impractical for PWA users who expect notifications when the app is closed
 
-All notable changes to VolleyKit will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
 
 ## [1.2.0] - 2026-01-11

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "volleykit-web",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "volleykit-web",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-query": "^5.90.16",


### PR DESCRIPTION
## Summary

- Fixed release workflow not extracting changelog entries for GitHub release notes - the sed pattern expected `## [1.3.0]` format but Changesets generates `## 1.3.0` without brackets
- Fixed package-lock.json not being updated during releases by adding `npm install --package-lock-only` after version bump
- Removed misplaced boilerplate text from the 1.3.0 changelog section
- Synced package-lock.json version with v1.3.0 release

## Test plan

- [ ] Run the release workflow with dry-run to verify release notes are extracted correctly
- [ ] Verify package-lock.json is included in the release commit