### PR TITLE
fix(demo): align calendar assignment IDs for conflict detection

### DIFF
--- a/.changeset/fix-demo-conflicts.md
+++ b/.changeset/fix-demo-conflicts.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": patch
+---
+
+Fixed conflict indicators not showing in demo mode - calendar assignment IDs now match the actual demo assignment IDs


### PR DESCRIPTION
## Summary
- Fixed conflict indicators not showing in demo mode
- Calendar assignment IDs now match actual demo assignment IDs (demo-g-* instead of demo-cal-*)
- Added cross-association conflict from SVRZ that conflicts with assignment 1

## Test plan
- [ ] Open demo mode and navigate to Assignments page
- [ ] Verify assignment 1 (2 days from now) shows a red conflict indicator
- [ ] Expand assignment 1 to see conflict details with SVRZ game