### PR TITLE
fix(mobile): implement auth login resolving TODO #47

### DIFF
--- a/packages/mobile/src/navigation/RootNavigator.tsx
+++ b/packages/mobile/src/navigation/RootNavigator.tsx
@@ -11,6 +11,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useAuth } from '@volleykit/shared/hooks';
 import { useTranslation } from '@volleykit/shared/i18n';
 
+import { login } from '../services/authService';
 import { LoginScreen } from '../screens/LoginScreen';
 import { LoadingScreen } from '../screens/LoadingScreen';
 import { AssignmentDetailScreen } from '../screens/AssignmentDetailScreen';
@@ -75,11 +76,19 @@ export function RootNavigator() {
     const result = await authenticate(t('auth.biometricPrompt'));
 
     if (result.success && result.credentials) {
-      // Biometric verified - credentials retrieved successfully
-      // TODO(#47): Implement actual re-login with credentials when auth API is ready
-      // For now, just mark the session as refreshed
-      handleBiometricSuccess();
-      resetAttempts();
+      // Biometric verified - credentials retrieved, now re-login
+      const loginResult = await login(
+        result.credentials.username,
+        result.credentials.password,
+        false // Don't save credentials again
+      );
+
+      if (loginResult.success) {
+        handleBiometricSuccess();
+        resetAttempts();
+      }
+      // If login fails, the biometric prompt will remain visible
+      // and failedAttempts will increment, eventually falling back to password
     }
   }, [authenticate, handleBiometricSuccess, resetAttempts, t]);
 

--- a/packages/mobile/src/screens/LoginScreen.tsx
+++ b/packages/mobile/src/screens/LoginScreen.tsx
@@ -11,6 +11,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 import { useTranslation } from '@volleykit/shared/i18n';
 import { useBiometricAuth } from '../hooks/useBiometricAuth';
+import { login } from '../services/authService';
 import { COLORS } from '../constants';
 import type { RootStackScreenProps } from '../navigation/types';
 
