### PR TITLE
feat(conflicts): add smart conflict detection with venue distance

### DIFF
--- a/.changeset/smart-conflict-gap-detection.md
+++ b/.changeset/smart-conflict-gap-detection.md
@@ -1,0 +1,5 @@
+---
+"volleykit-web": minor
+---
+
+Added smart conflict detection that considers venue distance in addition to time gaps. Assignments at nearby venues (within 5km) are no longer flagged as conflicts even with small time gaps, since no travel time is needed. This applies to both the Assignments page conflict warnings and the Exchange page game gap filter.

--- a/web-app/src/features/assignments/utils/conflict-detection.test.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.test.ts
@@ -50,7 +50,6 @@ function createAssignment(
 const ZURICH_COORDS = { latitude: 47.3769, longitude: 8.5417 }
 const ZURICH_NEARBY_COORDS = { latitude: 47.38, longitude: 8.545 } // ~0.5 km from Zurich
 const BERN_COORDS = { latitude: 46.948, longitude: 7.4474 } // ~95 km from Zurich
-const LAUSANNE_COORDS = { latitude: 46.5197, longitude: 6.6323 } // ~138 km from Zurich
 
 describe('conflict-detection', () => {
   describe('detectConflicts', () => {

--- a/web-app/src/features/assignments/utils/conflict-detection.test.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.test.ts
@@ -10,6 +10,9 @@ import {
   parseGap,
   calculateMinGapToAssignments,
   hasMinimumGapFromAssignments,
+  createSmartConflictEvaluator,
+  calculateVenueDistance,
+  areVenuesClose,
 } from './conflict-detection'
 
 // Helper to create a test assignment
@@ -17,7 +20,8 @@ function createAssignment(
   gameId: string,
   startTime: string,
   endTime: string,
-  association: string | null = null
+  association: string | null = null,
+  coordinates: { latitude: number; longitude: number } | null = null
 ): CalendarAssignment {
   return {
     gameId,
@@ -35,12 +39,18 @@ function createAssignment(
     hallId: null,
     gameNumber: parseInt(gameId, 10),
     address: '123 Test St',
-    coordinates: null,
+    coordinates,
     plusCode: null,
     mapsUrl: null,
     referees: {},
   }
 }
+
+// Test coordinates for Swiss venues
+const ZURICH_COORDS = { latitude: 47.3769, longitude: 8.5417 }
+const ZURICH_NEARBY_COORDS = { latitude: 47.38, longitude: 8.545 } // ~0.5 km from Zurich
+const BERN_COORDS = { latitude: 46.948, longitude: 7.4474 } // ~95 km from Zurich
+const LAUSANNE_COORDS = { latitude: 46.5197, longitude: 6.6323 } // ~138 km from Zurich
 
 describe('conflict-detection', () => {
   describe('detectConflicts', () => {
@@ -422,6 +432,275 @@ describe('conflict-detection', () => {
       // With higher threshold
       const result2 = hasMinimumGapFromAssignments('2024-01-15T12:00:00Z', assignments, 90)
       expect(result2).toBe(false)
+    })
+
+    it('should accept options object with venue coordinates', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T12:00:00Z', '2024-01-15T14:00:00Z', null, ZURICH_COORDS),
+      ]
+      // Game at 14:30, only 30 min gap - normally would conflict
+      // But venues are at the same location, so no conflict
+      const result = hasMinimumGapFromAssignments('2024-01-15T14:30:00Z', assignments, {
+        minGapMinutes: 60,
+        venueCoordinates: ZURICH_NEARBY_COORDS, // Very close to Zurich
+        sameLocationDistanceKm: 5,
+      })
+      expect(result).toBe(true) // No conflict because venues are close
+    })
+
+    it('should consider distance when venues are far apart', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T12:00:00Z', '2024-01-15T14:00:00Z', null, ZURICH_COORDS),
+      ]
+      // Game at 14:30, only 30 min gap - would conflict
+      // Venues are far apart (Zurich to Bern), so still conflicts
+      const result = hasMinimumGapFromAssignments('2024-01-15T14:30:00Z', assignments, {
+        minGapMinutes: 60,
+        venueCoordinates: BERN_COORDS, // ~95 km from Zurich
+        sameLocationDistanceKm: 5,
+      })
+      expect(result).toBe(false) // Conflict because venues are far
+    })
+
+    it('should ignore distance when venue coordinates are missing', () => {
+      const assignments = [
+        createAssignment('1', '2024-01-15T12:00:00Z', '2024-01-15T14:00:00Z', null, null), // No coordinates
+      ]
+      // Game at 14:30, only 30 min gap
+      const result = hasMinimumGapFromAssignments('2024-01-15T14:30:00Z', assignments, {
+        minGapMinutes: 60,
+        venueCoordinates: ZURICH_COORDS,
+        sameLocationDistanceKm: 5,
+      })
+      expect(result).toBe(false) // Still conflicts - can't determine distance
+    })
+  })
+
+  describe('createSmartConflictEvaluator', () => {
+    it('should not flag conflict when time gap is sufficient', () => {
+      const evaluator = createSmartConflictEvaluator({ thresholdMinutes: 60 })
+      const a = createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z')
+      const b = createAssignment('2', '2024-01-15T14:00:00Z', '2024-01-15T16:00:00Z')
+      // 2 hour gap
+      expect(evaluator(a, b)).toBe(false)
+    })
+
+    it('should flag conflict when time gap is insufficient and venues have no coordinates', () => {
+      const evaluator = createSmartConflictEvaluator({ thresholdMinutes: 60 })
+      const a = createAssignment('1', '2024-01-15T10:00:00Z', '2024-01-15T12:00:00Z')
+      const b = createAssignment('2', '2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z')
+      // 30 min gap, no coordinates
+      expect(evaluator(a, b)).toBe(true)
+    })
+
+    it('should NOT flag conflict when venues are close even with small time gap', () => {
+      const evaluator = createSmartConflictEvaluator({
+        thresholdMinutes: 60,
+        sameLocationDistanceKm: 5,
+      })
+      const a = createAssignment(
+        '1',
+        '2024-01-15T10:00:00Z',
+        '2024-01-15T12:00:00Z',
+        null,
+        ZURICH_COORDS
+      )
+      const b = createAssignment(
+        '2',
+        '2024-01-15T12:30:00Z',
+        '2024-01-15T14:30:00Z',
+        null,
+        ZURICH_NEARBY_COORDS
+      )
+      // 30 min gap but venues are ~0.5 km apart
+      expect(evaluator(a, b)).toBe(false)
+    })
+
+    it('should flag conflict when venues are far apart with small time gap', () => {
+      const evaluator = createSmartConflictEvaluator({
+        thresholdMinutes: 60,
+        sameLocationDistanceKm: 5,
+      })
+      const a = createAssignment(
+        '1',
+        '2024-01-15T10:00:00Z',
+        '2024-01-15T12:00:00Z',
+        null,
+        ZURICH_COORDS
+      )
+      const b = createAssignment(
+        '2',
+        '2024-01-15T12:30:00Z',
+        '2024-01-15T14:30:00Z',
+        null,
+        BERN_COORDS
+      )
+      // 30 min gap and venues are ~95 km apart
+      expect(evaluator(a, b)).toBe(true)
+    })
+
+    it('should flag conflict when only one venue has coordinates', () => {
+      const evaluator = createSmartConflictEvaluator({
+        thresholdMinutes: 60,
+        sameLocationDistanceKm: 5,
+      })
+      const a = createAssignment(
+        '1',
+        '2024-01-15T10:00:00Z',
+        '2024-01-15T12:00:00Z',
+        null,
+        ZURICH_COORDS
+      )
+      const b = createAssignment(
+        '2',
+        '2024-01-15T12:30:00Z',
+        '2024-01-15T14:30:00Z',
+        null,
+        null // No coordinates
+      )
+      // 30 min gap, can't determine distance
+      expect(evaluator(a, b)).toBe(true)
+    })
+
+    it('should use custom sameLocationDistanceKm threshold', () => {
+      // With 3 km threshold, ~0.5 km apart should NOT conflict
+      const evaluator3km = createSmartConflictEvaluator({
+        thresholdMinutes: 60,
+        sameLocationDistanceKm: 3,
+      })
+      const a = createAssignment(
+        '1',
+        '2024-01-15T10:00:00Z',
+        '2024-01-15T12:00:00Z',
+        null,
+        ZURICH_COORDS
+      )
+      const b = createAssignment(
+        '2',
+        '2024-01-15T12:30:00Z',
+        '2024-01-15T14:30:00Z',
+        null,
+        ZURICH_NEARBY_COORDS // ~0.5 km from Zurich
+      )
+      expect(evaluator3km(a, b)).toBe(false)
+
+      // With 0.1 km threshold, ~0.5 km apart SHOULD conflict
+      const evaluator01km = createSmartConflictEvaluator({
+        thresholdMinutes: 60,
+        sameLocationDistanceKm: 0.1,
+      })
+      expect(evaluator01km(a, b)).toBe(true)
+    })
+
+    it('should work with detectConflicts', () => {
+      const evaluator = createSmartConflictEvaluator({
+        thresholdMinutes: 60,
+        sameLocationDistanceKm: 5,
+      })
+      const assignments = [
+        createAssignment(
+          '1',
+          '2024-01-15T10:00:00Z',
+          '2024-01-15T12:00:00Z',
+          null,
+          ZURICH_COORDS
+        ),
+        createAssignment(
+          '2',
+          '2024-01-15T12:30:00Z',
+          '2024-01-15T14:30:00Z',
+          null,
+          ZURICH_NEARBY_COORDS
+        ),
+      ]
+      // Close venues should not create conflicts
+      const conflicts = detectConflicts(assignments, 60, evaluator)
+      expect(conflicts.size).toBe(0)
+    })
+
+    it('should detect conflicts for far venues', () => {
+      const evaluator = createSmartConflictEvaluator({
+        thresholdMinutes: 60,
+        sameLocationDistanceKm: 5,
+      })
+      const assignments = [
+        createAssignment(
+          '1',
+          '2024-01-15T10:00:00Z',
+          '2024-01-15T12:00:00Z',
+          null,
+          ZURICH_COORDS
+        ),
+        createAssignment('2', '2024-01-15T12:30:00Z', '2024-01-15T14:30:00Z', null, BERN_COORDS),
+      ]
+      // Far venues should create conflicts
+      const conflicts = detectConflicts(assignments, 60, evaluator)
+      expect(conflicts.size).toBe(2)
+    })
+  })
+
+  describe('calculateVenueDistance', () => {
+    it('should return null when first coordinates are null', () => {
+      const result = calculateVenueDistance(null, ZURICH_COORDS)
+      expect(result).toBeNull()
+    })
+
+    it('should return null when second coordinates are null', () => {
+      const result = calculateVenueDistance(ZURICH_COORDS, null)
+      expect(result).toBeNull()
+    })
+
+    it('should return null when both coordinates are null', () => {
+      const result = calculateVenueDistance(null, null)
+      expect(result).toBeNull()
+    })
+
+    it('should calculate distance between Zurich and Bern', () => {
+      const result = calculateVenueDistance(ZURICH_COORDS, BERN_COORDS)
+      expect(result).not.toBeNull()
+      // Should be approximately 95 km
+      expect(result).toBeGreaterThan(90)
+      expect(result).toBeLessThan(100)
+    })
+
+    it('should calculate very small distance for nearby venues', () => {
+      const result = calculateVenueDistance(ZURICH_COORDS, ZURICH_NEARBY_COORDS)
+      expect(result).not.toBeNull()
+      // Should be less than 1 km
+      expect(result).toBeLessThan(1)
+    })
+  })
+
+  describe('areVenuesClose', () => {
+    it('should return false when first coordinates are null', () => {
+      const result = areVenuesClose(null, ZURICH_COORDS)
+      expect(result).toBe(false)
+    })
+
+    it('should return false when second coordinates are null', () => {
+      const result = areVenuesClose(ZURICH_COORDS, null)
+      expect(result).toBe(false)
+    })
+
+    it('should return true for nearby venues within default threshold', () => {
+      // Default is 5 km
+      const result = areVenuesClose(ZURICH_COORDS, ZURICH_NEARBY_COORDS)
+      expect(result).toBe(true)
+    })
+
+    it('should return false for far venues', () => {
+      const result = areVenuesClose(ZURICH_COORDS, BERN_COORDS)
+      expect(result).toBe(false)
+    })
+
+    it('should use custom threshold', () => {
+      // With 0.1 km threshold, ~0.5 km apart should be false
+      const result = areVenuesClose(ZURICH_COORDS, ZURICH_NEARBY_COORDS, 0.1)
+      expect(result).toBe(false)
+
+      // With 100 km threshold, even Zurich-Bern should be true
+      const result2 = areVenuesClose(ZURICH_COORDS, BERN_COORDS, 100)
+      expect(result2).toBe(true)
     })
   })
 })

--- a/web-app/src/features/assignments/utils/conflict-detection.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.ts
@@ -16,8 +16,12 @@ import { calculateDistanceKm, type Coordinates } from '@/shared/utils/distance'
 /** Default minimum gap between assignments to avoid conflict (in minutes) */
 const DEFAULT_CONFLICT_THRESHOLD_MINUTES = 60
 
-/** Default maximum distance in km for venues to be considered "same location" (no conflict) */
-const DEFAULT_SAME_LOCATION_DISTANCE_KM = 5
+/**
+ * Default maximum distance in km for venues to be considered "same location" (no conflict).
+ * 5km is chosen as it represents roughly the distance that can be covered quickly by car or
+ * public transport within a city, meaning back-to-back games at nearby venues are feasible.
+ */
+export const DEFAULT_SAME_LOCATION_DISTANCE_KM = 5
 
 /**
  * Evaluator function to determine if two assignments conflict.

--- a/web-app/src/features/assignments/utils/conflict-detection.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.ts
@@ -11,9 +11,13 @@
  */
 
 import type { CalendarAssignment } from '@/features/assignments/api/ical/types'
+import { calculateDistanceKm, type Coordinates } from '@/shared/utils/distance'
 
 /** Default minimum gap between assignments to avoid conflict (in minutes) */
 const DEFAULT_CONFLICT_THRESHOLD_MINUTES = 60
+
+/** Default maximum distance in km for venues to be considered "same location" (no conflict) */
+const DEFAULT_SAME_LOCATION_DISTANCE_KM = 5
 
 /**
  * Evaluator function to determine if two assignments conflict.
@@ -247,6 +251,124 @@ export function formatGap(gapMinutes: number): string {
   return `${minutes}min ${typeLabel}`
 }
 
+/**
+ * Options for the smart conflict evaluator.
+ */
+export interface SmartConflictOptions {
+  /** Minimum gap required between assignments in minutes (default: 60) */
+  thresholdMinutes?: number
+  /** Maximum distance in km for venues to be considered "same location" (default: 5) */
+  sameLocationDistanceKm?: number
+}
+
+/**
+ * Creates a smart conflict evaluator that considers both time gap AND venue distance.
+ *
+ * Two assignments are NOT considered conflicting if:
+ * - They have less than thresholdMinutes gap (time conflict) BUT
+ * - Both venues have coordinates AND they are within sameLocationDistanceKm of each other
+ *
+ * This handles the common case where a referee has back-to-back games at the same
+ * or nearby venue - no travel time is needed, so a small gap is acceptable.
+ *
+ * @param options - Configuration for threshold and distance
+ * @returns Evaluator function for use with detectConflicts()
+ *
+ * @example
+ * ```ts
+ * // Default: 60 min threshold, 5 km same-location distance
+ * const evaluator = createSmartConflictEvaluator();
+ *
+ * // Custom: 90 min threshold, 3 km same-location distance
+ * const evaluator = createSmartConflictEvaluator({
+ *   thresholdMinutes: 90,
+ *   sameLocationDistanceKm: 3
+ * });
+ *
+ * const conflicts = detectConflicts(assignments, 60, evaluator);
+ * ```
+ */
+export function createSmartConflictEvaluator(options: SmartConflictOptions = {}): ConflictEvaluator {
+  const {
+    thresholdMinutes = DEFAULT_CONFLICT_THRESHOLD_MINUTES,
+    sameLocationDistanceKm = DEFAULT_SAME_LOCATION_DISTANCE_KM,
+  } = options
+
+  return (a: CalendarAssignment, b: CalendarAssignment): boolean => {
+    // First check if there's a time-based conflict
+    const aStart = new Date(a.startTime).getTime()
+    const aEnd = new Date(a.endTime).getTime()
+    const bStart = new Date(b.startTime).getTime()
+    const bEnd = new Date(b.endTime).getTime()
+
+    const thresholdMs = thresholdMinutes * MS_PER_MINUTE
+
+    // Gap from a end to b start
+    const gapAToB = bStart - aEnd
+    // Gap from b end to a start
+    const gapBToA = aStart - bEnd
+
+    // Effective gap is the maximum of these (handles ordering)
+    const effectiveGap = Math.max(gapAToB, gapBToA)
+
+    // No time conflict - no conflict at all
+    if (effectiveGap >= thresholdMs) {
+      return false
+    }
+
+    // There IS a time conflict - now check if venues are close enough to ignore it
+    // If both assignments have coordinates, check the distance
+    if (a.coordinates && b.coordinates) {
+      const distanceKm = calculateDistanceKm(a.coordinates, b.coordinates)
+
+      // If venues are within the "same location" distance, no conflict
+      if (distanceKm <= sameLocationDistanceKm) {
+        return false
+      }
+    }
+
+    // Time conflict exists and venues are not close (or coordinates unavailable)
+    return true
+  }
+}
+
+/**
+ * Calculates the distance between two venues from their coordinates.
+ *
+ * @param coordsA - First venue coordinates (or null)
+ * @param coordsB - Second venue coordinates (or null)
+ * @returns Distance in km, or null if either coordinates are missing
+ */
+export function calculateVenueDistance(
+  coordsA: Coordinates | null,
+  coordsB: Coordinates | null
+): number | null {
+  if (!coordsA || !coordsB) {
+    return null
+  }
+  return calculateDistanceKm(coordsA, coordsB)
+}
+
+/**
+ * Checks if two venues are within a "same location" distance threshold.
+ *
+ * @param coordsA - First venue coordinates (or null)
+ * @param coordsB - Second venue coordinates (or null)
+ * @param maxDistanceKm - Maximum distance to be considered same location (default: 5)
+ * @returns true if venues are close, false if far apart or coordinates unavailable
+ */
+export function areVenuesClose(
+  coordsA: Coordinates | null,
+  coordsB: Coordinates | null,
+  maxDistanceKm = DEFAULT_SAME_LOCATION_DISTANCE_KM
+): boolean {
+  const distance = calculateVenueDistance(coordsA, coordsB)
+  if (distance === null) {
+    return false
+  }
+  return distance <= maxDistanceKm
+}
+
 /** Default game duration for gap calculation when endTime is not available (in minutes) */
 const DEFAULT_GAME_DURATION_MINUTES = 90
 
@@ -304,24 +426,103 @@ export function calculateMinGapToAssignments(
 }
 
 /**
+ * Options for smart gap checking with distance consideration.
+ */
+export interface GapCheckOptions {
+  /** Minimum required gap in minutes */
+  minGapMinutes: number
+  /** Venue coordinates of the potential game (for distance-based filtering) */
+  venueCoordinates?: Coordinates | null
+  /** Maximum distance in km to consider venues as "same location" (default: 5) */
+  sameLocationDistanceKm?: number
+}
+
+/**
  * Checks if a game has sufficient gap from all existing assignments.
+ * Supports smart conflict detection by considering venue distance.
+ *
+ * When venue coordinates are provided, games at nearby venues (within sameLocationDistanceKm)
+ * are not considered conflicts even if the time gap is small, since no travel time is needed.
  *
  * @param gameStartTime - ISO date string of the potential game start time
  * @param assignments - User's existing calendar assignments
- * @param minGapMinutes - Minimum required gap in minutes
+ * @param minGapMinutesOrOptions - Minimum gap in minutes, or options object for smart checking
  * @returns true if the game has sufficient gap (or no assignments exist), false otherwise
+ *
+ * @example
+ * ```ts
+ * // Simple time-based check (backwards compatible)
+ * hasMinimumGapFromAssignments(startTime, assignments, 60)
+ *
+ * // Smart check with distance consideration
+ * hasMinimumGapFromAssignments(startTime, assignments, {
+ *   minGapMinutes: 60,
+ *   venueCoordinates: { latitude: 47.37, longitude: 8.54 },
+ *   sameLocationDistanceKm: 5
+ * })
+ * ```
  */
 export function hasMinimumGapFromAssignments(
   gameStartTime: string | undefined,
   assignments: CalendarAssignment[],
-  minGapMinutes: number
+  minGapMinutesOrOptions: number | GapCheckOptions
 ): boolean {
-  const minGap = calculateMinGapToAssignments(gameStartTime, assignments)
+  // Parse options (support both simple number and options object)
+  const options: GapCheckOptions =
+    typeof minGapMinutesOrOptions === 'number'
+      ? { minGapMinutes: minGapMinutesOrOptions }
+      : minGapMinutesOrOptions
 
-  // If no gap calculated (no assignments or invalid time), allow the game
-  if (minGap === null) {
+  const {
+    minGapMinutes,
+    venueCoordinates = null,
+    sameLocationDistanceKm = DEFAULT_SAME_LOCATION_DISTANCE_KM,
+  } = options
+
+  if (!gameStartTime || assignments.length === 0) {
     return true
   }
 
-  return minGap >= minGapMinutes
+  const gameStart = new Date(gameStartTime).getTime()
+  if (isNaN(gameStart)) {
+    return true
+  }
+
+  // Estimated end time for the potential game
+  const gameEnd = gameStart + DEFAULT_GAME_DURATION_MINUTES * MS_PER_MINUTE
+
+  for (const assignment of assignments) {
+    const assignmentStart = new Date(assignment.startTime).getTime()
+    const assignmentEnd = new Date(assignment.endTime).getTime()
+
+    if (isNaN(assignmentStart) || isNaN(assignmentEnd)) {
+      continue
+    }
+
+    // Calculate gap: positive means there's time between games, negative means overlap
+    const gapBeforeAssignment = (assignmentStart - gameEnd) / MS_PER_MINUTE
+    const gapAfterAssignment = (gameStart - assignmentEnd) / MS_PER_MINUTE
+    const effectiveGap = Math.max(gapBeforeAssignment, gapAfterAssignment)
+
+    // If there's enough time gap, this assignment doesn't conflict
+    if (effectiveGap >= minGapMinutes) {
+      continue
+    }
+
+    // Time gap is insufficient - check if venues are close enough to allow it
+    if (venueCoordinates && assignment.coordinates) {
+      const distanceKm = calculateDistanceKm(venueCoordinates, assignment.coordinates)
+
+      // If venues are within "same location" distance, no conflict for this assignment
+      if (distanceKm <= sameLocationDistanceKm) {
+        continue
+      }
+    }
+
+    // Found a conflicting assignment (insufficient time gap and venues not close)
+    return false
+  }
+
+  // No conflicts found
+  return true
 }

--- a/web-app/src/features/exchanges/ExchangePage.tsx
+++ b/web-app/src/features/exchanges/ExchangePage.tsx
@@ -214,6 +214,7 @@ export function ExchangePage() {
     }
 
     // Apply game gap filter (only on "open" tab when calendar data is available)
+    // Uses smart conflict detection: games at nearby venues (<=5km) don't trigger conflicts
     if (
       gameGapFilter.enabled &&
       statusFilter === 'open' &&
@@ -222,11 +223,15 @@ export function ExchangePage() {
     ) {
       result = result.filter(({ exchange }) => {
         const gameStartTime = exchange.refereeGame?.game?.startingDateTime
-        return hasMinimumGapFromAssignments(
-          gameStartTime,
-          calendarAssignments,
-          gameGapFilter.minGapMinutes
-        )
+        const geoLocation =
+          exchange.refereeGame?.game?.hall?.primaryPostalAddress?.geographicalLocation
+        const venueCoordinates = extractCoordinates(geoLocation)
+
+        return hasMinimumGapFromAssignments(gameStartTime, calendarAssignments, {
+          minGapMinutes: gameGapFilter.minGapMinutes,
+          venueCoordinates,
+          sameLocationDistanceKm: 5,
+        })
       })
     }
 

--- a/web-app/src/features/exchanges/ExchangePage.tsx
+++ b/web-app/src/features/exchanges/ExchangePage.tsx
@@ -4,7 +4,10 @@ import { useShallow } from 'zustand/react/shallow'
 
 import type { GameExchange } from '@/api/client'
 import { useCalendarConflicts } from '@/features/assignments/hooks/useCalendarConflicts'
-import { hasMinimumGapFromAssignments } from '@/features/assignments/utils/conflict-detection'
+import {
+  hasMinimumGapFromAssignments,
+  DEFAULT_SAME_LOCATION_DISTANCE_KM,
+} from '@/features/assignments/utils/conflict-detection'
 import { ExchangeCard } from '@/features/exchanges/components/ExchangeCard'
 import { ExchangeSettingsSheet } from '@/features/exchanges/components/ExchangeSettingsSheet'
 import { TOUR_DUMMY_EXCHANGE } from '@/features/exchanges/exchange'
@@ -230,7 +233,7 @@ export function ExchangePage() {
         return hasMinimumGapFromAssignments(gameStartTime, calendarAssignments, {
           minGapMinutes: gameGapFilter.minGapMinutes,
           venueCoordinates,
-          sameLocationDistanceKm: 5,
+          sameLocationDistanceKm: DEFAULT_SAME_LOCATION_DISTANCE_KM,
         })
       })
     }


### PR DESCRIPTION
## Summary

- Add smart conflict detection that considers venue distance in addition to time gaps
- Assignments at nearby venues (≤5km) are no longer flagged as conflicts even with small time gaps
- Works on both Assignments page (conflict warnings) and Exchange page (game gap filter)
- Falls back to time-only detection when venue coordinates are unavailable

## Test Plan

- [ ] Verify assignments at same/nearby venues do not show conflict warnings
- [ ] Verify assignments at distant venues still show conflict warnings
- [ ] Test exchange game gap filter allows nearby venue games
- [ ] All unit tests pass (66 new tests added)