### PR TITLE
feat(api): add pickFromRefereeGameExchange endpoint for exchange takeover

### DIFF
--- a/docs/api/captures/exchange_actions.md
+++ b/docs/api/captures/exchange_actions.md
@@ -7,33 +7,60 @@ When clicking the "more_horiz" (⋯) button on an exchange row, a popup menu app
 1. **Détails du match** (Match details) - View match details
 1. **Reprendre engagement** (Take over assignment) - Apply to take over the referee position
 
-## Apply for Exchange (Reprendre engagement)
+## Apply for Exchange / Take Over Assignment (Reprendre engagement) - Confirmed
 
-Based on the response structure and permissions, applying for an exchange updates the `appliedBy` field.
+Taking over a referee position from the exchange marketplace.
 
-### Endpoint (Hypothesized)
+### Endpoint
 
 ```
-PUT /api/indoorvolleyball.refadmin/api\refereegameexchange
+PUT /api/indoorvolleyball.refadmin/api\refereegameexchange/pickFromRefereeGameExchange
 ```
 
-### Request Format
+### Request Format (Confirmed)
 
 ```
 Content-Type: application/x-www-form-urlencoded
 
-__identity=<exchange-uuid>
-&appliedBy[indoorReferee][__identity]=<current-user-referee-uuid>
+refereeGameExchange[__identity]=<exchange-uuid>
 &__csrfToken=<csrf-token>
 ```
 
-Or possibly a simpler format:
+**Example:**
 
 ```
-__identity=<exchange-uuid>
-&apply=1
+refereeGameExchange%5B__identity%5D=eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee
 &__csrfToken=<csrf-token>
 ```
+
+### Response (200 OK)
+
+```json
+{
+  "refereeGameExchange": {
+    "__identity": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+    "persistenceObjectIdentifier": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+    "status": "applied",
+    "refereePosition": "head-two",
+    "submittingType": "referee",
+    "submittedAt": "2025-01-22T12:58:18.000000+00:00",
+    "appliedAt": "2025-01-23T20:38:41.954034+00:00",
+    "requiredRefereeLevel": "N3",
+    "requiredRefereeLevelGradationValue": 4,
+    "createdAt": "2025-01-22T12:58:18.000000+00:00",
+    "createdBy": "user_name",
+    "updatedAt": "2025-01-23T13:00:16.000000+00:00",
+    "updatedBy": "System",
+    "_permissions": { ... }
+  }
+}
+```
+
+**Notes:**
+
+- The endpoint name `pickFromRefereeGameExchange` suggests "picking" the assignment from the exchange
+- Status changes to `applied` after the action
+- `appliedAt` is set to the current timestamp
 
 ### Permissions Check
 
@@ -141,16 +168,11 @@ refereeConvocation=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
 
 ______________________________________________________________________
 
-## TODO: Capture Actual Requests
-
-Remaining items to confirm:
-
-1. Network request when clicking "Reprendre engagement" (carefully - will actually apply!)
-
-### Completed
+## Completed Captures
 
 - ✓ Delete from exchange: `deleteFromRefereeGameExchange` (batch array format)
 - ✓ Add to exchange: `putRefereeConvocationIntoRefereeGameExchange` (single item format)
+- ✓ Take over assignment: `pickFromRefereeGameExchange` (confirmed Jan 2026)
 
 ## Exchange Status Flow
 

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -356,6 +356,38 @@ paths:
           description: Operation successful
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /indoorvolleyball.refadmin/api\refereegameexchange/pickFromRefereeGameExchange:
+    put:
+      tags: [Exchanges]
+      summary: Pick an applicant for a referee game exchange
+      description: |
+        Allows a dispatcher or admin to pick/confirm an applicant for a referee position exchange.
+        This finalizes the exchange by assigning the position to the selected applicant.
+      operationId: pickFromRefereeGameExchange
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [refereeGameExchange, __csrfToken]
+              properties:
+                refereeGameExchange[__identity]:
+                  type: string
+                  format: uuid
+                  description: The exchange ID to pick from
+                __csrfToken:
+                  type: string
+                  description: CSRF token for request validation
+      responses:
+        '200':
+          description: Exchange pick successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PickExchangeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /sportmanager.indoorvolleyball/api\indoorseason/getActiveIndoorSeason:
     get:
       tags: [Settings]
@@ -1876,6 +1908,132 @@ components:
           type: integer
           minimum: 0
           example: 7
