### PR TITLE
feat(auth): extract calendar code from dashboard HTML for better reliability

### DIFF
--- a/.changeset/extract-calendar-from-dashboard.md
+++ b/.changeset/extract-calendar-from-dashboard.md
@@ -2,4 +2,4 @@
 "volleykit-web": minor
 ---
 
-Improved calendar code extraction reliability by parsing from dashboard HTML instead of fetching from a separate settings page
+Extract calendar code from dashboard HTML during login for scheduling conflict detection

--- a/.changeset/extract-calendar-from-dashboard.md
+++ b/.changeset/extract-calendar-from-dashboard.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": patch
+---
+
+Improved calendar code extraction reliability by parsing from dashboard HTML instead of fetching from a separate settings page

--- a/.changeset/extract-calendar-from-dashboard.md
+++ b/.changeset/extract-calendar-from-dashboard.md
@@ -1,5 +1,5 @@
 ---
-"volleykit-web": patch
+"volleykit-web": minor
 ---
 
 Improved calendar code extraction reliability by parsing from dashboard HTML instead of fetching from a separate settings page

--- a/web-app/src/features/auth/utils/calendar-code-extractor.test.ts
+++ b/web-app/src/features/auth/utils/calendar-code-extractor.test.ts
@@ -57,6 +57,17 @@ describe('calendar-code-extractor', () => {
       expect(extractCalendarCodeFromHtml(html)).toBe('VUEABC')
     })
 
+    it('should extract code from uniqueId in dashboard JSON data', () => {
+      const html = '{"uniqueId":"BLYMVF","createdAt":"2019-11-12"}'
+      expect(extractCalendarCodeFromHtml(html)).toBe('BLYMVF')
+    })
+
+    it('should extract code from HTML-encoded uniqueId in dashboard', () => {
+      // Dashboard HTML encodes quotes as &quot; which becomes \" when parsed
+      const html = '&quot;uniqueId&quot;:&quot;ABCD12&quot;'
+      expect(extractCalendarCodeFromHtml(html)).toBe('ABCD12')
+    })
+
     it('should handle standard VolleyManager iCal path', () => {
       // Real VolleyManager uses "iCal" (capital C, lowercase al)
       const html = '/iCal/referee/UPPER1'

--- a/web-app/src/features/auth/utils/calendar-code-extractor.ts
+++ b/web-app/src/features/auth/utils/calendar-code-extractor.ts
@@ -51,6 +51,10 @@ const VUE_HASH_PATTERNS = [
   /"hash"\s*:\s*["']([a-zA-Z0-9]{6})["']/,
   // JSON property "calendarCode": "XXXXXX"
   /"calendar[Cc]ode"\s*:\s*["']([a-zA-Z0-9]{6})["']/,
+  // JSON property "uniqueId": "XXXXXX" (in dashboard active party data)
+  /"uniqueId"\s*:\s*\\?"([a-zA-Z0-9]{6})\\?"/,
+  // HTML-encoded uniqueId: &quot;uniqueId&quot;:&quot;XXXXXX&quot;
+  /&quot;uniqueId&quot;:&quot;([a-zA-Z0-9]{6})&quot;/,
 ]
 
 /**

--- a/web-app/src/shared/stores/auth.test.ts
+++ b/web-app/src/shared/stores/auth.test.ts
@@ -398,8 +398,8 @@ describe('useAuthStore', () => {
       expect(result).toBe(true)
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(setCsrfToken).toHaveBeenCalledWith('my-csrf-token-12345678901234567890')
-      // Should make 4 calls: login page + auth POST + dashboard + calendar code (background)
-      expect(mockFetch).toHaveBeenCalledTimes(4)
+      // Should make 3 calls: login page + auth POST + dashboard (calendar code extracted from dashboard)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
     })
 
     it('failed login returns login page with error snackbar', async () => {
@@ -533,8 +533,8 @@ describe('useAuthStore', () => {
       expect(result).toBe(true)
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(setCsrfToken).toHaveBeenCalledWith('fresh-csrf-token-abcdef')
-      // 4 calls: login page fetch + auth POST + dashboard + calendar code (background)
-      expect(mockFetch).toHaveBeenCalledTimes(4)
+      // 3 calls: login page fetch + auth POST + dashboard (calendar code extracted from dashboard)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
     })
 
     it('fails when auth request returns non-ok response', async () => {
@@ -750,8 +750,8 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(useAuthStore.getState().user?.occupations).toHaveLength(1)
       expect(useAuthStore.getState().user?.occupations?.[0]?.type).toBe('referee')
-      // Should make 4 calls: login page + auth POST + dashboard + calendar code (background)
-      expect(mockFetch).toHaveBeenCalledTimes(4)
+      // Should make 3 calls: login page + auth POST + dashboard (calendar code extracted from dashboard)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
     })
 
     it('resets stale activeOccupationId when it does not exist in new occupations', async () => {

--- a/web-app/src/shared/stores/auth.test.ts
+++ b/web-app/src/shared/stores/auth.test.ts
@@ -398,7 +398,7 @@ describe('useAuthStore', () => {
       expect(result).toBe(true)
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(setCsrfToken).toHaveBeenCalledWith('my-csrf-token-12345678901234567890')
-      // Should make 3 calls: login page + auth POST + dashboard (calendar code extracted from dashboard)
+      // Should make 3 calls: login page + auth POST + dashboard
       expect(mockFetch).toHaveBeenCalledTimes(3)
     })
 
@@ -492,7 +492,7 @@ describe('useAuthStore', () => {
       expect(result).toBe(true)
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(setCsrfToken).toHaveBeenCalledWith('existing-session-csrf-token-1234')
-      // Should have made 2 calls: login page fetch + dashboard fetch for activeParty
+      // Should have made 2 calls: login page + dashboard
       expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
@@ -533,7 +533,7 @@ describe('useAuthStore', () => {
       expect(result).toBe(true)
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(setCsrfToken).toHaveBeenCalledWith('fresh-csrf-token-abcdef')
-      // 3 calls: login page fetch + auth POST + dashboard (calendar code extracted from dashboard)
+      // 3 calls: login page fetch + auth POST + dashboard
       expect(mockFetch).toHaveBeenCalledTimes(3)
     })
 
@@ -750,7 +750,7 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().status).toBe('authenticated')
       expect(useAuthStore.getState().user?.occupations).toHaveLength(1)
       expect(useAuthStore.getState().user?.occupations?.[0]?.type).toBe('referee')
-      // Should make 3 calls: login page + auth POST + dashboard (calendar code extracted from dashboard)
+      // Should make 3 calls: login page + auth POST + dashboard
       expect(mockFetch).toHaveBeenCalledTimes(3)
     })
 


### PR DESCRIPTION
## Summary

- Fix calendar code extraction by parsing from dashboard HTML instead of fetching separate settings page
- The settings page fetch was unreliable; dashboard HTML already contains the uniqueId field
- Eliminates extra network request during login (4 calls → 3 calls)
- Calendar code is persisted in localStorage and reused on subsequent logins

## Test plan

- [x] Unit tests updated and passing (fetch call count reduced from 4 to 3)
- [x] Calendar code extraction patterns tested with dashboard HTML formats
- [ ] Manual test: Login and verify calendar sync indicator appears in Settings