### PR TITLE
chore(ci): add automated dependency update workflows

### DIFF
--- a/.github/workflows/update-deps-mobile.yml
+++ b/.github/workflows/update-deps-mobile.yml
@@ -1,0 +1,234 @@
+name: Update Dependencies (Mobile)
+
+on:
+  # Run weekly on Mondays at 7:00 UTC (offset from web to avoid concurrent runs)
+  schedule:
+    - cron: '0 7 * * 1'
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      update_type:
+        description: 'Update type'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+# =============================================================================
+# Mobile App Dependency Update Workflow
+# =============================================================================
+#
+# This workflow automatically updates npm dependencies for the mobile app,
+# runs full validation, and creates a PR if successful.
+#
+# Flow:
+#   1. Check for updates using npm-check-updates
+#   2. If updates found, install and run validation
+#   3. Run typecheck, lint, and test
+#   4. Create PR with changes if all validations pass
+#
+# =============================================================================
+
+concurrency:
+  group: update-deps-mobile
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update Dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      has_updates: ${{ steps.check-updates.outputs.has_updates }}
+      updates_summary: ${{ steps.check-updates.outputs.updates_summary }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install npm-check-updates
+        run: npm install -g npm-check-updates
+
+      - name: Check for updates
+        id: check-updates
+        run: |
+          # Determine update target based on input or default to minor
+          UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
+
+          case "$UPDATE_TYPE" in
+            patch) NCU_TARGET="patch" ;;
+            minor) NCU_TARGET="minor" ;;
+            major) NCU_TARGET="latest" ;;
+          esac
+
+          echo "Checking for $UPDATE_TYPE updates..."
+
+          # Check packages/mobile updates
+          cd packages/mobile
+          MOBILE_UPDATES=$(ncu --target "$NCU_TARGET" --format lines 2>/dev/null || true)
+          cd ../..
+
+          # Check packages/shared updates
+          cd packages/shared
+          SHARED_UPDATES=$(ncu --target "$NCU_TARGET" --format lines 2>/dev/null || true)
+          cd ../..
+
+          # Combine updates
+          ALL_UPDATES=""
+          if [ -n "$MOBILE_UPDATES" ]; then
+            ALL_UPDATES="**packages/mobile:**\n$MOBILE_UPDATES"
+          fi
+          if [ -n "$SHARED_UPDATES" ]; then
+            if [ -n "$ALL_UPDATES" ]; then
+              ALL_UPDATES="$ALL_UPDATES\n\n**packages/shared:**\n$SHARED_UPDATES"
+            else
+              ALL_UPDATES="**packages/shared:**\n$SHARED_UPDATES"
+            fi
+          fi
+
+          if [ -n "$MOBILE_UPDATES" ] || [ -n "$SHARED_UPDATES" ]; then
+            echo "has_updates=true" >> "$GITHUB_OUTPUT"
+            # Escape for multiline output
+            {
+              echo "updates_summary<<EOF"
+              echo -e "$ALL_UPDATES"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "Updates found:"
+            echo -e "$ALL_UPDATES"
+          else
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+            echo "No updates available"
+          fi
+
+      - name: Apply updates
+        if: steps.check-updates.outputs.has_updates == 'true'
+        run: |
+          UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
+
+          case "$UPDATE_TYPE" in
+            patch) NCU_TARGET="patch" ;;
+            minor) NCU_TARGET="minor" ;;
+            major) NCU_TARGET="latest" ;;
+          esac
+
+          # Update packages/mobile dependencies
+          cd packages/mobile
+          ncu --target "$NCU_TARGET" -u
+          cd ../..
+
+          # Update packages/shared dependencies
+          cd packages/shared
+          ncu --target "$NCU_TARGET" -u
+          cd ../..
+
+          # Install updated dependencies
+          npm install
+
+          # Regenerate package-lock.json
+          npm install --package-lock-only
+
+      - name: Upload updated files
+        if: steps.check-updates.outputs.has_updates == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: updated-packages-mobile
+          path: |
+            package-lock.json
+            packages/mobile/package.json
+            packages/shared/package.json
+          retention-days: 1
+
+  validate:
+    name: Validate
+    needs: update
+    if: needs.update.outputs.has_updates == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download updated packages
+        uses: actions/download-artifact@v7
+        with:
+          name: updated-packages-mobile
+          path: .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Generate API types
+        run: npm run generate:api
+        working-directory: .
+
+      - name: TypeScript check
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --passWithNoTests
+
+  create-pr:
+    name: Create PR
+    needs: [update, validate]
+    if: needs.update.outputs.has_updates == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download updated packages
+        uses: actions/download-artifact@v7
+        with:
+          name: updated-packages-mobile
+          path: .
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(mobile): update npm dependencies'
+          title: 'chore(mobile): update npm dependencies'
+          body: |
+            ## Dependency Updates
+
+            This PR was automatically generated by the dependency update workflow.
+
+            ### Updated Packages
+
+            ${{ needs.update.outputs.updates_summary }}
+
+            ### Validation
+
+            All validations passed:
+            - TypeScript check
+            - Lint
+            - Tests
+          branch: chore/update-mobile-deps
+          delete-branch: true
+          labels: |
+            dependencies
+            automated

