### PR TITLE
feat(mobile): add EAS configuration for iOS App Store submission

### DIFF
--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -29,14 +29,22 @@
     "production": {
       "autoIncrement": false,
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "credentialsSource": "remote"
       },
       "ios": {
-        "resourceClass": "m-medium"
+        "resourceClass": "m-medium",
+        "credentialsSource": "remote"
       }
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascApiKeyId": "@APPLE_API_KEY_ID",
+        "ascApiKeyIssuerId": "@APPLE_API_ISSUER_ID",
+        "ascApiKeyPath": "@APPLE_API_KEY_PATH"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add iOS App Store Connect API key references for automated submission
- Configure remote credentials for iOS and Android production builds
- Keep existing build profiles (development, preview, device, production)

## Test plan
- [ ] Verify EAS env variables are configured: `eas env:list --environment production`
- [ ] Run `eas build --platform ios --profile production` locally to test credentials
- [ ] Verify Android build still works with remote credentials