+    PickExchangeResponse:
+      type: object
+      description: Response from picking an applicant for a referee game exchange
+      required: [refereeGameExchange]
+      properties:
+        refereeGameExchange:
+          $ref: '#/components/schemas/RefereeGameExchangeDetail'
+    RefereeGameExchangeDetail:
+      type: object
+      description: Detailed referee game exchange object with audit information
+      required: [__identity, status, refereePosition, submittingType, submittedAt]
+      properties:
+        __identity:
+          type: string
+          format: uuid
+          description: Unique identifier for this exchange
+          example: "d5a2a8e1-2ae7-4400-be39-8da8ecbce16f"
+        persistenceObjectIdentifier:
+          type: string
+          format: uuid
+          description: Persistence identifier (same as __identity)
+        status:
+          type: string
+          enum: [open, applied, closed]
+          description: Current status of the exchange
+          example: "applied"
+        refereePosition:
+          $ref: '#/components/schemas/RefereePosition'
+        refereeGame:
+          type: object
+          nullable: true
+          description: Reference to the referee game (if included)
+        submittingType:
+          type: string
+          enum: [referee, admin]
+          description: Who submitted the exchange request
+          example: "referee"
+        submittedAt:
+          type: string
+          format: date-time
+          description: When the exchange was submitted
+          example: "2026-01-22T12:58:18.000000+00:00"
+        submittedByPerson:
+          type: object
+          nullable: true
+          description: Person who submitted the exchange
+        appliedBy:
+          type: object
+          nullable: true
+          description: Person who applied for this exchange
+        appliedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When someone applied for this exchange
+          example: "2026-01-23T20:38:41.954034+00:00"
+        requiredRefereeLevel:
+          $ref: '#/components/schemas/RefereeLevel'
+        requiredRefereeLevelGradationValue:
+          type: integer
+          description: Gradation value for required referee level (1-4)
+          minimum: 1
+          maximum: 4
+          example: 4
+        responsibleClubIfApplicable:
+          type: object
+          nullable: true
+          description: Club responsible for the exchange if applicable
+        linkedDoubleConvocationGameNumberAndRefereePosition:
+          type: string
+          nullable: true
+          description: Linked double convocation info if applicable
+        latestReminderToChampionshipOwnerSentAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the last reminder was sent to championship owner
+        latestReminderToSubmittingTypeSentAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the last reminder was sent to submitting party
+        createdAt:
+          type: string
+          format: date-time
+          description: Creation timestamp
+          example: "2026-01-22T12:58:18.000000+00:00"
+        createdBy:
+          type: string
+          description: Username who created this exchange
+          example: "yannic_weber"
+        createdByPersistenceIdentifier:
+          type: string
+          format: uuid
+          description: Persistence identifier of the creator
+        createdByIpAddress:
+          type: string
+          nullable: true
+          description: IP address of the creator
+          example: "193.47.169.32"
+        updatedAt:
+          type: string
+          format: date-time
+          description: Last update timestamp
+        updatedBy:
+          type: string
+          description: Username who last updated this exchange
+          example: "System"
+        updatedByPersistenceIdentifier:
+          type: string
+          description: Persistence identifier of the last updater
+        updatedByIpAddress:
+          type: string
+          nullable: true
+          description: IP address of the last updater
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Soft delete timestamp (null if not deleted)
+        lastUpdatedByRealUser:
+          type: boolean
+          description: Whether last update was by a real user vs system
+          example: false
+        _permissions:
+          $ref: '#/components/schemas/Permissions'
     # ==================== Referee Backup Response Schemas ====================
     RefereeBackupSearchResponse:
       type: object

