### PR TITLE
fix(ci): optimize session-start hook for fast resume after timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ result
 # Claude Code (track settings.json, ignore local settings and state)
 .claude/settings.local.json
 .claude/.state/
+.claude/.install-marker
 
 # Cloudflare
 .wrangler/


### PR DESCRIPTION
## Summary

Optimizes the Claude Code session-start hook to skip redundant work when a session resumes after timeout:

- **Dependency caching**: Skip `npm install` if `package-lock.json` hash matches stored marker file
- **API type caching**: Skip generation if output files are newer than OpenAPI spec
- **Marker cleanup**: Delete stale marker before install to ensure retry on failure

## Performance

| Scenario | Before | After |
|----------|--------|-------|
| First run | ~45s | ~45s |
| Session resume | ~45s | **<1s** |

## Changes

- `.claude/hooks/session-start.sh`: Add freshness checks and caching logic
- `.gitignore`: Exclude `.claude/.install-marker` from version control

## Test plan

- [x] Tested first run - installs dependencies and creates marker file
- [x] Tested resume scenario - skips install and API generation  
- [x] Verified shell script syntax with `bash -n`
- [x] Addressed review feedback (removed parallel installs, added marker cleanup)