### PR TITLE
fix(web): use arrival time mode for SBB URL

### DIFF
--- a/.changeset/fix-sbb-arrival-time.md
+++ b/.changeset/fix-sbb-arrival-time.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fix SBB button using departure time instead of arrival time

--- a/web-app/src/shared/utils/sbb-url.test.ts
+++ b/web-app/src/shared/utils/sbb-url.test.ts
@@ -20,8 +20,8 @@ describe('sbb-url', () => {
         // Date should be in European format (dd.MM.yyyy)
         expect(url).toContain('datum=28.12.2024')
         expect(url).toContain('zeit=14:30')
-        // Should use arrival time mode (an=false means arrival)
-        expect(url).toContain('an=false')
+        // Should use arrival time mode (an=true = Ankunft/arrival)
+        expect(url).toContain('an=true')
         // Should trigger the search
         expect(url).toContain('suche=true')
         // Should NOT contain stops JSON

--- a/web-app/src/shared/utils/sbb-url.ts
+++ b/web-app/src/shared/utils/sbb-url.ts
@@ -122,9 +122,9 @@ export function generateSbbUrl(params: SbbUrlParams): string {
   // Parameters per SBB Deep Linking documentation:
   // - datum: date in dd.MM.yyyy format
   // - zeit: time in HH:mm format
-  // - an: false for arrival time (true = departure)
+  // - an: true for arrival time (an = Ankunft), false for departure
   // - suche: true to trigger the search
-  const baseParams = `datum=${formattedDate}&zeit=${formattedTime}&an=false&suche=true`
+  const baseParams = `datum=${formattedDate}&zeit=${formattedTime}&an=true&suche=true`
 
   // When both stations have IDs and no destination address override, use precise routing
   // If destinationAddress is provided, we want to route to the actual address, not just the station


### PR DESCRIPTION
## Summary
- Fix SBB button using departure time instead of arrival time
- The `an` parameter in SBB deep links stands for "Ankunft" (arrival): `an=true` = arrival, `an=false` = departure
- The previous implementation incorrectly used `an=false`, causing SBB to search for trains departing at the target time rather than arriving by it

## Test plan
- [ ] Click the SBB button on an assignment card
- [ ] Verify the SBB website shows "an" (arrival) mode, not "dp" (departure)
- [ ] Verify the time shown is the target arrival time (game time minus arrival buffer)