### PR TITLE
feat(web): redesign exchange filters with compact menu UI

### DIFF
--- a/.changeset/improve-exchange-filters.md
+++ b/.changeset/improve-exchange-filters.md
@@ -1,0 +1,11 @@
+---
+"volleykit-web": minor
+---
+
+Redesigned exchange filters UI with compact filter menu
+
+- Replaced horizontal filter pills with single "Filters" button that opens a menu
+- Added icon-only summary showing active filters at a glance
+- Filter settings (distance, travel time, game gap) now have integrated toggles and sliders
+- "Hide own exchanges" preference is now saved per association
+- Improved visual consistency with unified toggle rows in filter menu

--- a/web-app/src/features/assignments/Assignments.integration.test.tsx
+++ b/web-app/src/features/assignments/Assignments.integration.test.tsx
@@ -127,8 +127,9 @@ describe('Assignments Integration', () => {
       })
 
       // Upcoming assignments should have future dates
-      expect(futureAssignments.every((a) => new Date(a.refereeGame!.game!.startingDateTime!) >= now))
-        .toBe(true)
+      expect(
+        futureAssignments.every((a) => new Date(a.refereeGame!.game!.startingDateTime!) >= now)
+      ).toBe(true)
     })
   })
 

--- a/web-app/src/features/exchanges/ExchangePage.test.tsx
+++ b/web-app/src/features/exchanges/ExchangePage.test.tsx
@@ -152,7 +152,7 @@ describe('ExchangePage', () => {
       setLevelFilterEnabled: mockSetLevelFilterEnabled,
       gameGapFilter: { enabled: false, minGapMinutes: 120 },
       setGameGapFilterEnabled: vi.fn(),
-      isHideOwnExchangesForAssociation: () => true,
+      hideOwnExchangesByAssociation: {},
       setHideOwnExchangesForAssociation: vi.fn(),
     }
     vi.mocked(settingsStore.useSettingsStore).mockImplementation(
@@ -287,7 +287,7 @@ describe('ExchangePage', () => {
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
         gameGapFilter: { enabled: false, minGapMinutes: 120 },
         setGameGapFilterEnabled: vi.fn(),
-        isHideOwnExchangesForAssociation: () => false,
+        hideOwnExchangesByAssociation: { TEST: false },
         setHideOwnExchangesForAssociation: vi.fn(),
       }
       vi.mocked(settingsStore.useSettingsStore).mockImplementation(
@@ -324,7 +324,7 @@ describe('ExchangePage', () => {
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
         gameGapFilter: { enabled: false, minGapMinutes: 120 },
         setGameGapFilterEnabled: vi.fn(),
-        isHideOwnExchangesForAssociation: () => true,
+        hideOwnExchangesByAssociation: {},
         setHideOwnExchangesForAssociation: vi.fn(),
       }
       vi.mocked(settingsStore.useSettingsStore).mockImplementation(
@@ -365,7 +365,7 @@ describe('ExchangePage', () => {
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
         gameGapFilter: { enabled: false, minGapMinutes: 120 },
         setGameGapFilterEnabled: vi.fn(),
-        isHideOwnExchangesForAssociation: () => true,
+        hideOwnExchangesByAssociation: {},
         setHideOwnExchangesForAssociation: vi.fn(),
       }
       vi.mocked(settingsStore.useSettingsStore).mockImplementation(

--- a/web-app/src/features/exchanges/ExchangePage.test.tsx
+++ b/web-app/src/features/exchanges/ExchangePage.test.tsx
@@ -152,6 +152,8 @@ describe('ExchangePage', () => {
       setLevelFilterEnabled: mockSetLevelFilterEnabled,
       gameGapFilter: { enabled: false, minGapMinutes: 120 },
       setGameGapFilterEnabled: vi.fn(),
+      isHideOwnExchangesForAssociation: () => true,
+      setHideOwnExchangesForAssociation: vi.fn(),
     }
     vi.mocked(settingsStore.useSettingsStore).mockImplementation(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -161,8 +163,8 @@ describe('ExchangePage', () => {
     vi.mocked(useConvocations.useGameExchanges).mockReturnValue(createMockQueryResult([]))
   })
 
-  describe('Level Filter Toggle', () => {
-    it('should not show level filter when not in demo mode', () => {
+  describe('Filter Menu', () => {
+    it('should show filter menu button on Open tab', () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({
           dataSource: 'api',
@@ -173,11 +175,11 @@ describe('ExchangePage', () => {
 
       render(<ExchangePage />)
 
-      // Level filter should not be visible when not in demo mode
-      expect(screen.queryByRole('switch', { name: /level/i })).not.toBeInTheDocument()
+      // Filter menu button should be visible on Open tab
+      expect(screen.getByRole('button', { name: /filters/i })).toBeInTheDocument()
     })
 
-    it('should show level filter when in demo mode with user level', () => {
+    it('should show active filter count badge when filters are enabled', () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({
           dataSource: 'demo',
@@ -193,11 +195,12 @@ describe('ExchangePage', () => {
 
       render(<ExchangePage />)
 
-      // Level filter should be directly visible (no dropdown)
-      expect(screen.getByRole('switch', { name: /level/i })).toBeInTheDocument()
+      // With hideOwnExchanges enabled by default, filter button should be visible
+      // Use getByRole button to find the filter menu button specifically
+      expect(screen.getByRole('button', { name: /filters/i })).toBeInTheDocument()
     })
 
-    it('should not show level filter on Added by Me tab', () => {
+    it('should not show filter menu on Added by Me tab', () => {
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
         selector({
           dataSource: 'demo',
@@ -216,8 +219,8 @@ describe('ExchangePage', () => {
       // Click on "Added by Me" tab
       fireEvent.click(screen.getByText(/added by me/i))
 
-      // Level filter should not be visible on this tab
-      expect(screen.queryByRole('switch', { name: /level/i })).not.toBeInTheDocument()
+      // Filter menu should not be visible on this tab
+      expect(screen.queryByRole('button', { name: /filters/i })).not.toBeInTheDocument()
     })
   })
 
@@ -226,12 +229,14 @@ describe('ExchangePage', () => {
       __identity: 'exchange-n1',
       requiredRefereeLevel: 'N1',
       requiredRefereeLevelGradationValue: '1',
+      submittedByPerson: { __identity: 'other-person' },
     })
 
     const exchangeN2 = createMockExchange({
       __identity: 'exchange-n2',
       requiredRefereeLevel: 'N2',
       requiredRefereeLevelGradationValue: '2',
+      submittedByPerson: { __identity: 'other-person' },
     })
 
     const exchangeN3 = createMockExchange({
@@ -261,6 +266,35 @@ describe('ExchangePage', () => {
     })
 
     it('should show all exchanges when filter is off', () => {
+      // Mock hideOwnExchanges as false so all exchanges are visible
+      const stateNoHide = {
+        homeLocation: null,
+        distanceFilter: { enabled: false, maxDistanceKm: 50 },
+        setDistanceFilterEnabled: vi.fn(),
+        transportEnabled: false,
+        isTransportEnabledForAssociation: () => false,
+        getArrivalBufferForAssociation: () => 30,
+        travelTimeFilter: {
+          enabled: false,
+          maxTravelTimeMinutes: 120,
+          arrivalBufferMinutes: 30,
+          cacheInvalidatedAt: null,
+        },
+        setTravelTimeFilterEnabled: vi.fn(),
+        setMaxDistanceKm: vi.fn(),
+        setMaxTravelTimeMinutes: vi.fn(),
+        levelFilterEnabled: false,
+        setLevelFilterEnabled: mockSetLevelFilterEnabled,
+        gameGapFilter: { enabled: false, minGapMinutes: 120 },
+        setGameGapFilterEnabled: vi.fn(),
+        isHideOwnExchangesForAssociation: () => false,
+        setHideOwnExchangesForAssociation: vi.fn(),
+      }
+      vi.mocked(settingsStore.useSettingsStore).mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (selector?: (state: any) => any) => (selector ? selector(stateNoHide) : stateNoHide)
+      )
+
       render(<ExchangePage />)
 
       // All three exchanges should be visible (use getAllByText since they share team names)
@@ -268,19 +302,8 @@ describe('ExchangePage', () => {
       expect(exchanges).toHaveLength(3)
     })
 
-    it('should toggle level filter when clicked', () => {
-      render(<ExchangePage />)
-
-      // Click the level filter directly (no dropdown)
-      const toggle = screen.getByRole('switch', { name: /level/i })
-      fireEvent.click(toggle)
-
-      // Should call the setter to enable the filter
-      expect(mockSetLevelFilterEnabled).toHaveBeenCalledWith(true)
-    })
-
-    it('should show user level indicator when filter is enabled', () => {
-      // Mock filter as already enabled
+    it('should show active filter icons when filters are enabled', () => {
+      // Mock level filter as enabled
       const stateWithFilter = {
         homeLocation: null,
         distanceFilter: { enabled: false, maxDistanceKm: 50 },
@@ -301,6 +324,8 @@ describe('ExchangePage', () => {
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
         gameGapFilter: { enabled: false, minGapMinutes: 120 },
         setGameGapFilterEnabled: vi.fn(),
+        isHideOwnExchangesForAssociation: () => true,
+        setHideOwnExchangesForAssociation: vi.fn(),
       }
       vi.mocked(settingsStore.useSettingsStore).mockImplementation(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -309,8 +334,8 @@ describe('ExchangePage', () => {
 
       render(<ExchangePage />)
 
-      // Should show N2+ indicator in the chip (directly visible)
-      expect(screen.getByText('N2+')).toBeInTheDocument()
+      // Should show active filter icons and filter menu button
+      expect(screen.getByRole('button', { name: /filters/i })).toBeInTheDocument()
     })
 
     it('should show filtered empty state message when no exchanges match level', () => {
@@ -340,6 +365,8 @@ describe('ExchangePage', () => {
         setLevelFilterEnabled: mockSetLevelFilterEnabled,
         gameGapFilter: { enabled: false, minGapMinutes: 120 },
         setGameGapFilterEnabled: vi.fn(),
+        isHideOwnExchangesForAssociation: () => true,
+        setHideOwnExchangesForAssociation: vi.fn(),
       }
       vi.mocked(settingsStore.useSettingsStore).mockImplementation(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/web-app/src/features/exchanges/ExchangePage.tsx
+++ b/web-app/src/features/exchanges/ExchangePage.tsx
@@ -81,25 +81,36 @@ export function ExchangePage() {
       userRefereeLevelGradationValue: state.userRefereeLevelGradationValue,
     }))
   )
-  const { homeLocation, distanceFilter, travelTimeFilter, levelFilterEnabled, gameGapFilter } =
-    useSettingsStore(
-      useShallow((state) => ({
-        homeLocation: state.homeLocation,
-        distanceFilter: state.distanceFilter,
-        travelTimeFilter: state.travelTimeFilter,
-        levelFilterEnabled: state.levelFilterEnabled,
-        gameGapFilter: state.gameGapFilter,
-      }))
-    )
+  const {
+    homeLocation,
+    distanceFilter,
+    travelTimeFilter,
+    levelFilterEnabled,
+    gameGapFilter,
+    hideOwnExchangesByAssociation,
+  } = useSettingsStore(
+    useShallow((state) => ({
+      homeLocation: state.homeLocation,
+      distanceFilter: state.distanceFilter,
+      travelTimeFilter: state.travelTimeFilter,
+      levelFilterEnabled: state.levelFilterEnabled,
+      gameGapFilter: state.gameGapFilter,
+      hideOwnExchangesByAssociation: state.hideOwnExchangesByAssociation,
+    }))
+  )
 
   // Get hide own exchanges setting per-association
-  const isHideOwnExchangesForAssociation = useSettingsStore(
-    (state) => state.isHideOwnExchangesForAssociation
-  )
   const setHideOwnExchangesForAssociation = useSettingsStore(
     (state) => state.setHideOwnExchangesForAssociation
   )
-  const hideOwnExchanges = isHideOwnExchangesForAssociation(associationCode)
+
+  // Derive hideOwnExchanges from the map - defaults to true if not set
+  const hideOwnExchanges = useMemo(() => {
+    if (associationCode && hideOwnExchangesByAssociation[associationCode] !== undefined) {
+      return hideOwnExchangesByAssociation[associationCode]
+    }
+    return true // Default to hiding own exchanges
+  }, [associationCode, hideOwnExchangesByAssociation])
 
   const handleHideOwnToggle = useCallback(() => {
     if (associationCode) {

--- a/web-app/src/features/exchanges/Exchanges.integration.test.tsx
+++ b/web-app/src/features/exchanges/Exchanges.integration.test.tsx
@@ -338,7 +338,9 @@ describe('Exchanges Integration', () => {
       expect(state.assignments.find((a) => a.__identity === assignmentId)).toBeDefined()
 
       // Exchange should be removed
-      expect(state.exchanges.find((e) => e.__identity === createdExchange!.__identity)).toBeUndefined()
+      expect(
+        state.exchanges.find((e) => e.__identity === createdExchange!.__identity)
+      ).toBeUndefined()
     })
   })
 

--- a/web-app/src/features/exchanges/components/ActiveFilterIcons.tsx
+++ b/web-app/src/features/exchanges/components/ActiveFilterIcons.tsx
@@ -1,6 +1,7 @@
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 
-import { User, MapPin, TrainFront, CalendarX2 } from '@/shared/components/icons'
+import { User, MapPin, TrainFront, CalendarX2, Award } from '@/shared/components/icons'
+import { useTranslation } from '@/shared/hooks/useTranslation'
 
 export interface ActiveFilterIconsProps {
   /** Whether the "hide own" filter is active */
@@ -22,36 +23,64 @@ function ActiveFilterIconsComponent({
   gameGapActive,
   levelActive,
 }: ActiveFilterIconsProps) {
+  const { t } = useTranslation()
+
   const hasActiveFilters =
     hideOwnActive || distanceActive || travelTimeActive || gameGapActive || levelActive
+
+  // Build aria-label describing active filters for screen readers
+  const ariaLabel = useMemo(() => {
+    const activeNames: string[] = []
+    if (hideOwnActive) activeNames.push(t('exchange.hideOwn'))
+    if (distanceActive) activeNames.push(t('exchange.filterByDistance'))
+    if (travelTimeActive) activeNames.push(t('exchange.filterByTravelTime'))
+    if (gameGapActive) activeNames.push(t('exchange.filterByGameGap'))
+    if (levelActive) activeNames.push(t('exchange.filterByLevel'))
+    return activeNames.join(', ')
+  }, [hideOwnActive, distanceActive, travelTimeActive, gameGapActive, levelActive, t])
 
   if (!hasActiveFilters) return null
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1" role="img" aria-label={ariaLabel}>
       {hideOwnActive && (
-        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+        <span
+          className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300"
+          aria-hidden="true"
+        >
           <User className="w-full h-full" />
         </span>
       )}
       {distanceActive && (
-        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+        <span
+          className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300"
+          aria-hidden="true"
+        >
           <MapPin className="w-full h-full" />
         </span>
       )}
       {travelTimeActive && (
-        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+        <span
+          className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300"
+          aria-hidden="true"
+        >
           <TrainFront className="w-full h-full" />
         </span>
       )}
       {gameGapActive && (
-        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+        <span
+          className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300"
+          aria-hidden="true"
+        >
           <CalendarX2 className="w-full h-full" />
         </span>
       )}
       {levelActive && (
-        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
-          <User className="w-full h-full" />
+        <span
+          className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300"
+          aria-hidden="true"
+        >
+          <Award className="w-full h-full" />
         </span>
       )}
     </div>

--- a/web-app/src/features/exchanges/components/ActiveFilterIcons.tsx
+++ b/web-app/src/features/exchanges/components/ActiveFilterIcons.tsx
@@ -1,0 +1,61 @@
+import { memo } from 'react'
+
+import { User, MapPin, TrainFront, CalendarX2 } from '@/shared/components/icons'
+
+export interface ActiveFilterIconsProps {
+  /** Whether the "hide own" filter is active */
+  hideOwnActive: boolean
+  /** Whether the distance filter is active */
+  distanceActive: boolean
+  /** Whether the travel time filter is active */
+  travelTimeActive: boolean
+  /** Whether the game gap filter is active */
+  gameGapActive: boolean
+  /** Whether the level filter is active (demo mode) */
+  levelActive: boolean
+}
+
+function ActiveFilterIconsComponent({
+  hideOwnActive,
+  distanceActive,
+  travelTimeActive,
+  gameGapActive,
+  levelActive,
+}: ActiveFilterIconsProps) {
+  const hasActiveFilters =
+    hideOwnActive || distanceActive || travelTimeActive || gameGapActive || levelActive
+
+  if (!hasActiveFilters) return null
+
+  return (
+    <div className="flex items-center gap-1">
+      {hideOwnActive && (
+        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+          <User className="w-full h-full" />
+        </span>
+      )}
+      {distanceActive && (
+        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+          <MapPin className="w-full h-full" />
+        </span>
+      )}
+      {travelTimeActive && (
+        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+          <TrainFront className="w-full h-full" />
+        </span>
+      )}
+      {gameGapActive && (
+        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+          <CalendarX2 className="w-full h-full" />
+        </span>
+      )}
+      {levelActive && (
+        <span className="w-5 h-5 p-0.5 rounded-full bg-primary-100 text-primary-600 dark:bg-primary-900 dark:text-primary-300">
+          <User className="w-full h-full" />
+        </span>
+      )}
+    </div>
+  )
+}
+
+export const ActiveFilterIcons = memo(ActiveFilterIconsComponent)

--- a/web-app/src/features/exchanges/components/ExchangeFilterMenu.tsx
+++ b/web-app/src/features/exchanges/components/ExchangeFilterMenu.tsx
@@ -1,0 +1,409 @@
+import { useState, useCallback, memo, useMemo } from 'react'
+
+import { useShallow } from 'zustand/react/shallow'
+
+import { useActiveAssociationCode } from '@/features/auth/hooks/useActiveAssociation'
+import {
+  SlidersHorizontal,
+  X,
+  MapPin,
+  TrainFront,
+  User,
+  CalendarX2,
+} from '@/shared/components/icons'
+import { ResponsiveSheet } from '@/shared/components/ResponsiveSheet'
+import { useTranslation } from '@/shared/hooks/useTranslation'
+import { useSettingsStore } from '@/shared/stores/settings'
+import { formatTravelTime, MINUTES_PER_HOUR } from '@/shared/utils/format-travel-time'
+
+/** Distance presets for the slider (in kilometers) */
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- intentional UI presets
+const DISTANCE_PRESETS = [10, 25, 50, 75, 100] as const
+const DISTANCE_MIN = 10
+const DISTANCE_MAX = 100
+
+/** Travel time presets for the slider (in minutes) */
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- intentional UI presets
+const TRAVEL_TIME_PRESETS = [30, 45, 60, 90, 120] as const
+const TRAVEL_TIME_MIN = 30
+const TRAVEL_TIME_MAX = 120
+
+/** Game gap presets for the slider (in minutes) */
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- intentional UI presets
+const GAME_GAP_PRESETS = [60, 90, 120, 150, 180] as const
+const GAME_GAP_MIN = 60
+const GAME_GAP_MAX = 180
+
+interface FilterToggleRowProps {
+  icon: React.ReactNode
+  label: string
+  enabled: boolean
+  onToggle: () => void
+  value?: string
+  children?: React.ReactNode
+}
+
+function FilterToggleRow({
+  icon,
+  label,
+  enabled,
+  onToggle,
+  value,
+  children,
+}: FilterToggleRowProps) {
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center gap-3 p-3 rounded-lg bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark transition-colors"
+      >
+        <span
+          className={`w-5 h-5 flex-shrink-0 ${enabled ? 'text-primary-600 dark:text-primary-400' : 'text-text-muted dark:text-text-muted-dark'}`}
+        >
+          {icon}
+        </span>
+        <span
+          className={`flex-1 text-left text-sm font-medium ${enabled ? 'text-text-primary dark:text-text-primary-dark' : 'text-text-muted dark:text-text-muted-dark'}`}
+        >
+          {label}
+        </span>
+        {value && enabled && (
+          <span className="text-sm font-semibold text-primary-600 dark:text-primary-400">
+            {value}
+          </span>
+        )}
+        <div
+          className={`w-10 h-6 rounded-full transition-colors relative ${enabled ? 'bg-primary-600' : 'bg-gray-300 dark:bg-gray-600'}`}
+        >
+          <div
+            className={`absolute top-1 w-4 h-4 rounded-full bg-white shadow transition-transform ${enabled ? 'translate-x-5' : 'translate-x-1'}`}
+          />
+        </div>
+      </button>
+      {enabled && children && <div className="px-3 pb-2">{children}</div>}
+    </div>
+  )
+}
+
+interface SliderControlProps {
+  id: string
+  value: number
+  min: number
+  max: number
+  step: number
+  presets: number[]
+  formatPreset: (value: number) => string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+function SliderControl({
+  id,
+  value,
+  min,
+  max,
+  step,
+  presets,
+  formatPreset,
+  onChange,
+}: SliderControlProps) {
+  return (
+    <div className="space-y-2">
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={onChange}
+        className="w-full h-2 bg-surface-muted dark:bg-surface-muted-dark rounded-lg appearance-none cursor-pointer accent-primary-600"
+      />
+      <div className="flex justify-between text-xs text-text-muted dark:text-text-muted-dark">
+        {presets.map((preset) => (
+          <span key={preset}>{formatPreset(preset)}</span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export interface ExchangeFilterMenuProps {
+  /** Whether the "hide own" filter is enabled */
+  hideOwnExchanges: boolean
+  /** Callback when "hide own" is toggled */
+  onHideOwnToggle: () => void
+  /** Whether the level filter is available (demo mode only) */
+  isLevelFilterAvailable: boolean
+  /** Whether the distance filter is available (requires home location) */
+  isDistanceFilterAvailable: boolean
+  /** Whether the travel time filter is available */
+  isTravelTimeFilterAvailable: boolean
+  /** Whether the game gap filter is available (requires calendar data) */
+  isGameGapFilterAvailable: boolean
+  /** User's referee level for display (demo mode) */
+  userRefereeLevel?: string | null
+  /** Optional data-tour attribute */
+  dataTour?: string
+}
+
+function ExchangeFilterMenuComponent({
+  hideOwnExchanges,
+  onHideOwnToggle,
+  isLevelFilterAvailable,
+  isDistanceFilterAvailable,
+  isTravelTimeFilterAvailable,
+  isGameGapFilterAvailable,
+  userRefereeLevel,
+  dataTour,
+}: ExchangeFilterMenuProps) {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const associationCode = useActiveAssociationCode()
+
+  const {
+    distanceFilter,
+    distanceFilterByAssociation,
+    setDistanceFilterEnabled,
+    setDistanceFilterForAssociation,
+    travelTimeFilter,
+    setTravelTimeFilterEnabled,
+    setMaxTravelTimeForAssociation,
+    levelFilterEnabled,
+    setLevelFilterEnabled,
+    gameGapFilter,
+    setGameGapFilterEnabled,
+    setMinGameGapMinutes,
+  } = useSettingsStore(
+    useShallow((state) => ({
+      distanceFilter: state.distanceFilter,
+      distanceFilterByAssociation: state.distanceFilterByAssociation,
+      setDistanceFilterEnabled: state.setDistanceFilterEnabled,
+      setDistanceFilterForAssociation: state.setDistanceFilterForAssociation,
+      travelTimeFilter: state.travelTimeFilter,
+      setTravelTimeFilterEnabled: state.setTravelTimeFilterEnabled,
+      setMaxTravelTimeForAssociation: state.setMaxTravelTimeForAssociation,
+      levelFilterEnabled: state.levelFilterEnabled,
+      setLevelFilterEnabled: state.setLevelFilterEnabled,
+      gameGapFilter: state.gameGapFilter,
+      setGameGapFilterEnabled: state.setGameGapFilterEnabled,
+      setMinGameGapMinutes: state.setMinGameGapMinutes,
+    }))
+  )
+
+  // Get per-association distance filter
+  const currentDistanceFilter = useMemo(() => {
+    const filterMap = distanceFilterByAssociation ?? {}
+    if (associationCode && filterMap[associationCode] !== undefined) {
+      return filterMap[associationCode]
+    }
+    return distanceFilter
+  }, [associationCode, distanceFilterByAssociation, distanceFilter])
+
+  // Get per-association max travel time
+  const currentMaxTravelTime = useMemo(() => {
+    const timeMap = travelTimeFilter.maxTravelTimeByAssociation ?? {}
+    if (associationCode && timeMap[associationCode] !== undefined) {
+      return timeMap[associationCode]
+    }
+    return travelTimeFilter.maxTravelTimeMinutes
+  }, [associationCode, travelTimeFilter])
+
+  const handleDistanceChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!associationCode) return
+      setDistanceFilterForAssociation(associationCode, {
+        maxDistanceKm: Number(e.target.value),
+      })
+    },
+    [associationCode, setDistanceFilterForAssociation]
+  )
+
+  const handleTravelTimeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!associationCode) return
+      setMaxTravelTimeForAssociation(associationCode, Number(e.target.value))
+    },
+    [associationCode, setMaxTravelTimeForAssociation]
+  )
+
+  const handleGameGapChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setMinGameGapMinutes(Number(e.target.value))
+    },
+    [setMinGameGapMinutes]
+  )
+
+  // Count active filters
+  const activeFilterCount = useMemo(() => {
+    let count = 0
+    if (hideOwnExchanges) count++
+    if (isDistanceFilterAvailable && distanceFilter.enabled) count++
+    if (isTravelTimeFilterAvailable && travelTimeFilter.enabled) count++
+    if (isLevelFilterAvailable && levelFilterEnabled) count++
+    if (isGameGapFilterAvailable && gameGapFilter.enabled) count++
+    return count
+  }, [
+    hideOwnExchanges,
+    isDistanceFilterAvailable,
+    distanceFilter.enabled,
+    isTravelTimeFilterAvailable,
+    travelTimeFilter.enabled,
+    isLevelFilterAvailable,
+    levelFilterEnabled,
+    isGameGapFilterAvailable,
+    gameGapFilter.enabled,
+  ])
+
+  const formatDistance = (km: number): string => `${km} km`
+  const timeUnits = {
+    minutesUnit: t('common.minutesUnit'),
+    hoursUnit: t('common.hoursUnit'),
+  }
+  const formatTime = (minutes: number): string =>
+    minutes < MINUTES_PER_HOUR ? `${minutes}m` : `${minutes / MINUTES_PER_HOUR}h`
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        data-tour={dataTour}
+        className="
+          inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full
+          text-sm font-medium
+          bg-surface-subtle dark:bg-surface-subtle-dark
+          text-text-primary dark:text-text-primary-dark
+          hover:bg-surface-muted dark:hover:bg-surface-muted-dark
+          transition-colors cursor-pointer
+          focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1
+        "
+      >
+        <SlidersHorizontal className="w-4 h-4" />
+        <span>{t('exchange.filters')}</span>
+        {activeFilterCount > 0 && (
+          <span className="inline-flex items-center justify-center w-5 h-5 text-xs font-bold rounded-full bg-primary-600 text-white">
+            {activeFilterCount}
+          </span>
+        )}
+      </button>
+
+      <ResponsiveSheet
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        titleId="exchange-filter-menu-title"
+      >
+        <div className="flex items-center justify-between p-4 border-b border-border-default dark:border-border-default-dark">
+          <h2
+            id="exchange-filter-menu-title"
+            className="text-lg font-semibold text-text-primary dark:text-text-primary-dark"
+          >
+            {t('exchange.filters')}
+          </h2>
+          <button
+            type="button"
+            onClick={() => setIsOpen(false)}
+            className="p-2 -m-2 text-text-muted dark:text-text-muted-dark hover:text-text-primary dark:hover:text-text-primary-dark transition-colors"
+            aria-label={t('common.close')}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-3 overflow-y-auto">
+          {/* Hide own exchanges toggle */}
+          <FilterToggleRow
+            icon={<User className="w-full h-full" />}
+            label={t('exchange.hideOwn')}
+            enabled={hideOwnExchanges}
+            onToggle={onHideOwnToggle}
+          />
+
+          {/* Distance filter */}
+          {isDistanceFilterAvailable && (
+            <FilterToggleRow
+              icon={<MapPin className="w-full h-full" />}
+              label={t('exchange.filterByDistance')}
+              enabled={distanceFilter.enabled}
+              onToggle={() => setDistanceFilterEnabled(!distanceFilter.enabled)}
+              value={`≤${currentDistanceFilter.maxDistanceKm} km`}
+            >
+              <SliderControl
+                id="max-distance"
+                value={currentDistanceFilter.maxDistanceKm}
+                min={DISTANCE_MIN}
+                max={DISTANCE_MAX}
+                step={5}
+                presets={[...DISTANCE_PRESETS]}
+                formatPreset={formatDistance}
+                onChange={handleDistanceChange}
+              />
+            </FilterToggleRow>
+          )}
+
+          {/* Travel time filter */}
+          {isTravelTimeFilterAvailable && (
+            <FilterToggleRow
+              icon={<TrainFront className="w-full h-full" />}
+              label={t('exchange.filterByTravelTime')}
+              enabled={travelTimeFilter.enabled}
+              onToggle={() => setTravelTimeFilterEnabled(!travelTimeFilter.enabled)}
+              value={`≤${formatTravelTime(currentMaxTravelTime, timeUnits)}`}
+            >
+              <SliderControl
+                id="max-travel-time"
+                value={currentMaxTravelTime}
+                min={TRAVEL_TIME_MIN}
+                max={TRAVEL_TIME_MAX}
+                step={15}
+                presets={[...TRAVEL_TIME_PRESETS]}
+                formatPreset={formatTime}
+                onChange={handleTravelTimeChange}
+              />
+            </FilterToggleRow>
+          )}
+
+          {/* Game gap filter */}
+          {isGameGapFilterAvailable && (
+            <FilterToggleRow
+              icon={<CalendarX2 className="w-full h-full" />}
+              label={t('exchange.filterByGameGap')}
+              enabled={gameGapFilter.enabled}
+              onToggle={() => setGameGapFilterEnabled(!gameGapFilter.enabled)}
+              value={`≥${formatTravelTime(gameGapFilter.minGapMinutes, timeUnits)}`}
+            >
+              <SliderControl
+                id="min-game-gap"
+                value={gameGapFilter.minGapMinutes}
+                min={GAME_GAP_MIN}
+                max={GAME_GAP_MAX}
+                step={15}
+                presets={[...GAME_GAP_PRESETS]}
+                formatPreset={formatTime}
+                onChange={handleGameGapChange}
+              />
+            </FilterToggleRow>
+          )}
+
+          {/* Level filter (demo mode only) */}
+          {isLevelFilterAvailable && (
+            <FilterToggleRow
+              icon={<User className="w-full h-full" />}
+              label={t('exchange.filterByLevel')}
+              enabled={levelFilterEnabled}
+              onToggle={() => setLevelFilterEnabled(!levelFilterEnabled)}
+              value={userRefereeLevel ?? undefined}
+            />
+          )}
+
+          {/* Description */}
+          <p className="pt-2 text-xs text-text-muted dark:text-text-muted-dark">
+            {t('exchange.settings.description')}
+          </p>
+        </div>
+      </ResponsiveSheet>
+    </>
+  )
+}
+
+export const ExchangeFilterMenu = memo(ExchangeFilterMenuComponent)

--- a/web-app/src/features/exchanges/components/ExchangeFilterMenu.tsx
+++ b/web-app/src/features/exchanges/components/ExchangeFilterMenu.tsx
@@ -10,6 +10,7 @@ import {
   TrainFront,
   User,
   CalendarX2,
+  Award,
 } from '@/shared/components/icons'
 import { ResponsiveSheet } from '@/shared/components/ResponsiveSheet'
 import { useTranslation } from '@/shared/hooks/useTranslation'
@@ -55,6 +56,9 @@ function FilterToggleRow({
     <div className="space-y-2">
       <button
         type="button"
+        role="switch"
+        aria-checked={enabled}
+        aria-label={label}
         onClick={onToggle}
         className="w-full flex items-center gap-3 p-3 rounded-lg bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark transition-colors"
       >
@@ -388,7 +392,7 @@ function ExchangeFilterMenuComponent({
           {/* Level filter (demo mode only) */}
           {isLevelFilterAvailable && (
             <FilterToggleRow
-              icon={<User className="w-full h-full" />}
+              icon={<Award className="w-full h-full" />}
               label={t('exchange.filterByLevel')}
               enabled={levelFilterEnabled}
               onToggle={() => setLevelFilterEnabled(!levelFilterEnabled)}

--- a/web-app/src/features/exchanges/hooks/useExchanges.test.tsx
+++ b/web-app/src/features/exchanges/hooks/useExchanges.test.tsx
@@ -49,10 +49,7 @@ vi.mock('@/api/queryKeys', () => ({
   },
 }))
 
-const createMockExchange = (
-  id: string,
-  submittedByIdentity?: string
-): GameExchange =>
+const createMockExchange = (id: string, submittedByIdentity?: string): GameExchange =>
   ({
     __identity: id,
     status: 'open',

--- a/web-app/src/features/exchanges/index.ts
+++ b/web-app/src/features/exchanges/index.ts
@@ -11,6 +11,9 @@ export { useExchangeActions } from './hooks/useExchangeActions'
 
 // Components
 export { ExchangeCard } from './components/ExchangeCard'
+export { ExchangeFilterMenu } from './components/ExchangeFilterMenu'
+export { ActiveFilterIcons } from './components/ActiveFilterIcons'
+// Legacy - kept for backwards compatibility
 export { ExchangeSettingsSheet } from './components/ExchangeSettingsSheet'
 
 // Tour

--- a/web-app/src/shared/components/icons.tsx
+++ b/web-app/src/shared/components/icons.tsx
@@ -62,6 +62,7 @@ export { Volleyball } from 'lucide-react'
 // Indicator icons
 export { CircleAlert } from 'lucide-react'
 export { ExternalLink } from 'lucide-react'
+export { Award } from 'lucide-react'
 
 // Celebration/medical icons
 export { PartyPopper } from 'lucide-react'

--- a/web-app/src/shared/stores/demo.test.ts
+++ b/web-app/src/shared/stores/demo.test.ts
@@ -259,9 +259,7 @@ describe('useDemoStore', () => {
 
         const afterRemove = useDemoStore.getState()
         // Exchange should be removed
-        expect(
-          afterRemove.exchanges.find((e) => e.__identity === newExchangeId)
-        ).toBeUndefined()
+        expect(afterRemove.exchanges.find((e) => e.__identity === newExchangeId)).toBeUndefined()
         // Original assignment should be restored
         expect(
           afterRemove.assignments.find((a) => a.__identity === assignment.__identity)

--- a/web-app/src/shared/stores/settings.test.ts
+++ b/web-app/src/shared/stores/settings.test.ts
@@ -37,6 +37,7 @@ const DEFAULT_MODE_SETTINGS: ModeSettings = {
     enabled: false,
     minGapMinutes: 120,
   },
+  hideOwnExchangesByAssociation: {},
 }
 
 /** Helper to reset store to clean state */
@@ -666,7 +667,8 @@ describe('useSettingsStore', () => {
     })
 
     it('should fall back to global maxTravelTimeMinutes when no per-association setting exists', () => {
-      const { getMaxTravelTimeForAssociation, setMaxTravelTimeMinutes } = useSettingsStore.getState()
+      const { getMaxTravelTimeForAssociation, setMaxTravelTimeMinutes } =
+        useSettingsStore.getState()
 
       setMaxTravelTimeMinutes(90)
 
@@ -684,7 +686,8 @@ describe('useSettingsStore', () => {
     })
 
     it('should handle undefined association code', () => {
-      const { getMaxTravelTimeForAssociation, setMaxTravelTimeMinutes } = useSettingsStore.getState()
+      const { getMaxTravelTimeForAssociation, setMaxTravelTimeMinutes } =
+        useSettingsStore.getState()
 
       setMaxTravelTimeMinutes(60)
 


### PR DESCRIPTION
## Summary

- Replace horizontal filter pills with single Filters button that opens a menu
- Add icon-only summary showing active filters at a glance
- Create ExchangeFilterMenu component with integrated toggles and sliders
- Store hide own exchanges preference per-association in settings store
- Add migration for new hideOwnExchangesByAssociation setting (v8)
- Update ExchangePage tests for new filter UI

## Test plan

- [ ] Verify Filters button appears on Open tab of Exchange page
- [ ] Verify clicking button opens filter menu sheet
- [ ] Verify each filter toggle works
- [ ] Verify sliders appear when filter is enabled
- [ ] Verify active filter icons appear next to the Filters button
- [ ] Verify filter badge shows correct count of active filters
- [ ] Verify hide own exchanges preference persists per-association
- [ ] Verify filters menu does not appear on Added by Me tab