### PR TITLE
fix(ci): add --ignore-agent-tools to speckit workflow

### DIFF
--- a/.github/workflows/update-speckit.yml
+++ b/.github/workflows/update-speckit.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Update spec-kit templates
         run: |
           # Re-initialize to get latest templates (auto-confirm overwrite)
-          echo "y" | specify init . --ai claude --no-git
+          # --ignore-agent-tools: Skip claude CLI check (not available in CI)
+          echo "y" | specify init . --ai claude --no-git --ignore-agent-tools
 
           # Store the installed version for tracking
           specify version | grep -oP 'CLI Version:\s+\K[\d.]+' > .specify/version || true


### PR DESCRIPTION
## Summary

- Fix the Update Spec-Kit workflow that was failing because the `claude` CLI is not available on GitHub Actions runners
- Add `--ignore-agent-tools` flag to skip the agent tool check in CI

## Test plan

- [ ] Re-run the Update Spec-Kit workflow manually to verify it completes successfully