### PR TITLE
chore(mobile): remove unused PLACEHOLDER_REFRESH_DELAY_MS constant

### DIFF
--- a/packages/mobile/src/constants.ts
+++ b/packages/mobile/src/constants.ts
@@ -2,9 +2,6 @@
  * Mobile app constants
  */
 
-/** Placeholder refresh delay in milliseconds - will be removed when real API is integrated */
-export const PLACEHOLDER_REFRESH_DELAY_MS = 1000;
-
 /**
  * Theme colors for the mobile app
  * These match the Tailwind CSS color palette


### PR DESCRIPTION
## Summary
- Remove unused `PLACEHOLDER_REFRESH_DELAY_MS` constant from mobile constants
- This constant was explicitly marked for removal when the real API was integrated (PR #778)

## Test plan
- [x] TypeScript check passes
- [x] ESLint passes
- [x] Unit tests pass