### PR TITLE
fix(mobile): align app.json version and automate sync in release workflow

### DIFF
--- a/.changeset/fix-mobile-version-mismatch.md
+++ b/.changeset/fix-mobile-version-mismatch.md
@@ -1,0 +1,5 @@
+---
+"@volleykit/mobile": patch
+---
+
+Fix version mismatch between app.json and package.json (1.0.1 → 1.8.0)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,22 @@ jobs:
           # Sync package-lock.json with the new version in package.json
           npm install --package-lock-only
 
+      - name: Sync mobile app.json version
+        if: steps.check_changesets.outputs.changeset_count != '0'
+        run: |
+          # Get the new version from mobile package.json
+          MOBILE_VERSION=$(node -p "require('./packages/mobile/package.json').version")
+
+          # Update app.json expo.version to match
+          node -e "
+            const fs = require('fs');
+            const appJson = JSON.parse(fs.readFileSync('./packages/mobile/app.json', 'utf8'));
+            appJson.expo.version = '$MOBILE_VERSION';
+            fs.writeFileSync('./packages/mobile/app.json', JSON.stringify(appJson, null, 2) + '\n');
+          "
+
+          echo "Synced app.json version to $MOBILE_VERSION"
+
       - name: Get new version
         id: get_version
         run: |

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "VolleyKit",
     "slug": "volleykit",
-    "version": "1.0.1",
+    "version": "1.8.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "volleykit",


### PR DESCRIPTION
## Summary

- Fix version mismatch between app.json (1.0.1 → 1.8.0) and package.json for consistent beta builds
- Add changeset for version tracking
- Add step to release workflow that automatically syncs app.json expo.version after changeset version bump

## Test plan

- [ ] Verify app.json version now matches package.json (1.8.0)
- [ ] Run release workflow with dry_run=true to confirm app.json sync step works