### PR TITLE
feat(assignments): detect scheduling conflicts across associations

### DIFF
--- a/.changeset/detect-assignment-conflicts.md
+++ b/.changeset/detect-assignment-conflicts.md
@@ -1,0 +1,10 @@
+---
+"volleykit-web": minor
+---
+
+Add assignment conflict detection to warn when games are scheduled too close together
+
+- Detects assignments less than 1 hour apart using the calendar feed
+- Shows warning indicator on AssignmentCard for conflicting assignments
+- Displays conflict details in expanded view (association, time gap, hall)
+- Works across all associations since calendar contains all assignments

--- a/.changeset/detect-assignment-conflicts.md
+++ b/.changeset/detect-assignment-conflicts.md
@@ -8,3 +8,5 @@ Add assignment conflict detection to warn when games are scheduled too close tog
 - Shows warning indicator on AssignmentCard for conflicting assignments
 - Displays conflict details in expanded view (association, time gap, hall)
 - Works across all associations since calendar contains all assignments
+- Demo mode shows example conflicts for testing
+- Custom evaluator support for location-based or other conflict logic

--- a/web-app/src/features/assignments/AssignmentsPage.test.tsx
+++ b/web-app/src/features/assignments/AssignmentsPage.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -8,6 +9,24 @@ import * as authStore from '@/shared/stores/auth'
 import { AssignmentsPage } from './AssignmentsPage'
 
 import type { UseQueryResult } from '@tanstack/react-query'
