### PR TITLE
fix(ux): add pull-to-refresh to Compensations and Exchanges pages

### DIFF
--- a/.changeset/fix-pull-to-refresh.md
+++ b/.changeset/fix-pull-to-refresh.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": patch
+---
+
+Added pull-to-refresh to Compensations and Exchanges pages for consistent refresh behavior across all main tabs

--- a/web-app/src/features/compensations/CompensationsPage.tsx
+++ b/web-app/src/features/compensations/CompensationsPage.tsx
@@ -8,6 +8,7 @@ import { TOUR_DUMMY_COMPENSATION } from '@/features/compensations/compensations'
 import { CompensationCard } from '@/features/compensations/components/CompensationCard'
 import { useCompensations } from '@/features/validation/hooks/useConvocations'
 import { LoadingState, ErrorState, EmptyState } from '@/shared/components/LoadingSpinner'
+import { PullToRefresh } from '@/shared/components/PullToRefresh'
 import { SwipeableCard } from '@/shared/components/SwipeableCard'
 import { Tabs, TabPanel } from '@/shared/components/Tabs'
 import { WeekSeparator } from '@/shared/components/WeekSeparator'
@@ -163,6 +164,11 @@ export function CompensationsPage() {
     [editCompensationModal.open, handleGeneratePDF]
   )
 
