### PR TITLE
fix(mobile): use i18n translations in LastUpdatedIndicator component

### DIFF
--- a/.changeset/last-updated-i18n.md
+++ b/.changeset/last-updated-i18n.md
@@ -1,0 +1,6 @@
+---
+"@volleykit/mobile": patch
+"@volleykit/shared": patch
+---
+
+Use i18n translations for LastUpdatedIndicator hardcoded strings

--- a/packages/mobile/src/components/LastUpdatedIndicator.tsx
+++ b/packages/mobile/src/components/LastUpdatedIndicator.tsx
@@ -8,6 +8,7 @@ import type { JSX } from 'react';
 import { View, Text } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 
+import { useTranslation } from '@volleykit/shared/i18n';
 import { COLORS } from '../constants';
 import type { CacheStatus } from '../types/cache';
 import { getCacheStatus, formatCacheAge } from '../types/cache';
@@ -68,6 +69,8 @@ export function LastUpdatedIndicator({
   compact = false,
   label,
 }: LastUpdatedIndicatorProps): JSX.Element | null {
+  const { t } = useTranslation();
+
   if (!lastUpdatedAt) {
     return null;
   }
@@ -80,12 +83,13 @@ export function LastUpdatedIndicator({
   const color = getStatusColor(status);
   const icon = getStatusIcon(status);
   const timeAgo = formatCacheAge(lastUpdatedAt);
+  const defaultLabel = t('common.lastUpdated');
 
   if (compact) {
     return (
       <View
         className="flex-row items-center"
-        accessibilityLabel={`Last updated ${timeAgo}`}
+        accessibilityLabel={`${defaultLabel} ${timeAgo}`}
         accessibilityRole="text"
       >
         <Feather name={icon as keyof typeof Feather.glyphMap} size={12} color={color} />
@@ -97,19 +101,19 @@ export function LastUpdatedIndicator({
   return (
     <View
       className="flex-row items-center bg-gray-100 rounded-lg px-3 py-2"
-      accessibilityLabel={`${label ?? 'Last updated'} ${timeAgo}`}
+      accessibilityLabel={`${label ?? defaultLabel} ${timeAgo}`}
       accessibilityRole="text"
     >
       <Feather name={icon as keyof typeof Feather.glyphMap} size={14} color={color} />
       <View className="ml-2">
         <Text className="text-xs text-gray-500">
-          {label ?? 'Last updated'}
+          {label ?? defaultLabel}
         </Text>
         <Text className="text-sm text-gray-700 font-medium">{timeAgo}</Text>
       </View>
       {isFromCache && (
         <View className="ml-auto bg-gray-200 rounded px-2 py-0.5">
-          <Text className="text-xs text-gray-600">Cached</Text>
+          <Text className="text-xs text-gray-600">{t('common.cached')}</Text>
         </View>
       )}
     </View>
@@ -124,15 +128,18 @@ export function LastUpdatedText({
 }: {
   lastUpdatedAt: string | null;
 }): JSX.Element | null {
+  const { t } = useTranslation();
+
   if (!lastUpdatedAt) {
     return null;
   }
 
   const timeAgo = formatCacheAge(lastUpdatedAt);
+  const updatedLabel = t('common.updated');
 
   return (
-    <Text className="text-xs text-gray-400" accessibilityLabel={`Updated ${timeAgo}`}>
-      Updated {timeAgo}
+    <Text className="text-xs text-gray-400" accessibilityLabel={`${updatedLabel} ${timeAgo}`}>
+      {updatedLabel} {timeAgo}
     </Text>
   );
 }

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -39,6 +39,9 @@ const de: Translations = {
     hoursUnit: 'h',
     dob: 'Geb.',
     offline: 'Offline',
+    lastUpdated: 'Zuletzt aktualisiert',
+    updated: 'Aktualisiert',
+    cached: 'Zwischengespeichert',
   },
   auth: {
     login: 'Anmelden',

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -39,6 +39,9 @@ const en: Translations = {
     hoursUnit: 'h',
     dob: 'DOB',
     offline: 'Offline',
+    lastUpdated: 'Last updated',
+    updated: 'Updated',
+    cached: 'Cached',
   },
   auth: {
     login: 'Login',

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -39,6 +39,9 @@ const fr: Translations = {
     hoursUnit: 'h',
     dob: 'DDN',
     offline: 'Hors ligne',
+    lastUpdated: 'Dernière mise à jour',
+    updated: 'Mis à jour',
+    cached: 'En cache',
   },
   auth: {
     login: 'Connexion',

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -39,6 +39,9 @@ const it: Translations = {
     hoursUnit: 'h',
     dob: 'DDN',
     offline: 'Offline',
+    lastUpdated: 'Ultimo aggiornamento',
+    updated: 'Aggiornato',
+    cached: 'In cache',
   },
   auth: {
     login: 'Accesso',

--- a/packages/shared/src/i18n/types.ts
+++ b/packages/shared/src/i18n/types.ts
@@ -55,6 +55,9 @@ export interface Translations {
     hoursUnit: string;
     dob: string;
     offline: string;
+    lastUpdated: string;
+    updated: string;
+    cached: string;
   };
   auth: {
     login: string;


### PR DESCRIPTION
## Summary

- Replace hardcoded English strings in LastUpdatedIndicator component with i18n translations
- Added new translation keys: common.lastUpdated, common.updated, common.cached
- Added translations in all 4 languages (de/en/fr/it)

## Test plan

- [ ] Verify LastUpdatedIndicator displays correctly in all 4 languages
- [ ] Verify accessibility labels use translated text
- [ ] Verify Cached badge displays translated text