### PR TITLE
fix(web): respect API permissions when determining compensation editability

### DIFF
--- a/.changeset/fix-compensation-permission-check.md
+++ b/.changeset/fix-compensation-permission-check.md
@@ -1,0 +1,7 @@
+---
+"volleykit-web": patch
+---
+
+Fix compensation editing to respect API permissions
+
+The app now checks the `_permissions.properties.convocationCompensation.update` field from the API response before allowing compensation editing. This prevents users from seeing an edit option for compensations they cannot actually modify on volleymanager.

--- a/web-app/src/features/compensations/utils/compensation-actions.test.ts
+++ b/web-app/src/features/compensations/utils/compensation-actions.test.ts
@@ -376,6 +376,82 @@ describe('downloadCompensationPDF', () => {
 })
 
 describe('isCompensationEditable', () => {
+  describe('API permissions (_permissions field)', () => {
+    it('returns false when API explicitly denies update permission', () => {
+      const compensation = {
+        __identity: 'test-1',
+        convocationCompensation: {
+          paymentDone: false,
+          methodOfDisbursementArbitration: 'central_payout',
+          lockPayoutCentralPayoutCompensation: false,
+        },
+        refereeGame: {},
+        _permissions: {
+          properties: {
+            convocationCompensation: {
+              update: false,
+              create: true,
+            },
+          },
+        },
+      } as unknown as CompensationRecord
+
+      expect(isCompensationEditable(compensation)).toBe(false)
+    })
+
+    it('returns true when API explicitly allows update permission', () => {
+      const compensation = {
+        __identity: 'test-1',
+        convocationCompensation: {
+          paymentDone: false,
+          methodOfDisbursementArbitration: 'central_payout',
+          lockPayoutCentralPayoutCompensation: false,
+        },
+        refereeGame: {},
+        _permissions: {
+          properties: {
+            convocationCompensation: {
+              update: true,
+              create: true,
+            },
+          },
+        },
+      } as unknown as CompensationRecord
+
+      expect(isCompensationEditable(compensation)).toBe(true)
+    })
+
+    it('falls back to lock checks when _permissions is not present', () => {
+      const compensation = {
+        __identity: 'test-1',
+        convocationCompensation: {
+          paymentDone: false,
+          methodOfDisbursementArbitration: 'central_payout',
+          lockPayoutCentralPayoutCompensation: false,
+        },
+        refereeGame: {},
+        // No _permissions field
+      } as unknown as CompensationRecord
+
+      expect(isCompensationEditable(compensation)).toBe(true)
+    })
+
+    it('falls back to lock checks when _permissions.properties is not present', () => {
+      const compensation = {
+        __identity: 'test-1',
+        convocationCompensation: {
+          paymentDone: false,
+        },
+        refereeGame: {},
+        _permissions: {
+          object: { delete: false },
+        },
+      } as unknown as CompensationRecord
+
+      expect(isCompensationEditable(compensation)).toBe(true)
+    })
+  })
+
   it('returns true for unpaid compensation with central payout method', () => {
     const compensation = {
       __identity: 'test-1',
@@ -499,6 +575,87 @@ describe('isAssignmentCompensationEditable', () => {
         },
       },
     },
+  })
+
+  describe('API permissions (_permissions field)', () => {
+    it('returns false when API explicitly denies update permission', () => {
+      const assignment = {
+        __identity: 'test-1',
+        convocationCompensation: {
+          paymentDone: false,
+          methodOfDisbursementArbitration: 'central_payout',
+          lockPayoutCentralPayoutCompensation: false,
+        },
+        refereeGame: createRefereeGameWithLeague(),
+        _permissions: {
+          properties: {
+            convocationCompensation: {
+              update: false,
+              create: true,
+            },
+          },
+        },
+      } as unknown as Assignment
+
+      expect(isAssignmentCompensationEditable(assignment)).toBe(false)
+    })
+
+    it('returns true when API explicitly allows update permission', () => {
+      const assignment = {
+        __identity: 'test-1',
+        convocationCompensation: {
+          paymentDone: false,
+          methodOfDisbursementArbitration: 'central_payout',
+          lockPayoutCentralPayoutCompensation: false,
+        },
+        refereeGame: createRefereeGameWithLeague(),
+        _permissions: {
+          properties: {
+            convocationCompensation: {
+              update: true,
+              create: true,
+            },
+          },
+        },
+      } as unknown as Assignment
+
+      expect(isAssignmentCompensationEditable(assignment)).toBe(true)
+    })
+
+    it('falls back to lock checks when _permissions is not present', () => {
+      const assignment = {
+        __identity: 'test-1',
+        convocationCompensation: {
+          paymentDone: false,
+          methodOfDisbursementArbitration: 'central_payout',
+          lockPayoutCentralPayoutCompensation: false,
+        },
+        refereeGame: createRefereeGameWithLeague(),
+        // No _permissions field
+      } as unknown as Assignment
+
+      expect(isAssignmentCompensationEditable(assignment)).toBe(true)
+    })
+
+    it('checks _permissions before calendar mode check', () => {
+      // Even with league data, API permissions should be checked
+      const assignment = {
+        __identity: 'test-1',
+        convocationCompensation: {
+          paymentDone: false,
+        },
+        refereeGame: createRefereeGameWithLeague(),
+        _permissions: {
+          properties: {
+            convocationCompensation: {
+              update: false,
+            },
+          },
+        },
+      } as unknown as Assignment
+
+      expect(isAssignmentCompensationEditable(assignment)).toBe(false)
+    })
   })
 
   describe('calendar mode assignments', () => {

--- a/web-app/src/features/compensations/utils/compensation-actions.ts
+++ b/web-app/src/features/compensations/utils/compensation-actions.ts
@@ -51,6 +51,7 @@ function isCompensationLocked(cc: ConvocationCompensationWithLockFlags): boolean
  * Checks if a compensation record can be edited.
  *
  * Editability rules (based on disbursement method):
+ * - Non-editable: API explicitly denies update permission (_permissions.properties.convocationCompensation.update === false)
  * - Non-editable: paymentDone=true (already paid)
  * - Non-editable: relevant lock is true based on methodOfDisbursementArbitration
  *   - payout_on_site: check lockPayoutOnSiteCompensation
@@ -58,6 +59,11 @@ function isCompensationLocked(cc: ConvocationCompensationWithLockFlags): boolean
  * - Editable: not paid AND relevant lock is false
  */
 export function isCompensationEditable(compensation: CompensationRecord): boolean {
+  // Check API-level permissions first - server knows best
+  if (compensation._permissions?.properties?.convocationCompensation?.update === false) {
+    return false
+  }
+
   const cc = compensation.convocationCompensation as
     | ConvocationCompensationWithLockFlags
     | undefined
@@ -77,6 +83,7 @@ export function isCompensationEditable(compensation: CompensationRecord): boolea
  *
  * Editability rules (same as isCompensationEditable):
  * - Non-editable: Calendar mode assignments (missing compensation data entirely)
+ * - Non-editable: API explicitly denies update permission (_permissions.properties.convocationCompensation.update === false)
  * - Non-editable: paymentDone=true (already paid)
  * - Non-editable: relevant lock is true based on methodOfDisbursementArbitration
  * - Editable: convocationCompensation not present but NOT calendar mode (defaults to editable for backwards compatibility)
@@ -85,6 +92,11 @@ export function isCompensationEditable(compensation: CompensationRecord): boolea
 export function isAssignmentCompensationEditable(assignment: Assignment): boolean {
   // Calendar mode assignments are read-only - compensation editing not available
   if (isFromCalendarMode(assignment)) {
+    return false
+  }
+
+  // Check API-level permissions first - server knows best
+  if (assignment._permissions?.properties?.convocationCompensation?.update === false) {
     return false
   }
 


### PR DESCRIPTION
## Summary
- Added check for `_permissions.properties.convocationCompensation.update` from the API response before allowing compensation editing
- This ensures the app correctly hides the edit option for compensations that volleymanager does not permit the user to modify

## Test plan
- [x] Added unit tests for the new permission checks in both `isCompensationEditable` and `isAssignmentCompensationEditable` functions
- [x] Verified all 153 compensation-related tests pass
- [x] Build successful