### PR TITLE
feat(mobile): add domain association for password managers on login

### DIFF
--- a/.changeset/mobile-login-domain-association.md
+++ b/.changeset/mobile-login-domain-association.md
@@ -1,0 +1,11 @@
+---
+"@volleykit/mobile": minor
+---
+
+Add domain association for password managers on login screen
+
+Configured the login form to advertise volleymanager.volleyball.ch as the associated website,
+enabling password managers to suggest saved credentials from the web app.
+
+- Added `autoComplete` and `textContentType` props to username/password inputs
+- Added iOS Associated Domains configuration for webcredentials

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -16,6 +16,9 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "ch.volleyball.volleykit",
+      "associatedDomains": [
+        "webcredentials:volleymanager.volleyball.ch"
+      ],
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "VolleyKit uses your location to calculate public transport routes to your assignment venues.",
         "NSLocationAlwaysUsageDescription": "VolleyKit needs background location access to send smart departure reminders for your upcoming assignments."

--- a/packages/mobile/src/screens/LoginScreen.tsx
+++ b/packages/mobile/src/screens/LoginScreen.tsx
@@ -151,6 +151,8 @@ export function LoginScreen(_props: Props) {
             onChangeText={handleUsernameChange}
             autoCapitalize="none"
             autoCorrect={false}
+            autoComplete="username"
+            textContentType="username"
             placeholder={t('auth.usernamePlaceholder')}
             accessibilityLabel={t('auth.username')}
             accessibilityHint={t('auth.usernamePlaceholder')}
@@ -164,6 +166,8 @@ export function LoginScreen(_props: Props) {
             value={password}
             onChangeText={setPassword}
             secureTextEntry
+            autoComplete="password"
+            textContentType="password"
             placeholder={t('auth.passwordPlaceholder')}
             accessibilityLabel={t('auth.password')}
             accessibilityHint={t('auth.passwordPlaceholder')}


### PR DESCRIPTION
## Summary

- Configure login form to advertise volleymanager.volleyball.ch so password managers suggest saved credentials from the website
- Add `autoComplete` and `textContentType` props to username/password inputs
- Add iOS Associated Domains for `webcredentials:volleymanager.volleyball.ch`

## Test plan

- [ ] Build mobile app with `npm run typecheck` and `npm run lint`
- [ ] Test on iOS device/simulator that password manager suggests volleymanager.volleyball.ch credentials
- [ ] Test on Android device/emulator that autofill suggests relevant credentials

## Note

For the full password manager integration to work, the server at volleymanager.volleyball.ch needs to host:
- **iOS**: An `apple-app-site-association` file at `/.well-known/apple-app-site-association` containing the app's bundle ID (`ch.volleyball.volleykit`)
- **Android**: An `assetlinks.json` file at `/.well-known/assetlinks.json` with the app's package name and signing certificate fingerprint