@@ -94,8 +95,21 @@ export function LoginScreen(_props: Props) {
     setError(null);
 
     try {
-      // TODO(#47): Implement login logic in Phase 3
-      // Login will be implemented when auth integration is complete
+      const result = await login(username, password);
+
+      if (!result.success) {
+        // Handle specific error messages
+        if (result.lockedUntil) {
+          setError(t('auth.accountLocked'));
+        } else if (result.error.includes('Two-factor')) {
+          setError(t('auth.tfaNotSupported'));
+        } else if (result.error.includes('No referee role')) {
+          setError(t('auth.noRefereeRole'));
+        } else {
+          setError(t('auth.invalidCredentials'));
+        }
+      }
+      // On success, the auth store is updated and navigation will happen automatically
     } catch {
       setError(t('auth.loginFailed'));
     } finally {

--- a/packages/mobile/src/services/authService.ts
+++ b/packages/mobile/src/services/authService.ts
@@ -1,0 +1,272 @@
+/**
+ * Mobile authentication service.
+ *
+ * Wraps the shared auth service with mobile-specific functionality:
+ * - Secure credential storage for biometric login
+ * - Integration with the shared auth store
+ * - Mobile-specific session handling
+ */
+
+import { createAuthService, type LoginResult } from '@volleykit/shared/auth';
+import { useAuthStore } from '@volleykit/shared/stores';
+import { secureStorage } from '../platform/secureStorage';
+
+// API base URL - uses the same CORS proxy as web
+// In production, this would be configured via environment variables
+const API_BASE_URL = 'https://proxy.volleykit.app';
+
+// Session token storage (in-memory for now, could use AsyncStorage)
+let sessionToken: string | null = null;
+
+/**
+ * Get session headers for API requests.
+ */
+function getSessionHeaders(): Record<string, string> {
+  return sessionToken ? { 'X-Session-Token': sessionToken } : {};
+}
+
+/**
+ * Capture session token from response headers.
+ */
+function captureSessionToken(response: Response): void {
+  const token = response.headers.get('X-Session-Token');
+  if (token) {
+    sessionToken = token;
+  }
+}
+
+/**
+ * Clear the session token.
+ */
+export function clearSessionToken(): void {
+  sessionToken = null;
+}
+
+/**
+ * Simple logger for auth operations.
+ */
+const logger = {
+  info: (...args: unknown[]) => {
+    if (__DEV__) {
+      console.log('[Auth]', ...args);
+    }
+  },
+  warn: (...args: unknown[]) => {
+    if (__DEV__) {
+      console.warn('[Auth]', ...args);
+    }
+  },
+  error: (...args: unknown[]) => {
+    console.error('[Auth]', ...args);
+  },
+};
+
+/**
+ * Create the auth service instance.
+ */
+const authService = createAuthService({
+  apiBaseUrl: API_BASE_URL,
+  getSessionHeaders,
+  captureSessionToken,
+  logger,
+});
+
+/**
+ * Login with username and password.
+ *
+ * On success:
+ * - Updates the shared auth store
+ * - Stores credentials securely for biometric login (if enabled)
+ *
+ * @param username - SwissVolley username
+ * @param password - Password
+ * @param saveCredentials - Whether to save credentials for biometric login
+ * @returns Login result
+ */
+export async function login(
+  username: string,
+  password: string,
+  saveCredentials = true
+): Promise<LoginResult> {
+  const store = useAuthStore.getState();
+
+  // Set loading state
+  store.setStatus('loading');
+  store.setError(null);
+
+  try {
+    const result = await authService.login(username, password);
+
+    if (result.success) {
+      // Extract user data from dashboard HTML
+      const activeParty = authService.extractActivePartyFromHtml(result.dashboardHtml);
+      const { user, activeOccupationId } = authService.deriveUserFromActiveParty(
+        activeParty,
+        store.user,
+        store.activeOccupationId
+      );
+
+      // Check if user has referee role
+      if (user.occupations.length === 0) {
+        // Logout from server
+        await authService.logout();
+        clearSessionToken();
+
+        store.setError({
+          message: 'No referee role found. This app is for referees only.',
+          code: 'invalid_credentials',
+        });
+        store.setStatus('error');
+
+        return { success: false, error: 'No referee role found' };
+      }
+
+      // Update auth store
+      store.setUser(user);
+      if (activeOccupationId) {
+        store.setActiveOccupation(activeOccupationId);
+      }
+      store.setDataSource('api');
+
+      // Save credentials for biometric login
+      if (saveCredentials) {
+        try {
+          await secureStorage.setCredentials(username, password);
+          logger.info('Credentials saved for biometric login');
+        } catch (error) {
+          logger.warn('Failed to save credentials:', error);
+          // Don't fail login if credential storage fails
+        }
+      }
+
+      return result;
+    }
+
+    // Handle login failure
+    store.setError({
+      message: result.error,
+      code: result.lockedUntil ? 'locked' : 'invalid_credentials',
+      lockedUntilSeconds: result.lockedUntil,
+    });
+    store.setStatus('error');
+
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Login failed';
+    logger.error('Login error:', error);
+
+    store.setError({
+      message,
+      code: 'network_error',
+    });
+    store.setStatus('error');
+
+    return { success: false, error: message };
+  }
+}
+
+/**
+ * Logout from the current session.
+ */
+export async function logout(): Promise<void> {
+  const store = useAuthStore.getState();
+
+  try {
+    await authService.logout();
+  } catch (error) {
+    logger.error('Logout error:', error);
+  }
+
+  // Clear session token
+  clearSessionToken();
+
+  // Clear auth store
+  store.logout();
+}
+
+/**
+ * Check if the current session is valid.
+ *
+ * @returns True if session is valid
+ */
+export async function checkSession(): Promise<boolean> {
+  const store = useAuthStore.getState();
+
+  // Skip check for demo/calendar modes
+  if (store.dataSource !== 'api') {
+    return true;
+  }
+
+  try {
+    const result = await authService.checkSession();
+
+    if (result.valid && result.activeParty) {
+      // Update user data from active party
+      const { user, activeOccupationId } = authService.deriveUserFromActiveParty(
+        result.activeParty,
+        store.user,
+        store.activeOccupationId
+      );
+
+      store.setUser(user);
+      if (activeOccupationId) {
+        store.setActiveOccupation(activeOccupationId);
+      }
+
+      return true;
+    }
+
+    // Session invalid - clear auth state
+    store.logout();
+    clearSessionToken();
+
+    return false;
+  } catch (error) {
+    logger.error('Session check error:', error);
+    return false;
+  }
+}
+
+/**
+ * Re-login with stored credentials (for biometric login).
+ *
+ * @returns True if re-login succeeded
+ */
+export async function reloginWithStoredCredentials(): Promise<boolean> {
+  try {
+    const credentials = await secureStorage.getCredentials();
+    if (!credentials) {
+      logger.info('No stored credentials for re-login');
+      return false;
+    }
+
+    const result = await login(credentials.username, credentials.password, false);
+    return result.success;
+  } catch (error) {
+    logger.error('Re-login error:', error);
+    return false;
+  }
+}
+
+/**
+ * Clear stored credentials.
+ */
+export async function clearStoredCredentials(): Promise<void> {
+  try {
+    await secureStorage.clearCredentials();
+    logger.info('Stored credentials cleared');
+  } catch (error) {
+    logger.warn('Failed to clear credentials:', error);
+  }
+}
+
+/**
+ * Check if stored credentials exist.
+ */
+export async function hasStoredCredentials(): Promise<boolean> {
+  try {
+    return await secureStorage.hasCredentials();
+  } catch {
+    return false;
+  }
+}

--- a/packages/mobile/src/services/index.ts
+++ b/packages/mobile/src/services/index.ts
@@ -2,4 +2,5 @@
  * Mobile app services
  */
 
+export * from './authService';
 export * from './calendarSync';

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Authentication module.
+ *
+ * Platform-agnostic authentication utilities used by both web and mobile.
+ */
+
+// Types
+export type {
+  LoginFormFields,
+  LoginResult,
+  ActiveParty,
+  AttributeValue,
+  InflatedAssociationValue,
+  RoleDefinition,
+  AuthServiceConfig,
+} from './types';
+
+export { HTTP_STATUS, AUTH_ENDPOINTS } from './types';
+
+// Parsers
+export {
+  extractLoginFormFields,
+  extractCsrfTokenFromPage,
+  extractActivePartyFromHtml,
+  isDashboardHtmlContent,
+  isLoginPageHtmlContent,
+  isInflatedObject,
+  deriveAssociationCodeFromName,
+  parseOccupationFromActiveParty,
+  parseOccupationsFromActiveParty,
+  filterRefereeAssociations,
+  hasMultipleAssociations,
+  analyzeAuthResponseHtml,
+} from './parsers';
+
+// Service
+export { createAuthService, type AuthService } from './service';

--- a/packages/shared/src/auth/parsers.ts
+++ b/packages/shared/src/auth/parsers.ts
@@ -104,14 +104,17 @@ const ACTIVE_PARTY_PATTERN =
 
 /**
  * Regex pattern for Vue :active-party attribute.
+ * Uses [^"]* instead of .+? to avoid catastrophic backtracking (ReDoS).
+ * The JSON content is HTML-encoded so won't contain unescaped double quotes.
  */
 const VUE_ACTIVE_PARTY_PATTERN =
-  /:active-party="\$convertFromBackendToFrontend\((\{.+?\})\)"/gs;
+  /:active-party="\$convertFromBackendToFrontend\((\{[^"]*\})\)"/g;
 
 /**
  * Regex pattern for Vue :party attribute.
+ * Uses [^"]* instead of .+? to avoid catastrophic backtracking (ReDoS).
  */
