### PR TITLE
chore(speckit): remove branch name validation from speckit scripts

### DIFF
--- a/.github/workflows/update-speckit.yml
+++ b/.github/workflows/update-speckit.yml
@@ -41,6 +41,12 @@ jobs:
           # Store the installed version for tracking
           specify version | grep -oP 'CLI Version:\s+\K[\d.]+' > .specify/version || true
 
+      - name: Preserve local customizations
+        run: |
+          # Remove branch validation from check_feature_branch (local customization)
+          # This allows speckit commands to run from any branch, not just ###-feature-name
+          sed -i '/^check_feature_branch() {$/,/^}$/c\check_feature_branch() {\n    # Branch validation removed - speckit commands can run from any branch\n    return 0\n}' .specify/scripts/bash/common.sh
+
       - name: Check for changes
         id: changes
         run: |

--- a/.github/workflows/update-speckit.yml
+++ b/.github/workflows/update-speckit.yml
@@ -43,9 +43,22 @@ jobs:
 
       - name: Preserve local customizations
         run: |
-          # Remove branch validation from check_feature_branch (local customization)
-          # This allows speckit commands to run from any branch, not just ###-feature-name
+          # LOCAL CUSTOMIZATION: Remove branch validation from check_feature_branch
+          #
+          # Why: Upstream speckit enforces ###-feature-name branch naming pattern.
+          # We removed this restriction to allow speckit commands to run from any
+          # branch (e.g., claude/* branches used by Claude Code web sessions).
+          #
+          # This sed command replaces the check_feature_branch function body with
+          # a no-op that always returns success.
           sed -i '/^check_feature_branch() {$/,/^}$/c\check_feature_branch() {\n    # Branch validation removed - speckit commands can run from any branch\n    return 0\n}' .specify/scripts/bash/common.sh
+
+      - name: Verify customization applied
+        run: |
+          grep -q "Branch validation removed" .specify/scripts/bash/common.sh || {
+            echo "ERROR: Failed to apply branch validation customization"
+            exit 1
+          }
 
       - name: Check for changes
         id: changes

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -63,21 +63,7 @@ has_git() {
 }
 
 check_feature_branch() {
-    local branch="$1"
-    local has_git_repo="$2"
-
-    # For non-git repos, we can't enforce branch naming but still provide output
-    if [[ "$has_git_repo" != "true" ]]; then
-        echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
-        return 0
-    fi
-
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
-        echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name" >&2
-        return 1
-    fi
-
+    # Branch validation removed - speckit commands can run from any branch
     return 0
 }
 


### PR DESCRIPTION
## Summary

- Remove branch name validation from speckit scripts
- The `check_feature_branch` function no longer enforces the `###-feature-name` pattern
- Speckit commands can now run from any branch
- Add preservation step in `update-speckit.yml` workflow to maintain this customization after upstream updates

## Test plan

- [ ] Run speckit commands from a non-feature branch and verify they work without errors
- [ ] Verify the update-speckit workflow preserves the customization after updates