### PR TITLE
refactor(shared): add MS_PER_DAY constant and use shared time constants

### DIFF
--- a/.changeset/add-ms-per-day-constant.md
+++ b/.changeset/add-ms-per-day-constant.md
@@ -1,0 +1,7 @@
+---
+'@volleykit/shared': patch
+---
+
+Add MS_PER_DAY constant to date-helpers for time conversion consistency
+
+Added `MS_PER_DAY` constant (86400000 milliseconds) to the shared date-helpers module, completing the set of time conversion constants. Updated mobile app to use shared constants (`MS_PER_MINUTE`, `MS_PER_HOUR`, `MS_PER_DAY`) instead of inline magic numbers for improved code readability and maintainability.

--- a/packages/mobile/src/platform/location.ts
+++ b/packages/mobile/src/platform/location.ts
@@ -7,6 +7,8 @@
 import * as Location from 'expo-location'
 import * as TaskManager from 'expo-task-manager'
 
+import { MS_PER_HOUR } from '@volleykit/shared/utils'
+
 /** Background location task name */
 export const LOCATION_TASK_NAME = 'volleykit-background-location'
 
@@ -139,7 +141,7 @@ async function startBackgroundTracking(): Promise<void> {
     accuracy: Location.Accuracy.Balanced,
     // Use significant changes for battery efficiency
     distanceInterval: 500, // 500 meters
-    deferredUpdatesInterval: 1000 * 60 * 60, // 1 hour
+    deferredUpdatesInterval: MS_PER_HOUR, // 1 hour
     showsBackgroundLocationIndicator: false,
     foregroundService: {
       notificationTitle: 'VolleyKit',

--- a/packages/mobile/src/providers/AppProviders.tsx
+++ b/packages/mobile/src/providers/AppProviders.tsx
@@ -15,6 +15,7 @@ import { QueryClient, QueryClientProvider, QueryCache, MutationCache } from '@ta
 
 import { StorageContext } from '@volleykit/shared/adapters'
 import { HttpStatus } from '@volleykit/shared/api'
+import { MS_PER_MINUTE, MS_PER_DAY } from '@volleykit/shared/utils'
 
 import { SessionMonitorProvider, useSessionMonitorContext, ApiClientProvider } from '../contexts'
 import { NetworkProvider } from './NetworkProvider'
@@ -60,8 +61,8 @@ function QueryClientWithSessionMonitor({ children }: { children: ReactNode }) {
       }),
       defaultOptions: {
         queries: {
-          staleTime: 1000 * 60 * 5, // 5 minutes
-          gcTime: 1000 * 60 * 60 * 24, // 24 hours
+          staleTime: MS_PER_MINUTE * 5, // 5 minutes
+          gcTime: MS_PER_DAY, // 24 hours
           retry: (failureCount, error) => {
             // Don't retry on auth errors
             if (

--- a/packages/mobile/src/types/cache.ts
+++ b/packages/mobile/src/types/cache.ts
@@ -4,6 +4,8 @@
  * Defines types for cached data with metadata for freshness indicators.
  */
 
+import { MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '@volleykit/shared/utils'
+
 /**
  * Generic cached data wrapper with metadata.
  */
@@ -53,7 +55,7 @@ export interface CacheConfig {
  * Default cache configuration.
  */
 export const DEFAULT_CACHE_CONFIG: CacheConfig = {
-  defaultTtlMs: 30 * 24 * 60 * 60 * 1000, // 30 days
+  defaultTtlMs: MS_PER_DAY * 30, // 30 days
   maxSizeBytes: 10 * 1024 * 1024, // 10 MB
   version: 1,
 }
@@ -86,8 +88,7 @@ export function getCacheStatus(metadata: CacheMetadata | null): CacheStatus {
   }
 
   // Check if stale (older than 1 hour)
-  const staleThreshold = 60 * 60 * 1000 // 1 hour
-  if (now.getTime() - cachedAt.getTime() > staleThreshold) {
+  if (now.getTime() - cachedAt.getTime() > MS_PER_HOUR) {
     return 'stale'
   }
 
@@ -101,9 +102,9 @@ export function formatCacheAge(cachedAt: string): string {
   const cached = new Date(cachedAt)
   const now = new Date()
   const diffMs = now.getTime() - cached.getTime()
-  const diffMinutes = Math.floor(diffMs / (1000 * 60))
-  const diffHours = Math.floor(diffMinutes / 60)
-  const diffDays = Math.floor(diffHours / 24)
+  const diffMinutes = Math.floor(diffMs / MS_PER_MINUTE)
+  const diffHours = Math.floor(diffMs / MS_PER_HOUR)
+  const diffDays = Math.floor(diffMs / MS_PER_DAY)
 
   if (diffMinutes < 1) return 'just now'
   if (diffMinutes < 60) return `${diffMinutes}m ago`

--- a/packages/shared/src/utils/date-helpers.test.ts
+++ b/packages/shared/src/utils/date-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   MS_PER_SECOND,
   MS_PER_MINUTE,
   MS_PER_HOUR,
+  MS_PER_DAY,
   SECONDS_PER_MINUTE,
   MINUTES_PER_HOUR,
   HOURS_PER_DAY,
@@ -46,6 +47,10 @@ describe('Time Conversion Constants', () => {
 
   it('should have correct MS_PER_HOUR', () => {
     expect(MS_PER_HOUR).toBe(3600000)
+  })
+
+  it('should have correct MS_PER_DAY', () => {
+    expect(MS_PER_DAY).toBe(86400000)
   })
 })
 

--- a/packages/shared/src/utils/date-helpers.ts
+++ b/packages/shared/src/utils/date-helpers.ts
@@ -27,6 +27,9 @@ export const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
 /** Milliseconds in one hour */
 export const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR
 
+/** Milliseconds in one day */
+export const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY
+
 const DATE_TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
   weekday: 'short',
   year: 'numeric',


### PR DESCRIPTION
## Summary

- Add `MS_PER_DAY` constant (86400000 ms) to the shared date-helpers module, completing the set of time conversion constants
- Update mobile app to use shared time constants instead of inline magic numbers for improved code readability and maintainability

## Test plan

- [x] Added test for new `MS_PER_DAY` constant in date-helpers.test.ts
- [x] All shared package tests pass (62 tests)
- [x] Mobile app TypeScript compilation succeeds with no errors
- [x] Pre-commit validation passes (format, lint, knip, test, build)