### PR TITLE
fix(mobile): add status display to AssignmentsScreen for consistency

### DIFF
--- a/.changeset/add-status-to-assignments-screen.md
+++ b/.changeset/add-status-to-assignments-screen.md
@@ -1,0 +1,5 @@
+---
+"@volleykit/mobile": patch
+---
+
+Add status display with i18n translations to AssignmentsScreen for consistency with other list screens

--- a/packages/mobile/src/screens/AssignmentsScreen.tsx
+++ b/packages/mobile/src/screens/AssignmentsScreen.tsx
@@ -29,6 +29,13 @@ const PLACEHOLDER_ASSIGNMENTS: PlaceholderAssignment[] = [
   { id: '3', title: 'Game 3', date: '2026-02-01', venue: 'Sports Hall C', status: 'cancelled' },
 ];
 
+// Status badge color mappings
+const STATUS_COLORS = {
+  active: { bg: 'bg-green-100', text: 'text-green-700' },
+  cancelled: { bg: 'bg-red-100', text: 'text-red-700' },
+  archived: { bg: 'bg-gray-100', text: 'text-gray-700' },
+} as const;
+
 export function AssignmentsScreen(_props: Props) {
   const { t } = useTranslation();
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -68,12 +75,7 @@ export function AssignmentsScreen(_props: Props) {
         <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />
       }
       renderItem={({ item }) => {
-        const statusColors = {
-          active: { bg: 'bg-green-100', text: 'text-green-700' },
-          cancelled: { bg: 'bg-red-100', text: 'text-red-700' },
-          archived: { bg: 'bg-gray-100', text: 'text-gray-700' },
-        };
-        const colors = statusColors[item.status];
+        const colors = STATUS_COLORS[item.status];
 
         return (
           <View className="bg-white rounded-lg p-4 shadow-sm">

--- a/packages/mobile/src/screens/AssignmentsScreen.tsx
+++ b/packages/mobile/src/screens/AssignmentsScreen.tsx
@@ -7,17 +7,26 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { View, Text, FlatList, RefreshControl } from 'react-native';
 
-import { useTranslation } from '@volleykit/shared/i18n';
+import { useTranslation, type TranslationKey } from '@volleykit/shared/i18n';
 import type { MainTabScreenProps } from '../navigation/types';
 import { PLACEHOLDER_REFRESH_DELAY_MS } from '../constants';
 
 type Props = MainTabScreenProps<'Assignments'>;
 
+// Placeholder assignment type (matches API convocationStatusSchema values)
+type PlaceholderAssignment = {
+  id: string;
+  title: string;
+  date: string;
+  venue: string;
+  status: 'active' | 'cancelled' | 'archived';
+};
+
 // Placeholder data until API client is implemented
-const PLACEHOLDER_ASSIGNMENTS = [
-  { id: '1', title: 'Game 1', date: '2026-01-20', venue: 'Sports Hall A' },
-  { id: '2', title: 'Game 2', date: '2026-01-25', venue: 'Sports Hall B' },
-  { id: '3', title: 'Game 3', date: '2026-02-01', venue: 'Sports Hall C' },
+const PLACEHOLDER_ASSIGNMENTS: PlaceholderAssignment[] = [
+  { id: '1', title: 'Game 1', date: '2026-01-20', venue: 'Sports Hall A', status: 'active' },
+  { id: '2', title: 'Game 2', date: '2026-01-25', venue: 'Sports Hall B', status: 'active' },
+  { id: '3', title: 'Game 3', date: '2026-02-01', venue: 'Sports Hall C', status: 'cancelled' },
 ];
 
 export function AssignmentsScreen(_props: Props) {
@@ -58,12 +67,28 @@ export function AssignmentsScreen(_props: Props) {
       refreshControl={
         <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />
       }
-      renderItem={({ item }) => (
-        <View className="bg-white rounded-lg p-4 shadow-sm">
-          <Text className="text-gray-900 font-medium">{item.title}</Text>
-          <Text className="text-gray-500 text-sm mt-1">{item.date} - {item.venue}</Text>
-        </View>
-      )}
+      renderItem={({ item }) => {
+        const statusColors = {
+          active: { bg: 'bg-green-100', text: 'text-green-700' },
+          cancelled: { bg: 'bg-red-100', text: 'text-red-700' },
+          archived: { bg: 'bg-gray-100', text: 'text-gray-700' },
+        };
+        const colors = statusColors[item.status];
+
+        return (
+          <View className="bg-white rounded-lg p-4 shadow-sm">
+            <View className="flex-row justify-between items-center">
+              <Text className="text-gray-900 font-medium">{item.title}</Text>
+              <View className={`px-2 py-1 rounded ${colors.bg}`}>
+                <Text className={`text-xs font-medium ${colors.text}`}>
+                  {t(`assignments.${item.status}` as TranslationKey)}
+                </Text>
+              </View>
+            </View>
+            <Text className="text-gray-500 text-sm mt-1">{item.date} - {item.venue}</Text>
+          </View>
+        );
+      }}
     />
   );
 }

--- a/packages/mobile/src/screens/ExchangesScreen.tsx
+++ b/packages/mobile/src/screens/ExchangesScreen.tsx
@@ -13,12 +13,27 @@ import { PLACEHOLDER_REFRESH_DELAY_MS } from '../constants';
 
 type Props = MainTabScreenProps<'Exchanges'>;
 
+// Placeholder exchange type (matches API exchangeStatusSchema values)
+type PlaceholderExchange = {
+  id: string;
+  game: string;
+  date: string;
+  status: 'open' | 'applied' | 'closed';
+};
+
 // Placeholder data until API client is implemented
-const PLACEHOLDER_EXCHANGES = [
+const PLACEHOLDER_EXCHANGES: PlaceholderExchange[] = [
   { id: '1', game: 'Game A', date: '2026-01-22', status: 'open' },
   { id: '2', game: 'Game B', date: '2026-01-28', status: 'applied' },
   { id: '3', game: 'Game C', date: '2026-02-05', status: 'open' },
 ];
+
+// Status badge color mappings
+const STATUS_COLORS = {
+  open: { bg: 'bg-green-100', text: 'text-green-700' },
+  applied: { bg: 'bg-blue-100', text: 'text-blue-700' },
+  closed: { bg: 'bg-gray-100', text: 'text-gray-700' },
+} as const;
 
 export function ExchangesScreen(_props: Props) {
   const { t } = useTranslation();
@@ -58,19 +73,23 @@ export function ExchangesScreen(_props: Props) {
       refreshControl={
         <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />
       }
-      renderItem={({ item }) => (
-        <View className="bg-white rounded-lg p-4 shadow-sm">
-          <View className="flex-row justify-between items-center">
-            <Text className="text-gray-900 font-medium">{item.game}</Text>
-            <View className={`px-2 py-1 rounded ${item.status === 'open' ? 'bg-green-100' : 'bg-blue-100'}`}>
-              <Text className={`text-xs font-medium ${item.status === 'open' ? 'text-green-700' : 'text-blue-700'}`}>
-                {t(`exchange.${item.status}` as TranslationKey)}
-              </Text>
+      renderItem={({ item }) => {
+        const colors = STATUS_COLORS[item.status];
+
+        return (
+          <View className="bg-white rounded-lg p-4 shadow-sm">
+            <View className="flex-row justify-between items-center">
+              <Text className="text-gray-900 font-medium">{item.game}</Text>
+              <View className={`px-2 py-1 rounded ${colors.bg}`}>
+                <Text className={`text-xs font-medium ${colors.text}`}>
+                  {t(`exchange.${item.status}` as TranslationKey)}
+                </Text>
+              </View>
             </View>
+            <Text className="text-gray-500 text-sm mt-1">{item.date}</Text>
           </View>
-          <Text className="text-gray-500 text-sm mt-1">{item.date}</Text>
-        </View>
-      )}
+        );
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add status badges with i18n translations to AssignmentsScreen placeholder data
- Ensures visual consistency across all list screens (matches ExchangesScreen and CompensationsScreen pattern)

## Test plan
- [x] TypeScript check passes
- [x] Jest tests pass
- [ ] Manual verification: Open Assignments tab and verify status badges display