--- a/.github/workflows/update-deps-mobile.yml
+++ b/.github/workflows/update-deps-mobile.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           commit-message: 'chore(mobile): update npm dependencies'
           title: 'chore(mobile): update npm dependencies'
           body: |

--- a/.github/workflows/update-deps-mobile.yml
+++ b/.github/workflows/update-deps-mobile.yml
@@ -61,21 +61,25 @@ jobs:
           node-version: '22'
 
       - name: Install npm-check-updates
-        run: npm install -g npm-check-updates
+        run: npm install -g npm-check-updates@17
 
-      - name: Check for updates
-        id: check-updates
+      - name: Determine update target
+        id: update-target
         run: |
-          # Determine update target based on input or default to minor
           UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
-
           case "$UPDATE_TYPE" in
             patch) NCU_TARGET="patch" ;;
             minor) NCU_TARGET="minor" ;;
             major) NCU_TARGET="latest" ;;
           esac
+          echo "ncu_target=$NCU_TARGET" >> "$GITHUB_OUTPUT"
+          echo "Update target: $NCU_TARGET"
 
-          echo "Checking for $UPDATE_TYPE updates..."
+      - name: Check for updates
+        id: check-updates
+        run: |
+          NCU_TARGET="${{ steps.update-target.outputs.ncu_target }}"
+          echo "Checking for updates with target: $NCU_TARGET"
 
           # Check packages/mobile updates
           cd packages/mobile
@@ -118,13 +122,7 @@ jobs:
       - name: Apply updates
         if: steps.check-updates.outputs.has_updates == 'true'
         run: |
-          UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
-
-          case "$UPDATE_TYPE" in
-            patch) NCU_TARGET="patch" ;;
-            minor) NCU_TARGET="minor" ;;
-            major) NCU_TARGET="latest" ;;
-          esac
+          NCU_TARGET="${{ steps.update-target.outputs.ncu_target }}"
 
           # Update packages/mobile dependencies
           cd packages/mobile
@@ -171,14 +169,10 @@ jobs:
           name: updated-packages-mobile
           path: .
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
         with:
-          node-version: '22'
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: .
+          working-directory: packages/mobile
 
       - name: Generate API types
         run: npm run generate:api
@@ -190,12 +184,17 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Security audit
+        run: npm audit --audit-level=high --omit=dev
+        working-directory: .
+
       - name: Test
         run: npm test -- --passWithNoTests
 
   create-pr:
     name: Create PR
     needs: [update, validate]
+    # Note: For scheduled runs, github.event.inputs.dry_run is empty/null, so this evaluates to true (create PR)
     if: needs.update.outputs.has_updates == 'true' && github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -231,6 +230,7 @@ jobs:
             All validations passed:
             - TypeScript check
             - Lint
+            - Security audit
             - Tests
           branch: chore/update-mobile-deps
           delete-branch: true

--- a/.github/workflows/update-deps-mobile.yml
+++ b/.github/workflows/update-deps-mobile.yml
@@ -16,6 +16,11 @@ on:
           - patch
           - minor
           - major
+      dry_run:
+        description: 'Dry run (check updates and validate without creating PR)'
+        required: false
+        default: false
+        type: boolean
 
 # =============================================================================
 # Mobile App Dependency Update Workflow
@@ -191,7 +196,7 @@ jobs:
   create-pr:
     name: Create PR
     needs: [update, validate]
-    if: needs.update.outputs.has_updates == 'true'
+    if: needs.update.outputs.has_updates == 'true' && github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-deps-web.yml
+++ b/.github/workflows/update-deps-web.yml
@@ -62,25 +62,29 @@ jobs:
           node-version: '22'
 
       - name: Install npm-check-updates
-        run: npm install -g npm-check-updates
+        run: npm install -g npm-check-updates@17
 
-      - name: Check for updates
-        id: check-updates
+      - name: Determine update target
+        id: update-target
         run: |
-          # Determine update target based on input or default to minor
           UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
