### PR TITLE
refactor(shared): consolidate form serialization and property configs (#779)

### DIFF
--- a/packages/shared/src/api/form-serialization.ts
+++ b/packages/shared/src/api/form-serialization.ts
@@ -1,0 +1,79 @@
+/**
+ * Form data serialization utilities for the TYPO3 Neos/Flow API.
+ * The framework expects nested parameters in bracket notation:
+ * e.g., searchConfiguration[offset] = 0, searchConfiguration[limit] = 10
+ *
+ * This is a platform-agnostic implementation shared between web and mobile.
+ * Token management (CSRF, session) is handled by each platform separately.
+ */
+
+const MAX_DEPTH = 10
+
+export interface BuildFormDataOptions {
+  /**
+   * CSRF token to include in the request.
+   * Only include for state-changing requests (POST/PUT/DELETE).
+   * GET requests should not include CSRF tokens in URLs as they can leak
+   * through browser history, server logs, referer headers, and proxy logs.
+   */
+  csrfToken?: string | null
+}
+
+/**
+ * Build form data with nested bracket notation (Neos Flow format).
+ * Flattens nested objects/arrays into URL-encoded form parameters.
+ */
+export function buildFormData(
+  data: Record<string, unknown>,
+  options: BuildFormDataOptions = {}
+): URLSearchParams {
+  const { csrfToken } = options
+  const params = new URLSearchParams()
+  // Track objects in current path to detect true circular references
+  const pathStack = new Set<object>()
+
+  function flatten(obj: unknown, prefix: string, depth: number): void {
+    // Prevent infinite recursion from deeply nested structures
+    if (depth > MAX_DEPTH) {
+      throw new Error(`Form data exceeds maximum nesting depth of ${MAX_DEPTH}`)
+    }
+
+    if (obj === null || obj === undefined) return
+
+    if (typeof obj === 'object') {
+      // Detect circular references (object appearing in its own ancestry)
+      if (pathStack.has(obj)) {
+        throw new Error('Circular reference detected in form data')
+      }
+      pathStack.add(obj)
+
+      try {
+        if (Array.isArray(obj)) {
+          obj.forEach((item: unknown, index: number) => {
+            flatten(item, `${prefix}[${index}]`, depth + 1)
+          })
+        } else {
+          Object.entries(obj as Record<string, unknown>).forEach(([key, value]) => {
+            flatten(value, prefix ? `${prefix}[${key}]` : key, depth + 1)
+          })
+        }
+      } finally {
+        // Remove from path after processing to allow shared references
+        pathStack.delete(obj)
+      }
+    } else {
+      params.append(prefix, String(obj))
+    }
+  }
+
+  Object.entries(data).forEach(([key, value]) => {
+    flatten(value, key, 0)
+  })
+
+  // Include CSRF token if provided
+  if (csrfToken) {
+    params.append('__csrfToken', csrfToken)
+  }
+
+  return params
+}

--- a/packages/shared/src/api/index.ts
+++ b/packages/shared/src/api/index.ts
@@ -3,6 +3,8 @@
  */
 
 export * from './client';
+export * from './form-serialization';
+export * from './property-configs';
 export * from './queryKeys';
 export * from './validation';
 // schema.ts is generated from OpenAPI spec - run `npm run generate:api` from web-app

--- a/packages/shared/src/api/property-configs.ts
+++ b/packages/shared/src/api/property-configs.ts
@@ -1,6 +1,8 @@
 /**
  * Property render configurations for API endpoints.
  * These arrays tell the API which fields to include in responses.
+ *
+ * Shared between web and mobile apps to ensure consistent data fetching.
  */
 
 /**

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -754,7 +754,7 @@ import {
   EXCHANGE_PROPERTIES,
   COMPENSATION_PROPERTIES,
   REFEREE_BACKUP_PROPERTIES,
-} from './property-configs'
+} from '@volleykit/shared/api'
 
 /**
  * Returns the appropriate API client based on the data source.

--- a/web-app/src/api/form-serialization.ts
+++ b/web-app/src/api/form-serialization.ts
@@ -2,9 +2,12 @@
  * Form data serialization utilities for the TYPO3 Neos/Flow API.
  * The framework expects nested parameters in bracket notation:
  * e.g., searchConfiguration[offset] = 0, searchConfiguration[limit] = 10
+ *
+ * This module re-exports the shared buildFormData and provides web-specific
+ * token management (CSRF and session tokens with encryption for iOS Safari PWA).
  */
 
-const MAX_DEPTH = 10
+import { buildFormData as sharedBuildFormData } from '@volleykit/shared/api'
 
 let csrfToken: string | null = null
 
@@ -185,60 +188,19 @@ export interface BuildFormDataOptions {
 /**
  * Build form data with nested bracket notation (Neos Flow format).
  * Flattens nested objects/arrays into URL-encoded form parameters.
+ *
+ * Uses the shared implementation from @volleykit/shared and adds
+ * web-specific CSRF token handling.
  */
 export function buildFormData(
   data: Record<string, unknown>,
   options: BuildFormDataOptions = {}
 ): URLSearchParams {
   const { includeCsrfToken = true } = options
-  const params = new URLSearchParams()
-  // Track objects in current path to detect true circular references
-  const pathStack = new Set<object>()
-
-  function flatten(obj: unknown, prefix: string, depth: number): void {
-    // Prevent infinite recursion from deeply nested structures
-    if (depth > MAX_DEPTH) {
-      throw new Error(`Form data exceeds maximum nesting depth of ${MAX_DEPTH}`)
-    }
-
-    if (obj === null || obj === undefined) return
-
-    if (typeof obj === 'object') {
-      // Detect circular references (object appearing in its own ancestry)
-      if (pathStack.has(obj)) {
-        throw new Error('Circular reference detected in form data')
-      }
-      pathStack.add(obj)
-
-      try {
-        if (Array.isArray(obj)) {
-          obj.forEach((item: unknown, index: number) => {
-            flatten(item, `${prefix}[${index}]`, depth + 1)
-          })
-        } else {
-          Object.entries(obj as Record<string, unknown>).forEach(([key, value]) => {
-            flatten(value, prefix ? `${prefix}[${key}]` : key, depth + 1)
-          })
-        }
-      } finally {
-        // Remove from path after processing to allow shared references
-        pathStack.delete(obj)
-      }
-    } else {
-      params.append(prefix, String(obj))
-    }
-  }
-
-  Object.entries(data).forEach(([key, value]) => {
-    flatten(value, key, 0)
-  })
-
   // Only include CSRF token for state-changing requests (POST/PUT/DELETE).
   // GET requests should not include CSRF tokens in URLs as they can leak
   // through browser history, server logs, referer headers, and proxy logs.
-  if (includeCsrfToken && csrfToken) {
-    params.append('__csrfToken', csrfToken)
-  }
-
-  return params
+  return sharedBuildFormData(data, {
+    csrfToken: includeCsrfToken ? csrfToken : null,
+  })
 }


### PR DESCRIPTION
## Summary

- Move `buildFormData` function from web and mobile apps to `@volleykit/shared/api`
- Move property configurations (ASSIGNMENT_PROPERTIES, EXCHANGE_PROPERTIES, COMPENSATION_PROPERTIES, REFEREE_BACKUP_PROPERTIES) to shared package
- Update web-app and mobile to use shared modules with platform-specific token handling
- Reduces code duplication and ensures both platforms use identical API property configurations

Closes #779

## Test plan

- [x] TypeScript compilation passes for shared, web, and mobile packages
- [x] ESLint passes with no warnings
- [x] All 3477 tests pass
- [x] Knip dead code detection passes