### PR TITLE
docs(ci): optimize GitHub code review with hooks and checklist

### DIFF
--- a/.claude/hooks/session-start-review.sh
+++ b/.claude/hooks/session-start-review.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Session start hook for Claude Code Review (code review workflow only)
+# This hook ensures review guidelines are loaded before reviewing PRs
+
+# Only run when CLAUDE_CODE_REVIEW=true (set by claude-code-review.yml)
+# This prevents the hook from running for @claude implementation requests
+if [ "${CLAUDE_CODE_REVIEW:-}" != "true" ]; then
+  exit 0
+fi
+
+# Synchronous execution - block until complete
+cat << 'EOF'
+=== Claude Code Review Session ===
+
+MANDATORY: You MUST read these files FIRST before reviewing any code:
+
+1. docs/REVIEW_CHECKLIST.md - Primary review criteria (READ THIS FIRST)
+2. docs/SECURITY_CHECKLIST.md - Security review requirements
+3. docs/CODE_PATTERNS.md - Anti-patterns with examples
+
+These files define what violations to flag. Do not proceed with the review
+until you have read and understood the checklist.
+
+After reading, check for previous review comments on this PR to ensure
+consistency (don't repeat issues, acknowledge fixes).
+===============================
+EOF

--- a/.claude/settings-review.json
+++ b/.claude/settings-review.json
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "CLAUDE_CODE_REVIEW": "true"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh search:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-review.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,77 +62,30 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use review-specific settings with hooks that auto-load guidelines
+          # Note: Changes won't take effect until merged (GitHub runs base branch workflow)
+          settings: ".claude/settings-review.json"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
             EVENT TYPE: ${{ github.event.action }}
 
-            CRITICAL: You MUST read these files FIRST and strictly enforce all guidelines during this review:
-            - CLAUDE.md (main guidelines)
-            - docs/SECURITY_CHECKLIST.md (security review)
-            - docs/CODE_PATTERNS.md (anti-patterns and examples)
+            Review this PR following the guidelines in docs/REVIEW_CHECKLIST.md.
 
-            ## CONSISTENCY REQUIREMENTS
+            BEFORE reviewing, check for previous review comments:
+            1. Run `gh pr view ${{ github.event.pull_request.number || inputs.pr_number }} --comments`
+            2. For re-reviews (EVENT TYPE is "synchronize"): acknowledge fixes, flag new issues only
 
-            BEFORE reviewing, check for previous review comments on this PR:
-            1. Run `gh pr view ${{ github.event.pull_request.number || inputs.pr_number }} --comments` to see all previous comments
-            2. Identify any previous Claude Code Review comments (they follow the format below)
-            3. Track which issues were previously raised
-
-            When re-reviewing (EVENT TYPE is "synchronize"):
-            - DO NOT repeat issues that are still present - only reference them briefly
-            - DO acknowledge issues that have been FIXED with "✅ Fixed: [issue]"
-            - DO flag any NEW issues introduced in the latest commits
-            - Focus your detailed comments on changes since the last review
-
-            ## REVIEW CHECKLIST (CLAUDE.md requirements)
-
-            Flag violations of:
-            - Naming conventions (PascalCase components, camelCase hooks/variables, SCREAMING_SNAKE_CASE constants)
-            - Magic numbers (must use named constants)
-            - Array index as React key (must use unique identifiers)
-            - Memory leaks (intervals/timeouts/subscriptions not cleaned up)
-            - Outdated patterns (isMountedRef instead of AbortController)
-            - Missing accessibility (ARIA attributes, keyboard navigation)
-            - Functions over 20-30 lines or with more than 3-4 parameters
-            - Unnecessary comments (code should be self-documenting)
-
-            Also review for:
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage for business logic
-
-            ## OUTPUT FORMAT
-
-            Output your review as plain markdown (NOT wrapped in code blocks). GitHub will render the markdown formatting automatically when posted via `gh pr comment`.
-
-            Use this structure:
-
-            ## Claude Code Review
-
-            **Review type:** [Initial review | Re-review after changes]
-
-            ### Summary
-            [1-2 sentence overview]
-
-            ### Issues Found
-            [List issues with file:line references, or "No issues found"]
-
-            ### Fixed Since Last Review (re-reviews only)
-            [List resolved issues, or omit section for initial reviews]
-
-            ### Recommendations
-            [Optional suggestions for improvement]
-
-            ---
-
-            Be constructive but firm - violations of CLAUDE.md guidelines should be explicitly called out.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR. Pass the markdown content directly without wrapping in code blocks.
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+            Post your review using `gh pr comment`. Output plain markdown (not wrapped in code blocks).
+          claude_args: '--model opus'
+          allowed_tools: |
+            Bash(gh issue view:*)
+            Bash(gh search:*)
+            Bash(gh issue list:*)
+            Bash(gh pr comment:*)
+            Bash(gh pr diff:*)
+            Bash(gh pr view:*)
+            Bash(gh pr list:*)
 
     outputs:
       guidelines_changed: ${{ steps.check-claude-md.outputs.guidelines_changed }}

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -1,0 +1,73 @@
+# Code Review Checklist
+
+Single source of truth for Claude Code Review. This file is automatically loaded by the review hook.
+
+## CLAUDE.md Violations (Must Flag)
+
+### Naming Conventions (ESLint enforced)
+- Components: `PascalCase`
+- Hooks: `useCamelCase`
+- Constants: `SCREAMING_SNAKE_CASE`
+
+### Anti-Patterns (See [CODE_PATTERNS.md](CODE_PATTERNS.md) for examples)
+| Pattern | Issue | Fix |
+|---------|-------|-----|
+| Magic numbers | `setTimeout(fn, 300)` | Use named constant `ANIMATION_DURATION_MS` |
+| Array index as key | `key={index}` | Use unique identifier `key={item.id}` |
+| Uncleared intervals | No cleanup in useEffect | Return cleanup function |
+| `isMountedRef` pattern | Outdated (React 16/17) | Use `AbortController` |
+| Functions > 30 lines | Hard to test/maintain | Extract to custom hooks |
+| > 4 parameters | Code smell | Use options object |
+
+### Accessibility (Required)
+- Icon buttons need `aria-label`
+- Modals need `aria-modal`, `aria-labelledby`, keyboard dismiss
+- Dynamic content needs `aria-live` regions
+
+### i18n (4 languages: de/en/fr/it)
+- All user-facing strings must use `useTranslation()` hook
+- No hardcoded text in components
+
+## Security Review (See [SECURITY_CHECKLIST.md](SECURITY_CHECKLIST.md))
+
+### Quick Checks
+| Risk | What to look for |
+|------|------------------|
+| XSS | `dangerouslySetInnerHTML`, dynamic `href`, unvalidated URLs |
+| Injection | String interpolation in URLs (use `URLSearchParams`) |
+| Credentials | Hardcoded secrets, tokens in localStorage, sensitive data in logs |
+| Dependencies | New packages with network access, npm audit warnings |
+
+### Sensitive Files (Require extra scrutiny)
+- `worker/src/index.ts` - CORS proxy
+- `**/api/client.ts` - API requests
+- `**/stores/auth.ts` - Authentication
+- `vite.config.ts` - Build config
+
+## Review Output Format
+
+```markdown
+## Claude Code Review
+
+**Review type:** [Initial review | Re-review after changes]
+
+### Summary
+[1-2 sentence overview]
+
+### Issues Found
+[List issues with file:line references, or "No issues found"]
+
+### Fixed Since Last Review (re-reviews only)
+[List resolved issues, or omit section for initial reviews]
+
+### Recommendations
+[Optional suggestions for improvement]
+```
+
+## Re-Review Guidelines
+
+When `EVENT TYPE` is `synchronize`:
+- DO NOT repeat issues still present - reference briefly
+- DO acknowledge fixed issues with "Fixed: [issue]"
+- DO flag NEW issues in latest commits
+- Focus on changes since last review


### PR DESCRIPTION
## Summary
- Add `docs/REVIEW_CHECKLIST.md` as single source of truth for review criteria
- Add `.claude/settings-review.json` with `CLAUDE_CODE_REVIEW` env var to distinguish code review from @claude mentions
- Add `.claude/hooks/session-start-review.sh` that only runs when env var is set
- Simplify `claude-code-review.yml` prompt from 70 to 12 lines

The hook automatically instructs Claude to read the checklist before reviewing, ensuring consistency with CLAUDE.md guidelines. Settings include the allowed gh commands, removing need for inline `allowed_tools` in the workflow.

## Test plan
- [ ] Trigger code review workflow on a test PR - verify hook loads review instructions
- [ ] Use @claude in a comment - verify review hook does NOT trigger
- [ ] Verify Claude reads REVIEW_CHECKLIST.md during code review