--- a/packages/shared/src/api/client.ts
+++ b/packages/shared/src/api/client.ts
@@ -100,7 +100,7 @@ export interface ApiClient {
   searchExchanges(
     config: SearchConfiguration
   ): Promise<PaginatedResponse<GameExchange>>;
-  applyForExchange(exchangeId: string): Promise<PickFromExchangeResult>;
+  applyForExchange(exchangeId: string): Promise<PickExchangeResponse>;
   withdrawFromExchange(exchangeId: string): Promise<void>;
   addToExchange(assignmentId: string, reason?: string): Promise<void>;
 
@@ -157,12 +157,16 @@ export interface CompensationUpdateData {
 }
 
 /**
- * Result of picking an applicant from an exchange.
+ * Response from applying for/picking a referee game exchange.
+ * Matches the PickExchangeResponse schema from the OpenAPI spec.
  */
-export interface PickFromExchangeResult {
+export interface PickExchangeResponse {
   refereeGameExchange: {
     __identity: string;
     status: 'open' | 'applied' | 'closed';
+    refereePosition: string;
+    submittingType: 'referee' | 'admin';
+    submittedAt: string;
     appliedAt: string | null;
     [key: string]: unknown;
   };

--- a/packages/shared/src/api/client.ts
+++ b/packages/shared/src/api/client.ts
@@ -100,9 +100,8 @@ export interface ApiClient {
   searchExchanges(
     config: SearchConfiguration
   ): Promise<PaginatedResponse<GameExchange>>;
-  applyForExchange(exchangeId: string): Promise<void>;
+  applyForExchange(exchangeId: string): Promise<PickFromExchangeResult>;
   withdrawFromExchange(exchangeId: string): Promise<void>;
-  pickFromExchange(exchangeId: string): Promise<PickFromExchangeResult>;
   addToExchange(assignmentId: string, reason?: string): Promise<void>;
 
   // Settings

--- a/packages/shared/src/api/client.ts
+++ b/packages/shared/src/api/client.ts
@@ -102,6 +102,7 @@ export interface ApiClient {
   ): Promise<PaginatedResponse<GameExchange>>;
   applyForExchange(exchangeId: string): Promise<void>;
   withdrawFromExchange(exchangeId: string): Promise<void>;
+  pickFromExchange(exchangeId: string): Promise<PickFromExchangeResult>;
   addToExchange(assignmentId: string, reason?: string): Promise<void>;
 
   // Settings
@@ -154,6 +155,18 @@ export interface OccupationData {
 export interface CompensationUpdateData {
   kilometers?: number;
   reason?: string;
+}
+
+/**
+ * Result of picking an applicant from an exchange.
+ */
+export interface PickFromExchangeResult {
+  refereeGameExchange: {
+    __identity: string;
+    status: 'open' | 'applied' | 'closed';
+    appliedAt: string | null;
+    [key: string]: unknown;
+  };
 }
 
 /**

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -55,7 +55,6 @@ export type RefereeBackupEntry = Schemas['RefereeBackupEntry']
 export type RefereeBackupSearchResponse = Schemas['RefereeBackupSearchResponse']
 export type BackupRefereeAssignment = Schemas['BackupRefereeAssignment']
 export type PickExchangeResponse = Schemas['PickExchangeResponse']
-export type RefereeGameExchangeDetail = Schemas['RefereeGameExchangeDetail']
 
 export interface PersonSearchFilter {
   firstName?: string

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -292,21 +292,7 @@ export const api = {
     return data as ExchangesResponse
   },
 
-  async applyForExchange(exchangeId: string): Promise<void> {
-    return apiRequest('/indoorvolleyball.refadmin/api%5crefereegameexchange', 'PUT', {
-      __identity: exchangeId,
-      apply: '1',
-    })
-  },
-
-  async withdrawFromExchange(exchangeId: string): Promise<void> {
-    return apiRequest('/indoorvolleyball.refadmin/api%5crefereegameexchange', 'PUT', {
-      __identity: exchangeId,
-      withdrawApplication: '1',
-    })
-  },
-
-  async pickFromExchange(exchangeId: string): Promise<PickExchangeResponse> {
+  async applyForExchange(exchangeId: string): Promise<PickExchangeResponse> {
     return apiRequest<PickExchangeResponse>(
       '/indoorvolleyball.refadmin/api%5crefereegameexchange/pickFromRefereeGameExchange',
       'PUT',
@@ -314,6 +300,13 @@ export const api = {
         'refereeGameExchange[__identity]': exchangeId,
       }
     )
+  },
+
+  async withdrawFromExchange(exchangeId: string): Promise<void> {
+    return apiRequest('/indoorvolleyball.refadmin/api%5crefereegameexchange', 'PUT', {
+      __identity: exchangeId,
+      withdrawApplication: '1',
+    })
   },
 
   // Settings

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -54,6 +54,8 @@ export type PersonSearchResponse = Schemas['PersonSearchResponse']
 export type RefereeBackupEntry = Schemas['RefereeBackupEntry']
 export type RefereeBackupSearchResponse = Schemas['RefereeBackupSearchResponse']
 export type BackupRefereeAssignment = Schemas['BackupRefereeAssignment']
+export type PickExchangeResponse = Schemas['PickExchangeResponse']
+export type RefereeGameExchangeDetail = Schemas['RefereeGameExchangeDetail']
 
 export interface PersonSearchFilter {
   firstName?: string
@@ -302,6 +304,16 @@ export const api = {
       __identity: exchangeId,
       withdrawApplication: '1',
     })
+  },
+
+  async pickFromExchange(exchangeId: string): Promise<PickExchangeResponse> {
+    return apiRequest<PickExchangeResponse>(
+      '/indoorvolleyball.refadmin/api%5crefereegameexchange/pickFromRefereeGameExchange',
+      'PUT',
+      {
+        'refereeGameExchange[__identity]': exchangeId,
+      }
+    )
   },
 
   // Settings

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -373,11 +373,34 @@ export const mockApi = {
     return response
   },
 
-  async applyForExchange(exchangeId: string): Promise<void> {
+  async applyForExchange(exchangeId: string): Promise<PickExchangeResponse> {
     await delay(MOCK_MUTATION_DELAY_MS)
 
     const store = useDemoStore.getState()
+    const exchange = store.exchanges.find((e) => e.__identity === exchangeId)
+
+    if (!exchange) {
+      throw new Error(`Exchange not found: ${exchangeId}`)
+    }
+
+    // Update demo store state
     store.applyForExchange(exchangeId)
+
+    // Return response matching the real API
+    return {
+      refereeGameExchange: {
+        __identity: exchangeId,
+        persistenceObjectIdentifier: exchangeId,
+        status: 'applied',
+        refereePosition: exchange.refereePosition ?? 'head-one',
+        submittingType: exchange.submittingType ?? 'referee',
+        submittedAt: exchange.submittedAt ?? new Date().toISOString(),
+        appliedAt: new Date().toISOString(),
+        createdAt: exchange.submittedAt ?? new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        lastUpdatedByRealUser: false,
+      },
+    }
   },
 
   async withdrawFromExchange(exchangeId: string): Promise<void> {
@@ -395,34 +418,6 @@ export const mockApi = {
     } else {
       // Withdraw application from someone else's exchange
       store.withdrawFromExchange(exchangeId)
-    }
-  },
-
-  async pickFromExchange(exchangeId: string): Promise<PickExchangeResponse> {
-    await delay(MOCK_MUTATION_DELAY_MS)
-
-    const store = useDemoStore.getState()
-    const exchange = store.exchanges.find((e) => e.__identity === exchangeId)
-
-    if (!exchange) {
-      throw new Error(`Exchange not found: ${exchangeId}`)
-    }
-
-    // In demo mode, simulate picking the applicant by returning a mock response
-    // The real API would update the exchange status and assign the position
-    return {
-      refereeGameExchange: {
-        __identity: exchangeId,
-        persistenceObjectIdentifier: exchangeId,
-        status: 'applied',
-        refereePosition: exchange.refereePosition ?? 'head-one',
-        submittingType: exchange.submittingType ?? 'referee',
-        submittedAt: exchange.submittedAt ?? new Date().toISOString(),
-        appliedAt: new Date().toISOString(),
-        createdAt: exchange.submittedAt ?? new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        lastUpdatedByRealUser: false,
-      },
     }
   },
 

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -42,6 +42,7 @@ import type {
   PersonSearchResponse,
   PersonSearchResult,
   RefereeBackupSearchResponse,
+  PickExchangeResponse,
 } from './client'
 
 // Network delay constants for realistic demo behavior
@@ -394,6 +395,34 @@ export const mockApi = {
     } else {
       // Withdraw application from someone else's exchange
       store.withdrawFromExchange(exchangeId)
+    }
+  },
+
+  async pickFromExchange(exchangeId: string): Promise<PickExchangeResponse> {
+    await delay(MOCK_MUTATION_DELAY_MS)
+
+    const store = useDemoStore.getState()
+    const exchange = store.exchanges.find((e) => e.__identity === exchangeId)
+
+    if (!exchange) {
+      throw new Error(`Exchange not found: ${exchangeId}`)
+    }
+
+    // In demo mode, simulate picking the applicant by returning a mock response
+    // The real API would update the exchange status and assign the position
+    return {
+      refereeGameExchange: {
+        __identity: exchangeId,
+        persistenceObjectIdentifier: exchangeId,
+        status: 'applied',
+        refereePosition: exchange.refereePosition ?? 'head-one',
+        submittingType: exchange.submittingType ?? 'referee',
+        submittedAt: exchange.submittedAt ?? new Date().toISOString(),
+        appliedAt: new Date().toISOString(),
+        createdAt: exchange.submittedAt ?? new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        lastUpdatedByRealUser: false,
+      },
     }
   },
 

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -386,18 +386,20 @@ export const mockApi = {
     // Update demo store state
     store.applyForExchange(exchangeId)
 
-    // Return response matching the real API
+    // Return response matching the real API schema (RefereeGameExchangeDetail)
+    // All required fields from the schema are explicitly included
+    const now = new Date().toISOString()
     return {
       refereeGameExchange: {
         __identity: exchangeId,
         persistenceObjectIdentifier: exchangeId,
-        status: 'applied',
+        status: 'applied' as const,
         refereePosition: exchange.refereePosition ?? 'head-one',
-        submittingType: exchange.submittingType ?? 'referee',
-        submittedAt: exchange.submittedAt ?? new Date().toISOString(),
-        appliedAt: new Date().toISOString(),
-        createdAt: exchange.submittedAt ?? new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
+        submittingType: (exchange.submittingType as 'referee' | 'admin') ?? 'referee',
+        submittedAt: exchange.submittedAt ?? now,
+        appliedAt: now,
+        createdAt: exchange.submittedAt ?? now,
+        updatedAt: now,
         lastUpdatedByRealUser: false,
       },
     }

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -224,6 +224,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/indoorvolleyball.refadmin/api\\refereegameexchange/pickFromRefereeGameExchange": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Pick an applicant for a referee game exchange
+         * @description Allows a dispatcher or admin to pick/confirm an applicant for a referee position exchange.
+         *     This finalizes the exchange by assigning the position to the selected applicant.
+         */
+        put: operations["pickFromRefereeGameExchange"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sportmanager.indoorvolleyball/api\\indoorseason/getActiveIndoorSeason": {
         parameters: {
             query?: never;
@@ -1285,6 +1306,121 @@ export interface components {
             items: components["schemas"]["GameExchange"][];
             /** @example 7 */
             totalItemsCount: number;
+        };
+        /** @description Response from picking an applicant for a referee game exchange */
+        PickExchangeResponse: {
+            refereeGameExchange: components["schemas"]["RefereeGameExchangeDetail"];
+        };
+        /** @description Detailed referee game exchange object with audit information */
+        RefereeGameExchangeDetail: {
+            /**
+             * Format: uuid
+             * @description Unique identifier for this exchange
+             * @example d5a2a8e1-2ae7-4400-be39-8da8ecbce16f
+             */
+            __identity: string;
+            /**
+             * Format: uuid
+             * @description Persistence identifier (same as __identity)
+             */
+            persistenceObjectIdentifier?: string;
+            /**
+             * @description Current status of the exchange
+             * @example applied
+             * @enum {string}
+             */
+            status: "open" | "applied" | "closed";
+            refereePosition: components["schemas"]["RefereePosition"];
+            /** @description Reference to the referee game (if included) */
+            refereeGame?: Record<string, never> | null;
+            /**
+             * @description Who submitted the exchange request
+             * @example referee
+             * @enum {string}
+             */
+            submittingType: "referee" | "admin";
+            /**
+             * Format: date-time
+             * @description When the exchange was submitted
+             * @example 2026-01-22T12:58:18.000000+00:00
+             */
+            submittedAt: string;
+            /** @description Person who submitted the exchange */
+            submittedByPerson?: Record<string, never> | null;
+            /** @description Person who applied for this exchange */
+            appliedBy?: Record<string, never> | null;
+            /**
+             * Format: date-time
+             * @description When someone applied for this exchange
+             * @example 2026-01-23T20:38:41.954034+00:00
+             */
+            appliedAt?: string | null;
+            requiredRefereeLevel?: components["schemas"]["RefereeLevel"];
+            /**
+             * @description Gradation value for required referee level (1-4)
+             * @example 4
+             */
+            requiredRefereeLevelGradationValue?: number;
+            /** @description Club responsible for the exchange if applicable */
+            responsibleClubIfApplicable?: Record<string, never> | null;
+            /** @description Linked double convocation info if applicable */
+            linkedDoubleConvocationGameNumberAndRefereePosition?: string | null;
+            /**
+             * Format: date-time
+             * @description When the last reminder was sent to championship owner
+             */
+            latestReminderToChampionshipOwnerSentAt?: string | null;
+            /**
+             * Format: date-time
+             * @description When the last reminder was sent to submitting party
+             */
+            latestReminderToSubmittingTypeSentAt?: string | null;
+            /**
+             * Format: date-time
+             * @description Creation timestamp
+             * @example 2026-01-22T12:58:18.000000+00:00
+             */
+            createdAt?: string;
+            /**
+             * @description Username who created this exchange
+             * @example yannic_weber
+             */
+            createdBy?: string;
+            /**
+             * Format: uuid
+             * @description Persistence identifier of the creator
+             */
+            createdByPersistenceIdentifier?: string;
+            /**
+             * @description IP address of the creator
+             * @example 193.47.169.32
+             */
+            createdByIpAddress?: string | null;
+            /**
+             * Format: date-time
+             * @description Last update timestamp
+             */
+            updatedAt?: string;
+            /**
+             * @description Username who last updated this exchange
+             * @example System
+             */
+            updatedBy?: string;
+            /** @description Persistence identifier of the last updater */
+            updatedByPersistenceIdentifier?: string;
+            /** @description IP address of the last updater */
+            updatedByIpAddress?: string | null;
+            /**
+             * Format: date-time
+             * @description Soft delete timestamp (null if not deleted)
+             */
+            deletedAt?: string | null;
+            /**
+             * @description Whether last update was by a real user vs system
+             * @example false
+             */
+            lastUpdatedByRealUser?: boolean;
+            _permissions?: components["schemas"]["Permissions"];
         };
         /** @description Response containing referee backup (Pikett) entries */
         RefereeBackupSearchResponse: {
@@ -4711,6 +4847,39 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    pickFromRefereeGameExchange: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /**
+                     * Format: uuid
+                     * @description The exchange ID to pick from
+                     */
+                    "refereeGameExchange[__identity]"?: string;
+                    /** @description CSRF token for request validation */
+                    __csrfToken: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Exchange pick successful */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PickExchangeResponse"];
+                };
             };
             401: components["responses"]["Unauthorized"];
         };

--- a/web-app/src/features/assignments/api/calendar-client.ts
+++ b/web-app/src/features/assignments/api/calendar-client.ts
@@ -50,6 +50,7 @@ import type {
   PossibleNominationsResponse,
   PersonSearchResponse,
   RefereeBackupSearchResponse,
+  PickExchangeResponse,
 } from '@/api/client'
 import type { components } from '@/api/schema'
 import { useAuthStore } from '@/shared/stores/auth'
@@ -225,7 +226,7 @@ export const calendarApi = {
     throw new CalendarModeNotSupportedError('Exchanges')
   },
 
-  async applyForExchange(): Promise<void> {
+  async applyForExchange(): Promise<PickExchangeResponse> {
     throw new CalendarModeNotSupportedError('Exchange applications')
   },
 

--- a/web-app/src/features/exchanges/hooks/useExchanges.ts
+++ b/web-app/src/features/exchanges/hooks/useExchanges.ts
@@ -8,7 +8,12 @@ import {
 } from '@tanstack/react-query'
 import { startOfDay, endOfDay, format } from 'date-fns'
 
-import { getApiClient, type SearchConfiguration, type GameExchange } from '@/api/client'
+import {
+  getApiClient,
+  type SearchConfiguration,
+  type GameExchange,
+  type PickExchangeResponse,
+} from '@/api/client'
 import { queryKeys } from '@/api/queryKeys'
 import { DEFAULT_PAGE_SIZE } from '@/shared/hooks/usePaginatedQuery'
 import { useAuthStore } from '@/shared/stores/auth'
@@ -125,7 +130,11 @@ export function useGameExchanges(status: ExchangeStatus = 'all') {
 /**
  * Mutation hook to apply for an exchange.
  */
-export function useApplyForExchange(): UseMutationResult<void, Error, string> {
+export function useApplyForExchange(): UseMutationResult<
+  PickExchangeResponse,
+  Error,
+  string
+> {
   const queryClient = useQueryClient()
   const dataSource = useAuthStore((state) => state.dataSource)
   const apiClient = getApiClient(dataSource)


### PR DESCRIPTION
## Summary

- Add PUT endpoint `pickFromRefereeGameExchange` to OpenAPI spec with `PickExchangeResponse` and `RefereeGameExchangeDetail` schemas
- Update `applyForExchange` API method to use the confirmed endpoint instead of the hypothesized one
- Add `PickExchangeResponse` type exports to web-app and shared API clients
- Update mock-api and calendar-client with correct return types
- Document the confirmed endpoint in `exchange_actions.md` (closes TODO)

## Test plan

- [x] Endpoint confirmed working against real API (user tested)
- [x] All 3,682 unit tests pass
- [x] TypeScript types compile correctly
- [x] Safe mode protection verified in `useExchangeActions`