### PR TITLE
refactor(mobile): add EAS config to mobile app.json

### DIFF
--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -54,6 +54,12 @@
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "owner": "tachikoma",
+    "extra": {
+      "eas": {
+        "projectId": "8945a048-340b-4033-bb56-cb00b057d4c8"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `owner` and `extra.eas.projectId` fields to `packages/mobile/app.json` for EAS Build configuration

## Test plan
- [x] Run `npx expo config` in packages/mobile to verify config is valid
- [ ] Verify EAS builds work with the consolidated config