### PR TITLE
feat(ci): add mobile build workflows for Android and iOS

### DIFF
--- a/.changeset/add-mobile-build-workflows.md
+++ b/.changeset/add-mobile-build-workflows.md
@@ -1,0 +1,5 @@
+---
+'@volleykit/mobile': patch
+---
+
+Add missing expo-router dependency required for EAS builds

--- a/.github/workflows/build-mobile-reusable.yml
+++ b/.github/workflows/build-mobile-reusable.yml
@@ -1,0 +1,143 @@
+name: Build Mobile App (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Platform to build (android or ios)'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref to checkout'
+        required: true
+        type: string
+      version:
+        description: 'Version label for artifact filename'
+        required: true
+        type: string
+      upload_to_release:
+        description: 'Upload artifact to GitHub release'
+        required: false
+        type: boolean
+        default: false
+      release_tag:
+        description: 'Release tag to upload to (required if upload_to_release is true)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      EXPO_TOKEN:
+        required: true
+      RELEASE_TOKEN:
+        required: false
+
+jobs:
+  build-android:
+    if: inputs.platform == 'android'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          working-directory: packages/mobile
+
+      - name: Generate API types
+        run: npm run generate:api
+        working-directory: .
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android APK
+        run: eas build --platform android --profile production --non-interactive --local --output ./volleykit-${{ inputs.version }}.apk
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-${{ inputs.version }}
+          path: packages/mobile/volleykit-${{ inputs.version }}.apk
+          retention-days: 30
+
+      - name: Upload APK to Release
+        if: inputs.upload_to_release && inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            "./volleykit-${{ inputs.version }}.apk" \
+            --clobber
+
+      - name: Summary
+        run: |
+          echo "## Android Build Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Ref | \`${{ inputs.ref }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifact | \`volleykit-${{ inputs.version }}.apk\` |" >> "$GITHUB_STEP_SUMMARY"
+
+  build-ios:
+    if: inputs.platform == 'ios'
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: packages/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          working-directory: packages/mobile
+
+      - name: Generate API types
+        run: npm run generate:api
+        working-directory: .
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build iOS
+        run: eas build --platform ios --profile production --non-interactive --local --output ./volleykit-${{ inputs.version }}.ipa
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa-${{ inputs.version }}
+          path: packages/mobile/volleykit-${{ inputs.version }}.ipa
+          retention-days: 30
+
+      - name: Upload IPA to Release
+        if: inputs.upload_to_release && inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            "./volleykit-${{ inputs.version }}.ipa" \
+            --clobber
+
+      - name: Summary
+        run: |
+          echo "## iOS Build Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Ref | \`${{ inputs.ref }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifact | \`volleykit-${{ inputs.version }}.ipa\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -1,0 +1,183 @@
+name: Build Mobile Apps
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit SHA to build (must be on main branch)'
+        required: false
+        type: string
+        default: ''
+      platform:
+        description: 'Platform to build'
+        required: true
+        type: choice
+        options:
+          - android
+          - ios
+          - both
+        default: android
+
+permissions:
+  contents: write
+
+# Prevent concurrent builds
+concurrency:
+  group: build-mobile-${{ github.event.inputs.commit || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  # Verify actor is authorized
+  authorize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check authorization
+        run: |
+          if [ "${{ github.actor }}" != "Takishima" ]; then
+            echo "::error::This workflow can only be triggered by the repository owner (Takishima)."
+            exit 1
+          fi
+          echo "Authorized: ${{ github.actor }}"
+
+  # Validate commit is on main
+  validate:
+    needs: authorize
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.resolve.outputs.sha }}
+      short_sha: ${{ steps.resolve.outputs.short_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and validate commit
+        id: resolve
+        run: |
+          COMMIT="${{ github.event.inputs.commit }}"
+
+          # If no commit specified, use HEAD of main
+          if [ -z "$COMMIT" ]; then
+            COMMIT=$(git rev-parse origin/main)
+            echo "No commit specified, using main HEAD: $COMMIT"
+          fi
+
+          # Validate commit exists
+          if ! git cat-file -e "$COMMIT^{commit}" 2>/dev/null; then
+            echo "::error::Commit $COMMIT does not exist"
+            exit 1
+          fi
+
+          # Validate commit is on main branch
+          if ! git merge-base --is-ancestor "$COMMIT" origin/main 2>/dev/null; then
+            # Check if commit IS main HEAD or ancestor
+            MAIN_SHA=$(git rev-parse origin/main)
+            if [ "$COMMIT" != "$MAIN_SHA" ] && ! git merge-base --is-ancestor "$COMMIT" "$MAIN_SHA"; then
+              echo "::error::Commit $COMMIT is not on the main branch"
+              exit 1
+            fi
+          fi
+
+          FULL_SHA=$(git rev-parse "$COMMIT")
+          SHORT_SHA=$(git rev-parse --short "$COMMIT")
+
+          echo "sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "Building commit: $FULL_SHA ($SHORT_SHA)"
+
+  # Build Android APK
+  build-android:
+    needs: validate
+    if: github.event.inputs.platform == 'both' || github.event.inputs.platform == 'android'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.commit_sha }}
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          working-directory: packages/mobile
+
+      - name: Generate API types
+        run: npm run generate:api
+        working-directory: .
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android APK
+        run: eas build --platform android --profile production --non-interactive --local --output ./volleykit-${{ needs.validate.outputs.short_sha }}.apk
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-${{ needs.validate.outputs.short_sha }}
+          path: packages/mobile/volleykit-${{ needs.validate.outputs.short_sha }}.apk
+          retention-days: 30
+
+      - name: Summary
+        run: |
+          echo "## Android Build Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${{ needs.validate.outputs.commit_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifact | \`volleykit-${{ needs.validate.outputs.short_sha }}.apk\` |" >> "$GITHUB_STEP_SUMMARY"
+
+  # Build iOS app
+  build-ios:
+    needs: validate
+    if: github.event.inputs.platform == 'both' || github.event.inputs.platform == 'ios'
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: packages/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.commit_sha }}
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          working-directory: packages/mobile
+
+      - name: Generate API types
+        run: npm run generate:api
+        working-directory: .
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build iOS
+        run: eas build --platform ios --profile production --non-interactive --local --output ./volleykit-${{ needs.validate.outputs.short_sha }}.ipa
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa-${{ needs.validate.outputs.short_sha }}
+          path: packages/mobile/volleykit-${{ needs.validate.outputs.short_sha }}.ipa
+          retention-days: 30
+
+      - name: Summary
+        run: |
+          echo "## iOS Build Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${{ needs.validate.outputs.commit_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifact | \`volleykit-${{ needs.validate.outputs.short_sha }}.ipa\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -33,8 +33,8 @@ jobs:
     steps:
       - name: Check authorization
         run: |
