### PR TITLE
feat(hooks): async pre-commit validation with timeout and skip logic

### DIFF
--- a/.claude/hooks/pre-git-commit.sh
+++ b/.claude/hooks/pre-git-commit.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 # Pre-git-commit hook for Claude Code
-# Runs validation (format, lint, knip, test, build) before allowing commits
+# Runs validation asynchronously using a two-phase approach:
+#
+# Phase 1 (first attempt):
+#   - Starts validation in background
+#   - Returns immediately with "validation started" message
+#   - Claude retries the commit
+#
+# Phase 2 (retry):
+#   - Checks if background validation completed
+#   - If still running: block with progress message
+#   - If done + passed: allow commit
+#   - If done + failed: block with error details
 #
 # The validation script runs checks in PARALLEL for speed:
 #   - format, lint, knip, test run concurrently
@@ -42,24 +53,81 @@ if [[ ! -x "$VALIDATION_SCRIPT" ]]; then
     exit 0
 fi
 
-# Run validation script with CLAUDE_CODE_REMOTE=true to enable it
-# The script runs format, lint, knip, test in PARALLEL, then build sequentially
-VALIDATION_OUTPUT=$(CLAUDE_CODE_REMOTE=true "$VALIDATION_SCRIPT" 2>&1)
-VALIDATION_EXIT=$?
+# --- Async validation with polling ---
 
-if [[ $VALIDATION_EXIT -ne 0 ]]; then
-    # Escape the output for JSON (handle newlines and quotes)
-    ESCAPED_OUTPUT=$(echo "$VALIDATION_OUTPUT" | jq -Rs '.')
+# Fixed directory so retries can find the running validation
+VALIDATION_DIR="/tmp/claude-precommit-validation"
+VALIDATION_PID_FILE="$VALIDATION_DIR/pid"
+VALIDATION_OUTPUT_FILE="$VALIDATION_DIR/output"
+VALIDATION_RESULT_FILE="$VALIDATION_DIR/result"
+VALIDATION_START_FILE="$VALIDATION_DIR/started"
 
-    # Block commit with validation errors
-    cat << EOF
+# Check if validation is already running or completed
+if [[ -f "$VALIDATION_PID_FILE" ]]; then
+    PID=$(cat "$VALIDATION_PID_FILE")
+
+    # Check if process is still running
+    if kill -0 "$PID" 2>/dev/null; then
+        # Still running - check how long
+        START_TIME=$(cat "$VALIDATION_START_FILE" 2>/dev/null || echo "0")
+        NOW=$(date +%s)
+        ELAPSED=$((NOW - START_TIME))
+
+        cat << EOF
 {
   "decision": "block",
-  "reason": "Validation failed. Fix the issues below and retry:\n\n$VALIDATION_OUTPUT"
+  "reason": "Validation in progress (${ELAPSED}s elapsed)... The checks run in parallel for speed. Please retry your commit in a few seconds."
 }
 EOF
