### PR TITLE
feat(ci): add release-triggered workflows for Android and iOS builds

### DIFF
--- a/.changeset/release-build-workflows.md
+++ b/.changeset/release-build-workflows.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Add release-triggered workflows for Android and iOS builds (currently disabled pending Expo fixes)

--- a/.github/workflows/release-build-android.yml
+++ b/.github/workflows/release-build-android.yml
@@ -1,0 +1,42 @@
+name: Release Build (Android)
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+# Prevent concurrent builds for the same release
+concurrency:
+  group: release-build-android-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  # Extract version number from tag (removes 'v' prefix)
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract version from tag
+        id: extract
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION from tag: $TAG"
+
+  build:
+    needs: prepare
+    uses: ./.github/workflows/build-mobile-reusable.yml
+    with:
+      platform: android
+      ref: ${{ github.event.release.tag_name }}
+      version: ${{ needs.prepare.outputs.version }}
+      upload_to_release: true
+      release_tag: ${{ github.event.release.tag_name }}
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release-build-android.yml
+++ b/.github/workflows/release-build-android.yml
@@ -28,15 +28,44 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION from tag: $TAG"
 
+  # TODO: Re-enable EAS build once Expo issues are fixed
+  # build:
+  #   needs: prepare
+  #   uses: ./.github/workflows/build-mobile-reusable.yml
+  #   with:
+  #     platform: android
+  #     ref: ${{ github.event.release.tag_name }}
+  #     version: ${{ needs.prepare.outputs.version }}
+  #     upload_to_release: true
+  #     release_tag: ${{ github.event.release.tag_name }}
+  #   secrets:
+  #     EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+  #     RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
   build:
     needs: prepare
-    uses: ./.github/workflows/build-mobile-reusable.yml
-    with:
-      platform: android
-      ref: ${{ github.event.release.tag_name }}
-      version: ${{ needs.prepare.outputs.version }}
-      upload_to_release: true
-      release_tag: ${{ github.event.release.tag_name }}
-    secrets:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log build info (EAS build temporarily disabled)
+        run: |
+          echo "=================================================="
+          echo "Android Release Build - EAS build temporarily disabled"
+          echo "=================================================="
+          echo ""
+          echo "Release tag: ${{ github.event.release.tag_name }}"
+          echo "Version: ${{ needs.prepare.outputs.version }}"
+          echo "Release URL: ${{ github.event.release.html_url }}"
+          echo ""
+          echo "TODO: Re-enable EAS build once Expo issues are fixed"
+          echo "=================================================="
+
+      - name: Summary
+        run: |
+          echo "## Android Release Build (Disabled)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "EAS build is temporarily disabled due to Expo issues." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Release Tag | \`${{ github.event.release.tag_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version | \`${{ needs.prepare.outputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-build-ios.yml
+++ b/.github/workflows/release-build-ios.yml
@@ -1,0 +1,42 @@
+name: Release Build (iOS)
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+# Prevent concurrent builds for the same release
+concurrency:
+  group: release-build-ios-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  # Extract version number from tag (removes 'v' prefix)
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract version from tag
+        id: extract
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION from tag: $TAG"
+
+  build:
+    needs: prepare
+    uses: ./.github/workflows/build-mobile-reusable.yml
+    with:
+      platform: ios
+      ref: ${{ github.event.release.tag_name }}
+      version: ${{ needs.prepare.outputs.version }}
+      upload_to_release: true
+      release_tag: ${{ github.event.release.tag_name }}
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release-build-ios.yml
+++ b/.github/workflows/release-build-ios.yml
@@ -28,15 +28,44 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION from tag: $TAG"
 
+  # TODO: Re-enable EAS build once Expo issues are fixed
+  # build:
+  #   needs: prepare
+  #   uses: ./.github/workflows/build-mobile-reusable.yml
+  #   with:
+  #     platform: ios
+  #     ref: ${{ github.event.release.tag_name }}
+  #     version: ${{ needs.prepare.outputs.version }}
+  #     upload_to_release: true
+  #     release_tag: ${{ github.event.release.tag_name }}
+  #   secrets:
+  #     EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+  #     RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
   build:
     needs: prepare
-    uses: ./.github/workflows/build-mobile-reusable.yml
-    with:
-      platform: ios
-      ref: ${{ github.event.release.tag_name }}
-      version: ${{ needs.prepare.outputs.version }}
-      upload_to_release: true
-      release_tag: ${{ github.event.release.tag_name }}
-    secrets:
-      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log build info (EAS build temporarily disabled)
+        run: |
+          echo "=================================================="
+          echo "iOS Release Build - EAS build temporarily disabled"
+          echo "=================================================="
+          echo ""
+          echo "Release tag: ${{ github.event.release.tag_name }}"
+          echo "Version: ${{ needs.prepare.outputs.version }}"
+          echo "Release URL: ${{ github.event.release.html_url }}"
+          echo ""
+          echo "TODO: Re-enable EAS build once Expo issues are fixed"
+          echo "=================================================="
+
+      - name: Summary
+        run: |
+          echo "## iOS Release Build (Disabled)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "EAS build is temporarily disabled due to Expo issues." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Release Tag | \`${{ github.event.release.tag_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version | \`${{ needs.prepare.outputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Add `release-build-android.yml` workflow triggered when a GitHub release is published
- Add `release-build-ios.yml` workflow triggered when a GitHub release is published
- Both workflows use the existing reusable build workflow and upload artifacts to the release
- EAS builds are temporarily disabled (just logs release info) until Expo issues are fixed
- Original build configuration preserved in comments for easy re-enabling
- Created issue #846 to track re-enabling EAS builds

## Test Plan

- [ ] Create a test release to verify workflows trigger and log correctly
- [ ] Check job summary shows release info
- [ ] Once Expo issues are fixed, uncomment EAS build jobs and verify artifacts upload

https://claude.ai/code/session_01EEUydkw18A9FeQ5PvrpqRe