### PR TITLE
feat(settings): add calendar sync indicator to profile section

### DIFF
--- a/.changeset/add-calendar-icon-profile.md
+++ b/.changeset/add-calendar-icon-profile.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": minor
+---
+
+Added calendar sync indicator to profile section in settings page to show when calendar parsing is active for conflict detection

--- a/web-app/src/features/settings/components/ProfileSection.tsx
+++ b/web-app/src/features/settings/components/ProfileSection.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useEffect } from 'react'
 
 import { Badge } from '@/shared/components/Badge'
 import { Card, CardContent, CardHeader } from '@/shared/components/Card'
+import { Calendar } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useAuthStore } from '@/shared/stores/auth'
 import type { UserProfile } from '@/shared/stores/auth'
@@ -34,6 +35,7 @@ const DEMO_LAST_NAME = 'User'
 function ProfileSectionComponent({ user }: ProfileSectionProps) {
   const { t } = useTranslation()
   const dataSource = useAuthStore((state) => state.dataSource)
+  const calendarCode = useAuthStore((state) => state.calendarCode)
   const isDemoMode = dataSource === 'demo'
   const [profilePictureUrl, setProfilePictureUrl] = useState<string | null>(
     user.profilePictureUrl ?? null
@@ -172,6 +174,18 @@ function ProfileSectionComponent({ user }: ProfileSectionProps) {
                   {occ.associationCode && ` (${occ.associationCode})`}
                 </Badge>
               ))}
+            </div>
+          </div>
+        )}
+
+        {calendarCode && (
+          <div className="border-t border-border-subtle dark:border-border-subtle-dark pt-4">
+            <div
+              className="flex items-center gap-2 text-sm text-success-600 dark:text-success-400"
+              title={t('settings.calendarSyncedTooltip')}
+            >
+              <Calendar className="w-4 h-4" aria-hidden="true" />
+              <span>{t('settings.calendarSynced')}</span>
             </div>
           </div>
         )}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -544,6 +544,8 @@ const de: Translations = {
     platform: 'Plattform',
     openWebsite: 'VolleyManager-Website öffnen',
     roles: 'Rollen',
+    calendarSynced: 'Kalender synchronisiert',
+    calendarSyncedTooltip: 'Ihr Kalender ist für die Konflikterkennung verbunden',
     dataSource: 'Daten von volleymanager.volleyball.ch',
     disclaimer:
       'Inoffizielle App für den persönlichen Gebrauch. Alle Daten sind Eigentum von Swiss Volley.',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -525,6 +525,8 @@ const en: Translations = {
     platform: 'Platform',
     openWebsite: 'Open VolleyManager website',
     roles: 'Roles',
+    calendarSynced: 'Calendar synced',
+    calendarSyncedTooltip: 'Your calendar is connected for conflict detection',
     dataSource: 'Data from volleymanager.volleyball.ch',
     disclaimer: 'Unofficial app for personal use. All data is property of Swiss Volley.',
     updates: 'Updates',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -540,6 +540,8 @@ const fr: Translations = {
     platform: 'Plateforme',
     openWebsite: 'Ouvrir le site VolleyManager',
     roles: 'Rôles',
+    calendarSynced: 'Calendrier synchronisé',
+    calendarSyncedTooltip: 'Votre calendrier est connecté pour la détection des conflits',
     dataSource: 'Données de volleymanager.volleyball.ch',
     disclaimer:
       'Application non officielle pour usage personnel. Toutes les données sont la propriété de Swiss Volley.',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -537,6 +537,8 @@ const it: Translations = {
     platform: 'Piattaforma',
     openWebsite: 'Apri sito VolleyManager',
     roles: 'Ruoli',
+    calendarSynced: 'Calendario sincronizzato',
+    calendarSyncedTooltip: 'Il tuo calendario è connesso per il rilevamento dei conflitti',
     dataSource: 'Dati da volleymanager.volleyball.ch',
     disclaimer: 'App non ufficiale per uso personale. Tutti i dati sono proprietà di Swiss Volley.',
     updates: 'Aggiornamenti',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -400,6 +400,8 @@ export interface Translations {
     platform: string
     openWebsite: string
     roles: string
+    calendarSynced: string
+    calendarSyncedTooltip: string
     dataSource: string
     disclaimer: string
     updates: string


### PR DESCRIPTION
## Summary

- Added a calendar sync indicator to the profile section in the settings page
- Shows a green calendar icon when the user's calendar code is available
- Indicates that calendar parsing is active for conflict detection
- Added translations for all 4 languages (de, en, fr, it)

## Test plan

- [ ] Log in with a user that has calendar sync enabled
- [ ] Navigate to Settings page
- [ ] Verify the green calendar icon appears in the Profile section below roles
- [ ] Hover over the indicator to see the tooltip
- [ ] Test with a user without calendar sync - icon should not appear
- [ ] Verify all validation passes (lint, knip, test, build)