### PR TITLE
fix(mobile): translate hard-coded Offline text in OfflineIndicator

### DIFF
--- a/packages/mobile/src/components/OfflineBanner.tsx
+++ b/packages/mobile/src/components/OfflineBanner.tsx
@@ -77,6 +77,7 @@ export function OfflineBanner({
  * Compact offline indicator for use in headers.
  */
 export function OfflineIndicator(): JSX.Element | null {
+  const { t } = useTranslation();
   const { isOnline, isKnown } = useNetwork();
 
   if (isOnline || !isKnown) {
@@ -87,10 +88,10 @@ export function OfflineIndicator(): JSX.Element | null {
     <View
       className="flex-row items-center bg-amber-100 rounded-full px-2 py-1"
       accessibilityRole="alert"
-      accessibilityLabel="Offline"
+      accessibilityLabel={t('common.offline')}
     >
       <Feather name="wifi-off" size={12} color={COLORS.amber500} />
-      <Text className="text-amber-600 text-xs ml-1">Offline</Text>
+      <Text className="text-amber-600 text-xs ml-1">{t('common.offline')}</Text>
     </View>
   );
 }

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -38,6 +38,7 @@ const de: Translations = {
     minutesUnit: "'",
     hoursUnit: 'h',
     dob: 'Geb.',
+    offline: 'Offline',
   },
   auth: {
     login: 'Anmelden',

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -38,6 +38,7 @@ const en: Translations = {
     minutesUnit: "'",
     hoursUnit: 'h',
     dob: 'DOB',
+    offline: 'Offline',
   },
   auth: {
     login: 'Login',

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -38,6 +38,7 @@ const fr: Translations = {
     minutesUnit: "'",
     hoursUnit: 'h',
     dob: 'DDN',
+    offline: 'Hors ligne',
   },
   auth: {
     login: 'Connexion',

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -38,6 +38,7 @@ const it: Translations = {
     minutesUnit: "'",
     hoursUnit: 'h',
     dob: 'DDN',
+    offline: 'Offline',
   },
   auth: {
     login: 'Accesso',

--- a/packages/shared/src/i18n/types.ts
+++ b/packages/shared/src/i18n/types.ts
@@ -54,6 +54,7 @@ export interface Translations {
     minutesUnit: string;
     hoursUnit: string;
     dob: string;
+    offline: string;
   };
   auth: {
     login: string;


### PR DESCRIPTION
## Summary\n- Add `common.offline` translation key to all 4 locales (de, en, fr, it)\n- Update OfflineIndicator component to use translated text instead of hard-coded "Offline"\n- Apply translation to both visible text and accessibility label\n\n## Test plan\n- [x] TypeScript compiles without errors\n- [x] ESLint passes\n- [ ] Test OfflineIndicator displays correctly in each language