### PR TITLE
chore(changeset): add changelog entry for mobile app foundation

### DIFF
--- a/.changeset/mobile-foundation.md
+++ b/.changeset/mobile-foundation.md
@@ -1,0 +1,19 @@
+---
+"volleykit-web": minor
+---
+
+Add React Native mobile app foundation with shared code architecture
+
+**Phase 1: Project Setup**
+- Initialize monorepo workspace structure with packages/shared and packages/mobile
+- Configure npm workspaces and Expo project with TypeScript 5.9
+- Add NativeWind (Tailwind CSS for React Native)
+
+**Phase 2: Shared Code Architecture**
+- Extract platform-agnostic API client, validation schemas, and query keys to @volleykit/shared
+- Extract TanStack Query hooks (useAssignments, useCompensations, useExchanges)
+- Extract Zustand stores (auth, settings) with platform adapter interfaces
+- Extract i18n translations and date/error helpers
+- Migrate web-app to import from @volleykit/shared (~463 lines removed)
+
+This enables 70%+ code sharing between the PWA and upcoming native mobile app.


### PR DESCRIPTION
## Summary

Add changeset for the React Native mobile app foundation work (Phase 1-2) that was merged in PR #754.

This documents the following changes for the changelog:
- Monorepo workspace structure with `@volleykit/shared` package
- Shared code extraction (API, hooks, stores, i18n, utils)
- 70%+ code sharing enabled between PWA and mobile

## Test plan

- [x] Changeset file created with correct format
- [ ] CI validates changeset