### PR TITLE
feat(worker): add version tracking to preserve sessions on web-app-only updates

### DIFF
--- a/.changeset/worker-version-tracking.md
+++ b/.changeset/worker-version-tracking.md
@@ -1,0 +1,11 @@
+---
+"volleykit-web": minor
+---
+
+Add worker version tracking to preserve login sessions during web-app-only updates
+
+Previously, any app version update would force users to log out. Now the app tracks the worker (CORS proxy) version separately:
+- Worker version changes → clear session and reload (auth logic may have changed)
+- Web app only changes → reload without clearing session (preserves login)
+
+This improves user experience by avoiding unnecessary re-logins when only UI/feature changes are deployed.

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -37,8 +37,18 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Compute worker git hash
+        id: worker-hash
+        run: |
+          # Compute a short hash based on the last commit that modified worker/ files.
+          # This ensures the hash only changes when worker code changes, not when
+          # web app code changes. Used for PWA version tracking.
+          WORKER_GIT_HASH=$(git log -1 --format='%h' -- .)
+          echo "hash=$WORKER_GIT_HASH" >> "$GITHUB_OUTPUT"
+          echo "Worker git hash: $WORKER_GIT_HASH"
+
       - name: Deploy to Cloudflare Workers
-        run: npx wrangler deploy
+        run: npx wrangler deploy --define __WORKER_GIT_HASH__:\"${{ steps.worker-hash.outputs.hash }}\"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/web-app/src/contexts/PWAProviderInternal.tsx
+++ b/web-app/src/contexts/PWAProviderInternal.tsx
@@ -215,6 +215,7 @@ export default function PWAProviderInternal({ children }: PWAProviderInternalPro
       }
     } else {
       // No API proxy URL configured - clear session for safety (shouldn't happen in production)
+      logger.warn('No API proxy URL configured, clearing session for safety')
       shouldClearSession = true
     }
 

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -114,6 +114,7 @@ function versionFilePlugin(version: string, gitHash: string, basePath: string, a
         var BASE_PATH = '${basePath}';
         var API_PROXY_URL = '${apiProxyUrl}';
         var WORKER_VERSION_KEY = 'volleykit-worker-version';
+        var WORKER_VERSION_FETCH_TIMEOUT_MS = 5000;
 
         async function checkVersion() {
           try {
@@ -146,7 +147,7 @@ function versionFilePlugin(version: string, gitHash: string, basePath: string, a
             if (API_PROXY_URL) {
               try {
                 var controller = new AbortController();
-                var timeoutId = setTimeout(function() { controller.abort(); }, 5000);
+                var timeoutId = setTimeout(function() { controller.abort(); }, WORKER_VERSION_FETCH_TIMEOUT_MS);
                 var workerRes = await fetch(API_PROXY_URL + '/version?t=' + Date.now(), {
                   signal: controller.signal
                 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -187,7 +187,8 @@ export default {
       }
 
       // Check origin for version endpoint (required for CORS)
-      if (!isAllowedOrigin(origin, allowedOrigins)) {
+      // isAllowedOrigin returns false for null origin, so after this check origin is guaranteed non-null
+      if (!origin || !isAllowedOrigin(origin, allowedOrigins)) {
         const errorHeaders: HeadersInit = {
           "Content-Type": "text/plain",
           ...securityHeaders(),
@@ -201,11 +202,13 @@ export default {
         });
       }
 
+      // At this point, origin is guaranteed to be a non-null string
+
       // Handle CORS preflight for version endpoint
       if (request.method === "OPTIONS") {
         return new Response(null, {
           status: 204,
-          headers: corsHeaders(origin!),
+          headers: corsHeaders(origin),
         });
       }
 
@@ -224,7 +227,7 @@ export default {
             "Content-Type": "application/json",
             // Cache for 5 minutes - version doesn't change within a deployment
             "Cache-Control": "public, max-age=300",
-            ...corsHeaders(origin!),
+            ...corsHeaders(origin),
             ...securityHeaders(),
           },
         },

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -170,6 +170,67 @@ export default {
       });
     }
 
+    // Version endpoint - returns worker git hash for PWA version tracking.
+    // The web app compares this against its stored worker version to determine
+    // if session tokens need to be invalidated (worker auth logic changed).
+    // This endpoint is public and includes CORS headers for browser access.
+    if (url.pathname === "/version") {
+      const origin = request.headers.get("Origin");
+      let allowedOrigins: string[];
+      try {
+        allowedOrigins = parseAllowedOrigins(env.ALLOWED_ORIGINS);
+      } catch {
+        return new Response("Server configuration error", {
+          status: 500,
+          headers: { "Content-Type": "text/plain" },
+        });
+      }
+
+      // Check origin for version endpoint (required for CORS)
+      if (!isAllowedOrigin(origin, allowedOrigins)) {
+        const errorHeaders: HeadersInit = {
+          "Content-Type": "text/plain",
+          ...securityHeaders(),
+        };
+        if (origin) {
+          Object.assign(errorHeaders, corsHeaders(origin));
+        }
+        return new Response("Forbidden: Origin not allowed", {
+          status: 403,
+          headers: errorHeaders,
+        });
+      }
+
+      // Handle CORS preflight for version endpoint
+      if (request.method === "OPTIONS") {
+        return new Response(null, {
+          status: 204,
+          headers: corsHeaders(origin!),
+        });
+      }
+
+      // Return worker version info
+      // __WORKER_GIT_HASH__ is injected at deploy time via wrangler --define
+      const workerGitHash =
+        typeof __WORKER_GIT_HASH__ !== "undefined" ? __WORKER_GIT_HASH__ : "dev";
+      return new Response(
+        JSON.stringify({
+          workerGitHash,
+          timestamp: new Date().toISOString(),
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            // Cache for 5 minutes - version doesn't change within a deployment
+            "Cache-Control": "public, max-age=300",
+            ...corsHeaders(origin!),
+            ...securityHeaders(),
+          },
+        },
+      );
+    }
+
     // Kill switch - immediately disable proxy if requested by Swiss Volley
     if (env.KILL_SWITCH === "true") {
       return new Response(

--- a/worker/src/types.d.ts
+++ b/worker/src/types.d.ts
@@ -12,3 +12,10 @@
 export type HeadersWithCookies = Headers & {
   getSetCookie(): string[];
 };
+
+/**
+ * Worker git hash injected at deploy time via `wrangler deploy --define`.
+ * Used for version tracking - the web app checks this to determine if
+ * session tokens need to be invalidated (worker auth logic changed).
+ */
+declare const __WORKER_GIT_HASH__: string;


### PR DESCRIPTION
## Summary

- Add `/version` endpoint to worker that returns git hash of worker files
- Compute worker-specific git hash at deploy time via `git log -1 --format='%h' -- .`
- Web app now tracks worker version separately from app version
- Only clear session tokens when worker version changes (auth logic may have changed)
- Allow web-app-only updates without forcing re-login

## Test plan

- [ ] Verify worker `/version` endpoint returns JSON with `workerGitHash`
- [ ] Verify CORS headers are set correctly on `/version` endpoint
- [ ] Deploy web-app-only change and verify user stays logged in
- [ ] Deploy worker change and verify user is logged out
- [ ] Run `npm test` in worker directory - all tests pass