### PR TITLE
fix(mobile): connect screens to shared hooks resolving US1 TODOs

### DIFF
--- a/packages/mobile/src/api/client.ts
+++ b/packages/mobile/src/api/client.ts
@@ -4,6 +4,8 @@
  * Provides a mock implementation that returns placeholder data
  * while the real API integration is being developed.
  *
+ * TODO(#775): Replace with real API client when auth integration is complete.
+ *
  * This client implements the interfaces required by the shared hooks
  * (AssignmentsApiClient, ExchangesApiClient, CompensationsApiClient).
  */

--- a/packages/mobile/src/api/client.ts
+++ b/packages/mobile/src/api/client.ts
@@ -1,0 +1,336 @@
+/**
+ * Mobile API client implementation.
+ *
+ * Provides a mock implementation that returns placeholder data
+ * while the real API integration is being developed.
+ *
+ * This client implements the interfaces required by the shared hooks
+ * (AssignmentsApiClient, ExchangesApiClient, CompensationsApiClient).
+ */
+
+import type { SearchConfiguration } from '@volleykit/shared/api';
+import type { Assignment, CompensationRecord, GameExchange } from '@volleykit/shared/api';
+
+/** Network delay for realistic behavior */
+const MOCK_NETWORK_DELAY_MS = 100;
+
+/**
+ * Helper to simulate network delay.
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Mock assignment data.
+ * Matches the API Assignment schema structure.
+ */
+const MOCK_ASSIGNMENTS: Assignment[] = [
+  {
+    __identity: '1',
+    refereeGame: {
+      __identity: 'rg1',
+      game: {
+        __identity: 'g1',
+        gameNumber: 'G001',
+        startingDateTime: '2026-01-20T14:00:00.000+01:00',
+        teamHome: { __identity: 'th1', name: 'VC Zürich' },
+        teamAway: { __identity: 'ta1', name: 'Volley Luzern' },
+        hall: {
+          __identity: 'h1',
+          name: 'Sports Hall A',
+          primaryPostalAddress: {
+            combinedAddress: 'Sportstrasse 1, 8000 Zürich',
+            city: 'Zürich',
+          },
+        },
+      },
+    },
+    refereeConvocationStatus: 'active',
+    refereePosition: '1SR',
+    isOpenEntryInRefereeGameExchange: false,
+    hasLastMessageToReferee: false,
+    hasLinkedDoubleConvocation: false,
+  },
+  {
+    __identity: '2',
+    refereeGame: {
+      __identity: 'rg2',
+      game: {
+        __identity: 'g2',
+        gameNumber: 'G002',
+        startingDateTime: '2026-01-25T16:00:00.000+01:00',
+        teamHome: { __identity: 'th2', name: 'VBC Therwil' },
+        teamAway: { __identity: 'ta2', name: 'VC Kanti' },
+        hall: {
+          __identity: 'h2',
+          name: 'Sports Hall B',
+          primaryPostalAddress: {
+            combinedAddress: 'Hauptstrasse 10, 4106 Therwil',
+            city: 'Therwil',
+          },
+        },
+      },
+    },
+    refereeConvocationStatus: 'active',
+    refereePosition: '2SR',
+    isOpenEntryInRefereeGameExchange: false,
+    hasLastMessageToReferee: false,
+    hasLinkedDoubleConvocation: false,
+  },
+  {
+    __identity: '3',
+    refereeGame: {
+      __identity: 'rg3',
+      game: {
+        __identity: 'g3',
+        gameNumber: 'G003',
+        startingDateTime: '2026-02-01T18:00:00.000+01:00',
+        teamHome: { __identity: 'th3', name: 'Volley Amriswil' },
+        teamAway: { __identity: 'ta3', name: 'VC Schönenwerd' },
+        hall: {
+          __identity: 'h3',
+          name: 'Sports Hall C',
+          primaryPostalAddress: {
+            combinedAddress: 'Sportweg 5, 8580 Amriswil',
+            city: 'Amriswil',
+          },
+        },
+      },
+    },
+    refereeConvocationStatus: 'cancelled',
+    refereePosition: '1SR',
+    isOpenEntryInRefereeGameExchange: false,
+    hasLastMessageToReferee: false,
+    hasLinkedDoubleConvocation: false,
+  },
+];
+
+/**
+ * Mock exchange data.
+ * Matches the API GameExchange schema structure.
+ */
+const MOCK_EXCHANGES: GameExchange[] = [
+  {
+    __identity: '1',
+    refereeGame: {
+      __identity: 'rg1',
+      game: {
+        __identity: 'g1',
+        gameNumber: 'G004',
+        startingDateTime: '2026-01-22T19:00:00.000+01:00',
+        teamHome: { __identity: 'th4', name: 'VC Zürich' },
+        teamAway: { __identity: 'ta4', name: 'Volley Düdingen' },
+        hall: {
+          __identity: 'h4',
+          name: 'Sporthalle Hardau',
+          primaryPostalAddress: {
+            combinedAddress: 'Hardaustrasse 10, 8004 Zürich',
+            city: 'Zürich',
+          },
+        },
+      },
+    },
+    status: 'open',
+    refereePosition: '1SR',
+    submittedByPerson: { __identity: 'p1', displayName: 'Max Muster' },
+    exchangeReason: 'Konflikt mit anderem Termin',
+  },
+  {
+    __identity: '2',
+    refereeGame: {
+      __identity: 'rg2',
+      game: {
+        __identity: 'g2',
+        gameNumber: 'G005',
+        startingDateTime: '2026-01-28T17:00:00.000+01:00',
+        teamHome: { __identity: 'th5', name: 'VBC Therwil' },
+        teamAway: { __identity: 'ta5', name: 'Sm\'Aesch Pfeffingen' },
+        hall: {
+          __identity: 'h5',
+          name: 'Sporthalle Therwil',
+          primaryPostalAddress: {
+            combinedAddress: 'Benkenstrasse 5, 4106 Therwil',
+            city: 'Therwil',
+          },
+        },
+      },
+    },
+    status: 'applied',
+    refereePosition: '2SR',
+    submittedByPerson: { __identity: 'p2', displayName: 'Anna Beispiel' },
+  },
+  {
+    __identity: '3',
+    refereeGame: {
+      __identity: 'rg3',
+      game: {
+        __identity: 'g3',
+        gameNumber: 'G006',
+        startingDateTime: '2026-02-05T15:00:00.000+01:00',
+        teamHome: { __identity: 'th6', name: 'Volley Luzern' },
+        teamAway: { __identity: 'ta6', name: 'VC Kanti' },
+        hall: {
+          __identity: 'h6',
+          name: 'Sporthalle Utenberg',
+          primaryPostalAddress: {
+            combinedAddress: 'Utenbergstrasse 24, 6006 Luzern',
+            city: 'Luzern',
+          },
+        },
+      },
+    },
+    status: 'open',
+    refereePosition: '1SR',
+    submittedByPerson: { __identity: 'p3', displayName: 'Peter Test' },
+    exchangeReason: 'Krankheit',
+  },
+];
+
+/**
+ * Mock compensation data.
+ * Matches the API CompensationRecord schema structure.
+ */
+const MOCK_COMPENSATIONS: CompensationRecord[] = [
+  {
+    __identity: '1',
+    refereeGame: {
+      __identity: 'rg1',
+      game: {
+        __identity: 'g1',
+        gameNumber: 'G010',
+        startingDateTime: '2026-01-10T14:00:00.000+01:00',
+        teamHome: { __identity: 'th7', name: 'VC Zürich' },
+        teamAway: { __identity: 'ta7', name: 'Volley Luzern' },
+        hall: { __identity: 'h7', name: 'Sports Hall A' },
+      },
+    },
+    refereeConvocationStatus: 'active',
+    refereePosition: '1SR',
+    compensationDate: '2026-01-10T14:00:00.000+01:00',
+    convocationCompensation: {
+      __identity: 'cc1',
+      paymentDone: true,
+      gameCompensation: 120,
+      travelExpenses: 25,
+      gameCompensationFormatted: 'CHF 120.00',
+      travelExpensesFormatted: 'CHF 25.00',
+      costFormatted: 'CHF 145.00',
+      paymentValueDate: '2026-01-15',
+    },
+  },
+  {
+    __identity: '2',
+    refereeGame: {
+      __identity: 'rg2',
+      game: {
+        __identity: 'g2',
+        gameNumber: 'G011',
+        startingDateTime: '2026-01-05T16:00:00.000+01:00',
+        teamHome: { __identity: 'th8', name: 'VBC Therwil' },
+        teamAway: { __identity: 'ta8', name: 'VC Kanti' },
+        hall: { __identity: 'h8', name: 'Sports Hall B' },
+      },
+    },
+    refereeConvocationStatus: 'active',
+    refereePosition: '2SR',
+    compensationDate: '2026-01-05T16:00:00.000+01:00',
+    convocationCompensation: {
+      __identity: 'cc2',
+      paymentDone: false,
+      gameCompensation: 95,
+      travelExpenses: 30,
+      gameCompensationFormatted: 'CHF 95.00',
+      travelExpensesFormatted: 'CHF 30.00',
+      costFormatted: 'CHF 125.00',
+    },
+  },
+  {
+    __identity: '3',
+    refereeGame: {
+      __identity: 'rg3',
+      game: {
+        __identity: 'g3',
+        gameNumber: 'G012',
+        startingDateTime: '2025-12-20T18:00:00.000+01:00',
+        teamHome: { __identity: 'th9', name: 'Volley Amriswil' },
+        teamAway: { __identity: 'ta9', name: 'VC Schönenwerd' },
+        hall: { __identity: 'h9', name: 'Sports Hall C' },
+      },
+    },
+    refereeConvocationStatus: 'active',
+    refereePosition: '1SR',
+    compensationDate: '2025-12-20T18:00:00.000+01:00',
+    convocationCompensation: {
+      __identity: 'cc3',
+      paymentDone: true,
+      gameCompensation: 110,
+      travelExpenses: 40,
+      gameCompensationFormatted: 'CHF 110.00',
+      travelExpensesFormatted: 'CHF 40.00',
+      costFormatted: 'CHF 150.00',
+      paymentValueDate: '2025-12-28',
+    },
+  },
+];
+
+/**
+ * Mobile API client.
+ *
+ * Provides mock implementations for the shared hook interfaces.
+ * Replace with real API calls when auth integration is complete.
+ */
+export const mobileApiClient = {
+  /**
+   * Search assignments with optional filtering.
+   */
+  async searchAssignments(
+    _config: SearchConfiguration = {}
+  ): Promise<{ items: Assignment[]; totalItemsCount: number }> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+    return {
+      items: MOCK_ASSIGNMENTS,
+      totalItemsCount: MOCK_ASSIGNMENTS.length,
+    };
+  },
+
+  /**
+   * Get assignment details by ID.
+   */
+  async getAssignmentDetails(id: string): Promise<Assignment> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+    const assignment = MOCK_ASSIGNMENTS.find((a) => a.__identity === id);
+    if (!assignment) {
+      throw new Error(`Assignment not found: ${id}`);
+    }
+    return assignment;
+  },
+
+  /**
+   * Search exchanges with optional filtering.
+   */
+  async searchExchanges(
+    _config: SearchConfiguration = {}
+  ): Promise<{ items: GameExchange[]; totalItemsCount: number }> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+    return {
+      items: MOCK_EXCHANGES,
+      totalItemsCount: MOCK_EXCHANGES.length,
+    };
+  },
+
+  /**
+   * Search compensations with optional filtering.
+   */
+  async searchCompensations(
+    _config: SearchConfiguration = {}
+  ): Promise<{ items: CompensationRecord[]; totalItemsCount: number }> {
+    await delay(MOCK_NETWORK_DELAY_MS);
+    return {
+      items: MOCK_COMPENSATIONS,
+      totalItemsCount: MOCK_COMPENSATIONS.length,
+    };
+  },
+};
+
+export type MobileApiClient = typeof mobileApiClient;

