### PR TITLE
chore(worker): normalize package-lock.json version

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "volleykit-proxy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "volleykit-proxy",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260118.0",
         "@eslint/js": "^9.39.1",


### PR DESCRIPTION
## Summary

- Sync worker/package-lock.json version to match package.json (1.0.0 → 1.0.1)
- Ran `npm install --package-lock-only` on all 3 lock files in the repo

## Test plan

- [ ] Verify lock file is valid with `npm ci` in worker/