### PR TITLE
fix(mobile): auto-submit login after successful biometric authentication

### DIFF
--- a/.changeset/auto-login-biometric.md
+++ b/.changeset/auto-login-biometric.md
@@ -1,0 +1,7 @@
+---
+"@volleykit/mobile": patch
+---
+
+Auto-submit login form after successful biometric authentication
+
+Previously, biometric authentication would fill in credentials but require a manual tap on the login button. Now, when biometric auth succeeds and retrieves stored credentials, the login is automatically triggered.

--- a/packages/mobile/src/screens/LoginScreen.tsx
+++ b/packages/mobile/src/screens/LoginScreen.tsx
@@ -5,7 +5,7 @@
  * Falls back to password entry after 3 failed biometric attempts.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { View, Text, TextInput, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 
@@ -22,6 +22,9 @@ export function LoginScreen(_props: Props) {
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Track pending auto-login after biometric authentication
+  const pendingBiometricLoginRef = useRef(false);
 
   // Biometric authentication
   const {
@@ -52,13 +55,12 @@ export function LoginScreen(_props: Props) {
     const result = await authenticate(t('auth.biometricPrompt'));
 
     if (result.success && result.credentials) {
-      // Auto-fill credentials and trigger login
+      // Mark pending auto-login - the useEffect will trigger handleLogin
+      // once the credentials state is updated
+      pendingBiometricLoginRef.current = true;
       setUsername(result.credentials.username);
       setPassword(result.credentials.password);
       setError(null);
-
-      // TODO(#47): Implement actual login logic
-      // For now, credentials are filled and user can tap login
     } else if (!result.success) {
       setError(t('auth.biometricFailed'));
     }
@@ -75,7 +77,7 @@ export function LoginScreen(_props: Props) {
     [shouldFallbackToPassword, resetAttempts]
   );
 
-  const handleLogin = async () => {
+  const handleLogin = useCallback(async () => {
     if (!username || !password) {
       setError(t('auth.enterCredentials'));
       return;
@@ -92,7 +94,15 @@ export function LoginScreen(_props: Props) {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [username, password, t]);
+
+  // Auto-login after biometric authentication fills credentials
+  useEffect(() => {
+    if (pendingBiometricLoginRef.current && username && password) {
+      pendingBiometricLoginRef.current = false;
+      handleLogin();
+    }
+  }, [username, password, handleLogin]);
 
   return (
     <View className="flex-1 bg-white px-6 pt-20">


### PR DESCRIPTION
## Summary
- Auto-submit login form after successful biometric authentication
- Previously, biometric auth filled credentials but required a manual tap on the login button
- Now uses a ref and useEffect to automatically trigger login when credentials are set

## Test plan
- [ ] Enable biometric authentication in settings
- [ ] Log out and return to login screen
- [ ] Tap biometric login option
- [ ] Verify login is triggered automatically after successful biometric auth
- [ ] Verify manual login still works when typing credentials