### PR TITLE
feat(web): associate PWA login with volleymanager.volleyball.ch for password managers

### DIFF
--- a/.changeset/add-volleymanager-credential-association.md
+++ b/.changeset/add-volleymanager-credential-association.md
@@ -12,4 +12,3 @@ and Android credential association behavior.
 Changes:
 - Added `action="https://volleymanager.volleyball.ch"` to the login form
 - Added `name` attributes to username and password inputs
-- Added `<link rel="origin">` meta tag for credential association

--- a/.changeset/add-volleymanager-credential-association.md
+++ b/.changeset/add-volleymanager-credential-association.md
@@ -1,0 +1,15 @@
+---
+"volleykit-web": minor
+---
+
+Associate PWA login with volleymanager.volleyball.ch for password managers
+
+Added credential association hints to the PWA login form so that password managers
+(1Password, Bitwarden, browser autofill, etc.) will suggest volleymanager.volleyball.ch
+credentials when logging in to the PWA. This mirrors the native app's iOS `associatedDomains`
+and Android credential association behavior.
+
+Changes:
+- Added `action="https://volleymanager.volleyball.ch"` to the login form
+- Added `name` attributes to username and password inputs
+- Added `<link rel="origin">` meta tag for credential association

--- a/web-app/index.html
+++ b/web-app/index.html
@@ -13,6 +13,10 @@
     <link rel="preconnect" href="https://volleymanager.volleyball.ch" crossorigin="use-credentials" />
     <link rel="dns-prefetch" href="https://volleymanager.volleyball.ch" />
 
+    <!-- Credential association: helps password managers associate this PWA's login
+         with volleymanager.volleyball.ch (same as native app's associatedDomains) -->
+    <link rel="origin" href="https://volleymanager.volleyball.ch" />
+
     <!-- iOS PWA support -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/web-app/index.html
+++ b/web-app/index.html
@@ -13,10 +13,6 @@
     <link rel="preconnect" href="https://volleymanager.volleyball.ch" crossorigin="use-credentials" />
     <link rel="dns-prefetch" href="https://volleymanager.volleyball.ch" />
 
-    <!-- Credential association: helps password managers associate this PWA's login
-         with volleymanager.volleyball.ch (same as native app's associatedDomains) -->
-    <link rel="origin" href="https://volleymanager.volleyball.ch" />
-
     <!-- iOS PWA support -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/web-app/src/features/auth/LoginPage.test.tsx
+++ b/web-app/src/features/auth/LoginPage.test.tsx
@@ -273,6 +273,20 @@ describe('LoginPage', () => {
       expect(screen.getByLabelText(/password/i)).toHaveAttribute('autocomplete', 'current-password')
     })
 
+    it('has credential association attributes for password managers in full login mode', () => {
+      render(<LoginPage />)
+      switchToFullLogin()
+
+      // name attributes help password managers recognize credential fields
+      expect(screen.getByLabelText(/username/i)).toHaveAttribute('name', 'username')
+      expect(screen.getByLabelText(/password/i)).toHaveAttribute('name', 'password')
+
+      // form action associates credentials with volleymanager.volleyball.ch
+      // (mirrors native app's associatedDomains configuration)
+      const form = screen.getByLabelText(/username/i).closest('form')
+      expect(form).toHaveAttribute('action', 'https://volleymanager.volleyball.ch')
+    })
+
     it('has proper input types in full login mode', () => {
       render(<LoginPage />)
       switchToFullLogin()

--- a/web-app/src/features/auth/LoginPage.tsx
+++ b/web-app/src/features/auth/LoginPage.tsx
@@ -395,8 +395,16 @@ export function LoginPage() {
           {/* Full Login Panel - only shown when tab is selected (tabs hidden in demo-only mode) */}
           {loginMode === 'full' && (
             <div id="full-login-panel" role="tabpanel" aria-labelledby="full-login-tab">
-              {/* method="post" is defensive fallback if native submission somehow occurs */}
-              <form ref={formRef} onSubmit={handleSubmit} method="post" className="space-y-6">
+              {/* method="post" and action are defensive fallback if native submission somehow occurs.
+                  action="https://volleymanager.volleyball.ch" tells password managers to associate
+                  credentials with volleymanager.volleyball.ch (same as the native app's associatedDomains). */}
+              <form
+                ref={formRef}
+                onSubmit={handleSubmit}
+                method="post"
+                action="https://volleymanager.volleyball.ch"
+                className="space-y-6"
+              >
                 <div>
                   <label
                     htmlFor="username"
@@ -406,6 +414,7 @@ export function LoginPage() {
                   </label>
                   <input
                     id="username"
+                    name="username"
                     data-testid="username-input"
                     type="text"
                     value={username}
@@ -426,6 +435,7 @@ export function LoginPage() {
                   </label>
                   <input
                     id="password"
+                    name="password"
                     data-testid="password-input"
                     type="password"
                     ref={passwordRef}


### PR DESCRIPTION
## Summary
- Add credential association hints so password managers (1Password, Bitwarden, browser autofill) suggest volleymanager.volleyball.ch credentials when logging into the PWA
- Mirrors the native app's iOS `associatedDomains` configuration
- Added `action="https://volleymanager.volleyball.ch"` to the login form
- Added `name` attributes to username and password inputs

## Test plan
- [ ] Verify password managers suggest volleymanager.volleyball.ch credentials on PWA login
- [x] Added test coverage for credential association attributes
- [x] All 40 existing login tests pass