### PR TITLE
chore: add changeset for pickFromRefereeGameExchange endpoint

### DIFF
--- a/.changeset/pick-exchange-endpoint.md
+++ b/.changeset/pick-exchange-endpoint.md
@@ -1,0 +1,10 @@
+---
+"volleykit-web": minor
+"@volleykit/shared": minor
+---
+
+Add pickFromRefereeGameExchange endpoint for exchange takeover
+
+- Add PUT endpoint to OpenAPI spec for taking over referee assignments from the exchange
+- Update `applyForExchange` API method to use the confirmed endpoint
+- Add `PickExchangeResponse` type for the API response


### PR DESCRIPTION
## Summary
- Add changeset for the pickFromRefereeGameExchange endpoint feature (merged in #823)
- Bumps `volleykit-web` and `@volleykit/shared` as minor versions

## Test Plan
- [x] Changeset file is valid markdown
- [ ] CI passes