### PR TITLE
feat(ci): add CI status check to pr-review command

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -115,19 +115,29 @@ The `fix(review):` prefix prevents infinite review loops.
 If CI was failing in Step 6, fix those issues now:
 
 1. Review the failed check details via `html_url`
-2. Reproduce the failure locally by running the relevant commands:
+2. Reproduce the failure locally by running the relevant commands based on the failed check:
 
+**For web-app failures:**
 ```bash
-cd web-app && npm run lint
+cd web-app && npm run lint && npm test && npm run build
 ```
 
+**For shared library failures:**
 ```bash
-cd web-app && npm test
+cd packages/shared && npm run lint && npm test && npm run build
 ```
 
+**For mobile app failures:**
 ```bash
-cd web-app && npm run build
+cd packages/mobile && npm run typecheck && npm run lint && npm test
 ```
+
+**For worker failures:**
+```bash
+cd worker && npm run lint && npm test
+```
+
+Note: Match the local commands to the specific CI check that failed. The `html_url` will indicate which package/workflow failed.
 
 3. Fix the identified issues in the codebase
 4. Re-run the failed local commands to verify the fix
@@ -180,4 +190,4 @@ If any check fails, return to Step 9 to fix and push again.
 - `Committed CI fixes`
 - `Pushed all changes`
 - `Verifying remote CI...`
-- `CI passed` or `CI still failing - fixing...`
+- `Remote CI passed` or `Remote CI still failing - fixing...`

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -111,10 +111,10 @@ sleep 30
 Fetch check runs for the PR head commit:
 
 ```bash
-bash -c 'BRANCH=$(git rev-parse --abbrev-ref HEAD); SHA=$(git rev-parse HEAD); REMOTE=$(git remote get-url origin); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; fi; curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/commits/$SHA/check-runs" | jq "{total_count, check_runs: [.check_runs[] | {name, status, conclusion, html_url}]}"'
+bash -c 'SHA=$(git rev-parse HEAD); REMOTE=$(git remote get-url origin); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; fi; curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/commits/$SHA/check-runs" | jq "{total_count, check_runs: [.check_runs[] | {name, status, conclusion, html_url}]}"'
 ```
 
-If checks are still `in_progress`, wait 2 minutes and retry (up to 5 times):
+If checks are still `in_progress`, wait 2 minutes and retry. Track retry count (max 5 retries, ~10.5 minutes total wait):
 
 ```bash
 sleep 120
@@ -131,6 +131,8 @@ If any check has `conclusion: "failure"`:
 2. Identify and fix the issue in the codebase
 3. Commit with message `fix(ci): address CI failure in <check_name>`
 4. Push and return to Step 8 to re-check CI
+
+The `fix(ci):` prefix (like `fix(review):`) prevents infinite review loops.
 
 If all checks pass (`conclusion: "success"`), inform user and complete.
 


### PR DESCRIPTION
## Summary
- Add CI status checking (Step 6) before making any changes to identify failures upfront
- Restructure flow: check review + check CI → fix review issues → fix CI issues → push once
- Expand local CI commands to cover all packages (web-app, shared, mobile, worker)
- Add Step 11 to verify remote CI passes after pushing

## Changes
- **Step 6**: Check CI status on current commit before making changes
- **Step 7**: Parse and address review issues (unchanged logic)
- **Step 8**: Commit review fixes without pushing
- **Step 9**: Fix CI failures locally with package-specific commands, then commit
- **Step 10**: Push all changes at once
- **Step 11**: Verify remote CI passes, loop back if failures

## Test plan
- [ ] Run `/pr-review` on a PR with review comments only
- [ ] Run `/pr-review` on a PR with CI failures only
- [ ] Run `/pr-review` on a PR with both review comments and CI failures
- [ ] Verify all changes are pushed in a single push
- [ ] Verify package-specific CI commands work for non-web-app failures