### PR TITLE
refactor(mobile): consolidate duplicated constants into constants.ts

### DIFF
--- a/packages/mobile/src/api/realClient.ts
+++ b/packages/mobile/src/api/realClient.ts
@@ -16,6 +16,7 @@ import {
   EXCHANGE_PROPERTIES,
   COMPENSATION_PROPERTIES,
 } from '@volleykit/shared/api';
+import { SESSION_TOKEN_HEADER } from '../constants';
 
 /**
  * API base URL for requests.
@@ -24,11 +25,6 @@ import {
 const API_BASE_URL =
   (Constants.expoConfig?.extra?.apiBaseUrl as string | undefined) ??
   'https://proxy.volleykit.app';
-
-/**
- * Session token header name used by the Cloudflare Worker for iOS Safari PWA.
- */
-const SESSION_TOKEN_HEADER = 'X-Session-Token';
 
 /**
  * In-memory session token storage.

--- a/packages/mobile/src/constants.ts
+++ b/packages/mobile/src/constants.ts
@@ -49,3 +49,13 @@ export const MAX_BIOMETRIC_ATTEMPTS = 3;
 
 /** Icon size for biometric prompt modal */
 export const BIOMETRIC_ICON_SIZE = 64;
+
+// === Calendar ===
+
+/** Storage key for calendar settings */
+export const CALENDAR_SETTINGS_KEY = 'calendar_settings';
+
+// === API ===
+
+/** Session token header name used by the Cloudflare Worker for iOS Safari PWA */
+export const SESSION_TOKEN_HEADER = 'X-Session-Token';

--- a/packages/mobile/src/hooks/useCalendarSync.ts
+++ b/packages/mobile/src/hooks/useCalendarSync.ts
@@ -14,10 +14,8 @@ import type { Assignment } from '@volleykit/shared/api';
 import { calendarSyncService } from '../services/calendarSync';
 import { calendarMappingsStore } from '../stores/calendarMappings';
 import { calendar } from '../platform/calendar';
+import { CALENDAR_SETTINGS_KEY } from '../constants';
 import type { CalendarEventMapping, CalendarSettings } from '../types/calendar';
-
-/** Storage key for calendar settings */
-const CALENDAR_SETTINGS_KEY = 'calendar_settings';
 
 export interface UseCalendarSyncResult {
   /** Whether a sync is in progress */

--- a/packages/mobile/src/screens/CalendarSettingsScreen.tsx
+++ b/packages/mobile/src/screens/CalendarSettingsScreen.tsx
@@ -26,14 +26,11 @@ import { queryKeys, type Assignment } from '@volleykit/shared/api';
 import { calendar } from '../platform/calendar';
 import { useCalendarSync } from '../hooks';
 import { CalendarPicker } from '../components/CalendarPicker';
-import { COLORS, SETTINGS_ICON_SIZE } from '../constants';
+import { COLORS, SETTINGS_ICON_SIZE, CALENDAR_SETTINGS_KEY } from '../constants';
 import type { CalendarInfo, CalendarSyncMode, CalendarSettings } from '../types/calendar';
 import type { RootStackScreenProps } from '../navigation/types';
 
 type Props = RootStackScreenProps<'CalendarSettings'>;
-
-/** Storage key for calendar settings */
-const CALENDAR_SETTINGS_KEY = 'calendar_settings';
 
 /** Default calendar settings */
 const DEFAULT_SETTINGS: CalendarSettings = {

--- a/packages/mobile/src/services/authService.ts
+++ b/packages/mobile/src/services/authService.ts
@@ -17,6 +17,7 @@ import {
   clearTokens,
   getSessionToken,
 } from '../api';
+import { SESSION_TOKEN_HEADER } from '../constants';
 
 /**
  * API base URL for authentication requests.
@@ -26,11 +27,6 @@ import {
 const API_BASE_URL =
   (Constants.expoConfig?.extra?.apiBaseUrl as string | undefined) ??
   'https://proxy.volleykit.app';
-
-/**
- * Session token header name.
- */
-const SESSION_TOKEN_HEADER = 'X-Session-Token';
 
 /**
  * Get session headers for API requests.


### PR DESCRIPTION
## Summary

- Move `CALENDAR_SETTINGS_KEY` and `SESSION_TOKEN_HEADER` to the central `constants.ts` file
- Update imports in `useCalendarSync.ts`, `CalendarSettingsScreen.tsx`, `authService.ts`, and `realClient.ts`
- Eliminates code duplication across multiple files

## Test plan

- [x] TypeScript check passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Unit tests pass (`npm test`)