### PR TITLE
fix(settings): use primary app color for calendar sync indicator

### DIFF
--- a/.changeset/calendar-sync-color.md
+++ b/.changeset/calendar-sync-color.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": patch
+---
+
+Use primary app color for calendar sync indicator in settings for better visual consistency

--- a/web-app/src/features/settings/components/ProfileSection.tsx
+++ b/web-app/src/features/settings/components/ProfileSection.tsx
@@ -181,7 +181,7 @@ function ProfileSectionComponent({ user }: ProfileSectionProps) {
         {calendarCode && (
           <div className="border-t border-border-subtle dark:border-border-subtle-dark pt-4">
             <div
-              className="flex items-center gap-2 text-sm text-success-600 dark:text-success-400"
+              className="flex items-center gap-2 text-sm text-primary-600 dark:text-primary-400"
               title={t('settings.calendarSyncedTooltip')}
             >
               <Calendar className="w-4 h-4" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- Changed the calendar sync indicator from success green to the main app primary color for better visual consistency with the rest of the UI

## Test plan
- [ ] Verify the calendar sync indicator in Settings > Profile section shows the primary app color
- [ ] Check both light and dark mode appearance