### PR TITLE
fix(mobile): add missing i18n translations for DepartureReminderSettingsScreen

### DIFF
--- a/.changeset/fix-departure-reminder-i18n.md
+++ b/.changeset/fix-departure-reminder-i18n.md
@@ -1,0 +1,11 @@
+---
+"@volleykit/mobile": patch
+"@volleykit/shared": patch
+---
+
+Add missing i18n translations for DepartureReminderSettingsScreen
+
+- Add translation keys for background location and notification permission denied messages
+- Add translation keys for "How it works" section
+- Replace hardcoded English strings with proper t() function calls
+- Add translations for all 4 languages (de, en, fr, it)

--- a/packages/mobile/src/screens/DepartureReminderSettingsScreen.tsx
+++ b/packages/mobile/src/screens/DepartureReminderSettingsScreen.tsx
@@ -83,7 +83,7 @@ export function DepartureReminderSettingsScreen(_props: Props) {
       if (background !== 'granted') {
         Alert.alert(
           t('common.error'),
-          'Background location permission is required for departure reminders.',
+          t('settings.departure.backgroundLocationRequired'),
           [{ text: t('common.close') }]
         );
         return false;
@@ -92,7 +92,7 @@ export function DepartureReminderSettingsScreen(_props: Props) {
       // Request notification permission
       const notificationGranted = await notifications.requestPermissions();
       if (!notificationGranted) {
-        Alert.alert(t('common.error'), 'Notification permission is required.', [
+        Alert.alert(t('common.error'), t('settings.departure.notificationRequired'), [
           { text: t('common.close') },
         ]);
         return false;
@@ -256,25 +256,25 @@ export function DepartureReminderSettingsScreen(_props: Props) {
       {/* How it works */}
       <View className="mt-6 px-4 mb-8">
         <Text className="text-sm font-medium text-gray-500 mb-2 uppercase">
-          How it works
+          {t('settings.departure.howItWorks')}
         </Text>
         <View className="bg-white rounded-lg p-4 border border-gray-200">
           <View className="flex-row items-start mb-3">
             <Feather name="map-pin" size={16} color={COLORS.gray500} />
             <Text className="text-gray-600 ml-2 flex-1">
-              Your location is checked periodically when you have upcoming games
+              {t('settings.departure.howItWorksLocation')}
             </Text>
           </View>
           <View className="flex-row items-start mb-3">
             <Feather name="navigation" size={16} color={COLORS.gray500} />
             <Text className="text-gray-600 ml-2 flex-1">
-              Public transport routes are calculated automatically
+              {t('settings.departure.howItWorksRoutes')}
             </Text>
           </View>
           <View className="flex-row items-start">
             <Feather name="bell" size={16} color={COLORS.gray500} />
             <Text className="text-gray-600 ml-2 flex-1">
-              You get notified when it&apos;s time to leave
+              {t('settings.departure.howItWorksNotification')}
             </Text>
           </View>
         </View>

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -214,6 +214,14 @@ const de: Translations = {
       bufferTimeDescription: 'Zusätzliche Zeit vor der Abfahrt zur Vorbereitung.',
       locationRequired: 'Heimatstandort ist für Abfahrtserinnerungen erforderlich.',
       permissionDenied: 'Standortzugriff ist für Abfahrtsberechnungen erforderlich.',
+      backgroundLocationRequired:
+        'Hintergrund-Standortberechtigung ist für Abfahrtserinnerungen erforderlich.',
+      notificationRequired: 'Benachrichtigungsberechtigung ist erforderlich.',
+      howItWorks: 'So funktioniert es',
+      howItWorksLocation:
+        'Ihr Standort wird regelmässig überprüft, wenn Sie bevorstehende Spiele haben',
+      howItWorksRoutes: 'ÖV-Verbindungen werden automatisch berechnet',
+      howItWorksNotification: 'Sie werden benachrichtigt, wenn es Zeit ist zu gehen',
     },
     homeLocation: {
       title: 'Heimatstandort',

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -213,6 +213,14 @@ const en: Translations = {
       bufferTimeDescription: 'Extra time before departure for preparation.',
       locationRequired: 'Home location is required for departure reminders.',
       permissionDenied: 'Location access is required for departure calculations.',
+      backgroundLocationRequired:
+        'Background location permission is required for departure reminders.',
+      notificationRequired: 'Notification permission is required.',
+      howItWorks: 'How it works',
+      howItWorksLocation:
+        'Your location is checked periodically when you have upcoming games',
+      howItWorksRoutes: 'Public transport routes are calculated automatically',
+      howItWorksNotification: "You get notified when it's time to leave",
     },
     homeLocation: {
       title: 'Home Location',

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -216,6 +216,14 @@ const fr: Translations = {
       bufferTimeDescription: 'Temps supplémentaire avant le départ pour la préparation.',
       locationRequired: 'La position de domicile est requise pour les rappels de départ.',
       permissionDenied: "L'accès à la localisation est requis pour les calculs de départ.",
+      backgroundLocationRequired:
+        "L'autorisation de localisation en arrière-plan est requise pour les rappels de départ.",
+      notificationRequired: "L'autorisation de notification est requise.",
+      howItWorks: 'Comment ça marche',
+      howItWorksLocation:
+        'Votre position est vérifiée périodiquement lorsque vous avez des matchs à venir',
+      howItWorksRoutes: 'Les itinéraires de transport public sont calculés automatiquement',
+      howItWorksNotification: "Vous êtes notifié quand il est temps de partir",
     },
     homeLocation: {
       title: 'Emplacement domicile',

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -215,6 +215,14 @@ const it: Translations = {
       bufferTimeDescription: 'Tempo extra prima della partenza per prepararsi.',
       locationRequired: 'La posizione di casa è necessaria per i promemoria di partenza.',
       permissionDenied: "L'accesso alla posizione è necessario per i calcoli di partenza.",
+      backgroundLocationRequired:
+        "L'autorizzazione alla posizione in background è necessaria per i promemoria di partenza.",
+      notificationRequired: "L'autorizzazione alle notifiche è necessaria.",
+      howItWorks: 'Come funziona',
+      howItWorksLocation:
+        'La tua posizione viene controllata periodicamente quando hai partite in programma',
+      howItWorksRoutes: 'I percorsi dei trasporti pubblici vengono calcolati automaticamente',
+      howItWorksNotification: 'Ricevi una notifica quando è il momento di partire',
     },
     homeLocation: {
       title: 'Posizione casa',

--- a/packages/shared/src/i18n/types.ts
+++ b/packages/shared/src/i18n/types.ts
@@ -228,6 +228,12 @@ export interface Translations {
       bufferTimeDescription: string;
       locationRequired: string;
       permissionDenied: string;
+      backgroundLocationRequired: string;
+      notificationRequired: string;
+      howItWorks: string;
+      howItWorksLocation: string;
+      howItWorksRoutes: string;
+      howItWorksNotification: string;
     };
     homeLocation: {
       title: string;


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings with proper translation keys in DepartureReminderSettingsScreen
- Add translation keys for background location and notification permission denied messages
- Add translation keys for "How it works" section header and descriptions
- Add translations for all 4 supported languages (de, en, fr, it)

## Test plan
- [ ] Verify mobile app builds without TypeScript errors
- [ ] Test DepartureReminderSettingsScreen in each language (de, en, fr, it)
- [ ] Verify permission denied alerts show correct translated messages
- [ ] Verify "How it works" section displays in correct language