-
           case "$UPDATE_TYPE" in
             patch) NCU_TARGET="patch" ;;
             minor) NCU_TARGET="minor" ;;
             major) NCU_TARGET="latest" ;;
           esac
+          echo "ncu_target=$NCU_TARGET" >> "$GITHUB_OUTPUT"
+          echo "Update target: $NCU_TARGET"
 
-          echo "Checking for $UPDATE_TYPE updates..."
+      - name: Check for updates
+        id: check-updates
+        run: |
+          NCU_TARGET="${{ steps.update-target.outputs.ncu_target }}"
+          echo "Checking for updates with target: $NCU_TARGET"
 
           # Check web-app updates
           cd web-app
-          WEB_UPDATES=$(ncu --target "$NCU_TARGET" --format lines 2>/dev/null || true)
+          WEB_UPDATES=$(ncu --target "${NCU_TARGET}" --format lines 2>/dev/null || true)
           cd ..
 
           # Check packages/shared updates
@@ -119,13 +123,7 @@ jobs:
       - name: Apply updates
         if: steps.check-updates.outputs.has_updates == 'true'
         run: |
-          UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
-
-          case "$UPDATE_TYPE" in
-            patch) NCU_TARGET="patch" ;;
-            minor) NCU_TARGET="minor" ;;
-            major) NCU_TARGET="latest" ;;
-          esac
+          NCU_TARGET="${{ steps.update-target.outputs.ncu_target }}"
 
           # Update web-app dependencies
           cd web-app
@@ -172,14 +170,10 @@ jobs:
           name: updated-packages
           path: .
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
         with:
-          node-version: '22'
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: .
+          working-directory: web-app
 
       - name: Generate API types
         run: npm run generate:api
@@ -189,6 +183,10 @@ jobs:
 
       - name: Dead code check
         run: npm run knip
+
+      - name: Security audit
+        run: npm audit --audit-level=high --omit=dev
+        working-directory: .
 
       - name: Test
         run: npm test
@@ -202,6 +200,7 @@ jobs:
   create-pr:
     name: Create PR
     needs: [update, validate]
+    # Note: For scheduled runs, github.event.inputs.dry_run is empty/null, so this evaluates to true (create PR)
     if: needs.update.outputs.has_updates == 'true' && github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -237,6 +236,7 @@ jobs:
             All validations passed:
             - Lint
             - Dead code check (knip)
+            - Security audit
             - Tests
             - Build
             - Bundle size check

--- a/.github/workflows/update-deps-web.yml
+++ b/.github/workflows/update-deps-web.yml
@@ -16,6 +16,11 @@ on:
           - patch
           - minor
           - major
+      dry_run:
+        description: 'Dry run (check updates and validate without creating PR)'
+        required: false
+        default: false
+        type: boolean
 
 # =============================================================================
 # Web App Dependency Update Workflow
@@ -197,7 +202,7 @@ jobs:
   create-pr:
     name: Create PR
     needs: [update, validate]
-    if: needs.update.outputs.has_updates == 'true'
+    if: needs.update.outputs.has_updates == 'true' && github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-deps-web.yml
+++ b/.github/workflows/update-deps-web.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           commit-message: 'chore(web): update npm dependencies'
           title: 'chore(web): update npm dependencies'
           body: |