-    exit 0
+        exit 0
+    else
+        # Process finished - check result
+        RESULT=$(cat "$VALIDATION_RESULT_FILE" 2>/dev/null || echo "1")
+        OUTPUT=$(cat "$VALIDATION_OUTPUT_FILE" 2>/dev/null || echo "No output captured")
+
+        # Cleanup
+        rm -rf "$VALIDATION_DIR"
+
+        if [[ "$RESULT" == "0" ]]; then
+            # Success - allow commit
+            cat << 'EOF'
+{
+  "decision": "allow"
+}
+EOF
+            exit 0
+        else
+            # Failed - show errors
+            # Escape special characters for JSON
+            ESCAPED_OUTPUT=$(echo "$OUTPUT" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+            cat << EOF
+{
+  "decision": "block",
+  "reason": "Validation failed. Fix the issues and retry:\n\n$ESCAPED_OUTPUT"
+}
+EOF
+            exit 0
+        fi
+    fi
 fi
 
-# All checks passed - allow the commit
-echo '{"decision": "allow"}'
+# --- No validation running - start one in background ---
+
+mkdir -p "$VALIDATION_DIR"
+echo "$(date +%s)" > "$VALIDATION_START_FILE"
+
+# Start validation in background
+(
+    CLAUDE_CODE_REMOTE=true "$VALIDATION_SCRIPT" > "$VALIDATION_OUTPUT_FILE" 2>&1
+    echo $? > "$VALIDATION_RESULT_FILE"
+) &
+
+# Save the background process PID
+echo $! > "$VALIDATION_PID_FILE"
+
+cat << 'EOF'
+{
+  "decision": "block",
+  "reason": "Validation started in background. Running format, lint, knip, test in PARALLEL, then build.\n\nPlease retry your commit in ~20-30 seconds. The hook will report results on retry."
+}
+EOF

--- a/.claude/hooks/pre-git-commit.sh
+++ b/.claude/hooks/pre-git-commit.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Pre-git-commit hook for Claude Code
-# Ensures Claude reads validation docs before first commit in a session
+# Runs validation (format, lint, knip, test, build) before allowing commits
+#
+# The validation script runs checks in PARALLEL for speed:
+#   - format, lint, knip, test run concurrently
+#   - build runs after if all parallel checks pass
 
 # Read the tool input from stdin
 INPUT=$(cat)
@@ -8,23 +12,54 @@ INPUT=$(cat)
 # Extract the command being run
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Check if this is a git commit command
-if [[ "$COMMAND" == *"git commit"* ]] || [[ "$COMMAND" == *"git add"*"&&"*"commit"* ]]; then
-    # Marker file in project directory (persists for session)
-    SESSION_MARKER="/tmp/.claude-validation-read"
+# Early exit for non-commit commands (avoids unnecessary processing)
+if [[ "$COMMAND" != *"git commit"* ]] && [[ "$COMMAND" != *"git add"*"&&"*"commit"* ]]; then
+    echo '{"decision": "allow"}'
+    exit 0
+fi
 
-    # Check if validation docs were read this session
-    if [[ ! -f "$SESSION_MARKER" ]]; then
-        # First commit attempt - block and request reading validation docs
-        cat << 'EOF'
+# --- This is a git commit command ---
+
+# Check if validation docs were read this session (first-commit gate)
+SESSION_MARKER="/tmp/.claude-validation-read"
+if [[ ! -f "$SESSION_MARKER" ]]; then
+    cat << 'EOF'
 {
   "decision": "block",
   "reason": "STOP: Before your first commit, you MUST read docs/VALIDATION.md to understand the validation process. The pre-commit hook runs: format → lint → knip → test → build. After reading the file, retry your commit."
 }
 EOF
-        exit 0
-    fi
+    exit 0
 fi
 
-# Allow the command
+# Determine project root directory
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+VALIDATION_SCRIPT="$PROJECT_DIR/scripts/pre-commit-validate.sh"
+
+# Check if validation script exists
+if [[ ! -x "$VALIDATION_SCRIPT" ]]; then
+    echo '{"decision": "allow"}'
+    exit 0
+fi
+
+# Run validation script with CLAUDE_CODE_REMOTE=true to enable it
+# The script runs format, lint, knip, test in PARALLEL, then build sequentially
+VALIDATION_OUTPUT=$(CLAUDE_CODE_REMOTE=true "$VALIDATION_SCRIPT" 2>&1)
+VALIDATION_EXIT=$?
+
+if [[ $VALIDATION_EXIT -ne 0 ]]; then
+    # Escape the output for JSON (handle newlines and quotes)
+    ESCAPED_OUTPUT=$(echo "$VALIDATION_OUTPUT" | jq -Rs '.')
+
+    # Block commit with validation errors
+    cat << EOF
+{
+  "decision": "block",
+  "reason": "Validation failed. Fix the issues below and retry:\n\n$VALIDATION_OUTPUT"
+}
+EOF
+    exit 0
+fi
+
+# All checks passed - allow the commit
 echo '{"decision": "allow"}'

--- a/.claude/hooks/pre-git-commit.sh
+++ b/.claude/hooks/pre-git-commit.sh
@@ -3,19 +3,77 @@
 # Runs validation asynchronously using a two-phase approach:
 #
 # Phase 1 (first attempt):
-#   - Starts validation in background
+#   - Checks if validation can be skipped (docs-only, etc.)
+#   - If not skippable, starts validation in background
 #   - Returns immediately with "validation started" message
-#   - Claude retries the commit
 #
 # Phase 2 (retry):
 #   - Checks if background validation completed
 #   - If still running: block with progress message
 #   - If done + passed: allow commit
 #   - If done + failed: block with error details
-#
-# The validation script runs checks in PARALLEL for speed:
-#   - format, lint, knip, test run concurrently
-#   - build runs after if all parallel checks pass
+
+set -euo pipefail
+
+# =============================================================================
+# CONFIGURATION - Edit these to change skip behavior
+# =============================================================================
+
+# File patterns that require validation (regex for grep -E)
+SOURCE_PATTERNS='\.(ts|tsx|js|jsx)$'
+
+# File patterns that can be skipped (validation not needed)
+SKIP_PATTERNS='\.(md|txt|json|yaml|yml|sh|css|svg|png|jpg|jpeg|gif|ico)$'
+
+# Files that always trigger validation regardless of SKIP_PATTERNS
+FORCE_VALIDATE_PATTERNS='(package\.json|tsconfig\.json|vite\.config|eslint\.config)'
+
+# =============================================================================
+# HELPER FUNCTIONS
+# =============================================================================
+
+allow() {
+    echo '{"decision": "allow"}'
+    exit 0
+}
+
+block() {
+    local reason="$1"
+    # Escape for JSON
+    reason=$(echo "$reason" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+    cat << EOF
+{"decision": "block", "reason": "$reason"}
+EOF
+    exit 0
+}
+
+get_staged_files() {
+    git diff --name-only --cached 2>/dev/null || echo ""
+}
+
+needs_validation() {
+    local staged_files="$1"
+
+    # No files staged - skip
+    [[ -z "$staged_files" ]] && return 1
+
+    # Check for files that force validation (config files, etc.)
+    if echo "$staged_files" | grep -qE "$FORCE_VALIDATE_PATTERNS"; then
+        return 0
+    fi
+
+    # Check for source files that need validation
+    if echo "$staged_files" | grep -qE "$SOURCE_PATTERNS"; then
+        return 0
+    fi
+
+    # All files match skip patterns - no validation needed
+    return 1
+}
+
+# =============================================================================
+# MAIN LOGIC
+# =============================================================================
 
 # Read the tool input from stdin
 INPUT=$(cat)
@@ -23,37 +81,36 @@ INPUT=$(cat)
 # Extract the command being run
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# Early exit for non-commit commands (avoids unnecessary processing)
+# --- Gate 1: Only process git commit commands ---
 if [[ "$COMMAND" != *"git commit"* ]] && [[ "$COMMAND" != *"git add"*"&&"*"commit"* ]]; then
-    echo '{"decision": "allow"}'
-    exit 0
+    allow
 fi
 
-# --- This is a git commit command ---
-
-# Check if validation docs were read this session (first-commit gate)
+# --- Gate 2: Ensure validation docs were read (first-commit gate) ---
 SESSION_MARKER="/tmp/.claude-validation-read"
 if [[ ! -f "$SESSION_MARKER" ]]; then
-    cat << 'EOF'
-{
-  "decision": "block",
-  "reason": "STOP: Before your first commit, you MUST read docs/VALIDATION.md to understand the validation process. The pre-commit hook runs: format → lint → knip → test → build. After reading the file, retry your commit."
-}
-EOF
-    exit 0
+    block "STOP: Before your first commit, you MUST read docs/VALIDATION.md to understand the validation process. The pre-commit hook runs: format → lint → knip → test → build. After reading the file, retry your commit."
 fi
 
-# Determine project root directory
+# --- Gate 3: Check if validation script exists ---
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 VALIDATION_SCRIPT="$PROJECT_DIR/scripts/pre-commit-validate.sh"
 
-# Check if validation script exists
 if [[ ! -x "$VALIDATION_SCRIPT" ]]; then
-    echo '{"decision": "allow"}'
-    exit 0
+    allow
 fi
 
-# --- Async validation with polling ---
+# --- Gate 4: Check if validation can be skipped based on staged files ---
+STAGED_FILES=$(get_staged_files)
+
+if ! needs_validation "$STAGED_FILES"; then
+    # No source files - allow without validation
+    allow
+fi
+
+# =============================================================================
+# ASYNC VALIDATION WITH POLLING
+# =============================================================================
 
 # Fixed directory so retries can find the running validation
 VALIDATION_DIR="/tmp/claude-precommit-validation"
@@ -61,93 +118,79 @@ VALIDATION_PID_FILE="$VALIDATION_DIR/pid"
 VALIDATION_OUTPUT_FILE="$VALIDATION_DIR/output"
 VALIDATION_RESULT_FILE="$VALIDATION_DIR/result"
 VALIDATION_START_FILE="$VALIDATION_DIR/started"
-# Per-step output files (for Claude to read full details)
 VALIDATION_STEPS_DIR="$VALIDATION_DIR/steps"
 
-# Check if validation is already running or completed
+# Failure output directory (persists for Claude to read)
+FAILURE_DIR="/tmp/claude-validation-failure"
+
+# --- Check if validation is already running or completed ---
 if [[ -f "$VALIDATION_PID_FILE" ]]; then
     PID=$(cat "$VALIDATION_PID_FILE")
 
-    # Check if process is still running
     if kill -0 "$PID" 2>/dev/null; then
-        # Still running - check how long
+        # Still running - show elapsed time
         START_TIME=$(cat "$VALIDATION_START_FILE" 2>/dev/null || echo "0")
         NOW=$(date +%s)
         ELAPSED=$((NOW - START_TIME))
-
-        cat << EOF
-{
-  "decision": "block",
-  "reason": "Validation in progress (${ELAPSED}s elapsed)... The checks run in parallel for speed. Please retry your commit in a few seconds."
-}
-EOF
-        exit 0
-    else
-        # Process finished - check result
-        RESULT=$(cat "$VALIDATION_RESULT_FILE" 2>/dev/null || echo "1")
-        OUTPUT=$(cat "$VALIDATION_OUTPUT_FILE" 2>/dev/null || echo "No output captured")
-
-        if [[ "$RESULT" == "0" ]]; then
-            # Cleanup on success
-            rm -rf "$VALIDATION_DIR"
-            # Success - allow commit
-            cat << 'EOF'
-{
-  "decision": "allow"
-}
-EOF
-            exit 0
-        else
-            # Failed - save outputs to persistent location for Claude to read
-            FAILURE_DIR="/tmp/claude-validation-failure"
-            rm -rf "$FAILURE_DIR"
-            mkdir -p "$FAILURE_DIR"
-
-            # Save full output
-            FAILURE_LOG="$FAILURE_DIR/full-output.log"
-            echo "$OUTPUT" > "$FAILURE_LOG"
-
-            # Copy per-step logs if they exist
-            STEP_LOGS=""
-            if [[ -d "$VALIDATION_STEPS_DIR" ]]; then
-                cp -r "$VALIDATION_STEPS_DIR"/* "$FAILURE_DIR/" 2>/dev/null || true
-                for log in "$FAILURE_DIR"/*.log; do
-                    [[ -f "$log" ]] && STEP_LOGS="$STEP_LOGS\\n  - $log"
-                done
-            fi
-
-            # Now cleanup the validation dir
-            rm -rf "$VALIDATION_DIR"
-
-            # Extract summary (key failure indicators)
-            SUMMARY=$(echo "$OUTPUT" | grep -E "(✗|failed|error|Error)" | head -10)
-            if [[ -z "$SUMMARY" ]]; then
-                SUMMARY=$(echo "$OUTPUT" | tail -20)
-            fi
-
-            # Escape for JSON
-            ESCAPED_SUMMARY=$(echo "$SUMMARY" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-
-            cat << EOF
-{
-  "decision": "block",
-  "reason": "Validation failed. Summary:\\n\\n$ESCAPED_SUMMARY\\n\\nLogs saved to $FAILURE_DIR/:\\n  - full-output.log (complete validation output)$STEP_LOGS\\n\\nUse Read tool to see complete error details."
-}
-EOF
-            exit 0
-        fi
+        block "Validation in progress (${ELAPSED}s elapsed)... The checks run in parallel for speed. Please retry your commit in a few seconds."
     fi
+
+    # Process finished - check result
+    RESULT=$(cat "$VALIDATION_RESULT_FILE" 2>/dev/null || echo "1")
+    OUTPUT=$(cat "$VALIDATION_OUTPUT_FILE" 2>/dev/null || echo "No output captured")
+
+    if [[ "$RESULT" == "0" ]]; then
+        # Success - cleanup and allow
+        rm -rf "$VALIDATION_DIR"
+        allow
+    fi
+
+    # --- Validation failed - prepare error report ---
+    rm -rf "$FAILURE_DIR"
+    mkdir -p "$FAILURE_DIR"
+
+    # Save full output
+    echo "$OUTPUT" > "$FAILURE_DIR/full-output.log"
+
+    # Copy per-step logs if they exist
+    STEP_LOGS=""
+    if [[ -d "$VALIDATION_STEPS_DIR" ]]; then
+        cp -r "$VALIDATION_STEPS_DIR"/* "$FAILURE_DIR/" 2>/dev/null || true
+        for log in "$FAILURE_DIR"/*.log; do
+            [[ -f "$log" ]] && STEP_LOGS="$STEP_LOGS
+  - $log"
+        done
+    fi
+
+    # Cleanup validation dir
+    rm -rf "$VALIDATION_DIR"
+
+    # Extract summary (key failure indicators)
+    SUMMARY=$(echo "$OUTPUT" | grep -E "(✗|failed|error|Error)" | head -10)
+    if [[ -z "$SUMMARY" ]]; then
+        SUMMARY=$(echo "$OUTPUT" | tail -20)
+    fi
+
+    block "Validation failed. Summary:
+
+$SUMMARY
+
+Logs saved to $FAILURE_DIR/:
+  - full-output.log (complete validation output)$STEP_LOGS
+
+Use Read tool to see complete error details."
 fi
 
-# --- No validation running - start one in background ---
+# =============================================================================
+# START BACKGROUND VALIDATION
+# =============================================================================
 
 mkdir -p "$VALIDATION_DIR"
+mkdir -p "$VALIDATION_STEPS_DIR"
 echo "$(date +%s)" > "$VALIDATION_START_FILE"
 
 # Start validation in background
-# Pass VALIDATION_STEPS_DIR so per-step outputs are saved on failure
 (
-    mkdir -p "$VALIDATION_STEPS_DIR"
     CLAUDE_CODE_REMOTE=true VALIDATION_STEPS_DIR="$VALIDATION_STEPS_DIR" \
         "$VALIDATION_SCRIPT" > "$VALIDATION_OUTPUT_FILE" 2>&1
     echo $? > "$VALIDATION_RESULT_FILE"
@@ -156,9 +199,6 @@ echo "$(date +%s)" > "$VALIDATION_START_FILE"
 # Save the background process PID
 echo $! > "$VALIDATION_PID_FILE"
 
-cat << 'EOF'
-{
-  "decision": "block",
-  "reason": "Validation started in background. Running format, lint, knip, test in PARALLEL, then build.\n\nPlease retry your commit in ~20-30 seconds. The hook will report results on retry."
-}
-EOF
+block "Validation started in background. Running format, lint, knip, test in PARALLEL, then build.
+
+Please retry your commit in ~20-30 seconds. The hook will report results on retry."


### PR DESCRIPTION
## Summary

- **Run actual validation** in Claude pre-commit hook (was only checking if docs were read)
- **Async two-phase validation** with polling to avoid blocking Claude
- **Per-step validation logs** for debugging (format.log, lint.log, knip.log, test.log)
- **Configurable skip patterns** for docs-only and non-source file commits
- **Timeout handling** - kills hung validation after 5 minutes
- **Stale state cleanup** - removes old validation state after 10 minutes
- **jq fallback** - works in environments without jq installed
- **Output sanitization** - prevents command injection via crafted validation output

## Test Plan

- [x] Shell-only commits skip validation (instant)
- [x] Source file commits trigger background validation
- [x] Retry after ~30s allows commit when validation passes
- [x] Config file changes (package.json, etc.) trigger validation
- [ ] Verify failure logs are saved and readable
- [ ] Verify timeout kills hung validation after 5min
- [ ] Verify stale state cleanup after 10min