### PR TITLE
fix(auth): improve login UX on iOS PWA when app update is needed

### DIFF
--- a/.changeset/fix-login-update-message.md
+++ b/.changeset/fix-login-update-message.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": patch
+---
+
+Improved login error UX when PWA update is needed - shows inline update button when login fails, especially helpful on iOS where service worker update detection is unreliable

--- a/.changeset/fix-login-update-message.md
+++ b/.changeset/fix-login-update-message.md
@@ -2,4 +2,7 @@
 "volleykit-web": patch
 ---
 
-Improved login error UX when PWA update is needed - shows inline update button when login fails, especially helpful on iOS where service worker update detection is unreliable
+Improved login experience on iOS PWA when app update is needed:
+- Shows inline "Update Now" button when login fails, suggesting app update may fix the issue
+- Clears stale CSRF tokens when login page loads or app resumes from suspension
+- Added pageshow event fallback for more reliable update detection on iOS PWA

--- a/web-app/src/contexts/PWAProviderInternal.tsx
+++ b/web-app/src/contexts/PWAProviderInternal.tsx
@@ -49,10 +49,21 @@ export default function PWAProviderInternal({ children }: PWAProviderInternalPro
       }
     }
 
+    // pageshow event is more reliable on iOS Safari PWA for detecting
+    // app resume from suspension. The persisted property indicates if
+    // the page was restored from bfcache (back-forward cache).
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted && registrationRef.current) {
+        registrationRef.current.update().catch(() => {})
+      }
+    }
+
     document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('pageshow', handlePageShow)
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('pageshow', handlePageShow)
     }
   }, [])
 

