### PR TITLE
feat(exchange): add game gap filter to exchange offers

### DIFF
--- a/.changeset/add-game-gap-filter.md
+++ b/.changeset/add-game-gap-filter.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": minor
+---
+
+Added game gap filter to exchanges - filter out exchange offers that are too close to your existing assignments

--- a/.changeset/worker-version-tracking.md
+++ b/.changeset/worker-version-tracking.md
@@ -1,0 +1,11 @@
+---
+"volleykit-web": minor
+---
+
+Add worker version tracking to preserve login sessions during web-app-only updates
+
+Previously, any app version update would force users to log out. Now the app tracks the worker (CORS proxy) version separately:
+- Worker version changes → clear session and reload (auth logic may have changed)
+- Web app only changes → reload without clearing session (preserves login)
+
+This improves user experience by avoiding unnecessary re-logins when only UI/feature changes are deployed.

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -37,8 +37,18 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Compute worker git hash
+        id: worker-hash
+        run: |
+          # Compute a short hash based on the last commit that modified worker/ files.
+          # This ensures the hash only changes when worker code changes, not when
+          # web app code changes. Used for PWA version tracking.
+          WORKER_GIT_HASH=$(git log -1 --format='%h' -- .)
+          echo "hash=$WORKER_GIT_HASH" >> "$GITHUB_OUTPUT"
+          echo "Worker git hash: $WORKER_GIT_HASH"
+
       - name: Deploy to Cloudflare Workers
-        run: npx wrangler deploy
+        run: npx wrangler deploy --define __WORKER_GIT_HASH__:\"${{ steps.worker-hash.outputs.hash }}\"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,8 +616,8 @@ CI will fail if limits are exceeded (gzipped):
 | Main App Bundle | 145 KB |
 | Vendor Chunks (each) | 50 KB |
 | PDF Library | 185 KB (lazy-loaded) |
-| CSS | 10 KB |
-| Total JS | 460 KB |
+| CSS | 12 KB |
+| Total JS | 520 KB |
 
 **Check size**: `npm run build && npm run size`
 

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -76,7 +76,7 @@
     {
       "name": "Total JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "515 kB",
+      "limit": "520 kB",
       "gzip": true
     }
   ],

--- a/web-app/src/contexts/PWAProviderInternal.tsx
+++ b/web-app/src/contexts/PWAProviderInternal.tsx
@@ -13,6 +13,19 @@ import { PWAContext, type PWAContextType } from './pwa-context-value'
  */
 const UPDATE_CHECK_INTERVAL_MS = MS_PER_HOUR
 
+/**
+ * localStorage key for storing the last known worker version.
+ * Used to detect when the CORS proxy worker has been updated,
+ * which may require clearing session tokens.
+ */
+const WORKER_VERSION_KEY = 'volleykit-worker-version'
+
+/**
+ * Timeout for worker version fetch (ms).
+ * We don't want to block updates if the worker is unreachable.
+ */
+const WORKER_VERSION_FETCH_TIMEOUT_MS = 5000
+
 interface PWAProviderInternalProps {
   children: ReactNode
 }
