### PR TITLE
refactor(web): remove deprecated formatGap function

### DIFF
--- a/web-app/src/features/assignments/utils/conflict-detection.test.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.test.ts
@@ -6,7 +6,6 @@ import {
   detectConflicts,
   getConflictsForAssignment,
   hasConflicts,
-  formatGap,
   parseGap,
   calculateMinGapToAssignments,
   hasMinimumGapFromAssignments,
@@ -237,36 +236,6 @@ describe('conflict-detection', () => {
 
       expect(hasConflicts('1', conflictMap)).toBe(true)
       expect(hasConflicts('2', conflictMap)).toBe(true)
-    })
-  })
-
-  describe('formatGap', () => {
-    it('should format positive gap in minutes', () => {
-      expect(formatGap(30)).toBe('30min gap')
-    })
-
-    it('should format positive gap in hours', () => {
-      expect(formatGap(60)).toBe('1h gap')
-    })
-
-    it('should format positive gap in hours and minutes', () => {
-      expect(formatGap(90)).toBe('1h 30min gap')
-    })
-
-    it('should format negative gap (overlap) in minutes', () => {
-      expect(formatGap(-30)).toBe('30min overlap')
-    })
-
-    it('should format negative gap (overlap) in hours', () => {
-      expect(formatGap(-60)).toBe('1h overlap')
-    })
-
-    it('should format negative gap (overlap) in hours and minutes', () => {
-      expect(formatGap(-90)).toBe('1h 30min overlap')
-    })
-
-    it('should handle zero gap', () => {
-      expect(formatGap(0)).toBe('0min gap')
     })
   })
 

--- a/web-app/src/features/assignments/utils/conflict-detection.ts
+++ b/web-app/src/features/assignments/utils/conflict-detection.ts
@@ -236,26 +236,6 @@ export function parseGap(gapMinutes: number): ParsedGap {
 }
 
 /**
- * Formats the time gap for display.
- *
- * @param gapMinutes - Gap in minutes (can be negative for overlaps)
- * @returns Formatted string describing the gap
- * @deprecated Use parseGap() and handle formatting in the component with translations
- */
-export function formatGap(gapMinutes: number): string {
-  const { type, hours, minutes } = parseGap(gapMinutes)
-  const typeLabel = type === 'overlap' ? 'overlap' : 'gap'
-
-  if (hours > 0 && minutes > 0) {
-    return `${hours}h ${minutes}min ${typeLabel}`
-  }
-  if (hours > 0) {
-    return `${hours}h ${typeLabel}`
-  }
-  return `${minutes}min ${typeLabel}`
-}
-
-/**
  * Options for the smart conflict evaluator.
  */
 export interface SmartConflictOptions {


### PR DESCRIPTION
## Summary

- Remove deprecated `formatGap` function from `conflict-detection.ts`
- Remove associated tests for `formatGap` from test file
- The function was replaced by `parseGap()` with component-level formatting using translations

## Test plan

- [x] All 59 tests in `conflict-detection.test.ts` pass
- [x] Lint passes with no warnings
- [x] Knip (dead code detection) passes
- [x] Production build succeeds
- [x] TypeScript type checking passes