### PR TITLE
fix(mobile): use i18n translations for status labels in list screens

### DIFF
--- a/.changeset/fix-mobile-i18n-status-labels.md
+++ b/.changeset/fix-mobile-i18n-status-labels.md
@@ -1,0 +1,5 @@
+---
+"@volleykit/mobile": patch
+---
+
+Fix mobile screens to use i18n translations for status labels instead of hardcoded English strings

--- a/packages/mobile/src/screens/CompensationsScreen.tsx
+++ b/packages/mobile/src/screens/CompensationsScreen.tsx
@@ -7,7 +7,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { View, Text, FlatList, RefreshControl } from 'react-native';
 
-import { useTranslation } from '@volleykit/shared/i18n';
+import { useTranslation, type TranslationKey } from '@volleykit/shared/i18n';
 import type { MainTabScreenProps } from '../navigation/types';
 import { PLACEHOLDER_REFRESH_DELAY_MS } from '../constants';
 
@@ -64,7 +64,7 @@ export function CompensationsScreen(_props: Props) {
             <Text className="text-gray-900 font-medium">{item.game}</Text>
             <Text className="text-gray-900 font-semibold">CHF {item.amount}</Text>
           </View>
-          <Text className="text-gray-500 text-sm mt-1 capitalize">{item.status}</Text>
+          <Text className="text-gray-500 text-sm mt-1">{t(`compensations.${item.status}` as TranslationKey)}</Text>
         </View>
       )}
     />

--- a/packages/mobile/src/screens/ExchangesScreen.tsx
+++ b/packages/mobile/src/screens/ExchangesScreen.tsx
@@ -7,7 +7,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { View, Text, FlatList, RefreshControl } from 'react-native';
 
-import { useTranslation } from '@volleykit/shared/i18n';
+import { useTranslation, type TranslationKey } from '@volleykit/shared/i18n';
 import type { MainTabScreenProps } from '../navigation/types';
 import { PLACEHOLDER_REFRESH_DELAY_MS } from '../constants';
 
@@ -64,7 +64,7 @@ export function ExchangesScreen(_props: Props) {
             <Text className="text-gray-900 font-medium">{item.game}</Text>
             <View className={`px-2 py-1 rounded ${item.status === 'open' ? 'bg-green-100' : 'bg-blue-100'}`}>
               <Text className={`text-xs font-medium ${item.status === 'open' ? 'text-green-700' : 'text-blue-700'}`}>
-                {item.status.toUpperCase()}
+                {t(`exchange.${item.status}` as TranslationKey)}
               </Text>
             </View>
           </View>


### PR DESCRIPTION
## Summary

- Fixed ExchangesScreen to use `t(\`exchange.${status}\`)` translations instead of `item.status.toUpperCase()`
- Fixed CompensationsScreen to use `t(\`compensations.${status}\`)` translations instead of raw `item.status` with capitalize
- Ensures proper internationalization support for all 4 languages (de/en/fr/it)

## Test plan

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Jest tests pass
- [ ] Manual verification: Open Exchanges tab and verify status labels are translated
- [ ] Manual verification: Open Compensations tab and verify status labels are translated