-          if [ "${{ github.actor }}" != "Takishima" ]; then
-            echo "::error::This workflow can only be triggered by the repository owner (Takishima)."
+          if [ "${{ github.actor }}" != "${{ github.repository_owner }}" ]; then
+            echo "::error::This workflow can only be triggered by the repository owner (${{ github.repository_owner }})."
             exit 1
           fi
           echo "Authorized: ${{ github.actor }}"
@@ -61,6 +61,12 @@ jobs:
           if [ -z "$COMMIT" ]; then
             COMMIT=$(git rev-parse origin/main)
             echo "No commit specified, using main HEAD: $COMMIT"
+          else
+            # Validate SHA format to prevent command injection
+            if ! echo "$COMMIT" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
+              echo "::error::Invalid commit SHA format: $COMMIT"
+              exit 1
+            fi
           fi
 
           # Validate commit exists

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -96,94 +96,22 @@ jobs:
   build-android:
     needs: validate
     if: github.event.inputs.platform == 'both' || github.event.inputs.platform == 'android'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/mobile
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.validate.outputs.commit_sha }}
-
-      - name: Setup Node.js with dependencies
-        uses: ./.github/actions/setup-node-deps
-        with:
-          working-directory: packages/mobile
-
-      - name: Generate API types
-        run: npm run generate:api
-        working-directory: .
-
-      - name: Setup EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Build Android APK
-        run: eas build --platform android --profile production --non-interactive --local --output ./volleykit-${{ needs.validate.outputs.short_sha }}.apk
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-apk-${{ needs.validate.outputs.short_sha }}
-          path: packages/mobile/volleykit-${{ needs.validate.outputs.short_sha }}.apk
-          retention-days: 30
-
-      - name: Summary
-        run: |
-          echo "## Android Build Complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commit | \`${{ needs.validate.outputs.commit_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Artifact | \`volleykit-${{ needs.validate.outputs.short_sha }}.apk\` |" >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/build-mobile-reusable.yml
+    with:
+      platform: android
+      ref: ${{ needs.validate.outputs.commit_sha }}
+      version: ${{ needs.validate.outputs.short_sha }}
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
   # Build iOS app
   build-ios:
     needs: validate
     if: github.event.inputs.platform == 'both' || github.event.inputs.platform == 'ios'