--- a/packages/mobile/src/api/index.ts
+++ b/packages/mobile/src/api/index.ts
@@ -1,0 +1,5 @@
+/**
+ * API module exports for mobile app.
+ */
+
+export { mobileApiClient, type MobileApiClient } from './client';

--- a/packages/mobile/src/contexts/ApiClientContext.tsx
+++ b/packages/mobile/src/contexts/ApiClientContext.tsx
@@ -1,0 +1,61 @@
+/**
+ * API Client Context for mobile app.
+ *
+ * Provides the API client to all components via React Context.
+ * This allows screens to access the API client without prop drilling
+ * and enables easy swapping between mock and real implementations.
+ */
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+import { mobileApiClient, type MobileApiClient } from '../api';
+
+/**
+ * API client context value type.
+ */
+export interface ApiClientContextValue {
+  apiClient: MobileApiClient;
+}
+
+/**
+ * API client context.
+ */
+const ApiClientContext = createContext<ApiClientContextValue | null>(null);
+
+/**
+ * Props for ApiClientProvider.
+ */
+interface ApiClientProviderProps {
+  children: ReactNode;
+  /** Optional custom API client (useful for testing) */
+  apiClient?: MobileApiClient;
+}
+
+/**
+ * Provides the API client to the component tree.
+ */
+export function ApiClientProvider({
+  children,
+  apiClient = mobileApiClient,
+}: ApiClientProviderProps) {
+  return (
+    <ApiClientContext.Provider value={{ apiClient }}>
+      {children}
+    </ApiClientContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the API client from context.
+ *
+ * @throws Error if used outside of ApiClientProvider
+ */
+export function useApiClient(): MobileApiClient {
+  const context = useContext(ApiClientContext);
+
+  if (!context) {
+    throw new Error('useApiClient must be used within an ApiClientProvider');
+  }
+
+  return context.apiClient;
+}

--- a/packages/mobile/src/contexts/index.ts
+++ b/packages/mobile/src/contexts/index.ts
@@ -8,3 +8,9 @@ export {
   type SessionMonitorContextValue,
   type SessionMonitorState,
 } from './SessionMonitorContext';
+
+export {
+  ApiClientProvider,
+  useApiClient,
+  type ApiClientContextValue,
+} from './ApiClientContext';

--- a/packages/mobile/src/providers/AppProviders.tsx
+++ b/packages/mobile/src/providers/AppProviders.tsx
@@ -3,6 +3,7 @@
  *
  * Includes:
  * - StorageContext for platform storage adapters
+ * - ApiClientProvider for API client access
  * - QueryClient for data fetching with session expiry detection
  * - SessionMonitorProvider for biometric re-authentication
  */
@@ -20,7 +21,7 @@ import { StorageContext } from '@volleykit/shared/adapters';
 import { HttpStatus } from '@volleykit/shared/api';
 import { storage } from '../platform/storage';
 import { secureStorage } from '../platform/secureStorage';
-import { SessionMonitorProvider, useSessionMonitorContext } from '../contexts';
+import { SessionMonitorProvider, useSessionMonitorContext, ApiClientProvider } from '../contexts';
 
 interface AppProvidersProps {
   children: ReactNode;
@@ -91,9 +92,11 @@ function QueryClientWithSessionMonitor({ children }: { children: ReactNode }) {
 export function AppProviders({ children }: AppProvidersProps) {
   return (
     <StorageContext.Provider value={{ storage, secureStorage }}>
-      <SessionMonitorProvider>
-        <QueryClientWithSessionMonitor>{children}</QueryClientWithSessionMonitor>
-      </SessionMonitorProvider>
+      <ApiClientProvider>
+        <SessionMonitorProvider>
+          <QueryClientWithSessionMonitor>{children}</QueryClientWithSessionMonitor>
+        </SessionMonitorProvider>
+      </ApiClientProvider>
     </StorageContext.Provider>
   );
 }

--- a/packages/mobile/src/screens/AssignmentsScreen.tsx
+++ b/packages/mobile/src/screens/AssignmentsScreen.tsx
@@ -1,33 +1,19 @@
 /**
  * Assignments list screen
  *
- * TODO(#US1): Connect to API client when implemented
+ * Displays upcoming referee assignments fetched via the shared useAssignments hook.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { View, Text, FlatList, RefreshControl } from 'react-native';
+import { useCallback } from 'react';
+import { View, Text, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
 
 import { useTranslation, type TranslationKey } from '@volleykit/shared/i18n';
+import { useAssignments } from '@volleykit/shared/hooks';
+import type { Assignment } from '@volleykit/shared/api';
 import type { MainTabScreenProps } from '../navigation/types';
-import { PLACEHOLDER_REFRESH_DELAY_MS } from '../constants';
+import { useApiClient } from '../contexts';
 
 type Props = MainTabScreenProps<'Assignments'>;
-
-// Placeholder assignment type (matches API convocationStatusSchema values)
-type PlaceholderAssignment = {
-  id: string;
-  title: string;
-  date: string;
-  venue: string;
-  status: 'active' | 'cancelled' | 'archived';
-};
-
-// Placeholder data until API client is implemented
-const PLACEHOLDER_ASSIGNMENTS: PlaceholderAssignment[] = [
-  { id: '1', title: 'Game 1', date: '2026-01-20', venue: 'Sports Hall A', status: 'active' },
-  { id: '2', title: 'Game 2', date: '2026-01-25', venue: 'Sports Hall B', status: 'active' },
-  { id: '3', title: 'Game 3', date: '2026-02-01', venue: 'Sports Hall C', status: 'cancelled' },
-];
 
 // Status badge color mappings
 const STATUS_COLORS = {
@@ -36,27 +22,83 @@ const STATUS_COLORS = {
   archived: { bg: 'bg-gray-100', text: 'text-gray-700' },
 } as const;
 
+/**
+ * Format date from ISO string to display format.
+ */
+function formatDate(isoDate: string | null | undefined): string {
+  if (!isoDate) return '';
+  const date = new Date(isoDate);
+  return date.toLocaleDateString('de-CH', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Get display data from an assignment.
+ */
+function getAssignmentDisplay(assignment: Assignment): {
+  id: string;
+  title: string;
+  date: string;
+  venue: string;
+  status: 'active' | 'cancelled' | 'archived';
+} {
+  const game = assignment.refereeGame?.game;
+  const homeTeam = game?.teamHome?.name ?? 'TBD';
+  const awayTeam = game?.teamAway?.name ?? 'TBD';
+
+  return {
+    id: assignment.__identity,
+    title: `${homeTeam} vs ${awayTeam}`,
+    date: formatDate(game?.startingDateTime),
+    venue: game?.hall?.name ?? 'TBD',
+    status: assignment.refereeConvocationStatus,
+  };
+}
+
 export function AssignmentsScreen(_props: Props) {
   const { t } = useTranslation();
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const assignments = PLACEHOLDER_ASSIGNMENTS;
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const apiClient = useApiClient();
 
-  // Cleanup timeout on unmount to prevent memory leaks
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
+  const {
+    data: assignments = [],
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useAssignments({
+    apiClient,
+    period: 'upcoming',
+  });
 
   const onRefresh = useCallback(() => {
-    setIsRefreshing(true);
-    // TODO(#US1): Replace with TanStack Query refetch when API client is ready
-    timeoutRef.current = setTimeout(() => setIsRefreshing(false), PLACEHOLDER_REFRESH_DELAY_MS);
-  }, []);
+    refetch();
+  }, [refetch]);
 
+  // Loading state
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <View className="flex-1 items-center justify-center px-6">
+        <Text className="text-red-600 text-center">
+          {error?.message ?? t('common.error')}
+        </Text>
+      </View>
+    );
+  }
+
+  // Empty state
   if (assignments.length === 0) {
     return (
       <View className="flex-1 items-center justify-center px-6">
@@ -70,24 +112,25 @@ export function AssignmentsScreen(_props: Props) {
       className="flex-1 bg-gray-50"
       contentContainerClassName="p-4 gap-3"
       data={assignments}
-      keyExtractor={(item) => item.id}
+      keyExtractor={(item) => item.__identity}
       refreshControl={
-        <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />
+        <RefreshControl refreshing={isFetching && !isLoading} onRefresh={onRefresh} />
       }
       renderItem={({ item }) => {
-        const colors = STATUS_COLORS[item.status];
+        const display = getAssignmentDisplay(item);
+        const colors = STATUS_COLORS[display.status];
 
         return (
           <View className="bg-white rounded-lg p-4 shadow-sm">
             <View className="flex-row justify-between items-center">
-              <Text className="text-gray-900 font-medium">{item.title}</Text>
+              <Text className="text-gray-900 font-medium">{display.title}</Text>
               <View className={`px-2 py-1 rounded ${colors.bg}`}>
                 <Text className={`text-xs font-medium ${colors.text}`}>
-                  {t(`assignments.${item.status}` as TranslationKey)}
+                  {t(`assignments.${display.status}` as TranslationKey)}
                 </Text>
               </View>
             </View>
-            <Text className="text-gray-500 text-sm mt-1">{item.date} - {item.venue}</Text>
+            <Text className="text-gray-500 text-sm mt-1">{display.date} - {display.venue}</Text>
           </View>
         );
       }}

--- a/packages/mobile/src/screens/CompensationsScreen.tsx
+++ b/packages/mobile/src/screens/CompensationsScreen.tsx
@@ -5,7 +5,14 @@
  */
 
 import { useCallback } from 'react';
-import { View, Text, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
+import {
+  View,
+  Text,
+  FlatList,
+  RefreshControl,
+  ActivityIndicator,
+  TouchableOpacity,
+} from 'react-native';
 
 import { useTranslation, type TranslationKey } from '@volleykit/shared/i18n';
 import { useCompensations } from '@volleykit/shared/hooks';
@@ -66,7 +73,7 @@ export function CompensationsScreen(_props: Props) {
   if (isLoading) {
     return (
       <View className="flex-1 items-center justify-center">
-        <ActivityIndicator size="large" />
+        <ActivityIndicator size="large" accessibilityLabel={t('common.loading')} />
       </View>
     );
   }
@@ -75,9 +82,17 @@ export function CompensationsScreen(_props: Props) {
   if (isError) {
     return (
       <View className="flex-1 items-center justify-center px-6">
-        <Text className="text-red-600 text-center">
+        <Text className="text-red-600 text-center mb-4">
           {error?.message ?? t('common.error')}
         </Text>
+        <TouchableOpacity
+          className="bg-primary-600 rounded-lg px-6 py-3"
+          onPress={() => refetch()}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.retry')}
+        >
+          <Text className="text-white font-medium">{t('common.retry')}</Text>
+        </TouchableOpacity>
       </View>
     );
   }

--- a/packages/mobile/src/screens/CompensationsScreen.tsx
+++ b/packages/mobile/src/screens/CompensationsScreen.tsx
@@ -1,46 +1,88 @@
 /**
  * Compensations list screen
  *
- * TODO(#US1): Connect to API client when implemented
+ * Displays referee compensation records fetched via the shared useCompensations hook.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { View, Text, FlatList, RefreshControl } from 'react-native';
+import { useCallback } from 'react';
+import { View, Text, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
 
 import { useTranslation, type TranslationKey } from '@volleykit/shared/i18n';
+import { useCompensations } from '@volleykit/shared/hooks';
+import type { CompensationRecord } from '@volleykit/shared/api';
 import type { MainTabScreenProps } from '../navigation/types';
-import { PLACEHOLDER_REFRESH_DELAY_MS } from '../constants';
+import { useApiClient } from '../contexts';
 
 type Props = MainTabScreenProps<'Compensations'>;
 
-// Placeholder data until API client is implemented
-const PLACEHOLDER_COMPENSATIONS = [
-  { id: '1', game: 'Game 1', amount: '120.00', status: 'paid' },
-  { id: '2', game: 'Game 2', amount: '95.00', status: 'pending' },
-  { id: '3', game: 'Game 3', amount: '110.00', status: 'paid' },
-];
+/**
+ * Get display data from a compensation record.
+ */
+function getCompensationDisplay(record: CompensationRecord): {
+  id: string;
+  game: string;
+  amount: string;
+  status: 'paid' | 'pending';
+} {
+  const game = record.refereeGame?.game;
+  const homeTeam = game?.teamHome?.name ?? 'TBD';
+  const awayTeam = game?.teamAway?.name ?? 'TBD';
+  const compensation = record.convocationCompensation;
+
+  // Calculate total compensation
+  const gameComp = compensation?.gameCompensation ?? 0;
+  const travelExp = compensation?.travelExpenses ?? 0;
+  const total = gameComp + travelExp;
+
+  return {
+    id: record.__identity,
+    game: `${homeTeam} vs ${awayTeam}`,
+    amount: total.toFixed(2),
+    status: compensation?.paymentDone ? 'paid' : 'pending',
+  };
+}
 
 export function CompensationsScreen(_props: Props) {
   const { t } = useTranslation();
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const compensations = PLACEHOLDER_COMPENSATIONS;
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const apiClient = useApiClient();
 
-  // Cleanup timeout on unmount to prevent memory leaks
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
+  const {
+    data: compensations = [],
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useCompensations({
+    apiClient,
+    status: 'all',
+  });
 
   const onRefresh = useCallback(() => {
-    setIsRefreshing(true);
-    // TODO(#US1): Replace with TanStack Query refetch when API client is ready
-    timeoutRef.current = setTimeout(() => setIsRefreshing(false), PLACEHOLDER_REFRESH_DELAY_MS);
-  }, []);
+    refetch();
+  }, [refetch]);
 
+  // Loading state
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <View className="flex-1 items-center justify-center px-6">
+        <Text className="text-red-600 text-center">
+          {error?.message ?? t('common.error')}
+        </Text>
+      </View>
+    );
+  }
+
+  // Empty state
   if (compensations.length === 0) {
     return (
       <View className="flex-1 items-center justify-center px-6">
@@ -54,19 +96,25 @@ export function CompensationsScreen(_props: Props) {
       className="flex-1 bg-gray-50"
       contentContainerClassName="p-4 gap-3"
       data={compensations}
-      keyExtractor={(item) => item.id}
+      keyExtractor={(item) => item.__identity}
       refreshControl={
-        <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />
+        <RefreshControl refreshing={isFetching && !isLoading} onRefresh={onRefresh} />
       }
-      renderItem={({ item }) => (
-        <View className="bg-white rounded-lg p-4 shadow-sm">
-          <View className="flex-row justify-between items-center">
-            <Text className="text-gray-900 font-medium">{item.game}</Text>
-            <Text className="text-gray-900 font-semibold">CHF {item.amount}</Text>
+      renderItem={({ item }) => {
+        const display = getCompensationDisplay(item);
+
+        return (
+          <View className="bg-white rounded-lg p-4 shadow-sm">
+            <View className="flex-row justify-between items-center">
+              <Text className="text-gray-900 font-medium">{display.game}</Text>
+              <Text className="text-gray-900 font-semibold">CHF {display.amount}</Text>
+            </View>
+            <Text className="text-gray-500 text-sm mt-1">
+              {t(`compensations.${display.status}` as TranslationKey)}
+            </Text>
           </View>
-          <Text className="text-gray-500 text-sm mt-1">{t(`compensations.${item.status}` as TranslationKey)}</Text>
-        </View>
-      )}
+        );
+      }}
     />
   );
 }

--- a/packages/mobile/src/screens/ExchangesScreen.tsx
+++ b/packages/mobile/src/screens/ExchangesScreen.tsx
@@ -1,32 +1,19 @@
 /**
  * Exchanges list screen
  *
- * TODO(#US1): Connect to API client when implemented
+ * Displays available referee exchanges fetched via the shared useExchanges hook.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { View, Text, FlatList, RefreshControl } from 'react-native';
+import { useCallback } from 'react';
+import { View, Text, FlatList, RefreshControl, ActivityIndicator } from 'react-native';
 
 import { useTranslation, type TranslationKey } from '@volleykit/shared/i18n';
+import { useExchanges } from '@volleykit/shared/hooks';
+import type { GameExchange } from '@volleykit/shared/api';
 import type { MainTabScreenProps } from '../navigation/types';
-import { PLACEHOLDER_REFRESH_DELAY_MS } from '../constants';
+import { useApiClient } from '../contexts';
 
 type Props = MainTabScreenProps<'Exchanges'>;
-
-// Placeholder exchange type (matches API exchangeStatusSchema values)
-type PlaceholderExchange = {
-  id: string;
-  game: string;
-  date: string;
-  status: 'open' | 'applied' | 'closed';
-};
-
-// Placeholder data until API client is implemented
-const PLACEHOLDER_EXCHANGES: PlaceholderExchange[] = [
-  { id: '1', game: 'Game A', date: '2026-01-22', status: 'open' },
-  { id: '2', game: 'Game B', date: '2026-01-28', status: 'applied' },
-  { id: '3', game: 'Game C', date: '2026-02-05', status: 'open' },
-];
 
 // Status badge color mappings
 const STATUS_COLORS = {
@@ -35,27 +22,83 @@ const STATUS_COLORS = {
   closed: { bg: 'bg-gray-100', text: 'text-gray-700' },
 } as const;
 
+/**
+ * Format date from ISO string to display format.
+ */
+function formatDate(isoDate: string | null | undefined): string {
+  if (!isoDate) return '';
+  const date = new Date(isoDate);
+  return date.toLocaleDateString('de-CH', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Get display data from an exchange.
+ */
+function getExchangeDisplay(exchange: GameExchange): {
+  id: string;
+  game: string;
+  date: string;
+  venue: string;
+  status: 'open' | 'applied' | 'closed';
+} {
+  const game = exchange.refereeGame?.game;
+  const homeTeam = game?.teamHome?.name ?? 'TBD';
+  const awayTeam = game?.teamAway?.name ?? 'TBD';
+
+  return {
+    id: exchange.__identity,
+    game: `${homeTeam} vs ${awayTeam}`,
+    date: formatDate(game?.startingDateTime),
+    venue: game?.hall?.name ?? '',
+    status: exchange.status,
+  };
+}
+
 export function ExchangesScreen(_props: Props) {
   const { t } = useTranslation();
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const exchanges = PLACEHOLDER_EXCHANGES;
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const apiClient = useApiClient();
 
-  // Cleanup timeout on unmount to prevent memory leaks
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
+  const {
+    data: exchanges = [],
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useExchanges({
+    apiClient,
+    status: 'open',
+  });
 
   const onRefresh = useCallback(() => {
-    setIsRefreshing(true);
-    // TODO(#US1): Replace with TanStack Query refetch when API client is ready
-    timeoutRef.current = setTimeout(() => setIsRefreshing(false), PLACEHOLDER_REFRESH_DELAY_MS);
-  }, []);
+    refetch();
+  }, [refetch]);
 
+  // Loading state
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <View className="flex-1 items-center justify-center px-6">
+        <Text className="text-red-600 text-center">
+          {error?.message ?? t('common.error')}
+        </Text>
+      </View>
+    );
+  }
+
+  // Empty state
   if (exchanges.length === 0) {
     return (
       <View className="flex-1 items-center justify-center px-6">
@@ -69,24 +112,27 @@ export function ExchangesScreen(_props: Props) {
       className="flex-1 bg-gray-50"
       contentContainerClassName="p-4 gap-3"
       data={exchanges}
-      keyExtractor={(item) => item.id}
+      keyExtractor={(item) => item.__identity}
       refreshControl={
-        <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />
+        <RefreshControl refreshing={isFetching && !isLoading} onRefresh={onRefresh} />
       }
       renderItem={({ item }) => {
-        const colors = STATUS_COLORS[item.status];
+        const display = getExchangeDisplay(item);
+        const colors = STATUS_COLORS[display.status];
 
         return (
           <View className="bg-white rounded-lg p-4 shadow-sm">
             <View className="flex-row justify-between items-center">
-              <Text className="text-gray-900 font-medium">{item.game}</Text>
+              <Text className="text-gray-900 font-medium">{display.game}</Text>
               <View className={`px-2 py-1 rounded ${colors.bg}`}>
                 <Text className={`text-xs font-medium ${colors.text}`}>
-                  {t(`exchange.${item.status}` as TranslationKey)}
+                  {t(`exchange.${display.status}` as TranslationKey)}
                 </Text>
               </View>
             </View>
-            <Text className="text-gray-500 text-sm mt-1">{item.date}</Text>
+            <Text className="text-gray-500 text-sm mt-1">
+              {display.date}{display.venue ? ` - ${display.venue}` : ''}
+            </Text>
           </View>
         );
       }}

--- a/packages/mobile/src/utils/date.ts
+++ b/packages/mobile/src/utils/date.ts
@@ -1,0 +1,34 @@
+/**
+ * Date formatting utilities for mobile app.
+ */
+
+/**
+ * Locale mapping from i18n language codes to locale identifiers.
+ */
+const LOCALE_MAP: Record<string, string> = {
+  de: 'de-CH',
+  en: 'en-GB',
+  fr: 'fr-CH',
+  it: 'it-CH',
+};
+
+/**
+ * Format an ISO date string to a localized display format.
+ *
+ * @param isoDate - ISO date string or null/undefined
+ * @param locale - i18n locale code (de, en, fr, it)
+ * @returns Formatted date string or empty string if no date
+ */
+export function formatDate(
+  isoDate: string | null | undefined,
+  locale: string = 'de'
+): string {
+  if (!isoDate) return '';
+  const date = new Date(isoDate);
+  const localeId = LOCALE_MAP[locale] ?? LOCALE_MAP['de'];
+  return date.toLocaleDateString(localeId, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}

--- a/packages/mobile/src/utils/index.ts
+++ b/packages/mobile/src/utils/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './calendar';
+export * from './date';


### PR DESCRIPTION
## Summary

- Create mobile API client with mock data for development
- Add ApiClientContext to provide API client to components
- Update AssignmentsScreen to use shared useAssignments hook
- Update ExchangesScreen to use shared useExchanges hook
- Update CompensationsScreen to use shared useCompensations hook
- Implement proper loading, error, and empty states
- Use TanStack Query refetch for pull-to-refresh

## Test plan

- [ ] Verify AssignmentsScreen loads and displays mock data
- [ ] Verify ExchangesScreen loads and displays mock data
- [ ] Verify CompensationsScreen loads and displays mock data
- [ ] Verify pull-to-refresh works on all screens
- [ ] Verify loading states display correctly
- [ ] Verify empty states display when no data
- [ ] Verify TypeScript compiles without errors
- [ ] Verify ESLint passes without warnings