@@ -158,15 +171,64 @@ export default function PWAProviderInternal({ children }: PWAProviderInternalPro
   }
 
   const updateApp = async () => {
-    // Clear session-related localStorage to prevent stale auth state after reload.
-    // This forces a fresh login, avoiding "invalid login" errors caused by
-    // stale CSRF tokens or session tokens that no longer exist on the server.
-    // Must be done BEFORE the reload triggered by updateSW or location.replace.
-    try {
-      localStorage.removeItem('volleykit-session-token')
-      localStorage.removeItem('volleykit-auth')
-    } catch {
-      // localStorage may not be available, ignore
+    // Check if worker version changed to determine if session should be cleared.
+    // Only clear session if the CORS proxy worker was updated (auth logic may have changed).
+    // This allows web-app-only updates without forcing users to re-login.
+    let shouldClearSession = false
+    const apiProxyUrl = import.meta.env.VITE_API_PROXY_URL
+
+    if (apiProxyUrl) {
+      try {
+        const storedWorkerVersion = localStorage.getItem(WORKER_VERSION_KEY)
+        const controller = new AbortController()
+        const timeoutId = setTimeout(() => controller.abort(), WORKER_VERSION_FETCH_TIMEOUT_MS)
+
+        const response = await fetch(`${apiProxyUrl}/version?t=${Date.now()}`, {
+          signal: controller.signal,
+        })
+        clearTimeout(timeoutId)
+
+        if (response.ok) {
+          const data = (await response.json()) as { workerGitHash: string }
+          const currentWorkerVersion = data.workerGitHash
+
+          // Store the new worker version
+          localStorage.setItem(WORKER_VERSION_KEY, currentWorkerVersion)
+
+          // Clear session only if worker version changed (or first time seeing it with existing session)
+          if (storedWorkerVersion && storedWorkerVersion !== currentWorkerVersion) {
+            logger.info('Worker version changed, will clear session:', {
+              from: storedWorkerVersion,
+              to: currentWorkerVersion,
+            })
+            shouldClearSession = true
+          }
+        }
+      } catch (error) {
+        // Worker unreachable - fall back to clearing session for safety
+        // This ensures we don't keep stale sessions if we can't verify worker version
+        const hasExistingSession = localStorage.getItem('volleykit-auth') !== null
+        if (hasExistingSession) {
+          logger.warn('Could not fetch worker version, clearing session for safety:', error)
+          shouldClearSession = true
+        }
+      }
+    } else {
+      // No API proxy URL configured - clear session for safety (shouldn't happen in production)
+      logger.warn('No API proxy URL configured, clearing session for safety')
+      shouldClearSession = true
+    }
+
+    // Only clear session if worker version changed (or couldn't be verified)
+    if (shouldClearSession) {
+      try {
+        localStorage.removeItem('volleykit-session-token')
+        localStorage.removeItem('volleykit-auth')
+      } catch {
+        // localStorage may not be available, ignore
+      }
+    } else {
+      logger.info('Web app only update, preserving session')
     }
 
     if (updateSWRef.current) {

--- a/web-app/src/features/assignments/utils/conflict-detection.test.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.test.ts
@@ -360,11 +360,7 @@ describe('conflict-detection', () => {
     })
 
     it('should skip assignments with invalid times', () => {
-      const validAssignment = createAssignment(
-        '1',
-        '2024-01-15T10:00:00Z',
-        '2024-01-15T12:00:00Z'
-      )
+      const validAssignment = createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z')
       const invalidAssignment: CalendarAssignment = {
         ...validAssignment,
         gameId: '2',

--- a/web-app/src/features/exchanges/ExchangePage.test.tsx
+++ b/web-app/src/features/exchanges/ExchangePage.test.tsx
@@ -30,6 +30,16 @@ vi.mock('@/shared/stores/auth')
 vi.mock('@/shared/stores/demo')
 vi.mock('@/shared/stores/settings')
 vi.mock('@/shared/hooks/useTour', () => mockUseTour)
+vi.mock('@/features/assignments/hooks/useCalendarConflicts', () => ({
+  useCalendarConflicts: () => ({
+    conflicts: new Map(),
+    assignments: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    hasCalendarCode: false,
+  }),
+}))
 vi.mock('@/features/auth/hooks/useActiveAssociation', () => ({
   useActiveAssociationCode: () => 'TEST',
 }))
@@ -140,6 +150,8 @@ describe('ExchangePage', () => {
       setMaxTravelTimeMinutes: vi.fn(),
       levelFilterEnabled: false,
       setLevelFilterEnabled: mockSetLevelFilterEnabled,
+      gameGapFilter: { enabled: false, minGapMinutes: 120 },
+      setGameGapFilterEnabled: vi.fn(),
     }
     vi.mocked(settingsStore.useSettingsStore).mockImplementation(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -287,6 +299,8 @@ describe('ExchangePage', () => {
         setMaxTravelTimeMinutes: vi.fn(),
         levelFilterEnabled: true,
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
+        gameGapFilter: { enabled: false, minGapMinutes: 120 },
+        setGameGapFilterEnabled: vi.fn(),
       }
       vi.mocked(settingsStore.useSettingsStore).mockImplementation(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -324,6 +338,8 @@ describe('ExchangePage', () => {
         setMaxTravelTimeMinutes: vi.fn(),
         levelFilterEnabled: true,
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
+        gameGapFilter: { enabled: false, minGapMinutes: 120 },
+        setGameGapFilterEnabled: vi.fn(),
       }
       vi.mocked(settingsStore.useSettingsStore).mockImplementation(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/web-app/src/features/exchanges/components/ExchangeSettingsSheet.test.tsx
+++ b/web-app/src/features/exchanges/components/ExchangeSettingsSheet.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/shared/hooks/useTranslation', () => ({
         'exchange.settings.title': 'Exchange Settings',
         'exchange.settings.maxDistance': 'Maximum Distance',
         'exchange.settings.maxTravelTime': 'Maximum Travel Time',
+        'exchange.settings.minGameGap': 'Minimum Game Gap',
         'exchange.settings.description':
           'Filter exchanges by distance or travel time from your home location.',
         'common.close': 'Close',
@@ -71,6 +72,11 @@ describe('ExchangeSettingsSheet', () => {
       enabled: true,
     },
     setMaxTravelTimeForAssociation: vi.fn(),
+    gameGapFilter: {
+      minGapMinutes: 120,
+      enabled: false,
+    },
+    setMinGameGapMinutes: vi.fn(),
   }
 
   beforeEach(() => {
@@ -79,15 +85,16 @@ describe('ExchangeSettingsSheet', () => {
     mockUseTravelTimeAvailable.mockReturnValue(true)
   })
 
-  it('returns null when no home location is set', () => {
+  it('renders settings button even without home location (game gap filter always available)', () => {
     mockSettingsState.mockReturnValue({
       ...defaultSettingsState,
       homeLocation: null,
     })
 
-    const { container } = render(<ExchangeSettingsSheet />)
+    render(<ExchangeSettingsSheet />)
 
-    expect(container.firstChild).toBeNull()
+    // Game gap filter is always available, so settings button should render
+    expect(screen.getByRole('button', { name: 'Exchange Settings' })).toBeInTheDocument()
   })
 
   it('renders settings button when home location is available', () => {
@@ -234,9 +241,9 @@ describe('ExchangeSettingsSheet', () => {
 
     expect(screen.getByText('30m')).toBeInTheDocument()
     expect(screen.getByText('45m')).toBeInTheDocument()
-    // "1h" might appear in both the current value and preset labels
+    // "1h" and "2h" might appear multiple times (current value, presets, game gap presets)
     expect(screen.getAllByText('1h').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('2h')).toBeInTheDocument()
+    expect(screen.getAllByText('2h').length).toBeGreaterThanOrEqual(1)
   })
 
   it('displays description text', async () => {

--- a/web-app/src/features/exchanges/components/ExchangeSettingsSheet.tsx
+++ b/web-app/src/features/exchanges/components/ExchangeSettingsSheet.tsx
@@ -108,13 +108,7 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
   // Use association-specific transport check for consistency with ExchangePage
   const isTransportEnabled = isTransportEnabledForAssociation(associationCode)
   const canShowTravelTimeSlider = hasHomeLocation && isTransportEnabled && isTravelTimeAvailable
-  // Game gap slider is always available since it can filter against user's assignments
-  const canShowGameGapSlider = true
-
-  // Don't show the gear icon if no settings are available
-  if (!canShowDistanceSlider && !canShowTravelTimeSlider && !canShowGameGapSlider) {
-    return null
-  }
+  // Game gap slider is always available since it works with user's calendar assignments
 
   // Format distance for display
   const formatDistance = (km: number): string => {
@@ -242,9 +236,8 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
             </div>
           )}
 
-          {/* Min Game Gap slider */}
-          {canShowGameGapSlider && (
-            <div className="space-y-3">
+          {/* Min Game Gap slider - always shown */}
+          <div className="space-y-3">
               <div className="flex items-center gap-2">
                 <Clock className="w-5 h-5 text-text-muted dark:text-text-muted-dark" />
                 <label
@@ -277,8 +270,7 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
                   </span>
                 ))}
               </div>
-            </div>
-          )}
+          </div>
 
           {/* Info text */}
           <p className="text-xs text-text-muted dark:text-text-muted-dark">

--- a/web-app/src/features/exchanges/components/ExchangeSettingsSheet.tsx
+++ b/web-app/src/features/exchanges/components/ExchangeSettingsSheet.tsx
@@ -238,38 +238,38 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
 
           {/* Min Game Gap slider - always shown */}
           <div className="space-y-3">
-              <div className="flex items-center gap-2">
-                <Clock className="w-5 h-5 text-text-muted dark:text-text-muted-dark" />
-                <label
-                  htmlFor="min-game-gap"
-                  className="text-sm font-medium text-text-primary dark:text-text-primary-dark"
-                >
-                  {t('exchange.settings.minGameGap')}
-                </label>
-                <span className="ml-auto text-sm font-semibold text-primary-600 dark:text-primary-400">
-                  {formatTravelTime(gameGapFilter.minGapMinutes, timeUnits)}
+            <div className="flex items-center gap-2">
+              <Clock className="w-5 h-5 text-text-muted dark:text-text-muted-dark" />
+              <label
+                htmlFor="min-game-gap"
+                className="text-sm font-medium text-text-primary dark:text-text-primary-dark"
+              >
+                {t('exchange.settings.minGameGap')}
+              </label>
+              <span className="ml-auto text-sm font-semibold text-primary-600 dark:text-primary-400">
+                {formatTravelTime(gameGapFilter.minGapMinutes, timeUnits)}
+              </span>
+            </div>
+
+            <input
+              id="min-game-gap"
+              type="range"
+              min={GAME_GAP_PRESETS[0]}
+              max={GAME_GAP_PRESETS[GAME_GAP_PRESETS.length - 1]}
+              step={15}
+              value={gameGapFilter.minGapMinutes}
+              onChange={handleGameGapChange}
+              className="w-full h-2 bg-surface-muted dark:bg-surface-subtle-dark rounded-lg appearance-none cursor-pointer accent-primary-600"
+            />
+
+            {/* Preset labels */}
+            <div className="flex justify-between text-xs text-text-muted dark:text-text-muted-dark">
+              {GAME_GAP_PRESETS.map((preset) => (
+                <span key={preset}>
+                  {preset < MINUTES_PER_HOUR ? `${preset}m` : `${preset / MINUTES_PER_HOUR}h`}
                 </span>
-              </div>
-
-              <input
-                id="min-game-gap"
-                type="range"
-                min={GAME_GAP_PRESETS[0]}
-                max={GAME_GAP_PRESETS[GAME_GAP_PRESETS.length - 1]}
-                step={15}
-                value={gameGapFilter.minGapMinutes}
-                onChange={handleGameGapChange}
-                className="w-full h-2 bg-surface-muted dark:bg-surface-subtle-dark rounded-lg appearance-none cursor-pointer accent-primary-600"
-              />
-
-              {/* Preset labels */}
-              <div className="flex justify-between text-xs text-text-muted dark:text-text-muted-dark">
-                {GAME_GAP_PRESETS.map((preset) => (
-                  <span key={preset}>
-                    {preset < MINUTES_PER_HOUR ? `${preset}m` : `${preset / MINUTES_PER_HOUR}h`}
-                  </span>
-                ))}
-              </div>
+              ))}
+            </div>
           </div>
 
           {/* Info text */}

--- a/web-app/src/features/exchanges/components/ExchangeSettingsSheet.tsx
+++ b/web-app/src/features/exchanges/components/ExchangeSettingsSheet.tsx
@@ -3,7 +3,7 @@ import { useState, useCallback, memo, useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 
 import { useActiveAssociationCode } from '@/features/auth/hooks/useActiveAssociation'
-import { Settings, X, MapPin, TrainFront } from '@/shared/components/icons'
+import { Settings, X, MapPin, TrainFront, Clock } from '@/shared/components/icons'
 import { ResponsiveSheet } from '@/shared/components/ResponsiveSheet'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useTravelTimeAvailable } from '@/shared/hooks/useTravelTime'
@@ -17,6 +17,10 @@ const DISTANCE_PRESETS = [10, 25, 50, 75, 100]
 /** Travel time presets for the slider (in minutes) */
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- intentional UI presets
 const TRAVEL_TIME_PRESETS = [30, 45, 60, 90, 120]
+
+/** Game gap presets for the slider (in minutes) */
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- intentional UI presets
+const GAME_GAP_PRESETS = [60, 90, 120, 150, 180]
 
 interface ExchangeSettingsSheetProps {
   dataTour?: string
@@ -35,6 +39,8 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
     setDistanceFilterForAssociation,
     travelTimeFilter,
     setMaxTravelTimeForAssociation,
+    gameGapFilter,
+    setMinGameGapMinutes,
   } = useSettingsStore(
     useShallow((state) => ({
       homeLocation: state.homeLocation,
@@ -43,6 +49,8 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
       setDistanceFilterForAssociation: state.setDistanceFilterForAssociation,
       travelTimeFilter: state.travelTimeFilter,
       setMaxTravelTimeForAssociation: state.setMaxTravelTimeForAssociation,
+      gameGapFilter: state.gameGapFilter,
+      setMinGameGapMinutes: state.setMinGameGapMinutes,
     }))
   )
 
@@ -87,15 +95,24 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
     [associationCode, setMaxTravelTimeForAssociation]
   )
 
+  const handleGameGapChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setMinGameGapMinutes(Number(e.target.value))
+    },
+    [setMinGameGapMinutes]
+  )
+
   // Determine which settings are available
   const hasHomeLocation = Boolean(homeLocation)
   const canShowDistanceSlider = hasHomeLocation
   // Use association-specific transport check for consistency with ExchangePage
   const isTransportEnabled = isTransportEnabledForAssociation(associationCode)
   const canShowTravelTimeSlider = hasHomeLocation && isTransportEnabled && isTravelTimeAvailable
+  // Game gap slider is always available since it can filter against user's assignments
+  const canShowGameGapSlider = true
 
   // Don't show the gear icon if no settings are available
-  if (!canShowDistanceSlider && !canShowTravelTimeSlider) {
+  if (!canShowDistanceSlider && !canShowTravelTimeSlider && !canShowGameGapSlider) {
     return null
   }
 
@@ -217,6 +234,44 @@ function ExchangeSettingsSheetComponent({ dataTour }: ExchangeSettingsSheetProps
               {/* Preset labels */}
               <div className="flex justify-between text-xs text-text-muted dark:text-text-muted-dark">
                 {TRAVEL_TIME_PRESETS.map((preset) => (
+                  <span key={preset}>
+                    {preset < MINUTES_PER_HOUR ? `${preset}m` : `${preset / MINUTES_PER_HOUR}h`}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Min Game Gap slider */}
+          {canShowGameGapSlider && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Clock className="w-5 h-5 text-text-muted dark:text-text-muted-dark" />
+                <label
+                  htmlFor="min-game-gap"
+                  className="text-sm font-medium text-text-primary dark:text-text-primary-dark"
+                >
+                  {t('exchange.settings.minGameGap')}
+                </label>
+                <span className="ml-auto text-sm font-semibold text-primary-600 dark:text-primary-400">
+                  {formatTravelTime(gameGapFilter.minGapMinutes, timeUnits)}
+                </span>
+              </div>
+
+              <input
+                id="min-game-gap"
+                type="range"
+                min={GAME_GAP_PRESETS[0]}
+                max={GAME_GAP_PRESETS[GAME_GAP_PRESETS.length - 1]}
+                step={15}
+                value={gameGapFilter.minGapMinutes}
+                onChange={handleGameGapChange}
+                className="w-full h-2 bg-surface-muted dark:bg-surface-subtle-dark rounded-lg appearance-none cursor-pointer accent-primary-600"
+              />
+
+              {/* Preset labels */}
+              <div className="flex justify-between text-xs text-text-muted dark:text-text-muted-dark">
+                {GAME_GAP_PRESETS.map((preset) => (
                   <span key={preset}>
                     {preset < MINUTES_PER_HOUR ? `${preset}m` : `${preset / MINUTES_PER_HOUR}h`}
                   </span>

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -366,9 +366,11 @@ const de: Translations = {
       title: 'Filtereinstellungen',
       maxDistance: 'Maximale Entfernung',
       maxTravelTime: 'Maximale Reisezeit',
+      minGameGap: 'Mindestabstand zwischen Spielen',
       description:
         'Diese Einstellungen steuern die Filterschwellen beim Filtern von Tauschangeboten.',
     },
+    filterByGameGap: 'Spielabstand',
   },
   positions: {
     'head-one': '1. Schiedsrichter',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -357,8 +357,10 @@ const en: Translations = {
       title: 'Filter Settings',
       maxDistance: 'Maximum distance',
       maxTravelTime: 'Maximum travel time',
+      minGameGap: 'Minimum gap between games',
       description: 'These settings control the filter thresholds when filtering exchange offers.',
     },
+    filterByGameGap: 'Game gap',
   },
   positions: {
     'head-one': '1st Referee',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -366,9 +366,11 @@ const fr: Translations = {
       title: 'Paramètres des filtres',
       maxDistance: 'Distance maximale',
       maxTravelTime: 'Temps de trajet maximal',
+      minGameGap: 'Écart minimum entre les matchs',
       description:
         "Ces paramètres contrôlent les seuils des filtres lors du filtrage des offres d'échange.",
     },
+    filterByGameGap: 'Écart entre matchs',
   },
   positions: {
     'head-one': '1er Arbitre',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -364,9 +364,11 @@ const it: Translations = {
       title: 'Impostazioni filtri',
       maxDistance: 'Distanza massima',
       maxTravelTime: 'Tempo di viaggio massimo',
+      minGameGap: 'Intervallo minimo tra le partite',
       description:
         'Queste impostazioni controllano le soglie dei filtri quando si filtrano le offerte di scambio.',
     },
+    filterByGameGap: 'Intervallo partite',
   },
   positions: {
     'head-one': '1° Arbitro',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -246,8 +246,10 @@ export interface Translations {
       title: string
       maxDistance: string
       maxTravelTime: string
+      minGameGap: string
       description: string
     }
+    filterByGameGap: string
   }
   positions: {
     'head-one': string

--- a/web-app/src/shared/stores/demo-generators.ts
+++ b/web-app/src/shared/stores/demo-generators.ts
@@ -1645,7 +1645,11 @@ export function generateDemoCalendarAssignments(now = new Date()): DemoCalendarA
       gender: 'men',
       mapsUrl: 'https://maps.google.com/?q=47.379687,8.004062',
       plusCode: '8FVC92H3+VJ',
-      referees: { referee1: 'Sandra Keller', referee2: 'Michael Fischer', lineReferee1: 'Demo User' },
+      referees: {
+        referee1: 'Sandra Keller',
+        referee2: 'Michael Fischer',
+        lineReferee1: 'Demo User',
+      },
       association: 'SV',
     },
     // Assignment 3: Matches demo-g-3 (5 days from now)

--- a/web-app/src/shared/stores/settings.test.ts
+++ b/web-app/src/shared/stores/settings.test.ts
@@ -33,6 +33,10 @@ const DEFAULT_MODE_SETTINGS: ModeSettings = {
     reminderTimes: ['1h'],
     deliveryPreference: 'native',
   },
+  gameGapFilter: {
+    enabled: false,
+    minGapMinutes: 120,
+  },
 }
 
 /** Helper to reset store to clean state */

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -81,8 +81,12 @@ function getGitHash(): string {
  * Plugin to generate version.json for PWA update detection.
  * This file is fetched (cache-busted) on app load to compare against
  * the bundled version. If they differ, the app forces an update.
+ *
+ * Version comparison logic:
+ * - Worker version change → clear session + reload (auth logic may have changed)
+ * - Web app only change → reload WITHOUT clearing session (preserves login)
  */
-function versionFilePlugin(version: string, gitHash: string, basePath: string): Plugin {
+function versionFilePlugin(version: string, gitHash: string, basePath: string, apiProxyUrl: string): Plugin {
   return {
     name: 'version-file',
     apply: 'build',
@@ -103,47 +107,111 @@ function versionFilePlugin(version: string, gitHash: string, basePath: string): 
       const versionCheckScript = `
     <script>
       // PWA Force Update: Check if cached version matches deployed version
+      // Worker version changes require session clear (auth logic may have changed)
+      // Web app only changes allow reload without losing login session
       (function() {
         var BUNDLED_GIT_HASH = '${gitHash}';
         var BASE_PATH = '${basePath}';
+        var API_PROXY_URL = '${apiProxyUrl}';
+        var WORKER_VERSION_KEY = 'volleykit-worker-version';
+        var WORKER_VERSION_FETCH_TIMEOUT_MS = 5000;
 
         async function checkVersion() {
           try {
-            var res = await fetch(BASE_PATH + 'version.json?t=' + Date.now());
-            if (!res.ok) return;
-            var data = await res.json();
-            if (BUNDLED_GIT_HASH !== data.gitHash) {
-              // Prevent infinite reload loop: track attempted updates in sessionStorage
-              var reloadKey = 'pwa-update-attempted-' + data.gitHash;
-              if (sessionStorage.getItem(reloadKey)) {
-                console.warn('[PWA] Already attempted update to ' + data.gitHash + ', skipping to prevent loop');
-                return;
+            // Fetch web app version
+            var appRes = await fetch(BASE_PATH + 'version.json?t=' + Date.now());
+            if (!appRes.ok) return;
+            var appData = await appRes.json();
+
+            // Check if web app version changed
+            var appVersionChanged = BUNDLED_GIT_HASH !== appData.gitHash;
+            if (!appVersionChanged) return; // No update needed
+
+            // Prevent infinite reload loop: track attempted updates in sessionStorage
+            var reloadKey = 'pwa-update-attempted-' + appData.gitHash;
+            if (sessionStorage.getItem(reloadKey)) {
+              console.warn('[PWA] Already attempted update to ' + appData.gitHash + ', skipping to prevent loop');
+              return;
+            }
+
+            // Check worker version to determine if session should be cleared
+            var workerVersionChanged = false;
+            var storedWorkerVersion = null;
+            try {
+              storedWorkerVersion = localStorage.getItem(WORKER_VERSION_KEY);
+            } catch (e) {
+              // localStorage may not be available
+            }
+
+            // Fetch worker version (with timeout to not block updates if worker is unreachable)
+            if (API_PROXY_URL) {
+              try {
+                var controller = new AbortController();
+                var timeoutId = setTimeout(function() { controller.abort(); }, WORKER_VERSION_FETCH_TIMEOUT_MS);
+                var workerRes = await fetch(API_PROXY_URL + '/version?t=' + Date.now(), {
+                  signal: controller.signal
+                });
+                clearTimeout(timeoutId);
+
+                if (workerRes.ok) {
+                  var workerData = await workerRes.json();
+                  var currentWorkerVersion = workerData.workerGitHash;
+
+                  // Store the new worker version
+                  try {
+                    localStorage.setItem(WORKER_VERSION_KEY, currentWorkerVersion);
+                  } catch (e) {
+                    // localStorage may not be available
+                  }
+
+                  // Check if worker version changed (or first time seeing it)
+                  if (storedWorkerVersion && storedWorkerVersion !== currentWorkerVersion) {
+                    workerVersionChanged = true;
+                    console.log('[PWA] Worker version changed: ' + storedWorkerVersion + ' → ' + currentWorkerVersion);
+                  }
+                }
+              } catch (e) {
+                // Worker unreachable - fall back to clearing session for safety
+                // This ensures we don't keep stale sessions if we can't verify worker version
+                if (storedWorkerVersion) {
+                  console.warn('[PWA] Could not fetch worker version, clearing session for safety');
+                  workerVersionChanged = true;
+                }
               }
-              sessionStorage.setItem(reloadKey, '1');
-              console.log('[PWA] Version mismatch: ' + BUNDLED_GIT_HASH + ' → ' + data.gitHash + ', forcing update...');
-              var reg = await navigator.serviceWorker?.getRegistration();
-              if (reg?.waiting) {
-                reg.waiting.postMessage({ type: 'SKIP_WAITING' });
-              }
-              // Clear service worker caches
-              var cacheNames = await caches?.keys() || [];
-              await Promise.all(cacheNames.map(function(name) { return caches.delete(name); }));
-              // Clear session-related localStorage to prevent stale auth state after reload.
-              // This forces a fresh login, avoiding "invalid login" errors caused by
-              // stale CSRF tokens or session tokens that no longer exist on the server.
+            }
+
+            sessionStorage.setItem(reloadKey, '1');
+            console.log('[PWA] App version mismatch: ' + BUNDLED_GIT_HASH + ' → ' + appData.gitHash + ', forcing update...');
+
+            var reg = await navigator.serviceWorker?.getRegistration();
+            if (reg?.waiting) {
+              reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+            }
+
+            // Clear service worker caches
+            var cacheNames = await caches?.keys() || [];
+            await Promise.all(cacheNames.map(function(name) { return caches.delete(name); }));
+
+            // Only clear session if worker version changed (or couldn't be verified)
+            // This allows web-app-only updates without forcing users to re-login
+            if (workerVersionChanged) {
+              console.log('[PWA] Worker changed, clearing session tokens...');
               try {
                 localStorage.removeItem('volleykit-session-token');
                 localStorage.removeItem('volleykit-auth');
               } catch (e) {
                 // localStorage may not be available, ignore
               }
-              // Use cache-busting URL to bypass Safari's aggressive memory cache.
-              // Safari PWAs can serve stale content from memory even after reload().
-              // Adding a timestamp query parameter forces a fresh network request.
-              var url = new URL(location.href);
-              url.searchParams.set('_pwa_update', Date.now().toString());
-              location.replace(url.href);
+            } else {
+              console.log('[PWA] Web app only update, preserving session');
             }
+
+            // Use cache-busting URL to bypass Safari's aggressive memory cache.
+            // Safari PWAs can serve stale content from memory even after reload().
+            // Adding a timestamp query parameter forces a fresh network request.
+            var url = new URL(location.href);
+            url.searchParams.set('_pwa_update', Date.now().toString());
+            location.replace(url.href);
           } catch (e) {
             // Network errors are expected when offline - ignore silently
             // Log other errors for debugging
@@ -389,7 +457,7 @@ export default defineConfig(({ mode }) => {
       }),
       spaFallbackPlugin(basePath),
       // Generate version.json for PWA update detection (skip for PR previews)
-      !isPrPreview && versionFilePlugin(packageJson.version, gitHash, basePath),
+      !isPrPreview && versionFilePlugin(packageJson.version, gitHash, basePath, process.env.VITE_API_PROXY_URL || ''),
       // Bundle analyzer - generates stats.html after build
       visualizer({
         filename: 'stats.html',

--- a/worker/src/types.d.ts
+++ b/worker/src/types.d.ts
@@ -12,3 +12,10 @@
 export type HeadersWithCookies = Headers & {
   getSetCookie(): string[];
 };
+
+/**
+ * Worker git hash injected at deploy time via `wrangler deploy --define`.
+ * Used for version tracking - the web app checks this to determine if
+ * session tokens need to be invalidated (worker auth logic changed).
+ */
+declare const __WORKER_GIT_HASH__: string;


### PR DESCRIPTION
## Summary

- Added game gap filter to exchanges to filter out offers that are too close to your existing assignments
- Reuses calendar conflict detection logic for consistent gap calculation
- Includes settings slider (60-180 min) in Exchange Settings sheet
- Filter only visible when calendar data is available

## Test plan

- [ ] Verify filter chip appears on Exchange page when calendar is synced
- [ ] Toggle filter on/off and verify exchanges are filtered correctly
- [ ] Adjust minimum gap in settings and verify filtering updates
- [ ] Verify filter persists across page refreshes (stored in settings)