-const VUE_PARTY_PATTERN = /:party="\$convertFromBackendToFrontend\((\{.+?\})\)"/gs;
+const VUE_PARTY_PATTERN = /:party="\$convertFromBackendToFrontend\((\{[^"]*\})\)"/g;
 
 /**
  * Decode HTML entities in a string.

--- a/packages/shared/src/auth/parsers.ts
+++ b/packages/shared/src/auth/parsers.ts
@@ -1,0 +1,393 @@
+/**
+ * Authentication HTML parsing utilities.
+ *
+ * Platform-agnostic utilities for extracting data from Neos Flow login pages.
+ * Works in both browser (DOMParser) and React Native (regex fallback) environments.
+ */
+
+import type {
+  LoginFormFields,
+  ActiveParty,
+  AttributeValue,
+  InflatedAssociationValue,
+} from './types';
+import type { Occupation } from '../stores/auth';
+
+// ============================================================================
+// HTML Parsing - Login Form Fields
+// ============================================================================
+
+/**
+ * Extract required form fields from login page HTML.
+ * The Neos Flow framework uses __trustedProperties for CSRF protection.
+ *
+ * Uses regex for React Native compatibility (no DOMParser).
+ */
+export function extractLoginFormFields(html: string): LoginFormFields | null {
+  try {
+    // Extract trustedProperties (required)
+    const trustedPropsMatch = html.match(
+      /name="__trustedProperties"\s+value="([^"]*)"/
+    );
+    if (!trustedPropsMatch?.[1]) {
+      return null;
+    }
+
+    // Extract referrer fields with defaults
+    const getFieldValue = (name: string, defaultValue: string): string => {
+      const regex = new RegExp(`name="${name}"\\s+value="([^"]*)"`, 'i');
+      const match = html.match(regex);
+      return match?.[1] ?? defaultValue;
+    };
+
+    return {
+      trustedProperties: trustedPropsMatch[1],
+      referrerPackage: getFieldValue('__referrer[@package]', 'SportManager.Volleyball'),
+      referrerSubpackage: getFieldValue('__referrer[@subpackage]', ''),
+      referrerController: getFieldValue('__referrer[@controller]', 'Public'),
+      referrerAction: getFieldValue('__referrer[@action]', 'login'),
+      referrerArguments: getFieldValue('__referrer[arguments]', ''),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract CSRF token from authenticated page HTML.
+ * After login, the dashboard HTML contains data-csrf-token attribute.
+ */
+export function extractCsrfTokenFromPage(html: string): string | null {
+  try {
+    const match = html.match(/data-csrf-token="([^"]*)"/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks if HTML content represents the dashboard page.
+ * Used to detect successful login.
+ */
+export function isDashboardHtmlContent(html: string): boolean {
+  const hasCsrfToken = html.includes('data-csrf-token');
+  const hasLoginForm =
+    html.includes('action="/login"') ||
+    (html.includes('id="username"') && html.includes('id="password"'));
+
+  return hasCsrfToken && !hasLoginForm;
+}
+
+/**
+ * Checks if HTML content represents a login page.
+ */
+export function isLoginPageHtmlContent(html: string): boolean {
+  const hasLoginFormIndicators =
+    html.includes('action="/login"') ||
+    (html.includes('id="username"') && html.includes('id="password"'));
+
+  const hasDashboardIndicators = isDashboardHtmlContent(html);
+
+  return hasLoginFormIndicators && !hasDashboardIndicators;
+}
+
+// ============================================================================
+// HTML Parsing - Active Party
+// ============================================================================
+
+/**
+ * Regex pattern to match window.activeParty = JSON.parse('...') in HTML.
+ */
+const ACTIVE_PARTY_PATTERN =
+  /window\.activeParty\s*=\s*JSON\.parse\s*\(\s*'((?:[^'\\]|\\.)*)'\s*\)/;
+
+/**
+ * Regex pattern for Vue :active-party attribute.
+ */
+const VUE_ACTIVE_PARTY_PATTERN =
+  /:active-party="\$convertFromBackendToFrontend\((\{.+?\})\)"/gs;
+
+/**
+ * Regex pattern for Vue :party attribute.
+ */
+const VUE_PARTY_PATTERN = /:party="\$convertFromBackendToFrontend\((\{.+?\})\)"/gs;
+
+/**
+ * Decode HTML entities in a string.
+ */
+function decodeHtmlEntities(str: string): string {
+  const entities: Record<string, string> = {
+    '&quot;': '"',
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&apos;': "'",
+    '&#39;': "'",
+    '&#x27;': "'",
+    '&#34;': '"',
+    '&#x22;': '"',
+  };
+
+  let decoded = str;
+  for (const [entity, char] of Object.entries(entities)) {
+    decoded = decoded.split(entity).join(char);
+  }
+
+  return decoded;
+}
+
+/**
+ * Check if a parsed object looks like valid activeParty data.
+ */
+function looksLikeActiveParty(parsed: unknown): parsed is Record<string, unknown> {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return false;
+  }
+  const obj = parsed as Record<string, unknown>;
+  return (
+    'eligibleAttributeValues' in obj ||
+    'groupedEligibleAttributeValues' in obj ||
+    'eligibleRoles' in obj ||
+    'activeRoleIdentifier' in obj ||
+    'activeAttributeValue' in obj
+  );
+}
+
+/**
+ * Extract the activeParty JSON data from HTML page content.
+ *
+ * Supports multiple formats:
+ * 1. Script tag: window.activeParty = JSON.parse('...')
+ * 2. Vue :active-party attribute
+ * 3. Vue :party attribute
+ */
+export function extractActivePartyFromHtml(html: string): ActiveParty | null {
+  if (!html) {
+    return null;
+  }
+
+  try {
+    // Try the script tag pattern first (legacy format)
+    const scriptMatch = ACTIVE_PARTY_PATTERN.exec(html);
+    if (scriptMatch?.[1]) {
+      const decodedJson = decodeHtmlEntities(scriptMatch[1]);
+      const parsed = JSON.parse(decodedJson) as unknown;
+      if (looksLikeActiveParty(parsed)) {
+        return parsed as ActiveParty;
+      }
+    }
+
+    // Try the Vue :active-party pattern
+    VUE_ACTIVE_PARTY_PATTERN.lastIndex = 0;
+    let vueMatch: RegExpExecArray | null;
+
+    while ((vueMatch = VUE_ACTIVE_PARTY_PATTERN.exec(html)) !== null) {
+      const encodedJson = vueMatch[1];
+      if (!encodedJson) continue;
+
+      try {
+        const decodedJson = decodeHtmlEntities(encodedJson);
+        const parsed = JSON.parse(decodedJson) as unknown;
+
+        if (looksLikeActiveParty(parsed)) {
+          return parsed as ActiveParty;
+        }
+      } catch {
+        // Continue to next match
+      }
+    }
+
+    // Try the Vue :party pattern
+    VUE_PARTY_PATTERN.lastIndex = 0;
+
+    while ((vueMatch = VUE_PARTY_PATTERN.exec(html)) !== null) {
+      const encodedJson = vueMatch[1];
+      if (!encodedJson) continue;
+
+      try {
+        const decodedJson = decodeHtmlEntities(encodedJson);
+        const parsed = JSON.parse(decodedJson) as unknown;
+
+        if (looksLikeActiveParty(parsed)) {
+          return parsed as ActiveParty;
+        }
+      } catch {
+        // Continue to next match
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Occupation Parsing
+// ============================================================================
+
+/** Role identifier for referee role in the VolleyManager system */
+const REFEREE_ROLE_IDENTIFIER = 'Indoorvolleyball.RefAdmin:Referee';
+
+/** Type suffix for association memberships */
+const ASSOCIATION_TYPE_SUFFIX = 'AbstractAssociation';
+
+/**
+ * Role identifier patterns from the VolleyManager API.
+ */
+const ROLE_PATTERNS = {
+  referee: /:Referee$/,
+  player: /:Player$/,
+  clubAdmin: /:ClubAdmin$/,
+  associationAdmin: /:AssociationAdmin$/,
+} as const;
+
+/**
+ * Type guard to check if inflatedValue is an object.
+ */
+export function isInflatedObject(
+  value: InflatedAssociationValue | boolean | null | string | number | undefined
+): value is InflatedAssociationValue {
+  return value !== null && typeof value === 'object';
+}
+
+/**
+ * Words to exclude when deriving association code from name.
+ */
+const EXCLUDED_WORDS = new Set(['de', 'du', 'des', 'la', 'le', 'les', 'et', 'und', 'of', 'the']);
+
+/**
+ * Derives an association code from the full name by extracting first letters.
+ */
+export function deriveAssociationCodeFromName(name: string | undefined): string | undefined {
+  if (!name) {
+    return undefined;
+  }
+
+  const words = name.split(/\s+/);
+  const initials = words
+    .filter((word) => !EXCLUDED_WORDS.has(word.toLowerCase()))
+    .map((word) => word.charAt(0).toUpperCase())
+    .join('');
+
+  return initials || undefined;
+}
+
+/**
+ * Parses an ActiveParty AttributeValue into an Occupation with association code.
+ */
+export function parseOccupationFromActiveParty(attr: AttributeValue): Occupation | null {
+  const roleIdentifier = attr.roleIdentifier;
+  if (!roleIdentifier || !attr.__identity) {
+    return null;
+  }
+
+  // Only parse referee roles
+  if (!ROLE_PATTERNS.referee.test(roleIdentifier)) {
+    return null;
+  }
+
+  // Extract association code: prefer shortName, fall back to derived from name
+  const inflated = isInflatedObject(attr.inflatedValue) ? attr.inflatedValue : undefined;
+  const associationCode = inflated?.shortName ?? deriveAssociationCodeFromName(inflated?.name);
+
+  return {
+    id: attr.__identity,
+    type: 'referee',
+    associationCode,
+  };
+}
+
+/**
+ * Parses groupedEligibleAttributeValues from activeParty HTML data
+ * into an array of referee Occupations with association codes.
+ */
+export function parseOccupationsFromActiveParty(
+  attributeValues: AttributeValue[] | null | undefined
+): Occupation[] {
+  if (!attributeValues || attributeValues.length === 0) {
+    return [];
+  }
+
+  const occupations = attributeValues
+    .map((attr) => parseOccupationFromActiveParty(attr))
+    .filter((occ): occ is Occupation => occ !== null);
+
+  // Deduplicate by association code
+  const seen = new Set<string>();
+  return occupations.filter((occ) => {
+    const key = occ.associationCode ?? occ.id;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Filter attribute values to only include referee association memberships.
+ */
+export function filterRefereeAssociations(
+  attributeValues: AttributeValue[] | null | undefined
+): AttributeValue[] {
+  if (!attributeValues) {
+    return [];
+  }
+
+  return attributeValues.filter(
+    (av) =>
+      av.roleIdentifier === REFEREE_ROLE_IDENTIFIER && av.type?.includes(ASSOCIATION_TYPE_SUFFIX)
+  );
+}
+
+/**
+ * Check if a user has access to multiple associations.
+ */
+export function hasMultipleAssociations(
+  attributeValues: AttributeValue[] | null | undefined
+): boolean {
+  const refereeAssociations = filterRefereeAssociations(attributeValues);
+
+  const uniqueAssociations = new Set(
+    refereeAssociations
+      .map((av) => (isInflatedObject(av.inflatedValue) ? av.inflatedValue.__identity : undefined))
+      .filter(Boolean)
+  );
+
+  return uniqueAssociations.size > 1;
+}
+
+// ============================================================================
+// Login Response Analysis
+// ============================================================================
+
+/**
+ * HTML patterns that indicate authentication failure.
+ */
+const AUTH_ERROR_INDICATORS = ['color="error"', "color='error'"] as const;
+
+/**
+ * HTML patterns that indicate Two-Factor Authentication is required.
+ */
+const TFA_PAGE_INDICATORS = [
+  'secondFactorToken',
+  'SecondFactor',
+  'TwoFactorAuthentication',
+  'totp',
+  'TOTP',
+] as const;
+
+/**
+ * Analyzes HTML content to determine if it contains auth errors or TFA.
+ */
+export function analyzeAuthResponseHtml(html: string): {
+  hasAuthError: boolean;
+  hasTfaPage: boolean;
+} {
+  const hasAuthError = AUTH_ERROR_INDICATORS.some((indicator) => html.includes(indicator));
+  const hasTfaPage = TFA_PAGE_INDICATORS.some((indicator) => html.includes(indicator));
+
+  return { hasAuthError, hasTfaPage };
+}

--- a/packages/shared/src/auth/service.ts
+++ b/packages/shared/src/auth/service.ts
@@ -17,8 +17,8 @@ import {
 } from './parsers';
 import type { UserProfile, Occupation } from '../stores/auth';
 
-/** Delay in ms to allow browser to process Set-Cookie headers */
-const COOKIE_PROCESSING_DELAY_MS = 100;
+/** Default delay in ms to allow browser to process Set-Cookie headers */
+const DEFAULT_COOKIE_PROCESSING_DELAY_MS = 100;
 
 /**
  * Default logger that does nothing.
@@ -40,6 +40,7 @@ export function createAuthService(config: AuthServiceConfig) {
     apiBaseUrl,
     getSessionHeaders = () => ({}),
     captureSessionToken = () => {},
+    cookieProcessingDelayMs = DEFAULT_COOKIE_PROCESSING_DELAY_MS,
     logger = noopLogger,
   } = config;
 
@@ -105,8 +106,8 @@ export function createAuthService(config: AuthServiceConfig) {
    * Fetch the dashboard after successful login.
    */
   async function fetchDashboard(): Promise<{ html: string; csrfToken: string | null }> {
-    // Small delay to allow cookie processing
-    await new Promise((resolve) => setTimeout(resolve, COOKIE_PROCESSING_DELAY_MS));
+    // Small delay to allow cookie processing (configurable via cookieProcessingDelayMs)
+    await new Promise((resolve) => setTimeout(resolve, cookieProcessingDelayMs));
 
     const response = await fetch(DASHBOARD_URL, {
       credentials: 'include',

--- a/packages/shared/src/auth/service.ts
+++ b/packages/shared/src/auth/service.ts
@@ -1,0 +1,433 @@
+/**
+ * Authentication service.
+ *
+ * Platform-agnostic authentication service that handles login flow.
+ * Used by both web and mobile applications.
+ */
+
+import type { LoginFormFields, LoginResult, AuthServiceConfig, ActiveParty } from './types';
+import { HTTP_STATUS, AUTH_ENDPOINTS } from './types';
+import {
+  extractLoginFormFields,
+  extractCsrfTokenFromPage,
+  extractActivePartyFromHtml,
+  isDashboardHtmlContent,
+  analyzeAuthResponseHtml,
+  parseOccupationsFromActiveParty,
+} from './parsers';
+import type { UserProfile, Occupation } from '../stores/auth';
+
+/** Delay in ms to allow browser to process Set-Cookie headers */
+const COOKIE_PROCESSING_DELAY_MS = 100;
+
+/**
+ * Default logger that does nothing.
+ */
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/**
+ * Creates an authentication service instance.
+ *
+ * @param config - Configuration for the auth service
+ * @returns Auth service methods
+ */
+export function createAuthService(config: AuthServiceConfig) {
+  const {
+    apiBaseUrl,
+    getSessionHeaders = () => ({}),
+    captureSessionToken = () => {},
+    logger = noopLogger,
+  } = config;
+
+  const LOGIN_PAGE_URL = `${apiBaseUrl}${AUTH_ENDPOINTS.LOGIN_PAGE}`;
+  const AUTH_URL = `${apiBaseUrl}${AUTH_ENDPOINTS.AUTHENTICATE}`;
+  const LOGOUT_URL = `${apiBaseUrl}${AUTH_ENDPOINTS.LOGOUT}`;
+  const DASHBOARD_URL = `${apiBaseUrl}${AUTH_ENDPOINTS.DASHBOARD}`;
+
+  /**
+   * Build form data for login submission.
+   */
+  function buildLoginFormData(
+    username: string,
+    password: string,
+    formFields: LoginFormFields
+  ): URLSearchParams {
+    const formData = new URLSearchParams();
+
+    // Add referrer fields (required by Neos Flow)
+    formData.append('__referrer[@package]', formFields.referrerPackage);
+    formData.append('__referrer[@subpackage]', formFields.referrerSubpackage);
+    formData.append('__referrer[@controller]', formFields.referrerController);
+    formData.append('__referrer[@action]', formFields.referrerAction);
+    formData.append('__referrer[arguments]', formFields.referrerArguments);
+
+    // Add CSRF protection token
+    formData.append('__trustedProperties', formFields.trustedProperties);
+
+    // Add credentials with Neos Flow authentication token format
+    formData.append(
+      '__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]',
+      username
+    );
+    formData.append(
+      '__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]',
+      password
+    );
+
+    return formData;
+  }
+
+  /**
+   * Fetch the login page to get form fields.
+   */
+  async function fetchLoginPage(): Promise<{ html: string; response: Response }> {
+    const response = await fetch(LOGIN_PAGE_URL, {
+      credentials: 'include',
+      cache: 'no-store',
+      headers: getSessionHeaders(),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to load login page');
+    }
+
+    captureSessionToken(response);
+    const html = await response.text();
+
+    return { html, response };
+  }
+
+  /**
+   * Fetch the dashboard after successful login.
+   */
+  async function fetchDashboard(): Promise<{ html: string; csrfToken: string | null }> {
+    // Small delay to allow cookie processing
+    await new Promise((resolve) => setTimeout(resolve, COOKIE_PROCESSING_DELAY_MS));
+
+    const response = await fetch(DASHBOARD_URL, {
+      credentials: 'include',
+      cache: 'no-store',
+      redirect: 'follow',
+      headers: getSessionHeaders(),
+    });
+
+    captureSessionToken(response);
+
+    if (!response.ok) {
+      throw new Error('Failed to load dashboard');
+    }
+
+    const html = await response.text();
+    const csrfToken = extractCsrfTokenFromPage(html);
+
+    return { html, csrfToken };
+  }
+
+  /**
+   * Submit login credentials and handle the response.
+   */
+  async function submitCredentials(
+    username: string,
+    password: string,
+    formFields: LoginFormFields
+  ): Promise<LoginResult> {
+    const formData = buildLoginFormData(username, password, formFields);
+
+    const response = await fetch(AUTH_URL, {
+      method: 'POST',
+      credentials: 'include',
+      redirect: 'manual',
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...getSessionHeaders(),
+      },
+      body: formData,
+    });
+
+    captureSessionToken(response);
+
+    // Handle lockout response
+    if (response.status === HTTP_STATUS.LOCKED) {
+      try {
+        const lockoutData = (await response.json()) as {
+          lockedUntil?: number;
+          message?: string;
+        };
+        return {
+          success: false,
+          error: lockoutData.message ?? 'Account temporarily locked',
+          lockedUntil: lockoutData.lockedUntil,
+        };
+      } catch {
+        return {
+          success: false,
+          error: 'Account temporarily locked due to too many failed attempts',
+        };
+      }
+    }
+
+    logger.info('Auth response received', {
+      status: response.status,
+      type: response.type,
+    });
+
+    // Handle JSON response from proxy (iOS Safari PWA fix)
+    const contentType = response.headers.get('Content-Type');
+    if (response.status === HTTP_STATUS.OK && contentType?.includes('application/json')) {
+      try {
+        const jsonResponse = (await response.json()) as {
+          success?: boolean;
+          redirectUrl?: string;
+        };
+
+        if (jsonResponse.redirectUrl && jsonResponse.success) {
+          // Successful login - fetch dashboard for CSRF token
+          const { html, csrfToken } = await fetchDashboard();
+          if (csrfToken) {
+            return { success: true, csrfToken, dashboardHtml: html };
+          }
+          return { success: false, error: 'Login succeeded but session could not be established' };
+        }
+
+        if (jsonResponse.redirectUrl && !jsonResponse.success) {
+          return { success: false, error: 'Invalid username or password' };
+        }
+      } catch {
+        // Not valid JSON, continue with other handling
+      }
+    }
+
+    // Check for redirect response (303 = successful login)
+    const isRedirectResponse =
+      response.status >= HTTP_STATUS.REDIRECT_MIN &&
+      response.status < HTTP_STATUS.REDIRECT_MAX &&
+      response.type !== 'opaqueredirect';
+
+    const locationHeader = response.headers.get('Location');
+    const isRedirectToDashboard =
+      isRedirectResponse &&
+      locationHeader !== null &&
+      locationHeader.includes(AUTH_ENDPOINTS.DASHBOARD);
+
+    // Handle opaqueredirect
+    if (response.type === 'opaqueredirect') {
+      logger.info('Got opaqueredirect response, assuming successful login...');
+      try {
+        const { html, csrfToken } = await fetchDashboard();
+        if (csrfToken) {
+          return { success: true, csrfToken, dashboardHtml: html };
+        }
+      } catch {
+        return { success: false, error: 'Login succeeded but could not load dashboard' };
+      }
+    }
+
+    // If redirected to dashboard, fetch it for CSRF token
+    if (isRedirectToDashboard) {
+      logger.info('Login successful (detected from redirect), fetching dashboard...');
+      try {
+        const { html, csrfToken } = await fetchDashboard();
+        if (csrfToken) {
+          return { success: true, csrfToken, dashboardHtml: html };
+        }
+        return { success: false, error: 'Login succeeded but session could not be established' };
+      } catch {
+        return { success: false, error: 'Login succeeded but could not load dashboard' };
+      }
+    }
+
+    // Not a redirect - analyze response HTML
+    if (!response.ok) {
+      return { success: false, error: 'Authentication request failed' };
+    }
+
+    const html = await response.text();
+
+    // Check if this is actually the dashboard (content-based detection)
+    if (isDashboardHtmlContent(html)) {
+      const csrfToken = extractCsrfTokenFromPage(html);
+      if (csrfToken) {
+        return { success: true, csrfToken, dashboardHtml: html };
+      }
+    }
+
+    // Check for errors in HTML
+    const { hasAuthError, hasTfaPage } = analyzeAuthResponseHtml(html);
+
+    if (hasAuthError) {
+      return { success: false, error: 'Invalid username or password' };
+    }
+
+    if (hasTfaPage) {
+      return {
+        success: false,
+        error:
+          'Two-factor authentication is not supported. Please disable it in your VolleyManager account settings.',
+      };
+    }
+
+    return { success: false, error: 'Login failed - please try again' };
+  }
+
+  /**
+   * Main login function.
+   *
+   * @param username - SwissVolley username
+   * @param password - Password
+   * @returns Login result with CSRF token and user data on success
+   */
+  async function login(
+    username: string,
+    password: string
+  ): Promise<LoginResult> {
+    try {
+      // Step 1: Fetch login page to get form fields
+      const { html: loginPageHtml } = await fetchLoginPage();
+
+      // Check if already logged in (login page has CSRF token)
+      const existingCsrfToken = extractCsrfTokenFromPage(loginPageHtml);
+      if (existingCsrfToken) {
+        logger.info('Already logged in, fetching dashboard...');
+        const { html: dashboardHtml, csrfToken } = await fetchDashboard();
+        if (csrfToken) {
+          return { success: true, csrfToken, dashboardHtml };
+        }
+      }
+
+      // Step 2: Extract form fields
+      const formFields = extractLoginFormFields(loginPageHtml);
+      if (!formFields) {
+        return { success: false, error: 'Could not extract form fields from login page' };
+      }
+
+      // Step 3: Submit credentials
+      return await submitCredentials(username, password, formFields);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Login failed';
+      logger.error('Login error:', error);
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Logout from the current session.
+   */
+  async function logout(): Promise<void> {
+    try {
+      await fetch(LOGOUT_URL, {
+        credentials: 'include',
+        redirect: 'manual',
+      });
+    } catch (error) {
+      logger.error('Logout request failed:', error);
+    }
+  }
+
+  /**
+   * Check if the current session is valid.
+   *
+   * @returns True if session is valid, false otherwise
+   */
+  async function checkSession(): Promise<{
+    valid: boolean;
+    csrfToken?: string;
+    activeParty?: ActiveParty | null;
+  }> {
+    try {
+      const response = await fetch(DASHBOARD_URL, {
+        credentials: 'include',
+        redirect: 'follow',
+        cache: 'no-store',
+        headers: getSessionHeaders(),
+      });
+
+      captureSessionToken(response);
+
+      if (!response.ok) {
+        return { valid: false };
+      }
+
+      const html = await response.text();
+
+      // Check if we got the login page instead
+      if (!isDashboardHtmlContent(html)) {
+        return { valid: false };
+      }
+
+      const csrfToken = extractCsrfTokenFromPage(html);
+      const activeParty = extractActivePartyFromHtml(html);
+
+      if (!csrfToken) {
+        return { valid: false };
+      }
+
+      return { valid: true, csrfToken, activeParty };
+    } catch (error) {
+      logger.error('Session check failed:', error);
+      return { valid: false };
+    }
+  }
+
+  /**
+   * Derive user profile from active party data.
+   */
+  function deriveUserFromActiveParty(
+    activeParty: ActiveParty | null,
+    existingUser: UserProfile | null,
+    existingActiveOccupationId: string | null
+  ): { user: UserProfile; activeOccupationId: string | null } {
+    // Use groupedEligibleAttributeValues first, fall back to eligibleAttributeValues
+    const attributeValues = activeParty?.groupedEligibleAttributeValues?.length
+      ? activeParty.groupedEligibleAttributeValues
+      : (activeParty?.eligibleAttributeValues ?? null);
+
+    const parsedOccupations = parseOccupationsFromActiveParty(attributeValues);
+
+    // Preserve existing occupations if parsing returns empty
+    const occupations: Occupation[] =
+      parsedOccupations.length > 0 ? parsedOccupations : (existingUser?.occupations ?? []);
+
+    // Validate that the persisted activeOccupationId exists
+    const isPersistedIdValid =
+      existingActiveOccupationId !== null &&
+      occupations.some((occ) => occ.id === existingActiveOccupationId);
+    const activeOccupationId = isPersistedIdValid
+      ? existingActiveOccupationId
+      : (occupations[0]?.id ?? null);
+
+    // Use the person's __identity from activeParty as the user id
+    const userId = activeParty?.__identity ?? existingUser?.id ?? 'user';
+
+    const user: UserProfile = existingUser
+      ? { ...existingUser, id: userId, occupations }
+      : {
+          id: userId,
+          firstName: '',
+          lastName: '',
+          occupations,
+        };
+
+    return { user, activeOccupationId };
+  }
+
+  return {
+    login,
+    logout,
+    checkSession,
+    fetchLoginPage,
+    fetchDashboard,
+    submitCredentials,
+    deriveUserFromActiveParty,
+    extractActivePartyFromHtml,
+  };
+}
+
+/**
+ * Type for the auth service instance.
+ */
+export type AuthService = ReturnType<typeof createAuthService>;

--- a/packages/shared/src/auth/types.ts
+++ b/packages/shared/src/auth/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared authentication types.
+ *
+ * These types are platform-agnostic and used by both web and mobile.
+ */
+
+/**
+ * Login form fields extracted from the Neos Flow login page HTML.
+ * The framework requires these fields for CSRF protection.
+ */
+export interface LoginFormFields {
+  trustedProperties: string;
+  referrerPackage: string;
+  referrerSubpackage: string;
+  referrerController: string;
+  referrerAction: string;
+  referrerArguments: string;
+}
+
+/**
+ * Result of a login attempt.
+ */
+export type LoginResult =
+  | { success: true; csrfToken: string; dashboardHtml: string }
+  | { success: false; error: string; lockedUntil?: number };
+
+/**
+ * Represents an inflated association value with full details.
+ */
+export interface InflatedAssociationValue {
+  __identity?: string;
+  name?: string;
+  shortName?: string;
+  /** Association identifier code (e.g., "912000" for SVRZ) */
+  identifier?: string;
+  /**
+   * Origin ID to distinguish regional vs national associations.
+   * 0 = national (Swiss Volley), >0 = regional (e.g., 12 for SVRZ)
+   */
+  originId?: number;
+}
+
+/**
+ * Represents an association that a user is a member of.
+ * All fields are optional because the API may return incomplete items.
+ */
+export interface AttributeValue {
+  __identity?: string;
+  attributeIdentifier?: string;
+  roleIdentifier?: string;
+  /**
+   * Domain model type - used to distinguish association memberships from boolean flags.
+   * For associations: "SportManager\\Volleyball\\Domain\\Model\\AbstractAssociation"
+   * For player roles: "boolean"
+   */
+  type?: string;
+  /** UUID reference to the association entity */
+  value?: string;
+  /**
+   * Inflated value containing association details.
+   * Can be an object with association info, or a primitive value (boolean, null, string, number)
+   * for certain attribute types like boolean player flags.
+   */
+  inflatedValue?: InflatedAssociationValue | boolean | null | string | number;
+}
+
+/**
+ * Definition of a role in the VolleyManager system.
+ */
+export interface RoleDefinition {
+  identifier: string;
+  name?: string;
+  packageKey?: string;
+}
+
+/**
+ * The activeParty data embedded in VolleyManager HTML pages.
+ * Contains user context including association memberships and roles.
+ */
+export interface ActiveParty {
+  __identity?: string;
+  eligibleAttributeValues?: AttributeValue[];
+  eligibleRoles?: Record<string, RoleDefinition>;
+  activeAttributeValue?: AttributeValue;
+  activeRoleIdentifier?: string;
+  groupedEligibleAttributeValues?: AttributeValue[];
+}
+
+/**
+ * Configuration for the auth service.
+ */
+export interface AuthServiceConfig {
+  /** Base URL for API requests (e.g., proxy URL) */
+  apiBaseUrl: string;
+  /** Function to get session headers (e.g., X-Session-Token) */
+  getSessionHeaders?: () => Record<string, string>;
+  /** Function to capture session token from response */
+  captureSessionToken?: (response: Response) => void;
+  /** Logger for debug output */
+  logger?: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+}
+
+/**
+ * HTTP status codes used in auth flow.
+ */
+export const HTTP_STATUS = {
+  OK: 200,
+  REDIRECT_MIN: 300,
+  REDIRECT_MAX: 400,
+  LOCKED: 423,
+} as const;
+
+/**
+ * API endpoints for authentication.
+ */
+export const AUTH_ENDPOINTS = {
+  LOGIN_PAGE: '/login',
+  AUTHENTICATE: '/sportmanager.security/authentication/authenticate',
+  LOGOUT: '/logout',
+  DASHBOARD: '/sportmanager.volleyball/main/dashboard',
+} as const;

--- a/packages/shared/src/auth/types.ts
+++ b/packages/shared/src/auth/types.ts
@@ -96,6 +96,12 @@ export interface AuthServiceConfig {
   getSessionHeaders?: () => Record<string, string>;
   /** Function to capture session token from response */
   captureSessionToken?: (response: Response) => void;
+  /**
+   * Delay in ms to allow browser to process Set-Cookie headers after redirects.
+   * Increase this value if cookies are not being properly set on slower devices/networks.
+   * @default 100
+   */
+  cookieProcessingDelayMs?: number;
   /** Logger for debug output */
   logger?: {
     info: (...args: unknown[]) => void;

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -72,6 +72,8 @@ const de: Translations = {
     useBiometric: '{biometricType} verwenden',
     authenticateWith: 'Mit {biometricType} authentifizieren',
     attemptsRemaining: '{count} Versuch verbleibend',
+    accountLocked: 'Konto vorübergehend gesperrt wegen zu vieler Fehlversuche. Bitte versuchen Sie es später erneut.',
+    tfaNotSupported: 'Zwei-Faktor-Authentifizierung wird nicht unterstützt. Bitte deaktivieren Sie sie in Ihren VolleyManager-Einstellungen.',
   },
   assignments: {
     title: 'Einsätze',

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -71,6 +71,8 @@ const en: Translations = {
     useBiometric: 'Use {biometricType}',
     authenticateWith: 'Authenticate with {biometricType}',
     attemptsRemaining: '{count} attempt remaining',
+    accountLocked: 'Account temporarily locked due to too many failed attempts. Please try again later.',
+    tfaNotSupported: 'Two-factor authentication is not supported. Please disable it in your VolleyManager settings.',
   },
   assignments: {
     title: 'Assignments',

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -72,6 +72,8 @@ const fr: Translations = {
     useBiometric: 'Utiliser {biometricType}',
     authenticateWith: "S'authentifier avec {biometricType}",
     attemptsRemaining: '{count} tentative restante',
+    accountLocked: "Compte temporairement verrouillé en raison d'un trop grand nombre de tentatives. Veuillez réessayer plus tard.",
+    tfaNotSupported: "L'authentification à deux facteurs n'est pas prise en charge. Veuillez la désactiver dans vos paramètres VolleyManager.",
   },
   assignments: {
     title: 'Désignations',

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -72,6 +72,8 @@ const it: Translations = {
     useBiometric: 'Usa {biometricType}',
     authenticateWith: 'Autenticati con {biometricType}',
     attemptsRemaining: '{count} tentativo rimanente',
+    accountLocked: 'Account temporaneamente bloccato a causa di troppi tentativi falliti. Riprova più tardi.',
+    tfaNotSupported: "L'autenticazione a due fattori non è supportata. Disattivala nelle impostazioni di VolleyManager.",
   },
   assignments: {
     title: 'Designazioni',

--- a/packages/shared/src/i18n/types.ts
+++ b/packages/shared/src/i18n/types.ts
@@ -86,6 +86,8 @@ export interface Translations {
     useBiometric: string;
     authenticateWith: string;
     attemptsRemaining: string;
+    accountLocked: string;
+    tfaNotSupported: string;
   };
   assignments: {
     title: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -25,3 +25,6 @@ export * from './types';
 
 // Adapter exports
 export * from './adapters';
+
+// Auth exports
+export * from './auth';


### PR DESCRIPTION
## Summary

- Extract shared auth utilities from web-app to `packages/shared/src/auth/`
  - `parsers.ts`: HTML parsing for login forms, CSRF tokens, activeParty
  - `service.ts`: Platform-agnostic login service
  - `types.ts`: Shared auth types (LoginFormFields, LoginResult, etc.)
- Create mobile auth service (`packages/mobile/src/services/authService.ts`)
  - Uses shared auth service for login/logout/session check
  - Integrates with secure storage for biometric re-login
  - Updates shared auth store on login success
- Update LoginScreen.tsx to use auth service for actual login
- Update RootNavigator.tsx for biometric re-login with credentials
- Add i18n translations for accountLocked and tfaNotSupported (de/en/fr/it)

## Test Plan

- [ ] Verify shared package builds successfully
- [ ] Verify mobile package typecheck passes
- [ ] Test login flow on mobile app
- [ ] Test biometric re-login after session expiry
- [ ] Test error handling (invalid credentials, locked account, TFA)