--- a/web-app/src/features/auth/LoginPage.test.tsx
+++ b/web-app/src/features/auth/LoginPage.test.tsx
@@ -26,6 +26,7 @@ vi.mock('@/shared/hooks/useTranslation', () => ({
 const mockLogin = vi.fn()
 const mockLoginWithCalendar = vi.fn()
 const mockSetDemoAuthenticated = vi.fn()
+const mockClearStaleSession = vi.fn()
 const mockInitializeDemoData = vi.fn()
 
 function mockAuthStoreState(overrides = {}) {
@@ -34,7 +35,9 @@ function mockAuthStoreState(overrides = {}) {
     loginWithCalendar: mockLoginWithCalendar,
     status: 'idle' as const,
     error: null,
+    lockedUntil: null,
     setDemoAuthenticated: mockSetDemoAuthenticated,
+    clearStaleSession: mockClearStaleSession,
     ...overrides,
   }
   vi.mocked(authStore.useAuthStore).mockImplementation((selector?: unknown) => {

--- a/web-app/src/features/auth/LoginPage.tsx
+++ b/web-app/src/features/auth/LoginPage.tsx
@@ -28,17 +28,25 @@ type LoginMode = 'full' | 'calendar'
 
 export function LoginPage() {
   const navigate = useNavigate()
-  const { login, loginWithCalendar, status, error, lockedUntil, setDemoAuthenticated } =
-    useAuthStore(
-      useShallow((state) => ({
-        login: state.login,
-        loginWithCalendar: state.loginWithCalendar,
-        status: state.status,
-        error: state.error,
-        lockedUntil: state.lockedUntil,
-        setDemoAuthenticated: state.setDemoAuthenticated,
-      }))
-    )
+  const {
+    login,
+    loginWithCalendar,
+    status,
+    error,
+    lockedUntil,
+    setDemoAuthenticated,
+    clearStaleSession,
+  } = useAuthStore(
+    useShallow((state) => ({
+      login: state.login,
+      loginWithCalendar: state.loginWithCalendar,
+      status: state.status,
+      error: state.error,
+      lockedUntil: state.lockedUntil,
+      setDemoAuthenticated: state.setDemoAuthenticated,
+      clearStaleSession: state.clearStaleSession,
+    }))
+  )
   const initializeDemoData = useDemoStore((state) => state.initializeDemoData)
   const { t } = useTranslation()
   const { needRefresh, updateApp, checkForUpdate, isChecking: isCheckingForUpdate } = usePWA()
@@ -85,6 +93,13 @@ export function LoginPage() {
       calendarValidationAbortRef.current?.abort()
     }
   }, [])
+
+  // Clear stale session data on mount to prevent authentication errors.
+  // On iOS PWA, cached CSRF tokens can become stale and cause "invalid credentials"
+  // errors even with correct username/password.
+  useEffect(() => {
+    clearStaleSession()
+  }, [clearStaleSession])
 
   // Countdown timer for lockout - ticks every second until lockout expires
   useEffect(() => {

--- a/web-app/src/features/auth/components/LoginErrorWithUpdateHint.tsx
+++ b/web-app/src/features/auth/components/LoginErrorWithUpdateHint.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+
+import { RefreshCw } from '@/shared/components/icons'
+import { useTranslation } from '@/shared/hooks/useTranslation'
+
+interface LoginErrorWithUpdateHintProps {
+  errorMessage: string
+  showUpdateHint: boolean
+  updateAvailable: boolean
+  onUpdate: () => Promise<void>
+  isUpdating: boolean
+  isCheckingForUpdate: boolean
+}
+
+/**
+ * Error display component for the login page with optional update hint.
+ *
+ * On iOS PWA, service worker update detection is unreliable. When login fails,
+ * this component shows a hint to update the app, which can help users who are
+ * running an outdated version that can't properly parse new API responses.
+ */
+export function LoginErrorWithUpdateHint({
+  errorMessage,
+  showUpdateHint,
+  updateAvailable,
+  onUpdate,
+  isUpdating,
+  isCheckingForUpdate,
+}: LoginErrorWithUpdateHintProps) {
+  const { t } = useTranslation()
+  const [isButtonLoading, setIsButtonLoading] = useState(false)
+
+  const handleUpdateClick = async () => {
+    if (isButtonLoading || isUpdating) return
+    setIsButtonLoading(true)
+    try {
+      await onUpdate()
+    } finally {
+      // Note: onUpdate() typically reloads, so this may not execute
+      setIsButtonLoading(false)
+    }
+  }
+
+  const loading = isButtonLoading || isUpdating
+
+  return (
+    <div className="rounded-lg border border-danger-200 bg-danger-50 p-3 dark:border-danger-800 dark:bg-danger-900/20">
+      {/* Error message */}
+      <p className="text-sm text-danger-600 dark:text-danger-400">{errorMessage}</p>
+
+      {/* Update hint section */}
+      {showUpdateHint && (
+        <div className="mt-3 border-t border-danger-200 pt-3 dark:border-danger-700">
+          {isCheckingForUpdate ? (
+            <p className="text-xs text-danger-500 dark:text-danger-400">{t('settings.checking')}</p>
+          ) : (
+            <>
+              <p className="text-xs text-danger-500 dark:text-danger-400">
+                {updateAvailable
+                  ? t('auth.loginFailedUpdateAvailable')
+                  : t('auth.loginFailedTryUpdate')}
+              </p>
+              <button
+                type="button"
+                onClick={handleUpdateClick}
+                disabled={loading}
+                aria-busy={loading}
+                className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-danger-100 px-3 py-1.5 text-xs font-medium text-danger-700 transition-colors hover:bg-danger-200 focus:outline-none focus:ring-2 focus:ring-danger-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-danger-800/50 dark:text-danger-300 dark:hover:bg-danger-800"
+              >
+                {loading && <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />}
+                {loading ? t('auth.updating') : t('auth.updateNow')}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-app/src/features/auth/components/LoginErrorWithUpdateHint.tsx
+++ b/web-app/src/features/auth/components/LoginErrorWithUpdateHint.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-
 import { RefreshCw } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 
@@ -28,23 +26,17 @@ export function LoginErrorWithUpdateHint({
   isCheckingForUpdate,
 }: LoginErrorWithUpdateHintProps) {
   const { t } = useTranslation()
-  const [isButtonLoading, setIsButtonLoading] = useState(false)
 
-  const handleUpdateClick = async () => {
-    if (isButtonLoading || isUpdating) return
-    setIsButtonLoading(true)
-    try {
-      await onUpdate()
-    } finally {
-      // Note: onUpdate() typically reloads, so this may not execute
-      setIsButtonLoading(false)
-    }
+  const handleUpdateClick = () => {
+    if (isUpdating) return
+    onUpdate()
   }
 
-  const loading = isButtonLoading || isUpdating
-
   return (
-    <div className="rounded-lg border border-danger-200 bg-danger-50 p-3 dark:border-danger-800 dark:bg-danger-900/20">
+    <div
+      role="alert"
+      className="rounded-lg border border-danger-200 bg-danger-50 p-3 dark:border-danger-800 dark:bg-danger-900/20"
+    >
       {/* Error message */}
       <p className="text-sm text-danger-600 dark:text-danger-400">{errorMessage}</p>
 
@@ -63,12 +55,12 @@ export function LoginErrorWithUpdateHint({
               <button
                 type="button"
                 onClick={handleUpdateClick}
-                disabled={loading}
-                aria-busy={loading}
+                disabled={isUpdating}
+                aria-busy={isUpdating}
                 className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-danger-100 px-3 py-1.5 text-xs font-medium text-danger-700 transition-colors hover:bg-danger-200 focus:outline-none focus:ring-2 focus:ring-danger-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-danger-800/50 dark:text-danger-300 dark:hover:bg-danger-800"
               >
-                {loading && <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />}
-                {loading ? t('auth.updating') : t('auth.updateNow')}
+                {isUpdating && <RefreshCw className="h-3 w-3 animate-spin" aria-hidden="true" />}
+                {isUpdating ? t('auth.updating') : t('auth.updateNow')}
               </button>
             </>
           )}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -192,6 +192,10 @@ const de: Translations = {
       'Eine neue Version ist verfügbar. Bitte aktualisieren Sie vor der Anmeldung, um Fehler zu vermeiden.',
     updateNow: 'Jetzt aktualisieren',
     updating: 'Aktualisierung...',
+    loginFailedTryUpdate:
+      'Falls das Problem weiterhin besteht, versuchen Sie die App zu aktualisieren.',
+    loginFailedUpdateAvailable:
+      'Ein App-Update ist verfügbar, das dieses Problem möglicherweise behebt.',
   },
   calendarError: {
     title: 'Kalenderfehler',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -190,6 +190,8 @@ const en: Translations = {
       'A new version is available. Please update before logging in to avoid errors.',
     updateNow: 'Update Now',
     updating: 'Updating...',
+    loginFailedTryUpdate: 'If the problem persists, try updating the app.',
+    loginFailedUpdateAvailable: 'An app update is available that may fix this issue.',
   },
   calendarError: {
     title: 'Calendar Error',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -193,6 +193,9 @@ const fr: Translations = {
       'Une nouvelle version est disponible. Veuillez mettre à jour avant de vous connecter pour éviter les erreurs.',
     updateNow: 'Mettre à jour',
     updating: 'Mise à jour...',
+    loginFailedTryUpdate: "Si le problème persiste, essayez de mettre à jour l'application.",
+    loginFailedUpdateAvailable:
+      "Une mise à jour de l'application est disponible qui peut résoudre ce problème.",
   },
   calendarError: {
     title: 'Erreur de calendrier',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -192,6 +192,9 @@ const it: Translations = {
       'È disponibile una nuova versione. Aggiorna prima di accedere per evitare errori.',
     updateNow: 'Aggiorna ora',
     updating: 'Aggiornamento...',
+    loginFailedTryUpdate: "Se il problema persiste, prova ad aggiornare l'app.",
+    loginFailedUpdateAvailable:
+      "È disponibile un aggiornamento dell'app che potrebbe risolvere questo problema.",
   },
   calendarError: {
     title: 'Errore calendario',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -88,6 +88,8 @@ export interface Translations {
     updateRequiredDescription: string
     updateNow: string
     updating: string
+    loginFailedTryUpdate: string
+    loginFailedUpdateAvailable: string
   }
   calendarError: {
     title: string

--- a/web-app/src/shared/stores/auth.ts
+++ b/web-app/src/shared/stores/auth.ts
@@ -116,6 +116,12 @@ interface AuthState {
   setActiveOccupation: (id: string) => void
   setAssociationSwitching: (isSwitching: boolean) => void
   hasMultipleAssociations: () => boolean
+  /**
+   * Clears stale session data (CSRF token and session token).
+   * Call this when the login page is displayed to prevent stale tokens
+   * from causing authentication errors.
+   */
+  clearStaleSession: () => void
   /** Returns true if in calendar mode */
   isCalendarMode: () => boolean
   /** Login with a calendar code. Validates the code format and fetches calendar data. */
@@ -820,6 +826,14 @@ export const useAuthStore = create<AuthState>()(
       hasMultipleAssociations: () => {
         // Use groupedEligibleAttributeValues which contains all user associations
         return hasMultipleAssociations(get().groupedEligibleAttributeValues)
+      },
+
+      clearStaleSession: () => {
+        // Clear both the API client session (CSRF token + session token) and the store's csrfToken.
+        // This prevents stale tokens from causing authentication errors when the user
+        // arrives at the login page with outdated cached credentials.
+        clearSession()
+        set({ csrfToken: null })
       },
 
       isCalendarMode: () => {


### PR DESCRIPTION
## Summary

- Shows inline "Update Now" button when login fails, suggesting an app update may fix the issue
- Clears stale CSRF tokens when login page loads or app resumes from iOS suspension
- Added `pageshow` event fallback for more reliable PWA update detection on iOS
- Addresses confusing UX where "Invalid username or password" appears when the real issue is an outdated PWA

## Changes

1. **New `LoginErrorWithUpdateHint` component** - Shows error message with inline update suggestion
2. **Proactive update check on login failure** - Triggers PWA update check when login fails
3. **Clear stale session on mount/resume** - Clears CSRF tokens when login page loads or app resumes from suspension
4. **`pageshow` event fallback** - More reliable detection for iOS PWA suspension/resume
5. **Translations** - Added for all 4 languages (de, en, fr, it)

## Test plan

- [ ] Test login failure scenario on iOS PWA
- [ ] Verify update hint appears after login error
- [ ] Verify update button triggers PWA update flow (clears caches and reloads)
- [ ] Verify stale session is cleared when app resumes from iOS suspension
- [ ] Verify translations display correctly in all 4 languages