### PR TITLE
feat(mobile): implement language picker modal in SettingsScreen

### DIFF
--- a/packages/mobile/src/components/LanguagePicker.tsx
+++ b/packages/mobile/src/components/LanguagePicker.tsx
@@ -8,7 +8,7 @@ import { View, Text, TouchableOpacity, FlatList, Modal } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 
 import { useTranslation, SUPPORTED_LANGUAGES, LANGUAGE_NAMES, type Language } from '@volleykit/shared/i18n';
-import { COLORS } from '../constants';
+import { COLORS, SETTINGS_ICON_SIZE } from '../constants';
 
 interface LanguagePickerProps {
   /** Whether the picker is visible */
@@ -47,7 +47,7 @@ export function LanguagePicker({
           <Text className="text-gray-900 text-base">{LANGUAGE_NAMES[item]}</Text>
         </View>
         {isSelected && (
-          <Feather name="check" size={24} color={COLORS.primary} />
+          <Feather name="check" size={SETTINGS_ICON_SIZE} color={COLORS.primary} />
         )}
       </TouchableOpacity>
     );

--- a/packages/mobile/src/components/LanguagePicker.tsx
+++ b/packages/mobile/src/components/LanguagePicker.tsx
@@ -1,0 +1,94 @@
+/**
+ * Language Picker component
+ *
+ * Modal for selecting the app's display language.
+ */
+
+import { View, Text, TouchableOpacity, FlatList, Modal } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+import { useTranslation, SUPPORTED_LANGUAGES, LANGUAGE_NAMES, type Language } from '@volleykit/shared/i18n';
+import { COLORS } from '../constants';
+
+interface LanguagePickerProps {
+  /** Whether the picker is visible */
+  visible: boolean;
+  /** Currently selected language */
+  selectedLanguage: Language;
+  /** Called when a language is selected */
+  onSelect: (language: Language) => void;
+  /** Called when the picker is closed */
+  onClose: () => void;
+}
+
+export function LanguagePicker({
+  visible,
+  selectedLanguage,
+  onSelect,
+  onClose,
+}: LanguagePickerProps) {
+  const { t } = useTranslation();
+
+  const renderLanguageItem = ({ item }: { item: Language }) => {
+    const isSelected = item === selectedLanguage;
+
+    return (
+      <TouchableOpacity
+        className="flex-row items-center py-4 px-4 bg-white"
+        onPress={() => {
+          onSelect(item);
+          onClose();
+        }}
+        accessibilityRole="radio"
+        accessibilityState={{ checked: isSelected }}
+        accessibilityLabel={LANGUAGE_NAMES[item]}
+      >
+        <View className="flex-1">
+          <Text className="text-gray-900 text-base">{LANGUAGE_NAMES[item]}</Text>
+        </View>
+        {isSelected && (
+          <Feather name="check" size={24} color={COLORS.primary} />
+        )}
+      </TouchableOpacity>
+    );
+  };
+
+  const renderSeparator = () => (
+    <View className="h-px bg-gray-200 ml-4" />
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-gray-50">
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-4 py-4 bg-white border-b border-gray-200">
+          <TouchableOpacity
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel={t('common.cancel')}
+          >
+            <Text className="text-sky-500 text-base">{t('common.cancel')}</Text>
+          </TouchableOpacity>
+          <Text className="text-gray-900 text-lg font-semibold">
+            {t('settings.language')}
+          </Text>
+          <View className="w-16" />
+        </View>
+
+        {/* Language List */}
+        <FlatList
+          data={SUPPORTED_LANGUAGES}
+          keyExtractor={(item) => item}
+          renderItem={renderLanguageItem}
+          ItemSeparatorComponent={renderSeparator}
+          className="mt-4"
+        />
+      </View>
+    </Modal>
+  );
+}

--- a/packages/mobile/src/screens/SettingsScreen.tsx
+++ b/packages/mobile/src/screens/SettingsScreen.tsx
@@ -2,8 +2,8 @@
  * Settings screen
  */
 
-import { useMemo } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
+import { useMemo, useState } from 'react';
+import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
 import { Feather, MaterialCommunityIcons } from '@expo/vector-icons';
 
 import { useSettingsStore } from '@volleykit/shared/stores';
@@ -11,6 +11,7 @@ import { getAppVersion } from '../utils/version';
 import { useTranslation, LANGUAGE_NAMES } from '@volleykit/shared/i18n';
 import type { MainTabScreenProps } from '../navigation/types';
 import { COLORS, SETTINGS_ICON_SIZE, SMALL_ICON_SIZE } from '../constants';
+import { LanguagePicker } from '../components/LanguagePicker';
 
 type Props = MainTabScreenProps<'Settings'>;
 
@@ -58,11 +59,9 @@ function SettingRow({
 export function SettingsScreen({ navigation }: Props) {
   const { t } = useTranslation();
   const language = useSettingsStore((state) => state.language);
+  const setLanguage = useSettingsStore((state) => state.setLanguage);
   const appVersion = useMemo(() => getAppVersion(), []);
-
-  const showComingSoon = () => {
-    Alert.alert(t('settings.comingSoon'), undefined, [{ text: t('common.close') }]);
-  };
+  const [isLanguagePickerVisible, setLanguagePickerVisible] = useState(false);
 
   return (
     <ScrollView className="flex-1 bg-gray-50">
@@ -75,11 +74,8 @@ export function SettingsScreen({ navigation }: Props) {
             icon={<Feather name="globe" size={SETTINGS_ICON_SIZE} color={COLORS.gray500} />}
             title={t('settings.language')}
             value={LANGUAGE_NAMES[language]}
-            onPress={() => {
-              // TODO(#48): Implement language picker modal in Phase 3
-              showComingSoon();
-            }}
-            accessibilityHint={t('settings.comingSoon')}
+            onPress={() => setLanguagePickerVisible(true)}
+            accessibilityHint={t('settings.language')}
           />
         </View>
       </View>
@@ -131,6 +127,13 @@ export function SettingsScreen({ navigation }: Props) {
           />
         </View>
       </View>
+
+      <LanguagePicker
+        visible={isLanguagePickerVisible}
+        selectedLanguage={language}
+        onSelect={setLanguage}
+        onClose={() => setLanguagePickerVisible(false)}
+      />
     </ScrollView>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a LanguagePicker modal component for selecting display language
- Replaces "Coming Soon" placeholder with functional language selection
- Supports all four languages: German, English, French, Italian
- Resolves TODO(#48)

## Test plan
- [ ] Open Settings screen in the mobile app
- [ ] Tap on the Language setting row
- [ ] Verify the language picker modal opens
- [ ] Select a different language and verify it updates
- [ ] Verify the modal closes after selection
- [ ] Verify the cancel button dismisses the modal