+
+// Create a test query client
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  })
+}
+
+// Wrapper component for rendering with providers
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = createTestQueryClient()
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
 
 // Mock useTour to disable tour mode during tests (see src/test/mocks.ts for shared pattern)
 const mockUseTour = vi.hoisted(() => ({
@@ -200,7 +219,7 @@ describe('AssignmentsPage', () => {
 
   describe('Tab Navigation', () => {
     it('should default to Upcoming tab', () => {
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       const upcomingTab = screen.getByRole('tab', { name: /upcoming/i })
       expect(upcomingTab).toHaveClass('border-primary-500')
@@ -208,7 +227,7 @@ describe('AssignmentsPage', () => {
     })
 
     it('should switch to Validation Closed tab when clicked', () => {
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       fireEvent.click(screen.getByRole('tab', { name: /validation closed/i }))
 
@@ -220,7 +239,7 @@ describe('AssignmentsPage', () => {
     })
 
     it('should have proper ARIA attributes on tablist', () => {
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       const tablist = screen.getByRole('tablist')
       expect(tablist).toHaveAttribute('aria-label')
@@ -231,7 +250,7 @@ describe('AssignmentsPage', () => {
         createMockQueryResult([createMockAssignment(), createMockAssignment()])
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       const upcomingTab = screen.getByRole('tab', { name: /upcoming/i })
       expect(upcomingTab).toHaveTextContent('2')
@@ -246,7 +265,7 @@ describe('AssignmentsPage', () => {
         ])
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       const validationClosedTab = screen.getByRole('tab', {
         name: /validation closed/i,
@@ -261,7 +280,7 @@ describe('AssignmentsPage', () => {
         createMockQueryResult(undefined, true)
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       expect(screen.getByText(/loading/i)).toBeInTheDocument()
     })
@@ -271,7 +290,7 @@ describe('AssignmentsPage', () => {
         createMockQueryResult(undefined, false, new Error('Failed to load'))
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
@@ -280,7 +299,7 @@ describe('AssignmentsPage', () => {
     it('should show empty state when no upcoming assignments', () => {
       vi.mocked(useConvocations.useUpcomingAssignments).mockReturnValue(createMockQueryResult([]))
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       expect(screen.getByRole('heading', { name: /no upcoming/i })).toBeInTheDocument()
     })
@@ -291,7 +310,7 @@ describe('AssignmentsPage', () => {
         createMockQueryResult([assignment])
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       expect(screen.getByText(/VBC Zürich/i)).toBeInTheDocument()
       expect(screen.getByText(/VBC Basel/i)).toBeInTheDocument()
@@ -304,7 +323,7 @@ describe('AssignmentsPage', () => {
         createMockQueryResult(undefined, true)
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
       fireEvent.click(screen.getByRole('tab', { name: /validation closed/i }))
 
       expect(screen.getByText(/loading/i)).toBeInTheDocument()
@@ -315,7 +334,7 @@ describe('AssignmentsPage', () => {
         createMockQueryResult(undefined, false, new Error('Network error'))
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
       fireEvent.click(screen.getByRole('tab', { name: /validation closed/i }))
 
       expect(screen.getByText(/network error/i)).toBeInTheDocument()
@@ -326,7 +345,7 @@ describe('AssignmentsPage', () => {
         createMockQueryResult([])
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
       fireEvent.click(screen.getByRole('tab', { name: /validation closed/i }))
 
       expect(screen.getByRole('heading', { name: /no closed/i })).toBeInTheDocument()
@@ -350,7 +369,7 @@ describe('AssignmentsPage', () => {
         createMockQueryResult([assignment])
       )
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
       fireEvent.click(screen.getByRole('tab', { name: /validation closed/i }))
 
       expect(screen.getByText(/VBC Bern/i)).toBeInTheDocument()
@@ -360,7 +379,7 @@ describe('AssignmentsPage', () => {
 
   describe('Tab Panel Accessibility', () => {
     it('should have proper tabpanel aria attributes for upcoming tab', () => {
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
 
       const tabpanel = screen.getByRole('tabpanel')
       // Tab IDs follow the pattern: tab-{tabId}, tabpanel-{tabId}
@@ -369,7 +388,7 @@ describe('AssignmentsPage', () => {
     })
 
     it('should have proper tabpanel aria attributes for validation closed tab', () => {
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
       fireEvent.click(screen.getByRole('tab', { name: /validation closed/i }))
 
       const tabpanel = screen.getByRole('tabpanel')
@@ -387,7 +406,7 @@ describe('AssignmentsPage', () => {
         refetch: mockRefetch,
       } as unknown as UseQueryResult<Assignment[], Error>)
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
       fireEvent.click(screen.getByRole('button', { name: /retry/i }))
 
       expect(mockRefetch).toHaveBeenCalled()
@@ -400,7 +419,7 @@ describe('AssignmentsPage', () => {
         refetch: mockRefetch,
       } as unknown as UseQueryResult<Assignment[], Error>)
 
-      render(<AssignmentsPage />)
+      renderWithProviders(<AssignmentsPage />)
       fireEvent.click(screen.getByRole('tab', { name: /validation closed/i }))
       fireEvent.click(screen.getByRole('button', { name: /retry/i }))
 
@@ -459,7 +478,7 @@ describe('AssignmentsPage', () => {
 
     describe('Tab Labels', () => {
       it("should show 'Past' instead of 'Validation Closed' in calendar mode", () => {
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Should have "Past" tab, not "Validation Closed"
         expect(screen.getByRole('tab', { name: /past/i })).toBeInTheDocument()
@@ -467,7 +486,7 @@ describe('AssignmentsPage', () => {
       })
 
       it("should still show 'Upcoming' tab in calendar mode", () => {
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         expect(screen.getByRole('tab', { name: /upcoming/i })).toBeInTheDocument()
       })
@@ -479,7 +498,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult(undefined, true)
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         expect(screen.getByText(/loading/i)).toBeInTheDocument()
       })
@@ -493,7 +512,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([calendarAssignment])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Home team is shown directly
         expect(screen.getByText('Calendar Team A')).toBeInTheDocument()
@@ -509,7 +528,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([calendarAssignment])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // AssignmentCard shows translated position - role "referee2" maps to "head-two"
         // which is translated to "2nd Referee" by our mock
@@ -524,7 +543,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([calendarAssignment])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // AssignmentCard shows leagueCategory name - may appear in multiple places
         // (badge and league line), so we use getAllByText
@@ -539,7 +558,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Should show calendar-specific empty message
         expect(
@@ -553,7 +572,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Should find empty state heading
         const heading = screen.getByRole('heading')
@@ -569,7 +588,7 @@ describe('AssignmentsPage', () => {
           refetch: mockRefetch,
         } as unknown as ReturnType<typeof useConvocations.useCalendarAssignments>)
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         expect(screen.getByText(/calendar fetch failed/i)).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
@@ -582,7 +601,7 @@ describe('AssignmentsPage', () => {
           refetch: mockRefetch,
         } as unknown as ReturnType<typeof useConvocations.useCalendarAssignments>)
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
         fireEvent.click(screen.getByRole('button', { name: /retry/i }))
 
         expect(mockRefetch).toHaveBeenCalled()
@@ -599,7 +618,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([calendarAssignment])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Exchange action should not be visible in calendar mode
         expect(screen.queryByRole('button', { name: /exchange/i })).not.toBeInTheDocument()
@@ -624,7 +643,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult(assignments)
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Home teams are shown directly
         expect(screen.getByText('Team Alpha')).toBeInTheDocument()
@@ -644,7 +663,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult(assignments)
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         const upcomingTab = screen.getByRole('tab', { name: /upcoming/i })
         expect(upcomingTab).toHaveTextContent('3')
@@ -664,7 +683,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([calendarAssignment])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Time should be displayed (format may vary based on locale)
         expect(screen.getByText(/19:30/)).toBeInTheDocument()
@@ -678,7 +697,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([calendarAssignment])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // AssignmentCard shows city extracted from address in compact view
         expect(screen.getAllByText(/Bern/).length).toBeGreaterThan(0)
@@ -693,7 +712,7 @@ describe('AssignmentsPage', () => {
           createMockCalendarQueryResult([calendarAssignment])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Should use calendar data
         expect(useConvocations.useCalendarAssignments).toHaveBeenCalled()
@@ -707,7 +726,7 @@ describe('AssignmentsPage', () => {
           createMockQueryResult([apiAssignment])
         )
 
-        render(<AssignmentsPage />)
+        renderWithProviders(<AssignmentsPage />)
 
         // Should use API data
         expect(useConvocations.useUpcomingAssignments).toHaveBeenCalled()

--- a/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.test.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.test.tsx
@@ -1,9 +1,28 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 
 import type { Assignment } from '@/api/client'
 
 import { AssignmentCard } from './AssignmentCard'
+
+// Create a wrapper with QueryClientProvider for tests
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+// Wrapper function for rendering with QueryClientProvider
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = createQueryClient()
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
 
 // Helper to create mock assignment data
 function createMockAssignment(overrides: Partial<Assignment> = {}): Assignment {
@@ -37,7 +56,7 @@ function createMockAssignment(overrides: Partial<Assignment> = {}): Assignment {
 describe('AssignmentCard', () => {
   describe('rendering', () => {
     it('renders team names', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       expect(screen.getByText('VBC Zürich')).toBeInTheDocument()
       // Away team is rendered as "vs TeamName" in compact view
@@ -45,7 +64,7 @@ describe('AssignmentCard', () => {
     })
 
     it('renders hall name in expanded view', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       // Click to expand
       fireEvent.click(screen.getByRole('button'))
@@ -54,7 +73,7 @@ describe('AssignmentCard', () => {
     })
 
     it('renders formatted time', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       // Time is formatted in local timezone (not UTC)
       // Match any valid HH:MM format since timezone varies by test environment
@@ -62,13 +81,13 @@ describe('AssignmentCard', () => {
     })
 
     it('renders position label in compact view', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       expect(screen.getByText('1st Referee')).toBeInTheDocument()
     })
 
     it('renders status label in expanded view', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       // Click to expand
       fireEvent.click(screen.getByRole('button'))
@@ -77,7 +96,7 @@ describe('AssignmentCard', () => {
     })
 
     it('renders league category in compact view', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       // League category is visible in compact view (no expansion needed)
       expect(screen.getByText('NLA')).toBeInTheDocument()
@@ -107,7 +126,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       // Click to expand
       fireEvent.click(screen.getByRole('button'))
@@ -138,7 +157,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       // City appears in the address link
       expect(screen.getByRole('link', { name: /Zürich in maps/i })).toBeInTheDocument()
@@ -162,7 +181,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       // Should still render the expand button
       const button = screen.getByRole('button')
@@ -183,7 +202,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       expect(screen.getAllByText('TBD').length).toBeGreaterThan(0)
       expect(screen.getByText('Location TBD')).toBeInTheDocument()
@@ -192,7 +211,7 @@ describe('AssignmentCard', () => {
 
   describe('status colors', () => {
     it('shows green for active status in expanded view', () => {
-      render(
+      renderWithProviders(
         <AssignmentCard
           assignment={createMockAssignment({
             refereeConvocationStatus: 'active',
@@ -208,7 +227,7 @@ describe('AssignmentCard', () => {
     })
 
     it('shows red for cancelled status in expanded view', () => {
-      render(
+      renderWithProviders(
         <AssignmentCard
           assignment={createMockAssignment({
             refereeConvocationStatus: 'cancelled',
@@ -224,7 +243,7 @@ describe('AssignmentCard', () => {
     })
 
     it('shows gray for archived status in expanded view', () => {
-      render(
+      renderWithProviders(
         <AssignmentCard
           assignment={createMockAssignment({
             refereeConvocationStatus: 'archived',
@@ -243,7 +262,7 @@ describe('AssignmentCard', () => {
   describe('interactivity', () => {
     it('calls onClick when clicked', () => {
       const onClick = vi.fn()
-      render(<AssignmentCard assignment={createMockAssignment()} onClick={onClick} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} onClick={onClick} />)
 
       fireEvent.click(screen.getByRole('button'))
       expect(onClick).toHaveBeenCalledTimes(1)
@@ -251,7 +270,7 @@ describe('AssignmentCard', () => {
 
     it('handles keyboard activation (native button behavior)', () => {
       const onClick = vi.fn()
-      render(<AssignmentCard assignment={createMockAssignment()} onClick={onClick} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} onClick={onClick} />)
 
       // Native buttons handle Enter/Space automatically via click events
       const button = screen.getByRole('button')
@@ -260,7 +279,7 @@ describe('AssignmentCard', () => {
     })
 
     it('always has button role for expand/collapse functionality', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       // Card is always interactive for expand/collapse even without onClick handler
       expect(screen.getByRole('button')).toBeInTheDocument()
@@ -269,7 +288,7 @@ describe('AssignmentCard', () => {
 
   describe('accessibility', () => {
     it('uses aria-expanded for disclosure pattern', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       const button = screen.getByRole('button')
       expect(button).toHaveAttribute('aria-expanded', 'false')
@@ -277,7 +296,7 @@ describe('AssignmentCard', () => {
     })
 
     it('is naturally focusable as a native button', () => {
-      const { container } = render(<AssignmentCard assignment={createMockAssignment()} />)
+      const { container } = renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       // Native button elements are focusable by default
       const button = container.querySelector('button')
@@ -286,7 +305,7 @@ describe('AssignmentCard', () => {
     })
 
     it('hides location icon from screen readers', () => {
-      const { container } = render(<AssignmentCard assignment={createMockAssignment()} />)
+      const { container } = renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       // SVG icon should have aria-hidden for accessibility
       const svg = container.querySelector('svg[aria-hidden="true"]')
@@ -305,7 +324,7 @@ describe('AssignmentCard', () => {
 
     positions.forEach(({ key, label }) => {
       it(`renders correct label for ${key} in compact view`, () => {
-        render(<AssignmentCard assignment={createMockAssignment({ refereePosition: key })} />)
+        renderWithProviders(<AssignmentCard assignment={createMockAssignment({ refereePosition: key })} />)
         expect(screen.getByText(label)).toBeInTheDocument()
       })
     })
@@ -315,14 +334,14 @@ describe('AssignmentCard', () => {
       const assignment = createMockAssignment({
         refereePosition: 'unknown-position' as Assignment['refereePosition'],
       })
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
       expect(screen.getByText('unknown-position')).toBeInTheDocument()
     })
   })
 
   describe('expand/collapse', () => {
     it('expands on click', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       const card = screen.getByRole('button')
       expect(card).toHaveAttribute('aria-expanded', 'false')
@@ -332,7 +351,7 @@ describe('AssignmentCard', () => {
     })
 
     it('collapses on second click', () => {
-      render(<AssignmentCard assignment={createMockAssignment()} />)
+      renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       const card = screen.getByRole('button')
       fireEvent.click(card) // expand
@@ -342,7 +361,7 @@ describe('AssignmentCard', () => {
     })
 
     it('aria-controls links to details section', () => {
-      const { container } = render(<AssignmentCard assignment={createMockAssignment()} />)
+      const { container } = renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
 
       const button = screen.getByRole('button')
       const controlsId = button.getAttribute('aria-controls')
@@ -384,7 +403,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       // Expand to see location
       fireEvent.click(screen.getByRole('button'))
@@ -427,7 +446,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       // Expand to see location
       fireEvent.click(screen.getByRole('button'))
@@ -469,7 +488,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       // Expand to see location
       fireEvent.click(screen.getByRole('button'))
@@ -510,7 +529,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       const cardButton = screen.getByRole('button')
 
@@ -559,7 +578,7 @@ describe('AssignmentCard', () => {
         },
       } as Partial<Assignment>)
 
-      render(<AssignmentCard assignment={assignment} />)
+      renderWithProviders(<AssignmentCard assignment={assignment} />)
 
       // Expand to see location
       fireEvent.click(screen.getByRole('button'))

--- a/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.test.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.test.tsx
@@ -296,7 +296,9 @@ describe('AssignmentCard', () => {
     })
 
     it('is naturally focusable as a native button', () => {
-      const { container } = renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
+      const { container } = renderWithProviders(
+        <AssignmentCard assignment={createMockAssignment()} />
+      )
 
       // Native button elements are focusable by default
       const button = container.querySelector('button')
@@ -305,7 +307,9 @@ describe('AssignmentCard', () => {
     })
 
     it('hides location icon from screen readers', () => {
-      const { container } = renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
+      const { container } = renderWithProviders(
+        <AssignmentCard assignment={createMockAssignment()} />
+      )
 
       // SVG icon should have aria-hidden for accessibility
       const svg = container.querySelector('svg[aria-hidden="true"]')
@@ -324,7 +328,9 @@ describe('AssignmentCard', () => {
 
     positions.forEach(({ key, label }) => {
       it(`renders correct label for ${key} in compact view`, () => {
-        renderWithProviders(<AssignmentCard assignment={createMockAssignment({ refereePosition: key })} />)
+        renderWithProviders(
+          <AssignmentCard assignment={createMockAssignment({ refereePosition: key })} />
+        )
         expect(screen.getByText(label)).toBeInTheDocument()
       })
     })
@@ -361,7 +367,9 @@ describe('AssignmentCard', () => {
     })
 
     it('aria-controls links to details section', () => {
-      const { container } = renderWithProviders(<AssignmentCard assignment={createMockAssignment()} />)
+      const { container } = renderWithProviders(
+        <AssignmentCard assignment={createMockAssignment()} />
+      )
 
       const button = screen.getByRole('button')
       const controlsId = button.getAttribute('aria-controls')

--- a/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from 'react'
 
 import type { Assignment } from '@/api/client'
+import { useAssignmentConflicts } from '@/features/assignments/hooks/useCalendarConflicts'
 import { useActiveAssociationCode } from '@/features/auth/hooks/useActiveAssociation'
 import { ExpandableCard } from '@/shared/components/ExpandableCard'
 import { useDateFormat } from '@/shared/hooks/useDateFormat'
@@ -133,6 +134,11 @@ function AssignmentCardComponent({
   const singleBallMatch = detectSingleBallHall(assignment)
   const singleBallPdfPath = getSingleBallHallsPdfPath(locale)
 
+  // Get assignment conflicts from calendar data
+  // Uses the game ID to match against calendar assignments across all associations
+  const gameId = game?.__identity
+  const { conflicts } = useAssignmentConflicts(gameId)
+
   // Create context value
   const contextValue = useMemo(
     (): Omit<AssignmentCardContextValue, 'expandArrow'> => ({
@@ -160,6 +166,7 @@ function AssignmentCardComponent({
       openSbbConnection,
       singleBallMatch,
       singleBallPdfPath,
+      conflicts,
     }),
     [
       assignment,
@@ -186,6 +193,7 @@ function AssignmentCardComponent({
       openSbbConnection,
       singleBallMatch,
       singleBallPdfPath,
+      conflicts,
     ]
   )
 

--- a/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/AssignmentCard.tsx
@@ -136,6 +136,9 @@ function AssignmentCardComponent({
 
   // Get assignment conflicts from calendar data
   // Uses the game ID to match against calendar assignments across all associations
+  // Note: If performance becomes an issue with large lists, consider passing the
+  // conflict map via context from a parent component. TanStack Query deduplicates
+  // the fetch, but each card still creates its own filtered view.
   const gameId = game?.__identity
   const { conflicts } = useAssignmentConflicts(gameId)
 

--- a/web-app/src/features/assignments/components/AssignmentCard/CityInfo.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/CityInfo.tsx
@@ -1,11 +1,12 @@
 import { useTranslation } from '@/shared/hooks/useTranslation'
 
+import { ConflictIndicator } from './ConflictWarning'
 import { useAssignmentCardContext } from './context'
 
-/** Displays city, single-ball indicator, league category, and expand arrow in compact view */
+/** Displays city, conflict indicator, single-ball indicator, league category, and expand arrow in compact view */
 export function CityInfo() {
   const { t } = useTranslation()
-  const { city, game, singleBallMatch, expandArrow } = useAssignmentCardContext()
+  const { city, game, singleBallMatch, conflicts, expandArrow } = useAssignmentCardContext()
 
   const leagueCategory = game?.group?.phase?.league?.leagueCategory?.name
 
@@ -14,6 +15,7 @@ export function CityInfo() {
       <div className="flex flex-col items-end w-24">
         <span className="text-xs text-text-muted dark:text-text-muted-dark truncate w-full text-right flex items-center justify-end gap-1">
           {city || ''}
+          <ConflictIndicator conflicts={conflicts} />
           {singleBallMatch && (
             <span
               className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 text-[10px] font-bold flex-shrink-0"

--- a/web-app/src/features/assignments/components/AssignmentCard/ConflictNotice.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/ConflictNotice.tsx
@@ -1,0 +1,11 @@
+import { ConflictDetails } from './ConflictWarning'
+import { useAssignmentCardContext } from './context'
+
+/**
+ * Conflict notice for the expanded details view.
+ * Uses the assignment card context to get conflicts and displays them.
+ */
+export function ConflictNotice() {
+  const { conflicts } = useAssignmentCardContext()
+  return <ConflictDetails conflicts={conflicts} />
+}

--- a/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.test.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+import type { AssignmentConflict } from '@/features/assignments/utils/conflict-detection'
+
+import { ConflictDetails, ConflictIndicator } from './ConflictWarning'
+
+// Mock useTranslation
+vi.mock('@/shared/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'assignments.conflictWarningTooltip': 'Scheduling conflict',
+        'assignments.conflictWarningTitle': 'Potential scheduling conflict',
+        'assignments.conflictGap': 'gap',
+        'assignments.conflictOverlap': 'overlap',
+        'assignments.hall': 'Hall',
+      }
+      return translations[key] ?? key
+    },
+    locale: 'en',
+  }),
+}))
+
+// Mock useDateFormat
+vi.mock('@/shared/hooks/useDateFormat', () => ({
+  useDateFormat: (dateTime: string) => ({
+    dateLabel: 'Mon, Jan 15',
+    timeLabel: dateTime ? '14:00' : 'Unknown',
+    isToday: false,
+    isPast: false,
+  }),
+}))
+
+function createMockConflict(overrides: Partial<AssignmentConflict> = {}): AssignmentConflict {
+  return {
+    assignmentId: 'assignment-1',
+    conflictingAssignmentId: 'assignment-2',
+    gapMinutes: 30,
+    conflictingAssignment: {
+      gameId: 'game-2',
+      homeTeam: 'VBC Zürich',
+      awayTeam: 'VBC Basel',
+      startTime: '2025-01-15T14:00:00Z',
+      endTime: '2025-01-15T16:00:00Z',
+      league: 'NLA Men',
+      association: 'SVRZ',
+      hallName: 'Saalsporthalle',
+    },
+    ...overrides,
+  }
+}
+
+describe('ConflictWarning components', () => {
+  describe('ConflictIndicator', () => {
+    it('should render nothing when no conflicts', () => {
+      const { container } = render(<ConflictIndicator conflicts={[]} />)
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it('should render warning icon when conflicts exist', () => {
+      render(<ConflictIndicator conflicts={[createMockConflict()]} />)
+
+      const indicator = screen.getByLabelText('Scheduling conflict')
+      expect(indicator).toBeInTheDocument()
+    })
+
+    it('should have proper ARIA attributes', () => {
+      render(<ConflictIndicator conflicts={[createMockConflict()]} />)
+
+      const indicator = screen.getByLabelText('Scheduling conflict')
+      expect(indicator).toHaveAttribute('title', 'Scheduling conflict')
+      expect(indicator).toHaveAttribute('aria-label', 'Scheduling conflict')
+    })
+
+    it('should have visual warning styling', () => {
+      render(<ConflictIndicator conflicts={[createMockConflict()]} />)
+
+      const indicator = screen.getByLabelText('Scheduling conflict')
+      expect(indicator).toHaveClass('bg-red-100')
+      expect(indicator).toHaveClass('text-red-700')
+    })
+  })
+
+  describe('ConflictDetails', () => {
+    it('should render nothing when no conflicts', () => {
+      const { container } = render(<ConflictDetails conflicts={[]} />)
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    it('should display conflict warning title', () => {
+      render(<ConflictDetails conflicts={[createMockConflict()]} />)
+
+      expect(screen.getByText('Potential scheduling conflict')).toBeInTheDocument()
+    })
+
+    it('should display conflicting team names', () => {
+      render(<ConflictDetails conflicts={[createMockConflict()]} />)
+
+      expect(screen.getByText('VBC Zürich - VBC Basel')).toBeInTheDocument()
+    })
+
+    it('should display association label', () => {
+      render(<ConflictDetails conflicts={[createMockConflict()]} />)
+
+      expect(screen.getByText('(SVRZ)')).toBeInTheDocument()
+    })
+
+    it('should display hall name', () => {
+      render(<ConflictDetails conflicts={[createMockConflict()]} />)
+
+      expect(screen.getByText(/Hall:.*Saalsporthalle/)).toBeInTheDocument()
+    })
+
+    it('should display gap in minutes', () => {
+      render(<ConflictDetails conflicts={[createMockConflict({ gapMinutes: 30 })]} />)
+
+      expect(screen.getByText(/30min gap/)).toBeInTheDocument()
+    })
+
+    it('should display gap in hours and minutes', () => {
+      render(<ConflictDetails conflicts={[createMockConflict({ gapMinutes: 90 })]} />)
+
+      expect(screen.getByText(/1h 30min gap/)).toBeInTheDocument()
+    })
+
+    it('should display overlap for negative gap', () => {
+      render(<ConflictDetails conflicts={[createMockConflict({ gapMinutes: -45 })]} />)
+
+      expect(screen.getByText(/45min overlap/)).toBeInTheDocument()
+    })
+
+    it('should display multiple conflicts', () => {
+      const conflicts = [
+        createMockConflict({
+          conflictingAssignmentId: 'game-2',
+          conflictingAssignment: {
+            gameId: 'game-2',
+            homeTeam: 'Team A',
+            awayTeam: 'Team B',
+            startTime: '2025-01-15T14:00:00Z',
+            endTime: '2025-01-15T16:00:00Z',
+            league: 'NLA',
+            association: 'SVRZ',
+            hallName: 'Hall 1',
+          },
+        }),
+        createMockConflict({
+          conflictingAssignmentId: 'game-3',
+          conflictingAssignment: {
+            gameId: 'game-3',
+            homeTeam: 'Team C',
+            awayTeam: 'Team D',
+            startTime: '2025-01-15T15:00:00Z',
+            endTime: '2025-01-15T17:00:00Z',
+            league: 'NLB',
+            association: 'SV',
+            hallName: 'Hall 2',
+          },
+        }),
+      ]
+
+      render(<ConflictDetails conflicts={conflicts} />)
+
+      expect(screen.getByText('Team A - Team B')).toBeInTheDocument()
+      expect(screen.getByText('Team C - Team D')).toBeInTheDocument()
+    })
+
+    it('should not display association when null', () => {
+      const conflict = createMockConflict({
+        conflictingAssignment: {
+          gameId: 'game-2',
+          homeTeam: 'Team A',
+          awayTeam: 'Team B',
+          startTime: '2025-01-15T14:00:00Z',
+          endTime: '2025-01-15T16:00:00Z',
+          league: 'NLA',
+          association: null,
+          hallName: 'Hall 1',
+        },
+      })
+
+      render(<ConflictDetails conflicts={[conflict]} />)
+
+      // Association should not be shown
+      expect(screen.queryByText(/\([A-Z]+\)/)).not.toBeInTheDocument()
+    })
+
+    it('should not display hall when null', () => {
+      const conflict = createMockConflict({
+        conflictingAssignment: {
+          gameId: 'game-2',
+          homeTeam: 'Team A',
+          awayTeam: 'Team B',
+          startTime: '2025-01-15T14:00:00Z',
+          endTime: '2025-01-15T16:00:00Z',
+          league: 'NLA',
+          association: 'SVRZ',
+          hallName: null,
+        },
+      })
+
+      render(<ConflictDetails conflicts={[conflict]} />)
+
+      expect(screen.queryByText(/Hall:/)).not.toBeInTheDocument()
+    })
+
+    it('should have visual warning styling', () => {
+      render(<ConflictDetails conflicts={[createMockConflict()]} />)
+
+      const container = screen.getByText('Potential scheduling conflict').closest('div')?.parentElement
+      expect(container).toHaveClass('bg-red-50')
+      expect(container).toHaveClass('border-red-200')
+    })
+  })
+})

--- a/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.test.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.test.tsx
@@ -208,7 +208,9 @@ describe('ConflictWarning components', () => {
     it('should have visual warning styling', () => {
       render(<ConflictDetails conflicts={[createMockConflict()]} />)
 
-      const container = screen.getByText('Potential scheduling conflict').closest('div')?.parentElement
+      const container = screen
+        .getByText('Potential scheduling conflict')
+        .closest('div')?.parentElement
       expect(container).toHaveClass('bg-red-50')
       expect(container).toHaveClass('border-red-200')
     })

--- a/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.tsx
@@ -13,7 +13,8 @@ function useFormatGap() {
 
   return (gapMinutes: number): string => {
     const { type, hours, minutes } = parseGap(gapMinutes)
-    const typeLabel = type === 'overlap' ? t('assignments.conflictOverlap') : t('assignments.conflictGap')
+    const typeLabel =
+      type === 'overlap' ? t('assignments.conflictOverlap') : t('assignments.conflictGap')
 
     if (hours > 0 && minutes > 0) {
       return `${hours}h ${minutes}min ${typeLabel}`

--- a/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.tsx
@@ -1,9 +1,29 @@
 import { AlertTriangle } from 'lucide-react'
 
 import type { AssignmentConflict } from '@/features/assignments/utils/conflict-detection'
-import { formatGap } from '@/features/assignments/utils/conflict-detection'
+import { parseGap } from '@/features/assignments/utils/conflict-detection'
 import { useDateFormat } from '@/shared/hooks/useDateFormat'
 import { useTranslation } from '@/shared/hooks/useTranslation'
+
+/**
+ * Formats a gap using translations.
+ */
+function useFormatGap() {
+  const { t } = useTranslation()
+
+  return (gapMinutes: number): string => {
+    const { type, hours, minutes } = parseGap(gapMinutes)
+    const typeLabel = type === 'overlap' ? t('assignments.conflictOverlap') : t('assignments.conflictGap')
+
+    if (hours > 0 && minutes > 0) {
+      return `${hours}h ${minutes}min ${typeLabel}`
+    }
+    if (hours > 0) {
+      return `${hours}h ${typeLabel}`
+    }
+    return `${minutes}min ${typeLabel}`
+  }
+}
 
 interface ConflictWarningProps {
   conflicts: AssignmentConflict[]
@@ -36,6 +56,7 @@ export function ConflictIndicator({ conflicts }: ConflictWarningProps) {
  */
 function ConflictDetail({ conflict }: { conflict: AssignmentConflict }) {
   const { t } = useTranslation()
+  const formatGapText = useFormatGap()
   const { timeLabel } = useDateFormat(conflict.conflictingAssignment.startTime)
 
   const { conflictingAssignment } = conflict
@@ -51,7 +72,7 @@ function ConflictDetail({ conflict }: { conflict: AssignmentConflict }) {
       <span className="text-xs text-text-muted dark:text-text-muted-dark">
         {timeLabel} {associationLabel && <span className="font-medium">{associationLabel}</span>}
         {' · '}
-        {formatGap(conflict.gapMinutes)}
+        {formatGapText(conflict.gapMinutes)}
       </span>
       {conflictingAssignment.hallName && (
         <span className="text-xs text-text-subtle dark:text-text-subtle-dark">

--- a/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/ConflictWarning.tsx
@@ -1,0 +1,92 @@
+import { AlertTriangle } from 'lucide-react'
+
+import type { AssignmentConflict } from '@/features/assignments/utils/conflict-detection'
+import { formatGap } from '@/features/assignments/utils/conflict-detection'
+import { useDateFormat } from '@/shared/hooks/useDateFormat'
+import { useTranslation } from '@/shared/hooks/useTranslation'
+
+interface ConflictWarningProps {
+  conflicts: AssignmentConflict[]
+}
+
+/**
+ * Displays a compact warning indicator for scheduling conflicts.
+ * Shows in the compact view alongside the city info.
+ */
+export function ConflictIndicator({ conflicts }: ConflictWarningProps) {
+  const { t } = useTranslation()
+
+  if (conflicts.length === 0) {
+    return null
+  }
+
+  return (
+    <span
+      className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 flex-shrink-0"
+      title={t('assignments.conflictWarningTooltip')}
+      aria-label={t('assignments.conflictWarningTooltip')}
+    >
+      <AlertTriangle className="w-3 h-3" aria-hidden="true" />
+    </span>
+  )
+}
+
+/**
+ * Displays conflict details for a single conflicting assignment.
+ */
+function ConflictDetail({ conflict }: { conflict: AssignmentConflict }) {
+  const { t } = useTranslation()
+  const { timeLabel } = useDateFormat(conflict.conflictingAssignment.startTime)
+
+  const { conflictingAssignment } = conflict
+  const associationLabel = conflictingAssignment.association
+    ? `(${conflictingAssignment.association})`
+    : ''
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-sm font-medium text-red-700 dark:text-red-300">
+        {conflictingAssignment.homeTeam} - {conflictingAssignment.awayTeam}
+      </span>
+      <span className="text-xs text-text-muted dark:text-text-muted-dark">
+        {timeLabel} {associationLabel && <span className="font-medium">{associationLabel}</span>}
+        {' · '}
+        {formatGap(conflict.gapMinutes)}
+      </span>
+      {conflictingAssignment.hallName && (
+        <span className="text-xs text-text-subtle dark:text-text-subtle-dark">
+          {t('assignments.hall')}: {conflictingAssignment.hallName}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Displays detailed conflict information in the expanded view.
+ * Shows each conflicting assignment with time gap and association.
+ */
+export function ConflictDetails({ conflicts }: ConflictWarningProps) {
+  const { t } = useTranslation()
+
+  if (conflicts.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex items-start gap-2 py-1.5 px-2 bg-red-50 dark:bg-red-950/30 rounded-md border border-red-200 dark:border-red-800/50">
+      <AlertTriangle
+        className="w-4 h-4 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5"
+        aria-hidden="true"
+      />
+      <div className="flex flex-col gap-1.5 min-w-0">
+        <span className="text-xs font-medium text-red-700 dark:text-red-300">
+          {t('assignments.conflictWarningTitle')}
+        </span>
+        {conflicts.map((conflict) => (
+          <ConflictDetail key={conflict.conflictingAssignmentId} conflict={conflict} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web-app/src/features/assignments/components/AssignmentCard/Details.tsx
+++ b/web-app/src/features/assignments/components/AssignmentCard/Details.tsx
@@ -1,3 +1,4 @@
+import { ConflictNotice } from './ConflictNotice'
 import { GameInfo } from './GameInfo'
 import { Location } from './Location'
 import { Referees } from './Referees'
@@ -6,12 +7,13 @@ import { Status } from './Status'
 
 /**
  * Composed details section for the expanded view.
- * Renders Location, SingleBallNotice, Status, GameInfo, and Referees.
+ * Renders Location, ConflictNotice, SingleBallNotice, Status, GameInfo, and Referees.
  */
 export function Details() {
   return (
     <div className="px-2 pb-2 pt-0 border-t border-border-subtle dark:border-border-subtle-dark space-y-1">
       <Location />
+      <ConflictNotice />
       <SingleBallNotice />
       <Status />
       <GameInfo />

--- a/web-app/src/features/assignments/components/AssignmentCard/context.ts
+++ b/web-app/src/features/assignments/components/AssignmentCard/context.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react'
 import type { ReactNode } from 'react'
 
 import type { Assignment } from '@/api/client'
+import type { AssignmentConflict } from '@/features/assignments/utils/conflict-detection'
 
 /** Helper to extract referee display name from deep nested structure */
 export function getRefereeDisplayName(
@@ -70,6 +71,8 @@ export interface AssignmentCardContextValue {
   singleBallPdfPath: string
   /** Pre-rendered expand arrow element */
   expandArrow: ReactNode | null
+  /** Scheduling conflicts with other assignments */
+  conflicts: AssignmentConflict[]
 }
 
 export const AssignmentCardContext = createContext<AssignmentCardContextValue | null>(null)

--- a/web-app/src/features/assignments/hooks/useCalendarConflicts.test.ts
+++ b/web-app/src/features/assignments/hooks/useCalendarConflicts.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+
+import type { CalendarAssignment } from '@/features/assignments/api/ical/types'
+
+import { createTimeGapEvaluator } from './useCalendarConflicts'
+
+// Helper to create a test assignment
+function createAssignment(startTime: string, endTime: string): CalendarAssignment {
+  return {
+    gameId: '1',
+    startTime,
+    endTime,
+    homeTeam: 'Home',
+    awayTeam: 'Away',
+    league: 'Test League',
+    role: 'referee1',
+    roleRaw: 'ARB 1',
+    association: null,
+    leagueCategory: '3L',
+    gender: 'men',
+    hallName: 'Hall',
+    hallId: null,
+    gameNumber: 1,
+    address: '123 Test St',
+    coordinates: null,
+    plusCode: null,
+    mapsUrl: null,
+    referees: {},
+  }
+}
+
+describe('createTimeGapEvaluator', () => {
+  it('should return true when gap is less than threshold', () => {
+    const evaluator = createTimeGapEvaluator(60) // 60 min threshold
+    const a = createAssignment('2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z')
+    const b = createAssignment('2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z')
+    // 30 min gap < 60 min threshold -> conflict
+    expect(evaluator(a, b)).toBe(true)
+  })
+
+  it('should return false when gap equals threshold', () => {
+    const evaluator = createTimeGapEvaluator(60) // 60 min threshold
+    const a = createAssignment('2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z')
+    const b = createAssignment('2024-01-15T13:00:00Z', '2024-01-15T15:00:00Z')
+    // 60 min gap >= 60 min threshold -> no conflict
+    expect(evaluator(a, b)).toBe(false)
+  })
+
+  it('should return false when gap is greater than threshold', () => {
+    const evaluator = createTimeGapEvaluator(60) // 60 min threshold
+    const a = createAssignment('2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z')
+    const b = createAssignment('2024-01-15T14:00:00Z', '2024-01-15T16:00:00Z')
+    // 120 min gap > 60 min threshold -> no conflict
+    expect(evaluator(a, b)).toBe(false)
+  })
+
+  it('should handle overlapping assignments as conflicts', () => {
+    const evaluator = createTimeGapEvaluator(60)
+    const a = createAssignment('2024-01-15T10:00:00Z', '2024-01-15T14:00:00Z')
+    const b = createAssignment('2024-01-15T12:00:00Z', '2024-01-15T16:00:00Z')
+    // Overlapping -> negative gap -> definitely < threshold
+    expect(evaluator(a, b)).toBe(true)
+  })
+
+  it('should work regardless of assignment order', () => {
+    const evaluator = createTimeGapEvaluator(60)
+    const earlier = createAssignment('2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z')
+    const later = createAssignment('2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z')
+    // Should work in both orders
+    expect(evaluator(earlier, later)).toBe(true)
+    expect(evaluator(later, earlier)).toBe(true)
+  })
+
+  it('should respect custom threshold', () => {
+    const strictEvaluator = createTimeGapEvaluator(120) // 2 hour threshold
+    const a = createAssignment('2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z')
+    const b = createAssignment('2024-01-15T13:00:00Z', '2024-01-15T15:00:00Z')
+    // 60 min gap < 120 min threshold -> conflict
+    expect(strictEvaluator(a, b)).toBe(true)
+
+    const relaxedEvaluator = createTimeGapEvaluator(30) // 30 min threshold
+    // 60 min gap >= 30 min threshold -> no conflict
+    expect(relaxedEvaluator(a, b)).toBe(false)
+  })
+})

--- a/web-app/src/features/assignments/hooks/useCalendarConflicts.ts
+++ b/web-app/src/features/assignments/hooks/useCalendarConflicts.ts
@@ -1,0 +1,145 @@
+/**
+ * Hook for detecting assignment conflicts using calendar data.
+ *
+ * This hook fetches all assignments from the iCal calendar feed and
+ * detects conflicts - assignments that are scheduled too close together
+ * (less than 1 hour apart by default).
+ *
+ * The calendar is particularly useful for conflict detection because:
+ * - It contains ALL assignments across ALL associations
+ * - The API only returns assignments for the currently active association
+ * - By using the calendar, we can detect cross-association conflicts
+ */
+
+import { useMemo } from 'react'
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+
+import { queryKeys } from '@/api/queryKeys'
+import { fetchCalendarAssignments } from '@/features/assignments/api/calendar-api'
+import type { CalendarAssignment } from '@/features/assignments/api/ical/types'
+import {
+  detectConflicts,
+  type ConflictMap,
+  type AssignmentConflict,
+} from '@/features/assignments/utils/conflict-detection'
+import { useAuthStore } from '@/shared/stores/auth'
+
+// Re-export types for convenience
+export type { ConflictMap, AssignmentConflict }
+
+/** Default conflict threshold in minutes */
+const DEFAULT_CONFLICT_THRESHOLD_MINUTES = 60
+
+/** Stale time for calendar conflicts - 5 minutes (background data) */
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+const CALENDAR_CONFLICTS_STALE_TIME_MS = 5 * 60 * 1000
+
+// Stable empty map for consistent references
+const EMPTY_CONFLICT_MAP: ConflictMap = new Map()
+
+/**
+ * Result of the calendar conflicts query.
+ */
+export interface CalendarConflictsResult {
+  /** Map of assignment ID to its conflicts */
+  conflicts: ConflictMap
+  /** All calendar assignments (raw data) */
+  assignments: CalendarAssignment[]
+  /** Whether the query is loading */
+  isLoading: boolean
+  /** Whether the query has an error */
+  isError: boolean
+  /** Error object if query failed */
+  error: Error | null
+  /** Whether the calendar code is available */
+  hasCalendarCode: boolean
+}
+
+/**
+ * Hook that fetches calendar assignments and detects conflicts.
+ *
+ * This hook uses the calendar code stored in the auth store. The code
+ * can be set during login (from the dashboard HTML) or manually.
+ *
+ * In calendar mode, this uses the same calendar code as the main app.
+ * In API mode, this fetches the calendar in the background to detect
+ * conflicts with assignments from other associations.
+ *
+ * @param thresholdMinutes - Minimum gap required between assignments (default: 60)
+ * @returns Conflict detection result with map and loading state
+ *
+ * @example
+ * ```tsx
+ * function AssignmentCard({ assignment }) {
+ *   const { conflicts, isLoading } = useCalendarConflicts();
+ *   const assignmentConflicts = conflicts.get(assignment.gameId);
+ *
+ *   if (assignmentConflicts?.length) {
+ *     return <WarningBadge conflicts={assignmentConflicts} />;
+ *   }
+ * }
+ * ```
+ */
+export function useCalendarConflicts(
+  thresholdMinutes = DEFAULT_CONFLICT_THRESHOLD_MINUTES
+): CalendarConflictsResult {
+  const calendarCode = useAuthStore((state) => state.calendarCode)
+  const isAuthenticated = useAuthStore((state) => state.status === 'authenticated')
+
+  const query: UseQueryResult<CalendarAssignment[], Error> = useQuery({
+    queryKey: queryKeys.calendar.assignmentsByCode(calendarCode ?? ''),
+    queryFn: ({ signal }) => {
+      if (!calendarCode) {
+        return Promise.resolve([])
+      }
+      return fetchCalendarAssignments(calendarCode, signal)
+    },
+    // Only fetch when authenticated and have a calendar code
+    enabled: isAuthenticated && !!calendarCode,
+    staleTime: CALENDAR_CONFLICTS_STALE_TIME_MS,
+    // Use empty array as placeholder
+    placeholderData: [],
+  })
+
+  // Memoize conflict detection to avoid recalculating on every render
+  const conflicts = useMemo(() => {
+    if (!query.data || query.data.length === 0) {
+      return EMPTY_CONFLICT_MAP
+    }
+    return detectConflicts(query.data, thresholdMinutes)
+  }, [query.data, thresholdMinutes])
+
+  return {
+    conflicts,
+    assignments: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    hasCalendarCode: !!calendarCode,
+  }
+}
+
+/**
+ * Gets conflicts for a specific assignment.
+ *
+ * Helper hook that uses useCalendarConflicts internally and filters
+ * to just the conflicts for a single assignment.
+ *
+ * @param assignmentId - The assignment ID (game ID) to check
+ * @returns Array of conflicts for this assignment, or empty array
+ */
+export function useAssignmentConflicts(assignmentId: string | undefined): {
+  conflicts: AssignmentConflict[]
+  isLoading: boolean
+  hasCalendarCode: boolean
+} {
+  const { conflicts: conflictMap, isLoading, hasCalendarCode } = useCalendarConflicts()
+
+  const conflicts = useMemo(() => {
+    if (!assignmentId) return []
+    return conflictMap.get(assignmentId) ?? []
+  }, [conflictMap, assignmentId])
+
+  return { conflicts, isLoading, hasCalendarCode }
+}

--- a/web-app/src/features/assignments/hooks/useCalendarConflicts.ts
+++ b/web-app/src/features/assignments/hooks/useCalendarConflicts.ts
@@ -31,9 +31,10 @@ export type { ConflictMap, AssignmentConflict }
 /** Default conflict threshold in minutes */
 const DEFAULT_CONFLICT_THRESHOLD_MINUTES = 60
 
-/** Stale time for calendar conflicts - 5 minutes (background data) */
-// eslint-disable-next-line @typescript-eslint/no-magic-numbers
-const CALENDAR_CONFLICTS_STALE_TIME_MS = 5 * 60 * 1000
+/** Stale time configuration for calendar conflicts (background data) */
+const STALE_TIME_MINUTES = 5
+const MS_PER_MINUTE = 60000
+const CALENDAR_CONFLICTS_STALE_TIME_MS = STALE_TIME_MINUTES * MS_PER_MINUTE
 
 // Stable empty map for consistent references
 const EMPTY_CONFLICT_MAP: ConflictMap = new Map()

--- a/web-app/src/features/assignments/utils/conflict-detection.test.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.test.ts
@@ -7,6 +7,7 @@ import {
   getConflictsForAssignment,
   hasConflicts,
   formatGap,
+  parseGap,
 } from './conflict-detection'
 
 // Helper to create a test assignment
@@ -216,6 +217,48 @@ describe('conflict-detection', () => {
 
     it('should handle zero gap', () => {
       expect(formatGap(0)).toBe('0min gap')
+    })
+  })
+
+  describe('parseGap', () => {
+    it('should parse positive gap in minutes only', () => {
+      const result = parseGap(30)
+      expect(result).toEqual({ type: 'gap', hours: 0, minutes: 30 })
+    })
+
+    it('should parse positive gap in hours only', () => {
+      const result = parseGap(60)
+      expect(result).toEqual({ type: 'gap', hours: 1, minutes: 0 })
+    })
+
+    it('should parse positive gap in hours and minutes', () => {
+      const result = parseGap(90)
+      expect(result).toEqual({ type: 'gap', hours: 1, minutes: 30 })
+    })
+
+    it('should parse negative gap (overlap) in minutes only', () => {
+      const result = parseGap(-30)
+      expect(result).toEqual({ type: 'overlap', hours: 0, minutes: 30 })
+    })
+
+    it('should parse negative gap (overlap) in hours only', () => {
+      const result = parseGap(-60)
+      expect(result).toEqual({ type: 'overlap', hours: 1, minutes: 0 })
+    })
+
+    it('should parse negative gap (overlap) in hours and minutes', () => {
+      const result = parseGap(-90)
+      expect(result).toEqual({ type: 'overlap', hours: 1, minutes: 30 })
+    })
+
+    it('should handle zero as gap', () => {
+      const result = parseGap(0)
+      expect(result).toEqual({ type: 'gap', hours: 0, minutes: 0 })
+    })
+
+    it('should handle large values', () => {
+      const result = parseGap(150) // 2h 30min
+      expect(result).toEqual({ type: 'gap', hours: 2, minutes: 30 })
     })
   })
 })

--- a/web-app/src/features/assignments/utils/conflict-detection.test.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest'
+
+import type { CalendarAssignment } from '@/features/assignments/api/ical/types'
+
+import {
+  detectConflicts,
+  getConflictsForAssignment,
+  hasConflicts,
+  formatGap,
+} from './conflict-detection'
+
+// Helper to create a test assignment
+function createAssignment(
+  gameId: string,
+  startTime: string,
+  endTime: string,
+  association: string | null = null
+): CalendarAssignment {
+  return {
+    gameId,
+    startTime,
+    endTime,
+    homeTeam: `Home ${gameId}`,
+    awayTeam: `Away ${gameId}`,
+    league: 'Test League',
+    role: 'referee1',
+    roleRaw: 'ARB 1',
+    association,
+    leagueCategory: '3L',
+    gender: 'men',
+    hallName: `Hall ${gameId}`,
+    hallId: null,
+    gameNumber: parseInt(gameId, 10),
+    address: '123 Test St',
+    coordinates: null,
+    plusCode: null,
+    mapsUrl: null,
+    referees: {},
+  }
+}
+
+describe('conflict-detection', () => {
+  describe('detectConflicts', () => {
+    it('should return empty map when no assignments', () => {
+      const conflicts = detectConflicts([])
+      expect(conflicts.size).toBe(0)
+    })
+
+    it('should return empty map when single assignment', () => {
+      const assignments = [createAssignment('1', '2024-01-15T14:00:00Z', '2024-01-15T16:00:00Z')]
+      const conflicts = detectConflicts(assignments)
+      expect(conflicts.size).toBe(0)
+    })
+
+    it('should return empty map when assignments are far apart', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z'),
+        createAssignment('2', '2024-01-15T14:00:00Z', '2024-01-15T16:00:00Z'),
+      ]
+      const conflicts = detectConflicts(assignments)
+      expect(conflicts.size).toBe(0)
+    })
+
+    it('should detect conflict when assignments are within threshold', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z'),
+        createAssignment('2', '2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z'),
+      ]
+      // 30 min gap, default threshold is 60 min
+      const conflicts = detectConflicts(assignments)
+
+      expect(conflicts.size).toBe(2)
+      expect(conflicts.has('1')).toBe(true)
+      expect(conflicts.has('2')).toBe(true)
+
+      const conflict1 = conflicts.get('1')
+      expect(conflict1?.length).toBe(1)
+      expect(conflict1?.[0]?.conflictingAssignmentId).toBe('2')
+    })
+
+    it('should detect overlapping assignments', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T14:00:00Z'),
+        createAssignment('2', '2024-01-15T12:00:00Z', '2024-01-15T16:00:00Z'),
+      ]
+      const conflicts = detectConflicts(assignments)
+
+      expect(conflicts.size).toBe(2)
+      const conflict1 = conflicts.get('1')
+      expect(conflict1).toBeDefined()
+      // Gap should be negative for overlapping assignments
+      expect(conflict1?.[0]?.gapMinutes).toBeLessThan(0)
+    })
+
+    it('should respect custom threshold', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z'),
+        createAssignment('2', '2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z'),
+      ]
+
+      // With 30 min threshold, 30 min gap is not a conflict
+      const conflictsLowThreshold = detectConflicts(assignments, 30)
+      expect(conflictsLowThreshold.size).toBe(0)
+
+      // With 90 min threshold, 30 min gap is a conflict
+      const conflictsHighThreshold = detectConflicts(assignments, 90)
+      expect(conflictsHighThreshold.size).toBe(2)
+    })
+
+    it('should include association info in conflicts', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z', 'SVRZ'),
+        createAssignment('2', '2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z', 'SVRBA'),
+      ]
+      const conflicts = detectConflicts(assignments)
+
+      const conflict1 = conflicts.get('1')
+      expect(conflict1?.[0]?.conflictingAssignment.association).toBe('SVRBA')
+
+      const conflict2 = conflicts.get('2')
+      expect(conflict2?.[0]?.conflictingAssignment.association).toBe('SVRZ')
+    })
+
+    it('should handle multiple conflicts for same assignment', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T11:00:00Z'),
+        createAssignment('2', '2024-01-15T11:15:00Z', '2024-01-15T12:15:00Z'),
+        createAssignment('3', '2024-01-15T12:30:00Z', '2024-01-15T13:30:00Z'),
+      ]
+      // Assignment 2 should conflict with both 1 and 3
+      const conflicts = detectConflicts(assignments)
+
+      const conflict2 = conflicts.get('2')
+      expect(conflict2?.length).toBe(2)
+    })
+
+    it('should not detect conflict on different days', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T22:00:00Z', '2024-01-16T00:00:00Z'),
+        createAssignment('2', '2024-01-16T00:30:00Z', '2024-01-16T02:30:00Z'),
+      ]
+      // Even though times are close, should still detect since gap < threshold
+      const conflicts = detectConflicts(assignments)
+      expect(conflicts.size).toBe(2)
+    })
+  })
+
+  describe('getConflictsForAssignment', () => {
+    it('should return empty array for non-existent assignment', () => {
+      const conflicts = detectConflicts([])
+      const result = getConflictsForAssignment('nonexistent', conflicts)
+      expect(result).toEqual([])
+    })
+
+    it('should return conflicts for existing assignment', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z'),
+        createAssignment('2', '2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z'),
+      ]
+      const conflictMap = detectConflicts(assignments)
+      const result = getConflictsForAssignment('1', conflictMap)
+
+      expect(result.length).toBe(1)
+      expect(result[0]?.conflictingAssignmentId).toBe('2')
+    })
+  })
+
+  describe('hasConflicts', () => {
+    it('should return false for assignment without conflicts', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z'),
+        createAssignment('2', '2024-01-15T15:00:00Z', '2024-01-15T17:00:00Z'),
+      ]
+      const conflictMap = detectConflicts(assignments)
+
+      expect(hasConflicts('1', conflictMap)).toBe(false)
+      expect(hasConflicts('2', conflictMap)).toBe(false)
+    })
+
+    it('should return true for assignment with conflicts', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z'),
+        createAssignment('2', '2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z'),
+      ]
+      const conflictMap = detectConflicts(assignments)
+
+      expect(hasConflicts('1', conflictMap)).toBe(true)
+      expect(hasConflicts('2', conflictMap)).toBe(true)
+    })
+  })
+
+  describe('formatGap', () => {
+    it('should format positive gap in minutes', () => {
+      expect(formatGap(30)).toBe('30min gap')
+    })
+
+    it('should format positive gap in hours', () => {
+      expect(formatGap(60)).toBe('1h gap')
+    })
+
+    it('should format positive gap in hours and minutes', () => {
+      expect(formatGap(90)).toBe('1h 30min gap')
+    })
+
+    it('should format negative gap (overlap) in minutes', () => {
+      expect(formatGap(-30)).toBe('30min overlap')
+    })
+
+    it('should format negative gap (overlap) in hours', () => {
+      expect(formatGap(-60)).toBe('1h overlap')
+    })
+
+    it('should format negative gap (overlap) in hours and minutes', () => {
+      expect(formatGap(-90)).toBe('1h 30min overlap')
+    })
+
+    it('should handle zero gap', () => {
+      expect(formatGap(0)).toBe('0min gap')
+    })
+  })
+})

--- a/web-app/src/features/assignments/utils/conflict-detection.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.ts
@@ -1,0 +1,205 @@
+/**
+ * Assignment conflict detection utilities.
+ *
+ * Detects assignments that may conflict due to overlapping times.
+ * A conflict is when two assignments are scheduled less than a threshold
+ * apart (default: 1 hour), making it potentially impossible to attend both.
+ *
+ * This is particularly important for referees with multiple associations,
+ * as they may have assignments from different regional/national associations
+ * that could overlap.
+ */
+
+import type { CalendarAssignment } from '@/features/assignments/api/ical/types'
+
+/** Default minimum gap between assignments to avoid conflict (in minutes) */
+const DEFAULT_CONFLICT_THRESHOLD_MINUTES = 60
+
+/** Time conversion constants */
+const MINUTES_PER_HOUR = 60
+const MS_PER_MINUTE = 60000 // 60 * 1000
+
+/**
+ * Represents a detected conflict between two assignments.
+ */
+export interface AssignmentConflict {
+  /** The ID of the first assignment (current/primary) */
+  assignmentId: string
+  /** The ID of the conflicting assignment */
+  conflictingAssignmentId: string
+  /** Time gap between assignments in minutes (can be negative for overlaps) */
+  gapMinutes: number
+  /** The conflicting assignment details */
+  conflictingAssignment: {
+    gameId: string
+    homeTeam: string
+    awayTeam: string
+    startTime: string
+    endTime: string
+    league: string
+    /** Association code (e.g., 'SV', 'SVRZ', 'SVRBA') - null if not from calendar */
+    association: string | null
+    /** Hall name if available */
+    hallName?: string | null
+  }
+}
+
+/**
+ * Map of assignment ID to its conflicts.
+ */
+export type ConflictMap = Map<string, AssignmentConflict[]>
+
+/**
+ * Detects conflicts between calendar assignments.
+ *
+ * Two assignments conflict if:
+ * - They are on the same day
+ * - The gap between end of one and start of another is less than the threshold
+ * - They are not the same assignment
+ *
+ * @param assignments - All calendar assignments to check
+ * @param thresholdMinutes - Minimum required gap between assignments (default: 60)
+ * @returns Map of assignment IDs to their conflicts
+ */
+export function detectConflicts(
+  assignments: CalendarAssignment[],
+  thresholdMinutes = DEFAULT_CONFLICT_THRESHOLD_MINUTES
+): ConflictMap {
+  const conflicts: ConflictMap = new Map()
+
+  // Sort assignments by start time
+  const sorted = [...assignments].sort(
+    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+  )
+
+  // Check each pair of assignments
+  for (let i = 0; i < sorted.length; i++) {
+    const current = sorted[i]!
+    const currentStart = new Date(current.startTime)
+    const currentEnd = new Date(current.endTime)
+
+    // Only check assignments within a reasonable window (same day + threshold)
+    for (let j = i + 1; j < sorted.length; j++) {
+      const other = sorted[j]!
+      const otherStart = new Date(other.startTime)
+      const otherEnd = new Date(other.endTime)
+
+      // If other starts more than threshold after current ends, no conflict possible
+      const gapFromCurrentEndToOtherStart =
+        (otherStart.getTime() - currentEnd.getTime()) / MS_PER_MINUTE
+
+      if (gapFromCurrentEndToOtherStart >= thresholdMinutes) {
+        // Since sorted by start time, no more conflicts possible for current
+        break
+      }
+
+      // Check if there's a conflict (gap is less than threshold)
+      // Gap can be negative if assignments overlap
+      const gapFromOtherEndToCurrentStart =
+        (currentStart.getTime() - otherEnd.getTime()) / MS_PER_MINUTE
+
+      // The relevant gap depends on which assignment starts first
+      const effectiveGap = Math.max(gapFromCurrentEndToOtherStart, gapFromOtherEndToCurrentStart)
+
+      if (effectiveGap < thresholdMinutes) {
+        // Found a conflict - add to both assignments
+        const conflictForCurrent: AssignmentConflict = {
+          assignmentId: current.gameId,
+          conflictingAssignmentId: other.gameId,
+          gapMinutes: Math.round(gapFromCurrentEndToOtherStart),
+          conflictingAssignment: {
+            gameId: other.gameId,
+            homeTeam: other.homeTeam,
+            awayTeam: other.awayTeam,
+            startTime: other.startTime,
+            endTime: other.endTime,
+            league: other.league,
+            association: other.association,
+            hallName: other.hallName,
+          },
+        }
+
+        const conflictForOther: AssignmentConflict = {
+          assignmentId: other.gameId,
+          conflictingAssignmentId: current.gameId,
+          gapMinutes: Math.round(-gapFromCurrentEndToOtherStart),
+          conflictingAssignment: {
+            gameId: current.gameId,
+            homeTeam: current.homeTeam,
+            awayTeam: current.awayTeam,
+            startTime: current.startTime,
+            endTime: current.endTime,
+            league: current.league,
+            association: current.association,
+            hallName: current.hallName,
+          },
+        }
+
+        // Add to current's conflicts
+        const currentConflicts = conflicts.get(current.gameId) ?? []
+        currentConflicts.push(conflictForCurrent)
+        conflicts.set(current.gameId, currentConflicts)
+
+        // Add to other's conflicts
+        const otherConflicts = conflicts.get(other.gameId) ?? []
+        otherConflicts.push(conflictForOther)
+        conflicts.set(other.gameId, otherConflicts)
+      }
+    }
+  }
+
+  return conflicts
+}
+
+/**
+ * Finds conflicts for a specific assignment ID.
+ *
+ * @param assignmentId - The assignment ID (game ID) to check
+ * @param conflictMap - The conflict map from detectConflicts()
+ * @returns Array of conflicts for this assignment, or empty array if none
+ */
+export function getConflictsForAssignment(
+  assignmentId: string,
+  conflictMap: ConflictMap
+): AssignmentConflict[] {
+  return conflictMap.get(assignmentId) ?? []
+}
+
+/**
+ * Checks if an assignment has any conflicts.
+ *
+ * @param assignmentId - The assignment ID (game ID) to check
+ * @param conflictMap - The conflict map from detectConflicts()
+ * @returns true if the assignment has conflicts
+ */
+export function hasConflicts(assignmentId: string, conflictMap: ConflictMap): boolean {
+  const conflicts = conflictMap.get(assignmentId)
+  return conflicts !== undefined && conflicts.length > 0
+}
+
+/**
+ * Formats the time gap for display.
+ *
+ * @param gapMinutes - Gap in minutes (can be negative for overlaps)
+ * @returns Formatted string describing the gap
+ */
+export function formatGap(gapMinutes: number): string {
+  if (gapMinutes < 0) {
+    // Overlapping
+    const overlap = Math.abs(gapMinutes)
+    if (overlap >= MINUTES_PER_HOUR) {
+      const hours = Math.floor(overlap / MINUTES_PER_HOUR)
+      const mins = overlap % MINUTES_PER_HOUR
+      return mins > 0 ? `${hours}h ${mins}min overlap` : `${hours}h overlap`
+    }
+    return `${overlap}min overlap`
+  }
+
+  // Gap between assignments
+  if (gapMinutes >= MINUTES_PER_HOUR) {
+    const hours = Math.floor(gapMinutes / MINUTES_PER_HOUR)
+    const mins = gapMinutes % MINUTES_PER_HOUR
+    return mins > 0 ? `${hours}h ${mins}min gap` : `${hours}h gap`
+  }
+  return `${gapMinutes}min gap`
+}

--- a/web-app/src/features/auth/utils/calendar-code-extractor.test.ts
+++ b/web-app/src/features/auth/utils/calendar-code-extractor.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  extractCalendarCodeFromHtml,
+  isValidCalendarCode,
+  getCalendarUrl,
+} from './calendar-code-extractor'
+
+describe('calendar-code-extractor', () => {
+  describe('extractCalendarCodeFromHtml', () => {
+    it('should return null for empty HTML', () => {
+      expect(extractCalendarCodeFromHtml('')).toBeNull()
+    })
+
+    it('should return null for HTML without calendar code', () => {
+      const html = '<html><body>No calendar code here</body></html>'
+      expect(extractCalendarCodeFromHtml(html)).toBeNull()
+    })
+
+    it('should extract code from iCal URL path', () => {
+      const html = '<a href="/iCal/referee/ABC123">Calendar</a>'
+      expect(extractCalendarCodeFromHtml(html)).toBe('ABC123')
+    })
+
+    it('should extract code from indoor iCal URL path', () => {
+      const html = '<a href="/indoor/iCal/referee/XYZ789">Calendar</a>'
+      expect(extractCalendarCodeFromHtml(html)).toBe('XYZ789')
+    })
+
+    it('should extract code from full HTTPS URL', () => {
+      const html = 'https://volleymanager.volleyball.ch/iCal/referee/TEST12'
+      expect(extractCalendarCodeFromHtml(html)).toBe('TEST12')
+    })
+
+    it('should extract code from webcal URL', () => {
+      const html = 'webcal://volleymanager.volleyball.ch/iCal/referee/CODE99'
+      expect(extractCalendarCodeFromHtml(html)).toBe('CODE99')
+    })
+
+    it('should extract code from href attribute', () => {
+      const html = `<a href="https://volleymanager.volleyball.ch/iCal/referee/ABCDEF">Subscribe</a>`
+      expect(extractCalendarCodeFromHtml(html)).toBe('ABCDEF')
+    })
+
+    it('should extract code from calendar path', () => {
+      const html = '/calendar/QWERTY'
+      expect(extractCalendarCodeFromHtml(html)).toBe('QWERTY')
+    })
+
+    it('should extract code from JSON iCalHash property', () => {
+      const html = '{"iCalHash": "HASH01"}'
+      expect(extractCalendarCodeFromHtml(html)).toBe('HASH01')
+    })
+
+    it('should extract code from Vue component prop', () => {
+      const html = '<calendar-component :ical-hash="VUEABC"></calendar-component>'
+      expect(extractCalendarCodeFromHtml(html)).toBe('VUEABC')
+    })
+
+    it('should handle standard VolleyManager iCal path', () => {
+      // Real VolleyManager uses "iCal" (capital C, lowercase al)
+      const html = '/iCal/referee/UPPER1'
+      expect(extractCalendarCodeFromHtml(html)).toBe('UPPER1')
+    })
+
+    it('should not extract invalid codes (too short)', () => {
+      const html = '/iCal/referee/SHORT'
+      expect(extractCalendarCodeFromHtml(html)).toBeNull()
+    })
+
+    it('should not extract invalid codes (too long)', () => {
+      const html = '/iCal/referee/TOOLONGCODE'
+      expect(extractCalendarCodeFromHtml(html)).toBeNull()
+    })
+
+    it('should not extract codes with special characters', () => {
+      const html = '/iCal/referee/ABC-12'
+      expect(extractCalendarCodeFromHtml(html)).toBeNull()
+    })
+  })
+
+  describe('isValidCalendarCode', () => {
+    it('should return true for valid 6-character alphanumeric code', () => {
+      expect(isValidCalendarCode('ABC123')).toBe(true)
+      expect(isValidCalendarCode('abcdef')).toBe(true)
+      expect(isValidCalendarCode('ABCDEF')).toBe(true)
+      expect(isValidCalendarCode('123456')).toBe(true)
+    })
+
+    it('should return false for codes that are too short', () => {
+      expect(isValidCalendarCode('ABC12')).toBe(false)
+      expect(isValidCalendarCode('')).toBe(false)
+    })
+
+    it('should return false for codes that are too long', () => {
+      expect(isValidCalendarCode('ABC1234')).toBe(false)
+    })
+
+    it('should return false for codes with special characters', () => {
+      expect(isValidCalendarCode('ABC-12')).toBe(false)
+      expect(isValidCalendarCode('ABC_12')).toBe(false)
+      expect(isValidCalendarCode('ABC.12')).toBe(false)
+    })
+  })
+
+  describe('getCalendarUrl', () => {
+    it('should construct URL with given code', () => {
+      const url = getCalendarUrl('ABC123', '')
+      expect(url).toBe('/iCal/referee/ABC123')
+    })
+
+    it('should prepend proxy URL when provided', () => {
+      const url = getCalendarUrl('ABC123', 'https://proxy.example.com')
+      expect(url).toBe('https://proxy.example.com/iCal/referee/ABC123')
+    })
+  })
+})

--- a/web-app/src/features/auth/utils/calendar-code-extractor.ts
+++ b/web-app/src/features/auth/utils/calendar-code-extractor.ts
@@ -1,0 +1,111 @@
+/**
+ * Calendar code extraction from VolleyManager HTML pages.
+ *
+ * The calendar code (6 alphanumeric characters) is embedded in the HTML of
+ * the calendar settings page and other pages. It's used to construct the
+ * public iCal URL: /iCal/referee/{code}
+ *
+ * This code is unique per referee (not per association), so it can be used
+ * to fetch ALL assignments across ALL associations the referee belongs to.
+ */
+
+import { logger } from '@/shared/utils/logger'
+
+/** Calendar codes are exactly 6 alphanumeric characters */
+const CALENDAR_CODE_PATTERN = /^[a-zA-Z0-9]{6}$/
+
+/**
+ * Regex patterns to extract calendar code from HTML.
+ *
+ * The code appears in various formats:
+ * - In iCal URLs: /iCal/referee/XXXXXX or /indoor/iCal/referee/XXXXXX
+ * - In webcal:// links: webcal://volleymanager.volleyball.ch/iCal/referee/XXXXXX
+ * - In Vue components as props or data
+ */
+const CALENDAR_URL_PATTERNS = [
+  // Direct iCal path: /iCal/referee/XXXXXX or /indoor/iCal/referee/XXXXXX
+  /\/i[Cc]al\/referee\/([a-zA-Z0-9]{6})(?:["'\s<]|$)/,
+  // Full URL with domain: https://volleymanager.volleyball.ch/iCal/referee/XXXXXX
+  /volleymanager\.volleyball\.ch\/(?:indoor\/)?i[Cc]al\/referee\/([a-zA-Z0-9]{6})/,
+  // webcal:// protocol link
+  /webcal:\/\/[^"'\s]*\/i[Cc]al\/referee\/([a-zA-Z0-9]{6})/,
+  // In href attribute: href="...iCal/referee/XXXXXX..."
+  /href=["'][^"']*\/i[Cc]al\/referee\/([a-zA-Z0-9]{6})[^"']*["']/,
+  // Calendar/sportmanager paths
+  /\/calendar\/(?:ical\/)?([a-zA-Z0-9]{6})(?:["'\s<]|$)/,
+  /\/sportmanager\.volleyball\/calendar\/ical\/([a-zA-Z0-9]{6})/,
+]
+
+/**
+ * Vue component patterns for calendar hash property.
+ * The calendar settings page may have the hash in a Vue component prop.
+ */
+const VUE_HASH_PATTERNS = [
+  // :ical-hash="..." or icalHash="..."
+  /:?[iI][cC][aA][lL]-?[hH][aA][sS][hH]=["']([a-zA-Z0-9]{6})["']/,
+  // :hash="..." prop (when in calendar context)
+  /:hash=["']([a-zA-Z0-9]{6})["']/,
+  // JSON property "iCalHash": "XXXXXX"
+  /"i[Cc]al[Hh]ash"\s*:\s*["']([a-zA-Z0-9]{6})["']/,
+  // JSON property "hash": "XXXXXX" (in calendar context)
+  /"hash"\s*:\s*["']([a-zA-Z0-9]{6})["']/,
+  // JSON property "calendarCode": "XXXXXX"
+  /"calendar[Cc]ode"\s*:\s*["']([a-zA-Z0-9]{6})["']/,
+]
+
+/**
+ * Extracts the calendar code from HTML content.
+ *
+ * Searches for calendar URLs and Vue component props that contain the
+ * 6-character calendar code.
+ *
+ * @param html - The HTML content to search
+ * @returns The 6-character calendar code, or null if not found
+ */
+export function extractCalendarCodeFromHtml(html: string): string | null {
+  if (!html) {
+    return null
+  }
+
+  // Try URL patterns first (most reliable)
+  for (const pattern of CALENDAR_URL_PATTERNS) {
+    const match = html.match(pattern)
+    if (match?.[1] && CALENDAR_CODE_PATTERN.test(match[1])) {
+      logger.info('Extracted calendar code from URL pattern')
+      return match[1]
+    }
+  }
+
+  // Try Vue component patterns
+  for (const pattern of VUE_HASH_PATTERNS) {
+    const match = html.match(pattern)
+    if (match?.[1] && CALENDAR_CODE_PATTERN.test(match[1])) {
+      logger.info('Extracted calendar code from Vue/JSON pattern')
+      return match[1]
+    }
+  }
+
+  return null
+}
+
+/**
+ * Validates a calendar code format.
+ *
+ * @param code - The code to validate
+ * @returns true if the code matches the expected format
+ */
+export function isValidCalendarCode(code: string): boolean {
+  return CALENDAR_CODE_PATTERN.test(code)
+}
+
+/**
+ * Constructs the iCal URL for a given calendar code.
+ *
+ * @param code - The 6-character calendar code
+ * @param proxyUrl - Optional proxy URL prefix (defaults to env variable)
+ * @returns The full iCal URL
+ */
+export function getCalendarUrl(code: string, proxyUrl?: string): string {
+  const baseUrl = proxyUrl ?? import.meta.env.VITE_API_PROXY_URL ?? ''
+  return `${baseUrl}/iCal/referee/${code}`
+}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -268,6 +268,9 @@ const de: Translations = {
     singleBallHallConditional:
       'Spiel mit 1 Ball möglich (nur wenn ausnahmsweise nur eine Teilhalle zur Verfügung steht)',
     singleBallHallTooltip: '1-Ball-Halle',
+    conflictWarningTooltip: 'Terminkonflikt',
+    conflictWarningTitle: 'Möglicher Terminkonflikt',
+    hall: 'Halle',
   },
   compensations: {
     title: 'Entschädigungen',

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -270,6 +270,8 @@ const de: Translations = {
     singleBallHallTooltip: '1-Ball-Halle',
     conflictWarningTooltip: 'Terminkonflikt',
     conflictWarningTitle: 'Möglicher Terminkonflikt',
+    conflictGap: 'Abstand',
+    conflictOverlap: 'Überlappung',
     hall: 'Halle',
   },
   compensations: {

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -267,6 +267,8 @@ const en: Translations = {
     singleBallHallTooltip: 'Single ball hall',
     conflictWarningTooltip: 'Scheduling conflict',
     conflictWarningTitle: 'Potential scheduling conflict',
+    conflictGap: 'gap',
+    conflictOverlap: 'overlap',
     hall: 'Hall',
   },
   compensations: {

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -265,6 +265,9 @@ const en: Translations = {
     singleBallHallConditional:
       'Single ball game possible (only when exceptionally one sub-hall available)',
     singleBallHallTooltip: 'Single ball hall',
+    conflictWarningTooltip: 'Scheduling conflict',
+    conflictWarningTitle: 'Potential scheduling conflict',
+    hall: 'Hall',
   },
   compensations: {
     title: 'Compensations',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -272,6 +272,8 @@ const fr: Translations = {
     singleBallHallTooltip: 'Salle 1 ballon',
     conflictWarningTooltip: 'Conflit de planning',
     conflictWarningTitle: 'Conflit de planning possible',
+    conflictGap: 'écart',
+    conflictOverlap: 'chevauchement',
     hall: 'Salle',
   },
   compensations: {

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -270,6 +270,9 @@ const fr: Translations = {
     singleBallHallConditional:
       'Rencontre avec 1 ballon possible (seulement si exceptionnellement une seule salle partielle disponible)',
     singleBallHallTooltip: 'Salle 1 ballon',
+    conflictWarningTooltip: 'Conflit de planning',
+    conflictWarningTitle: 'Conflit de planning possible',
+    hall: 'Salle',
   },
   compensations: {
     title: 'Indemnités',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -271,6 +271,8 @@ const it: Translations = {
     singleBallHallTooltip: 'Sala 1 pallone',
     conflictWarningTooltip: 'Conflitto di programmazione',
     conflictWarningTitle: 'Possibile conflitto di programmazione',
+    conflictGap: 'intervallo',
+    conflictOverlap: 'sovrapposizione',
     hall: 'Sala',
   },
   compensations: {

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -269,6 +269,9 @@ const it: Translations = {
     singleBallHallConditional:
       'Partita con 1 pallone possibile (solo se eccezionalmente disponibile una sola sala parziale)',
     singleBallHallTooltip: 'Sala 1 pallone',
+    conflictWarningTooltip: 'Conflitto di programmazione',
+    conflictWarningTitle: 'Possibile conflitto di programmazione',
+    hall: 'Sala',
   },
   compensations: {
     title: 'Compensi',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -158,6 +158,9 @@ export interface Translations {
     singleBallHall: string
     singleBallHallConditional: string
     singleBallHallTooltip: string
+    conflictWarningTooltip: string
+    conflictWarningTitle: string
+    hall: string
   }
   compensations: {
     title: string

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -160,6 +160,8 @@ export interface Translations {
     singleBallHallTooltip: string
     conflictWarningTooltip: string
     conflictWarningTitle: string
+    conflictGap: string
+    conflictOverlap: string
     hall: string
   }
   compensations: {

--- a/web-app/src/shared/stores/auth.test.ts
+++ b/web-app/src/shared/stores/auth.test.ts
@@ -398,8 +398,8 @@ describe('useAuthStore', () => {
       expect(result).toBe(true)
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(setCsrfToken).toHaveBeenCalledWith('my-csrf-token-12345678901234567890')
-      // Should make 3 calls: login page + auth POST + manual dashboard fetch
-      expect(mockFetch).toHaveBeenCalledTimes(3)
+      // Should make 4 calls: login page + auth POST + dashboard + calendar code (background)
+      expect(mockFetch).toHaveBeenCalledTimes(4)
     })
 
     it('failed login returns login page with error snackbar', async () => {
@@ -533,8 +533,8 @@ describe('useAuthStore', () => {
       expect(result).toBe(true)
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(setCsrfToken).toHaveBeenCalledWith('fresh-csrf-token-abcdef')
-      // 3 calls: login page fetch + auth POST + dashboard
-      expect(mockFetch).toHaveBeenCalledTimes(3)
+      // 4 calls: login page fetch + auth POST + dashboard + calendar code (background)
+      expect(mockFetch).toHaveBeenCalledTimes(4)
     })
 
     it('fails when auth request returns non-ok response', async () => {
@@ -750,8 +750,8 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(useAuthStore.getState().user?.occupations).toHaveLength(1)
       expect(useAuthStore.getState().user?.occupations?.[0]?.type).toBe('referee')
-      // Should make 3 calls: login page + auth POST + dashboard
-      expect(mockFetch).toHaveBeenCalledTimes(3)
+      // Should make 4 calls: login page + auth POST + dashboard + calendar code (background)
+      expect(mockFetch).toHaveBeenCalledTimes(4)
     })
 
     it('resets stale activeOccupationId when it does not exist in new occupations', async () => {

--- a/web-app/src/shared/stores/auth.ts
+++ b/web-app/src/shared/stores/auth.ts
@@ -23,6 +23,7 @@ import {
   submitLoginCredentials,
   isDashboardHtmlContent,
 } from '@/features/auth/utils/auth-parsers'
+import { extractCalendarCodeFromHtml } from '@/features/auth/utils/calendar-code-extractor'
 import {
   filterRefereeOccupations,
   parseOccupationsFromActiveParty,
@@ -137,6 +138,9 @@ const SESSION_CHECK_GRACE_PERIOD_MS = 5_000
 /** Calendar codes are exactly 6 alphanumeric characters */
 const CALENDAR_CODE_PATTERN = /^[a-zA-Z0-9]{6}$/
 
+/** URL for the calendar settings page where the calendar code is embedded */
+const CALENDAR_SETTINGS_URL = `${API_BASE}/sportmanager.indoorvolleyball/icalhashgamepropertyfiltersettings/index`
+
 /**
  * Dummy association code for calendar mode transport settings.
  * Using a dedicated code ensures calendar mode settings don't interfere
@@ -167,6 +171,47 @@ async function rejectNonRefereeUser(set: (state: Partial<AuthState>) => void): P
   clearSession()
   set({ status: 'error', error: NO_REFEREE_ROLE_ERROR_KEY })
   return false
+}
+
+/**
+ * Fetches the calendar code from the calendar settings page.
+ *
+ * The calendar code is embedded in the HTML of the calendar settings page.
+ * This code is unique per referee and provides access to ALL assignments
+ * across ALL associations, which is useful for conflict detection.
+ *
+ * This function is called in the background after successful login to
+ * extract and store the calendar code without blocking the login flow.
+ *
+ * @returns The 6-character calendar code, or null if not found
+ */
+async function fetchCalendarCode(): Promise<string | null> {
+  try {
+    const response = await fetch(CALENDAR_SETTINGS_URL, {
+      credentials: 'include',
+      cache: 'no-store',
+      headers: getSessionHeaders(),
+    })
+
+    if (!response.ok) {
+      logger.warn('Failed to fetch calendar settings page:', response.status)
+      return null
+    }
+
+    const html = await response.text()
+    const code = extractCalendarCodeFromHtml(html)
+
+    if (code) {
+      logger.info('Successfully extracted calendar code from settings page')
+    } else {
+      logger.info('Calendar code not found in settings page')
+    }
+
+    return code
+  } catch (error) {
+    logger.warn('Error fetching calendar code:', error)
+    return null
+  }
 }
 
 /**
@@ -281,6 +326,21 @@ async function handleSuccessfulLoginResult(
       logger.warn('Failed to sync active association after login:', error)
     }
   }
+
+  // Fetch calendar code in the background for conflict detection.
+  // This doesn't block login - it's a background enhancement.
+  // The calendar code provides access to ALL assignments across ALL
+  // associations, which is needed to detect scheduling conflicts.
+  fetchCalendarCode()
+    .then((code) => {
+      if (code) {
+        set({ calendarCode: code })
+      }
+    })
+    .catch((error) => {
+      // Silent failure - calendar conflicts feature is optional
+      logger.info('Background calendar code fetch failed:', error)
+    })
 
   return true
 }

--- a/web-app/src/shared/stores/demo-generators.ts
+++ b/web-app/src/shared/stores/demo-generators.ts
@@ -1504,3 +1504,186 @@ export function updateCompensationRecord(
     },
   }
 }
+
+/**
+ * Demo calendar assignment for conflict detection.
+ * Matches the CalendarAssignment type from the iCal parser.
+ */
+export interface DemoCalendarAssignment {
+  gameId: string
+  gameNumber: number | null
+  role: 'referee1' | 'referee2' | 'lineReferee' | 'scorer' | 'unknown'
+  roleRaw: string
+  startTime: string
+  endTime: string
+  homeTeam: string
+  awayTeam: string
+  league: string
+  leagueCategory: string | null
+  address: string | null
+  coordinates: { latitude: number; longitude: number } | null
+  hallName: string | null
+  hallId: string | null
+  gender: 'men' | 'women' | 'mixed' | 'unknown'
+  mapsUrl: string | null
+  plusCode: string | null
+  referees: {
+    referee1?: string
+    referee2?: string
+    lineReferee1?: string
+    lineReferee2?: string
+  }
+  association: string | null
+}
+
+/**
+ * Generates demo calendar assignments with scheduling conflicts.
+ *
+ * Creates assignments across multiple associations to demonstrate
+ * cross-association conflict detection. Includes:
+ * - Two assignments on the same day with only 30 min gap (conflict)
+ * - One assignment from a different association (SVRZ) also conflicting
+ * - Several non-conflicting assignments
+ *
+ * @param now - Current date/time for relative date calculations
+ * @returns Array of CalendarAssignment objects with intentional conflicts
+ */
+export function generateDemoCalendarAssignments(now = new Date()): DemoCalendarAssignment[] {
+  // Game in 2 days at 14:00, ends ~16:00 (SV)
+  const game1Start = addDays(now, 2)
+  game1Start.setHours(14, 0, 0, 0)
+  const game1End = new Date(game1Start)
+  game1End.setHours(16, 0, 0, 0)
+
+  // Game in 2 days at 16:30 - only 30 min after game1 ends (SV) - CONFLICT!
+  const game2Start = addDays(now, 2)
+  game2Start.setHours(16, 30, 0, 0)
+  const game2End = new Date(game2Start)
+  game2End.setHours(18, 30, 0, 0)
+
+  // Game in 2 days at 17:00 from different association (SVRZ) - CONFLICT with game2!
+  const game3Start = addDays(now, 2)
+  game3Start.setHours(17, 0, 0, 0)
+  const game3End = new Date(game3Start)
+  game3End.setHours(19, 0, 0, 0)
+
+  // Game in 5 days - no conflict
+  const game4Start = addDays(now, 5)
+  game4Start.setHours(18, 0, 0, 0)
+  const game4End = new Date(game4Start)
+  game4End.setHours(20, 0, 0, 0)
+
+  // Game in 7 days - no conflict
+  const game5Start = addDays(now, 7)
+  game5Start.setHours(15, 0, 0, 0)
+  const game5End = new Date(game5Start)
+  game5End.setHours(17, 0, 0, 0)
+
+  return [
+    {
+      gameId: generateDemoUuid('demo-cal-1'),
+      gameNumber: 382700,
+      role: 'referee1',
+      roleRaw: 'ARB 1',
+      startTime: game1Start.toISOString(),
+      endTime: game1End.toISOString(),
+      homeTeam: 'NLZ Volleyball Academy',
+      awayTeam: 'Volley Luzern',
+      league: 'NLA Herren',
+      leagueCategory: 'NLA',
+      address: 'Talacherstrasse 2, 8302 Kloten',
+      coordinates: { latitude: 47.462187, longitude: 8.577813 },
+      hallName: 'Sporthalle Ruebisbach',
+      hallId: '3661',
+      gender: 'men',
+      mapsUrl: 'https://maps.google.com/?q=47.462187,8.577813',
+      plusCode: '8FVCFH6H+V4',
+      referees: { referee1: 'Demo User', referee2: 'Max Mustermann' },
+      association: 'SV',
+    },
+    {
+      gameId: generateDemoUuid('demo-cal-2'),
+      gameNumber: 382701,
+      role: 'referee1',
+      roleRaw: 'ARB 1',
+      startTime: game2Start.toISOString(),
+      endTime: game2End.toISOString(),
+      homeTeam: 'Volley Schönenwerd',
+      awayTeam: 'Traktor Basel',
+      league: 'NLA Herren',
+      leagueCategory: 'NLA',
+      address: 'Aarestrasse 20, 5012 Schönenwerd',
+      coordinates: { latitude: 47.379687, longitude: 8.004062 },
+      hallName: 'Betoncoupe Arena',
+      hallId: '3662',
+      gender: 'men',
+      mapsUrl: 'https://maps.google.com/?q=47.379687,8.004062',
+      plusCode: '8FVC92H3+VJ',
+      referees: { referee1: 'Demo User', referee2: 'Anna Schmidt' },
+      association: 'SV',
+    },
+    {
+      gameId: generateDemoUuid('demo-cal-3'),
+      gameNumber: 382702,
+      role: 'referee2',
+      roleRaw: 'ARB 2',
+      startTime: game3Start.toISOString(),
+      endTime: game3End.toISOString(),
+      homeTeam: 'VBC Zürich',
+      awayTeam: 'VBC Winterthur',
+      league: '2L Herren',
+      leagueCategory: '2L',
+      address: 'Wallisellerstrasse 57, 8050 Zürich',
+      coordinates: { latitude: 47.405062, longitude: 8.551313 },
+      hallName: 'Sporthalle Oerlikon',
+      hallId: '3663',
+      gender: 'men',
+      mapsUrl: 'https://maps.google.com/?q=47.405062,8.551313',
+      plusCode: null,
+      referees: { referee1: 'Thomas Weber', referee2: 'Demo User' },
+      association: 'SVRZ',
+    },
+    {
+      gameId: generateDemoUuid('demo-cal-4'),
+      gameNumber: 382703,
+      role: 'referee1',
+      roleRaw: 'ARB 1',
+      startTime: game4Start.toISOString(),
+      endTime: game4End.toISOString(),
+      homeTeam: 'Volley Näfels',
+      awayTeam: 'Volero Zürich',
+      league: 'NLB Damen',
+      leagueCategory: 'NLB',
+      address: 'Oberurnerstrasse 14, 8752 Näfels',
+      coordinates: { latitude: 47.108062, longitude: 9.065563 },
+      hallName: 'Lintharena',
+      hallId: '3664',
+      gender: 'women',
+      mapsUrl: 'https://maps.google.com/?q=47.108062,9.065563',
+      plusCode: '8FVF4358+66',
+      referees: { referee1: 'Demo User', referee2: 'Lisa Weber' },
+      association: 'SV',
+    },
+    {
+      gameId: generateDemoUuid('demo-cal-5'),
+      gameNumber: 382704,
+      role: 'referee1',
+      roleRaw: 'ARB 1',
+      startTime: game5Start.toISOString(),
+      endTime: game5End.toISOString(),
+      homeTeam: 'BTV Aarau',
+      awayTeam: 'TV Schönenwerd',
+      league: '3L Herren',
+      leagueCategory: '3L',
+      address: 'Tellistrasse 58, 5001 Aarau',
+      coordinates: { latitude: 47.396438, longitude: 8.057063 },
+      hallName: 'Berufsschule BSA',
+      hallId: '3665',
+      gender: 'men',
+      mapsUrl: 'https://maps.google.com/?q=47.396438,8.057063',
+      plusCode: '8FVC93W4+HR',
+      referees: { referee1: 'Demo User' },
+      association: 'SV',
+    },
+  ]
+}


### PR DESCRIPTION
Add assignment conflict detection that uses calendar data to identify games scheduled less than 1 hour apart. Since the API only returns assignments for the active association, we use the iCal feed which contains ALL assignments across ALL associations.

## Changes

### Core Conflict Detection
- Extract calendar code from HTML settings page after login
- Create conflict detection utility comparing assignment times
- Add useCalendarConflicts hook to fetch calendar and detect conflicts
- Show warning indicator on AssignmentCard for conflicting assignments
- Display conflict details in expanded view (association, time gap, hall)
- Add translations for conflict warnings in all 4 languages (de/en/fr/it)

### Demo Mode Support
- Add demo calendar assignments with intentional scheduling conflicts
- Conflicts visible in demo mode for testing without real data

### Custom Evaluator API
- Export ConflictEvaluator type for custom conflict detection logic
- Export createTimeGapEvaluator helper for building custom evaluators
- Allows location-based or other custom conflict rules

## Test Plan
- [x] Conflict detection works with default 60-minute threshold
- [x] Custom threshold can be configured
- [x] Custom evaluator overrides default time-based logic
- [x] Demo mode shows example conflicts
- [x] All 3447 tests pass
- [x] Build succeeds