### PR TITLE
fix(ci): link packages in changeset config for proper version bumping

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   ],
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [["volleykit-web", "@volleykit/shared", "@volleykit/mobile"]],
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
## Summary

- Link `volleykit-web`, `@volleykit/shared`, and `@volleykit/mobile` in changeset config
- Fixes issue where release workflow would read unchanged web-app version when changesets only target mobile/shared packages
- With linked packages, all packages bump together using the highest semver change type

## Test plan

- [ ] Run release workflow with dry-run to verify version increments correctly
- [ ] Verify changeset config is valid JSON