--- a/.github/workflows/update-deps-web.yml
+++ b/.github/workflows/update-deps-web.yml
@@ -1,0 +1,242 @@
+name: Update Dependencies (Web)
+
+on:
+  # Run weekly on Mondays at 6:00 UTC
+  schedule:
+    - cron: '0 6 * * 1'
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      update_type:
+        description: 'Update type'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+# =============================================================================
+# Web App Dependency Update Workflow
+# =============================================================================
+#
+# This workflow automatically updates npm dependencies for the web app,
+# runs full validation, and creates a PR if successful.
+#
+# Flow:
+#   1. Check for updates using npm-check-updates
+#   2. If updates found, install and run validation
+#   3. Generate API types (in case openapi-typescript updated)
+#   4. Run lint, knip, test, and build
+#   5. Create PR with changes if all validations pass
+#
+# =============================================================================
+
+concurrency:
+  group: update-deps-web
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update Dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      has_updates: ${{ steps.check-updates.outputs.has_updates }}
+      updates_summary: ${{ steps.check-updates.outputs.updates_summary }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install npm-check-updates
+        run: npm install -g npm-check-updates
+
+      - name: Check for updates
+        id: check-updates
+        run: |
+          # Determine update target based on input or default to minor
+          UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
+
+          case "$UPDATE_TYPE" in
+            patch) NCU_TARGET="patch" ;;
+            minor) NCU_TARGET="minor" ;;
+            major) NCU_TARGET="latest" ;;
+          esac
+
+          echo "Checking for $UPDATE_TYPE updates..."
+
+          # Check web-app updates
+          cd web-app
+          WEB_UPDATES=$(ncu --target "$NCU_TARGET" --format lines 2>/dev/null || true)
+          cd ..
+
+          # Check packages/shared updates
+          cd packages/shared
+          SHARED_UPDATES=$(ncu --target "$NCU_TARGET" --format lines 2>/dev/null || true)
+          cd ..
+
+          # Combine updates
+          ALL_UPDATES=""
+          if [ -n "$WEB_UPDATES" ]; then
+            ALL_UPDATES="**web-app:**\n$WEB_UPDATES"
+          fi
+          if [ -n "$SHARED_UPDATES" ]; then
+            if [ -n "$ALL_UPDATES" ]; then
+              ALL_UPDATES="$ALL_UPDATES\n\n**packages/shared:**\n$SHARED_UPDATES"
+            else
+              ALL_UPDATES="**packages/shared:**\n$SHARED_UPDATES"
+            fi
+          fi
+
+          if [ -n "$WEB_UPDATES" ] || [ -n "$SHARED_UPDATES" ]; then
+            echo "has_updates=true" >> "$GITHUB_OUTPUT"
+            # Escape for multiline output
+            {
+              echo "updates_summary<<EOF"
+              echo -e "$ALL_UPDATES"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "Updates found:"
+            echo -e "$ALL_UPDATES"
+          else
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+            echo "No updates available"
+          fi
+
+      - name: Apply updates
+        if: steps.check-updates.outputs.has_updates == 'true'
+        run: |
+          UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
+
+          case "$UPDATE_TYPE" in
+            patch) NCU_TARGET="patch" ;;
+            minor) NCU_TARGET="minor" ;;
+            major) NCU_TARGET="latest" ;;
+          esac
+
+          # Update web-app dependencies
+          cd web-app
+          ncu --target "$NCU_TARGET" -u
+          cd ..
+
+          # Update packages/shared dependencies
+          cd packages/shared
+          ncu --target "$NCU_TARGET" -u
+          cd ..
+
+          # Install updated dependencies
+          npm install
+
+          # Regenerate package-lock.json
+          npm install --package-lock-only
+
+      - name: Upload updated files
+        if: steps.check-updates.outputs.has_updates == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: updated-packages
+          path: |
+            package-lock.json
+            web-app/package.json
+            packages/shared/package.json
+          retention-days: 1
+
+  validate:
+    name: Validate
+    needs: update
+    if: needs.update.outputs.has_updates == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download updated packages
+        uses: actions/download-artifact@v7
+        with:
+          name: updated-packages
+          path: .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Generate API types
+        run: npm run generate:api
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Dead code check
+        run: npm run knip
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Bundle size check
+        run: npm run size
+
+  create-pr:
+    name: Create PR
+    needs: [update, validate]
+    if: needs.update.outputs.has_updates == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download updated packages
+        uses: actions/download-artifact@v7
+        with:
+          name: updated-packages
+          path: .
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(web): update npm dependencies'
+          title: 'chore(web): update npm dependencies'
+          body: |
+            ## Dependency Updates
+
+            This PR was automatically generated by the dependency update workflow.
+
+            ### Updated Packages
+
+            ${{ needs.update.outputs.updates_summary }}
+
+            ### Validation
+
+            All validations passed:
+            - Lint
+            - Dead code check (knip)
+            - Tests
+            - Build
+            - Bundle size check
+          branch: chore/update-web-deps
+          delete-branch: true
+          labels: |
+            dependencies
+            automated


### PR DESCRIPTION
## Summary

- Add `update-deps-web.yml` workflow for web-app and shared package dependencies
- Add `update-deps-mobile.yml` workflow for mobile app and shared package dependencies
- Use `RELEASE_TOKEN` for PR creation (fine-grained PAT)
- Add dry run mode to validate without creating PR

Both workflows:
- Run weekly on Mondays (staggered by 1 hour to avoid conflicts)
- Support manual trigger with patch/minor/major update options
- Run full validation (lint, test, build, etc.) before creating a PR
- Use npm-check-updates to detect and apply updates
- Create PRs with detailed changelogs if validation passes

## Test plan

- [ ] Trigger web workflow manually with dry_run=true
- [ ] Trigger mobile workflow manually with dry_run=true
- [ ] Verify updates are detected and validation runs
- [ ] Verify no PR is created in dry run mode
- [ ] Trigger without dry run to verify PR creation works