### PR TITLE
fix(ci): handle divergent linked package versions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,21 @@ jobs:
             echo "released=false" >> "$GITHUB_OUTPUT"
             echo "version=" >> "$GITHUB_OUTPUT"
           else
-            VERSION=$(node -p "require('./web-app/package.json').version")
+            # Get versions from all linked packages and use the highest
+            # This handles cases where changesets only bump some packages
+            VERSION=$(node -e "
+              const semver = require('semver');
+              const versions = [
+                require('./web-app/package.json').version,
+                require('./packages/shared/package.json').version,
+                require('./packages/mobile/package.json').version
+              ];
+              const sorted = versions.sort(semver.rcompare);
+              console.log(sorted[0]);
+            ")
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "released=true" >> "$GITHUB_OUTPUT"
-            echo "New version: $VERSION"
+            echo "New version: $VERSION (highest across linked packages)"
           fi
 
       - name: Extract release notes
@@ -172,9 +183,24 @@ jobs:
       - name: Show changes (dry run)
         if: inputs.dry_run && steps.get_version.outputs.released == 'true'
         run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          TAG="v$VERSION"
+
           echo "=== Version bump ==="
-          echo "New version: ${{ steps.get_version.outputs.version }}"
+          echo "New version: $VERSION"
           echo ""
+          echo "=== Package versions ==="
+          echo "  - volleykit-web: $(node -p \"require('./web-app/package.json').version\")"
+          echo "  - @volleykit/shared: $(node -p \"require('./packages/shared/package.json').version\")"
+          echo "  - @volleykit/mobile: $(node -p \"require('./packages/mobile/package.json').version\")"
+          echo ""
+
+          # Check if tag already exists
+          if git tag -l "$TAG" | grep -q "$TAG" || git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "::warning::Tag $TAG already exists! Release would fail."
+            echo "::warning::Linked packages may have divergent versions."
+          fi
+
           echo "=== CHANGELOG.md changes ==="
           git diff CHANGELOG.md
           echo ""
@@ -184,7 +210,7 @@ jobs:
           echo "=== Release notes ==="
           cat /tmp/release_notes.md
           echo ""
-          echo "=== Would create tag: v${{ steps.get_version.outputs.version }} ==="
+          echo "=== Would create tag: $TAG ==="
 
       - name: Commit changes
         if: ${{ !inputs.dry_run && steps.get_version.outputs.released == 'true' }}
@@ -197,7 +223,26 @@ jobs:
 
       - name: Create tag
         if: ${{ !inputs.dry_run && steps.get_version.outputs.released == 'true' }}
-        run: git tag -a "v${{ steps.get_version.outputs.version }}" -m "Release v${{ steps.get_version.outputs.version }}"
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          TAG="v$VERSION"
+
+          # Check if tag already exists (locally or remotely)
+          if git tag -l "$TAG" | grep -q "$TAG" || git ls-remote --tags origin "$TAG" | grep -q "$TAG"; then
+            echo "::error::Tag $TAG already exists!"
+            echo "::error::This usually means the linked packages have divergent versions."
+            echo "::error::Check that volleykit-web, @volleykit/shared, and @volleykit/mobile have consistent versions."
+            echo ""
+            echo "Current package versions:"
+            echo "  - volleykit-web: $(node -p \"require('./web-app/package.json').version\")"
+            echo "  - @volleykit/shared: $(node -p \"require('./packages/shared/package.json').version\")"
+            echo "  - @volleykit/mobile: $(node -p \"require('./packages/mobile/package.json').version\")"
+            echo ""
+            echo "To fix: Ensure all linked packages have the same version, or manually bump versions."
+            exit 1
+          fi
+
+          git tag -a "$TAG" -m "Release $TAG"
 
       - name: Push changes
         if: ${{ !inputs.dry_run && steps.get_version.outputs.released == 'true' }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31883,7 +31883,7 @@
     },
     "packages/mobile": {
       "name": "@volleykit/mobile",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.0",
         "@react-native-async-storage/async-storage": "2.1.0",
@@ -31945,7 +31945,7 @@
     },
     "packages/shared": {
       "name": "@volleykit/shared",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "devDependencies": {
         "@tanstack/react-query": "^5.90.19",
         "@testing-library/dom": "^10.4.1",

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "VolleyKit",
     "slug": "volleykit",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "volleykit",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volleykit/mobile",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "VolleyKit React Native mobile app",
   "type": "module",
   "private": true,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@volleykit/shared",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Shared code between VolleyKit web and mobile apps",
   "private": true,
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Read highest version across all linked packages (web, shared, mobile) instead of just web-app
- Check if tag already exists before attempting to create it
- Show all package versions in dry run mode
- Provide helpful error message when versions are out of sync
- Align all linked package versions to 1.9.0

## Test plan

- [ ] Run release workflow with `dry_run: true` to verify version detection
- [ ] Verify all packages now show version 1.9.0