-    runs-on: macos-latest
-    defaults:
-      run:
-        working-directory: packages/mobile
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.validate.outputs.commit_sha }}
-
-      - name: Setup Node.js with dependencies
-        uses: ./.github/actions/setup-node-deps
-        with:
-          working-directory: packages/mobile
-
-      - name: Generate API types
-        run: npm run generate:api
-        working-directory: .
-
-      - name: Setup EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Build iOS
-        run: eas build --platform ios --profile production --non-interactive --local --output ./volleykit-${{ needs.validate.outputs.short_sha }}.ipa
-
-      - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-ipa-${{ needs.validate.outputs.short_sha }}
-          path: packages/mobile/volleykit-${{ needs.validate.outputs.short_sha }}.ipa
-          retention-days: 30
-
-      - name: Summary
-        run: |
-          echo "## iOS Build Complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commit | \`${{ needs.validate.outputs.commit_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Artifact | \`volleykit-${{ needs.validate.outputs.short_sha }}.ipa\` |" >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/build-mobile-reusable.yml
+    with:
+      platform: ios
+      ref: ${{ needs.validate.outputs.commit_sha }}
+      version: ${{ needs.validate.outputs.short_sha }}
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,90 +349,28 @@ jobs:
   build-android:
     needs: release
     if: needs.release.outputs.released == 'true' && !inputs.dry_run
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/mobile
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: v${{ needs.release.outputs.version }}
-
-      - name: Setup Node.js with dependencies
-        uses: ./.github/actions/setup-node-deps
-        with:
-          working-directory: packages/mobile
-
-      - name: Generate API types
-        run: npm run generate:api
-        working-directory: .
-
-      - name: Setup EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Build Android APK
-        run: eas build --platform android --profile production --non-interactive --local --output ./volleykit-${{ needs.release.outputs.version }}.apk
-
-      - name: Upload APK to Release
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          gh release upload "v${{ needs.release.outputs.version }}" \
-            "./volleykit-${{ needs.release.outputs.version }}.apk" \
-            --clobber
-
-      - name: Summary
-        run: |
-          echo "## Android Build Complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "APK uploaded to release v${{ needs.release.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/build-mobile-reusable.yml
+    with:
+      platform: android
+      ref: v${{ needs.release.outputs.version }}
+      version: ${{ needs.release.outputs.version }}
+      upload_to_release: true
+      release_tag: v${{ needs.release.outputs.version }}
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
   # Build iOS app and attach to release (optional - requires Apple credentials)
   build-ios:
     needs: release
     if: needs.release.outputs.released == 'true' && !inputs.dry_run && inputs.build_ios
-    runs-on: macos-latest
-    defaults:
-      run:
-        working-directory: packages/mobile
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: v${{ needs.release.outputs.version }}
-
-      - name: Setup Node.js with dependencies
-        uses: ./.github/actions/setup-node-deps
-        with:
-          working-directory: packages/mobile
-
-      - name: Generate API types
-        run: npm run generate:api
-        working-directory: .
-
-      - name: Setup EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Build iOS
-        run: eas build --platform ios --profile production --non-interactive --local --output ./volleykit-${{ needs.release.outputs.version }}.ipa
-
-      - name: Upload IPA to Release
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          gh release upload "v${{ needs.release.outputs.version }}" \
-            "./volleykit-${{ needs.release.outputs.version }}.ipa" \
-            --clobber
-
-      - name: Summary
-        run: |
-          echo "## iOS Build Complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "IPA uploaded to release v${{ needs.release.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/build-mobile-reusable.yml
+    with:
+      platform: ios
+      ref: v${{ needs.release.outputs.version }}
+      version: ${{ needs.release.outputs.version }}
+      upload_to_release: true
+      release_tag: v${{ needs.release.outputs.version }}
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         default: false
+      build_ios:
+        description: 'Build iOS app (requires Apple credentials to be configured)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -339,3 +344,95 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "[View Release](https://github.com/${{ github.repository }}/releases/tag/v$VERSION)" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  # Build Android APK and attach to release
+  build-android:
+    needs: release
+    if: needs.release.outputs.released == 'true' && !inputs.dry_run
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          working-directory: packages/mobile
+
+      - name: Generate API types
+        run: npm run generate:api
+        working-directory: .
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android APK
+        run: eas build --platform android --profile production --non-interactive --local --output ./volleykit-${{ needs.release.outputs.version }}.apk
+
+      - name: Upload APK to Release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh release upload "v${{ needs.release.outputs.version }}" \
+            "./volleykit-${{ needs.release.outputs.version }}.apk" \
+            --clobber
+
+      - name: Summary
+        run: |
+          echo "## Android Build Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "APK uploaded to release v${{ needs.release.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+
+  # Build iOS app and attach to release (optional - requires Apple credentials)
+  build-ios:
+    needs: release
+    if: needs.release.outputs.released == 'true' && !inputs.dry_run && inputs.build_ios
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: packages/mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          working-directory: packages/mobile
+
+      - name: Generate API types
+        run: npm run generate:api
+        working-directory: .
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build iOS
+        run: eas build --platform ios --profile production --non-interactive --local --output ./volleykit-${{ needs.release.outputs.version }}.ipa
+
+      - name: Upload IPA to Release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh release upload "v${{ needs.release.outputs.version }}" \
+            "./volleykit-${{ needs.release.outputs.version }}.ipa" \
+            --clobber
+
+      - name: Summary
+        run: |
+          echo "## iOS Build Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "IPA uploaded to release v${{ needs.release.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4398,6 +4398,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@expo/metro-runtime": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-5.0.4.tgz",
+      "integrity": "sha512-r694MeO+7Vi8IwOsDIDzH/Q5RPMt1kUDYbiTJwnO15nIqiDwlE8HU55UlRhffKZy6s5FmxQsZ8HA+T8DqUW8cQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/@expo/osascript": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.3.8.tgz",
@@ -4511,6 +4520,18 @@
       "resolved": "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz",
       "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==",
       "license": "MIT"
+    },
+    "node_modules/@expo/server": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@expo/server/-/server-0.6.3.tgz",
+      "integrity": "sha512-Ea7NJn9Xk1fe4YeJ86rObHSv/bm3u/6WiQPXEqXJ2GrfYpVab2Swoh9/PnSM3KjR64JAgKjArDn1HiPjITCfHA==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "debug": "^4.3.4",
+        "source-map-support": "~0.5.21",
+        "undici": "^6.18.2 || ^7.0.0"
+      }
     },
     "node_modules/@expo/spawn-async": {
       "version": "1.7.2",
@@ -7500,6 +7521,39 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
+      "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@react-native-async-storage/async-storage": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.0.tgz",
@@ -9181,7 +9235,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -10165,6 +10218,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/anser": {
       "version": "1.4.10",
@@ -12183,6 +12275,12 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -14682,6 +14780,60 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-router": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-5.0.7.tgz",
+      "integrity": "sha512-NlEgRXCKtseDuIHBp87UfkvqsuVrc0MYG+zg33dopaN6wik4RkrWWxUYdNPHub0s/7qMye6zZBY4ZCrXwd/xpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/metro-runtime": "5.0.4",
+        "@expo/server": "^0.6.2",
+        "@radix-ui/react-slot": "1.2.0",
+        "@react-navigation/bottom-tabs": "^7.3.10",
+        "@react-navigation/native": "^7.1.6",
+        "@react-navigation/native-stack": "^7.3.10",
+        "client-only": "^0.0.1",
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "react-native-is-edge-to-edge": "^1.1.6",
+        "schema-utils": "^4.0.1",
+        "semver": "~7.6.3",
+        "server-only": "^0.0.1",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/drawer": "^7.3.9",
+        "expo": "*",
+        "expo-constants": "*",
+        "expo-linking": "*",
+        "react-native-reanimated": "*",
+        "react-native-safe-area-context": "*",
+        "react-native-screens": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-navigation/drawer": {
+          "optional": true
+        },
+        "@testing-library/jest-native": {
+          "optional": true
+        },
+        "react-native-reanimated": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-router/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-secure-store": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
@@ -14836,7 +14988,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24530,6 +24681,12 @@
         "react-dom": ">=16.4.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
     "node_modules/react-freeze": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
@@ -26229,6 +26386,59 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/scslre": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
@@ -26369,7 +26579,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/set-cookie-parser": {
@@ -26440,6 +26649,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.33.5",
@@ -31953,6 +32168,7 @@
         "expo-local-authentication": "~17.0.0",
         "expo-location": "~19.0.0",
         "expo-notifications": "~0.32.0",
+        "expo-router": "~5.0.0",
         "expo-secure-store": "~15.0.0",
         "expo-status-bar": "~3.0.0",
         "expo-task-manager": "~14.0.0",

--- a/packages/mobile/.gitignore
+++ b/packages/mobile/.gitignore
@@ -16,5 +16,5 @@ dist/
 .env.local
 .env.*.local
 
-# Sensitive EAS configuration
-eas.json
+# Note: eas.json is committed (contains build profiles, not secrets)
+# Sensitive credentials should use EAS managed credentials or EXPO_TOKEN

--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -1,0 +1,42 @@
+{
+  "cli": {
+    "version": ">= 15.0.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": true
+      }
+    },
+    "device": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "resourceClass": "m-medium"
+      }
+    },
+    "production": {
+      "autoIncrement": false,
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "resourceClass": "m-medium"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -33,6 +33,7 @@
     "expo-calendar": "~15.0.0",
     "expo-constants": "~18.0.0",
     "expo-linking": "~8.0.0",
+    "expo-router": "~5.0.0",
     "expo-local-authentication": "~17.0.0",
     "expo-location": "~19.0.0",
     "expo-notifications": "~0.32.0",


### PR DESCRIPTION
## Summary

- Add `build-android` and `build-ios` jobs to release workflow
  - Android builds always run; iOS is optional via `build_ios` input
  - Artifacts are attached to GitHub releases
- Create `build-mobile.yml` for manual builds from any commit on main
  - Restricted to repository owner (Takishima)
  - Defaults to Android only, iOS opt-in
- Add `eas.json` with production and device build profiles
- Add missing `expo-router` dependency
- Update `.gitignore` to track `eas.json` (contains config, not secrets)

Requires `EXPO_TOKEN` secret to be configured for EAS Build access.
iOS builds require Apple credentials to be set up via `eas credentials`.

## Test plan

- [ ] Configure `EXPO_TOKEN` secret in repository settings
- [ ] Run `npm install` to install expo-router
- [ ] Trigger "Build Mobile Apps" workflow to verify Android build
- [ ] Once Apple credentials configured, enable `build_ios` in release workflow