### PR TITLE
fix(mobile): use i18n translations in AssignmentDetailScreen

### DIFF
--- a/.changeset/fix-mobile-assignment-detail-i18n.md
+++ b/.changeset/fix-mobile-assignment-detail-i18n.md
@@ -1,0 +1,6 @@
+---
+"@volleykit/mobile": patch
+"@volleykit/shared": patch
+---
+
+Use i18n translations in AssignmentDetailScreen instead of hardcoded English text

--- a/packages/mobile/src/screens/AssignmentDetailScreen.tsx
+++ b/packages/mobile/src/screens/AssignmentDetailScreen.tsx
@@ -4,38 +4,40 @@
 
 import { View, Text, ScrollView } from 'react-native';
 
+import { useTranslation } from '@volleykit/shared/i18n';
 import type { RootStackScreenProps } from '../navigation/types';
 
 type Props = RootStackScreenProps<'AssignmentDetail'>;
 
 export function AssignmentDetailScreen({ route }: Props) {
+  const { t } = useTranslation();
   const { id } = route.params;
 
   return (
     <ScrollView className="flex-1 bg-white">
       <View className="p-6">
-        <Text className="text-2xl font-bold text-gray-900">Assignment Details</Text>
-        <Text className="text-gray-600 mt-2">Assignment ID: {id}</Text>
+        <Text className="text-2xl font-bold text-gray-900">{t('assignments.details')}</Text>
+        <Text className="text-gray-600 mt-2">ID: {id}</Text>
 
         <View className="mt-6 gap-4">
           <View className="bg-gray-50 rounded-lg p-4">
-            <Text className="text-sm font-medium text-gray-500">Date & Time</Text>
-            <Text className="text-gray-900 mt-1">Placeholder</Text>
+            <Text className="text-sm font-medium text-gray-500">{t('common.dateTime')}</Text>
+            <Text className="text-gray-900 mt-1">{t('common.tbd')}</Text>
           </View>
 
           <View className="bg-gray-50 rounded-lg p-4">
-            <Text className="text-sm font-medium text-gray-500">Venue</Text>
-            <Text className="text-gray-900 mt-1">Placeholder</Text>
+            <Text className="text-sm font-medium text-gray-500">{t('assignments.venue')}</Text>
+            <Text className="text-gray-900 mt-1">{t('common.tbd')}</Text>
           </View>
 
           <View className="bg-gray-50 rounded-lg p-4">
-            <Text className="text-sm font-medium text-gray-500">Teams</Text>
-            <Text className="text-gray-900 mt-1">Home vs Away</Text>
+            <Text className="text-sm font-medium text-gray-500">{t('assignments.teams')}</Text>
+            <Text className="text-gray-900 mt-1">{t('common.home')} {t('common.vs')} {t('common.away')}</Text>
           </View>
 
           <View className="bg-gray-50 rounded-lg p-4">
-            <Text className="text-sm font-medium text-gray-500">Role</Text>
-            <Text className="text-gray-900 mt-1">Placeholder</Text>
+            <Text className="text-sm font-medium text-gray-500">{t('common.position')}</Text>
+            <Text className="text-gray-900 mt-1">{t('common.tbd')}</Text>
           </View>
         </View>
       </View>

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -75,6 +75,9 @@ const de: Translations = {
   },
   assignments: {
     title: 'Einsätze',
+    details: 'Einsatzdetails',
+    venue: 'Spielort',
+    teams: 'Teams',
     upcoming: 'Bevorstehend',
     past: 'Vergangen',
     loading: 'Einsätze werden geladen...',

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -74,6 +74,9 @@ const en: Translations = {
   },
   assignments: {
     title: 'Assignments',
+    details: 'Assignment Details',
+    venue: 'Venue',
+    teams: 'Teams',
     upcoming: 'Upcoming',
     past: 'Past',
     loading: 'Loading assignments...',

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -75,6 +75,9 @@ const fr: Translations = {
   },
   assignments: {
     title: 'Désignations',
+    details: 'Détails de la désignation',
+    venue: 'Lieu',
+    teams: 'Équipes',
     upcoming: 'À venir',
     past: 'Passées',
     loading: 'Chargement des désignations...',

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -75,6 +75,9 @@ const it: Translations = {
   },
   assignments: {
     title: 'Designazioni',
+    details: 'Dettagli designazione',
+    venue: 'Sede',
+    teams: 'Squadre',
     upcoming: 'Prossime',
     past: 'Passate',
     loading: 'Caricamento designazioni...',

--- a/packages/shared/src/i18n/types.ts
+++ b/packages/shared/src/i18n/types.ts
@@ -89,6 +89,9 @@ export interface Translations {
   };
   assignments: {
     title: string;
+    details: string;
+    venue: string;
+    teams: string;
     upcoming: string;
     past: string;
     loading: string;


### PR DESCRIPTION
## Summary
- Replace hardcoded English text in AssignmentDetailScreen with proper i18n translations
- Add new translation keys: `assignments.details`, `assignments.venue`, `assignments.teams`
- Use existing common keys: `dateTime`, `position`, `home`, `away`, `vs`, `tbd`
- Add translations for all 4 languages (de/en/fr/it)

## Test plan
- [ ] Verify TypeScript compilation passes for mobile and shared packages
- [ ] Verify ESLint passes with no warnings
- [ ] Verify all tests pass
- [ ] Test AssignmentDetailScreen displays correctly in different languages