### PR TITLE
fix(mobile): use i18n translations for status values in list screens

### DIFF
--- a/packages/mobile/src/screens/CompensationsScreen.tsx
+++ b/packages/mobile/src/screens/CompensationsScreen.tsx
@@ -64,7 +64,9 @@ export function CompensationsScreen(_props: Props) {
             <Text className="text-gray-900 font-medium">{item.game}</Text>
             <Text className="text-gray-900 font-semibold">CHF {item.amount}</Text>
           </View>
-          <Text className="text-gray-500 text-sm mt-1 capitalize">{item.status}</Text>
+          <Text className="text-gray-500 text-sm mt-1">
+            {item.status === 'paid' ? t('compensations.paid') : t('compensations.pending')}
+          </Text>
         </View>
       )}
     />

--- a/packages/mobile/src/screens/ExchangesScreen.tsx
+++ b/packages/mobile/src/screens/ExchangesScreen.tsx
@@ -64,7 +64,7 @@ export function ExchangesScreen(_props: Props) {
             <Text className="text-gray-900 font-medium">{item.game}</Text>
             <View className={`px-2 py-1 rounded ${item.status === 'open' ? 'bg-green-100' : 'bg-blue-100'}`}>
               <Text className={`text-xs font-medium ${item.status === 'open' ? 'text-green-700' : 'text-blue-700'}`}>
-                {item.status.toUpperCase()}
+                {item.status === 'open' ? t('exchange.open') : t('exchange.applied')}
               </Text>
             </View>
           </View>


### PR DESCRIPTION
## Summary

- Replace hardcoded status strings with proper i18n translations in mobile list screens
- ExchangesScreen: Use `exchange.open`/`exchange.applied` instead of uppercase status string
- CompensationsScreen: Use `compensations.paid`/`compensations.pending` instead of capitalized status

## Test plan

- [x] TypeScript check passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Jest tests pass (`npm test`)
- [ ] Verify translations display correctly in ExchangesScreen
- [ ] Verify translations display correctly in CompensationsScreen