+  // Handler for pull-to-refresh - wraps refetch in async function
+  const handleRefresh = useCallback(async () => {
+    await refetch()
+  }, [refetch])
+
   const getEmptyStateContent = () => {
     switch (filter) {
       case 'pendingPast':
@@ -252,30 +258,32 @@ export function CompensationsPage() {
   }
 
   return (
-    <div className="space-y-3">
-      {/* Filter tabs with keyboard navigation */}
-      <Tabs
-        tabs={tabs}
-        activeTab={filter}
-        onTabChange={handleTabChange}
-        ariaLabel={t('compensations.title')}
-      />
+    <PullToRefresh onRefresh={handleRefresh}>
+      <div className="space-y-3">
+        {/* Filter tabs with keyboard navigation */}
+        <Tabs
+          tabs={tabs}
+          activeTab={filter}
+          onTabChange={handleTabChange}
+          ariaLabel={t('compensations.title')}
+        />
 
-      {/* Content - single TabPanel since all tabs show same component with different data */}
-      <TabPanel tabId={filter} activeTab={filter}>
-        {renderContent()}
-      </TabPanel>
+        {/* Content - single TabPanel since all tabs show same component with different data */}
+        <TabPanel tabId={filter} activeTab={filter}>
+          {renderContent()}
+        </TabPanel>
 
-      {/* Edit Compensation Modal - compensation is guaranteed non-null by conditional render */}
-      {editCompensationModal.compensation && (
-        <Suspense fallback={null}>
-          <EditCompensationModal
-            isOpen={editCompensationModal.isOpen}
-            onClose={editCompensationModal.close}
-            compensation={editCompensationModal.compensation}
-          />
-        </Suspense>
-      )}
-    </div>
+        {/* Edit Compensation Modal - compensation is guaranteed non-null by conditional render */}
+        {editCompensationModal.compensation && (
+          <Suspense fallback={null}>
+            <EditCompensationModal
+              isOpen={editCompensationModal.isOpen}
+              onClose={editCompensationModal.close}
+              compensation={editCompensationModal.compensation}
+            />
+          </Suspense>
+        )}
+      </div>
+    </PullToRefresh>
   )
 }

--- a/web-app/src/features/exchanges/ExchangePage.tsx
+++ b/web-app/src/features/exchanges/ExchangePage.tsx
@@ -11,6 +11,7 @@ import { DistanceFilterToggle } from '@/shared/components/DistanceFilterToggle'
 import { FilterChip } from '@/shared/components/FilterChip'
 import { LevelFilterToggle } from '@/shared/components/LevelFilterToggle'
 import { LoadingState, ErrorState, EmptyState } from '@/shared/components/LoadingSpinner'
+import { PullToRefresh } from '@/shared/components/PullToRefresh'
 import { SwipeableCard } from '@/shared/components/SwipeableCard'
 import { Tabs, TabPanel } from '@/shared/components/Tabs'
 import { TravelTimeFilterToggle } from '@/shared/components/TravelTimeFilterToggle'
@@ -307,6 +308,11 @@ export function ExchangePage() {
   const hasAnyFilter =
     isLevelFilterAvailable || isDistanceFilterAvailable || isTravelTimeFilterAvailable
 
+  // Handler for pull-to-refresh - wraps refetch in async function
+  const handleRefresh = useCallback(async () => {
+    await refetch()
+  }, [refetch])
+
   // Horizontal scrollable filter chips with settings gear - only show on "Open" tab when any filter is available
   // Always show filter bar on "open" tab (at minimum we have "hide own" filter)
   const filterContent =
@@ -434,43 +440,45 @@ export function ExchangePage() {
   }
 
   return (
-    <div className="space-y-3">
-      {/* Filter tabs with optional filters */}
-      <Tabs
-        tabs={tabs}
-        activeTab={statusFilter}
-        onTabChange={handleTabChange}
-        ariaLabel={t('exchange.title')}
-        endContent={filterContent}
-      />
+    <PullToRefresh onRefresh={handleRefresh}>
+      <div className="space-y-3">
+        {/* Filter tabs with optional filters */}
+        <Tabs
+          tabs={tabs}
+          activeTab={statusFilter}
+          onTabChange={handleTabChange}
+          ariaLabel={t('exchange.title')}
+          endContent={filterContent}
+        />
 
-      {/* Content - single TabPanel since all tabs show same component with different data */}
-      <TabPanel tabId={statusFilter} activeTab={statusFilter}>
-        {renderContent()}
-      </TabPanel>
+        {/* Content - single TabPanel since all tabs show same component with different data */}
+        <TabPanel tabId={statusFilter} activeTab={statusFilter}>
+          {renderContent()}
+        </TabPanel>
 
-      {/* Modals - exchange is guaranteed non-null by conditional render */}
-      {takeOverModal.exchange && (
-        <Suspense fallback={null}>
-          <TakeOverExchangeModal
-            exchange={takeOverModal.exchange}
-            isOpen={takeOverModal.isOpen}
-            onClose={takeOverModal.close}
-            onConfirm={handleTakeOverConfirm}
-          />
-        </Suspense>
-      )}
+        {/* Modals - exchange is guaranteed non-null by conditional render */}
+        {takeOverModal.exchange && (
+          <Suspense fallback={null}>
+            <TakeOverExchangeModal
+              exchange={takeOverModal.exchange}
+              isOpen={takeOverModal.isOpen}
+              onClose={takeOverModal.close}
+              onConfirm={handleTakeOverConfirm}
+            />
+          </Suspense>
+        )}
 
-      {removeFromExchangeModal.exchange && (
-        <Suspense fallback={null}>
-          <RemoveFromExchangeModal
-            exchange={removeFromExchangeModal.exchange}
-            isOpen={removeFromExchangeModal.isOpen}
-            onClose={removeFromExchangeModal.close}
-            onConfirm={handleRemoveConfirm}
-          />
-        </Suspense>
-      )}
-    </div>
+        {removeFromExchangeModal.exchange && (
+          <Suspense fallback={null}>
+            <RemoveFromExchangeModal
+              exchange={removeFromExchangeModal.exchange}
+              isOpen={removeFromExchangeModal.isOpen}
+              onClose={removeFromExchangeModal.close}
+              onConfirm={handleRemoveConfirm}
+            />
+          </Suspense>
+        )}
+      </div>
+    </PullToRefresh>
   )
 }


### PR DESCRIPTION
## Summary
- Added pull-to-refresh to Compensations and Exchanges pages
- Previously only the Assignments tab supported pull-to-refresh
- Now all main tabs have consistent refresh behavior in PWA mode

## Test plan
- [ ] Install as PWA and open Compensations tab, swipe down to refresh
- [ ] Install as PWA and open Exchanges tab, swipe down to refresh
- [ ] Verify refresh triggers data refetch on both pages