### PR TITLE
fix(mobile): use i18n translations for TBD fallbacks in list screens

### DIFF
--- a/packages/mobile/src/screens/AssignmentsScreen.tsx
+++ b/packages/mobile/src/screens/AssignmentsScreen.tsx
@@ -35,7 +35,8 @@ const STATUS_COLORS = {
  */
 function getAssignmentDisplay(
   assignment: Assignment,
-  language: string
+  language: string,
+  tbd: string
 ): {
   id: string;
   title: string;
@@ -44,14 +45,14 @@ function getAssignmentDisplay(
   status: 'active' | 'cancelled' | 'archived';
 } {
   const game = assignment.refereeGame?.game;
-  const homeTeam = game?.teamHome?.name ?? 'TBD';
-  const awayTeam = game?.teamAway?.name ?? 'TBD';
+  const homeTeam = game?.teamHome?.name ?? tbd;
+  const awayTeam = game?.teamAway?.name ?? tbd;
 
   return {
     id: assignment.__identity,
     title: `${homeTeam} vs ${awayTeam}`,
     date: formatDate(game?.startingDateTime, language),
-    venue: game?.hall?.name ?? 'TBD',
+    venue: game?.hall?.name ?? tbd,
     status: assignment.refereeConvocationStatus,
   };
 }
@@ -123,7 +124,7 @@ export function AssignmentsScreen(_props: Props) {
         <RefreshControl refreshing={isFetching && !isLoading} onRefresh={onRefresh} />
       }
       renderItem={({ item }) => {
-        const display = getAssignmentDisplay(item, language);
+        const display = getAssignmentDisplay(item, language, t('common.tbd'));
         const colors = STATUS_COLORS[display.status];
 
         return (

--- a/packages/mobile/src/screens/CompensationsScreen.tsx
+++ b/packages/mobile/src/screens/CompensationsScreen.tsx
@@ -25,15 +25,18 @@ type Props = MainTabScreenProps<'Compensations'>;
 /**
  * Get display data from a compensation record.
  */
-function getCompensationDisplay(record: CompensationRecord): {
+function getCompensationDisplay(
+  record: CompensationRecord,
+  tbd: string
+): {
   id: string;
   game: string;
   amount: string;
   status: 'paid' | 'pending';
 } {
   const game = record.refereeGame?.game;
-  const homeTeam = game?.teamHome?.name ?? 'TBD';
-  const awayTeam = game?.teamAway?.name ?? 'TBD';
+  const homeTeam = game?.teamHome?.name ?? tbd;
+  const awayTeam = game?.teamAway?.name ?? tbd;
   const compensation = record.convocationCompensation;
 
   // Calculate total compensation
@@ -116,7 +119,7 @@ export function CompensationsScreen(_props: Props) {
         <RefreshControl refreshing={isFetching && !isLoading} onRefresh={onRefresh} />
       }
       renderItem={({ item }) => {
-        const display = getCompensationDisplay(item);
+        const display = getCompensationDisplay(item, t('common.tbd'));
 
         return (
           <View className="bg-white rounded-lg p-4 shadow-sm">

--- a/packages/mobile/src/screens/ExchangesScreen.tsx
+++ b/packages/mobile/src/screens/ExchangesScreen.tsx
@@ -35,7 +35,8 @@ const STATUS_COLORS = {
  */
 function getExchangeDisplay(
   exchange: GameExchange,
-  language: string
+  language: string,
+  tbd: string
 ): {
   id: string;
   game: string;
@@ -44,8 +45,8 @@ function getExchangeDisplay(
   status: 'open' | 'applied' | 'closed';
 } {
   const game = exchange.refereeGame?.game;
-  const homeTeam = game?.teamHome?.name ?? 'TBD';
-  const awayTeam = game?.teamAway?.name ?? 'TBD';
+  const homeTeam = game?.teamHome?.name ?? tbd;
+  const awayTeam = game?.teamAway?.name ?? tbd;
 
   return {
     id: exchange.__identity,
@@ -123,7 +124,7 @@ export function ExchangesScreen(_props: Props) {
         <RefreshControl refreshing={isFetching && !isLoading} onRefresh={onRefresh} />
       }
       renderItem={({ item }) => {
-        const display = getExchangeDisplay(item, language);
+        const display = getExchangeDisplay(item, language, t('common.tbd'));
         const colors = STATUS_COLORS[display.status];
 
         return (


### PR DESCRIPTION
## Summary

- Replace hard-coded 'TBD' strings with translated values using `t('common.tbd')` in mobile list screens
- Updates AssignmentsScreen, CompensationsScreen, and ExchangesScreen
- Ensures proper localization when team names or venues are not yet available

## Test plan

- [x] TypeScript compilation passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] All tests pass (`npm test`)