### PR TITLE
fix(web): use correct SBB URL parameters for arrival time

### DIFF
--- a/.changeset/fix-sbb-button-time.md
+++ b/.changeset/fix-sbb-button-time.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fixed SBB button to correctly use arrival time instead of departure time. Updated URL parameters to use the correct SBB format (`datum`, `zeit`, `an=false`) per the official SBB Deep Linking documentation.

--- a/web-app/src/shared/utils/sbb-url.test.ts
+++ b/web-app/src/shared/utils/sbb-url.test.ts
@@ -17,11 +17,13 @@ describe('sbb-url', () => {
 
         expect(url).toContain('https://www.sbb.ch/de?')
         expect(url).toContain('nach=Bern')
-        // Date and time should be quoted and encoded
-        expect(url).toContain('date=%222024-12-28%22')
-        expect(url).toContain('time=%2214:30%22')
-        // Should use arrival time mode
-        expect(url).toContain('moment=%22ARRIVAL%22')
+        // Date should be in European format (dd.MM.yyyy)
+        expect(url).toContain('datum=28.12.2024')
+        expect(url).toContain('zeit=14:30')
+        // Should use arrival time mode (an=false means arrival)
+        expect(url).toContain('an=false')
+        // Should trigger the search
+        expect(url).toContain('suche=true')
         // Should NOT contain stops JSON
         expect(url).not.toContain('stops=')
       })
@@ -207,14 +209,14 @@ describe('sbb-url', () => {
     })
 
     describe('date formatting', () => {
-      it('formats date as YYYY-MM-DD with leading zeros and quotes', () => {
+      it('formats date as dd.MM.yyyy with leading zeros', () => {
         const params = {
           ...baseParams,
           date: new Date('2024-01-05T10:00:00'),
           arrivalTime: new Date('2024-01-05T10:00:00'),
         }
         const url = generateSbbUrl(params)
-        expect(url).toContain('date=%222024-01-05%22')
+        expect(url).toContain('datum=05.01.2024')
       })
 
       it('formats single-digit month with leading zero', () => {
@@ -224,27 +226,27 @@ describe('sbb-url', () => {
           arrivalTime: new Date('2024-03-15T10:00:00'),
         }
         const url = generateSbbUrl(params)
-        expect(url).toContain('date=%222024-03-15%22')
+        expect(url).toContain('datum=15.03.2024')
       })
     })
 
     describe('time formatting', () => {
-      it('formats single-digit hours with leading zero and quotes', () => {
+      it('formats single-digit hours with leading zero', () => {
         const params = {
           ...baseParams,
           arrivalTime: new Date('2024-12-28T09:05:00'),
         }
         const url = generateSbbUrl(params)
-        expect(url).toContain('time=%2209:05%22')
+        expect(url).toContain('zeit=09:05')
       })
 
-      it('formats midnight correctly with quotes', () => {
+      it('formats midnight correctly', () => {
         const params = {
           ...baseParams,
           arrivalTime: new Date('2024-12-28T00:00:00'),
         }
         const url = generateSbbUrl(params)
-        expect(url).toContain('time=%2200:00%22')
+        expect(url).toContain('zeit=00:00')
       })
     })
   })

--- a/web-app/src/shared/utils/sbb-url.ts
+++ b/web-app/src/shared/utils/sbb-url.ts
@@ -58,13 +58,14 @@ function normalizeSwissStationId(id: string): string {
 }
 
 /**
- * Format a date as YYYY-MM-DD for SBB URL parameters.
+ * Format a date as dd.MM.yyyy for SBB URL parameters.
+ * SBB expects European date format, not ISO format.
  */
 function formatDateSbb(date: Date): string {
   const day = String(date.getDate()).padStart(2, '0')
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const year = date.getFullYear()
-  return `${year}-${month}-${day}`
+  return `${day}.${month}.${year}`
 }
 
 /**
@@ -118,10 +119,12 @@ export function generateSbbUrl(params: SbbUrlParams): string {
   const dest = destinationAddress ?? destinationStation?.name ?? destination
 
   // Generate SBB website URL
-  // Common time/date parameters (quoted per SBB spec)
-  const quotedDate = `%22${formattedDate}%22`
-  const quotedTime = `%22${formattedTime}%22`
-  const baseParams = `date=${quotedDate}&time=${quotedTime}&moment=%22ARRIVAL%22`
+  // Parameters per SBB Deep Linking documentation:
+  // - datum: date in dd.MM.yyyy format
+  // - zeit: time in HH:mm format
+  // - an: false for arrival time (true = departure)
+  // - suche: true to trigger the search
+  const baseParams = `datum=${formattedDate}&zeit=${formattedTime}&an=false&suche=true`
 
   // When both stations have IDs and no destination address override, use precise routing
   // If destinationAddress is provided, we want to route to the actual address, not just the station


### PR DESCRIPTION
## Summary

- Fixed SBB button to correctly use arrival time instead of departure time
- Updated URL parameters to use the correct SBB format per official documentation:
  - Changed `date` to `datum` with European format (dd.MM.yyyy)
  - Changed `time` to `zeit`
  - Changed `moment="ARRIVAL"` to `an=false` for arrival time
  - Added `suche=true` to trigger the search

## Test plan

- [x] Unit tests updated and passing
- [ ] Manually verify SBB button opens correct timetable with arrival time