### PR TITLE
feat(ci): add worker npm update workflow and reschedule before Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
-      timezone: "Europe/Zurich"
+      time: "07:00"
+      timezone: "UTC"
     open-pull-requests-limit: 10
     reviewers:
       - "Takishima"
@@ -35,8 +35,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
-      timezone: "Europe/Zurich"
+      time: "07:00"
+      timezone: "UTC"
     open-pull-requests-limit: 5
     reviewers:
       - "Takishima"
@@ -53,8 +53,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
-      timezone: "Europe/Zurich"
+      time: "07:00"
+      timezone: "UTC"
     open-pull-requests-limit: 10
     reviewers:
       - "Takishima"
@@ -70,8 +70,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
-      timezone: "Europe/Zurich"
+      time: "07:00"
+      timezone: "UTC"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"

--- a/.github/workflows/update-deps-mobile.yml
+++ b/.github/workflows/update-deps-mobile.yml
@@ -1,9 +1,9 @@
 name: Update Dependencies (Mobile)
 
 on:
-  # Run weekly on Mondays at 7:00 UTC (offset from web to avoid concurrent runs)
+  # Run weekly on Sundays at 14:30 UTC (offset from web, before Dependabot on Monday 07:00 UTC)
   schedule:
-    - cron: '0 7 * * 1'
+    - cron: '30 14 * * 0'
   # Allow manual trigger
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-deps-web.yml
+++ b/.github/workflows/update-deps-web.yml
@@ -1,9 +1,9 @@
 name: Update Dependencies (Web)
 
 on:
-  # Run weekly on Mondays at 6:00 UTC
+  # Run weekly on Sundays at 14:00 UTC (before Dependabot on Monday 07:00 UTC)
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 14 * * 0'
   # Allow manual trigger
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-deps-worker.yml
+++ b/.github/workflows/update-deps-worker.yml
@@ -1,9 +1,9 @@
 name: Update Dependencies (Worker)
 
 on:
-  # Run weekly on Mondays at 8:00 UTC (offset from web/mobile, before Dependabot at 9:00 UTC)
+  # Run weekly on Sundays at 15:00 UTC (offset from web/mobile, before Dependabot on Monday 07:00 UTC)
   schedule:
-    - cron: '0 8 * * 1'
+    - cron: '0 15 * * 0'
   # Allow manual trigger
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-deps-worker.yml
+++ b/.github/workflows/update-deps-worker.yml
@@ -83,7 +83,7 @@ jobs:
 
           # Check worker updates
           cd worker
-          WORKER_UPDATES=$(ncu --target "$NCU_TARGET" --format lines 2>/dev/null || true)
+          WORKER_UPDATES=$(ncu --target "${NCU_TARGET}" --format lines 2>/dev/null || true)
           cd ..
 
           if [ -n "$WORKER_UPDATES" ]; then
@@ -146,14 +146,10 @@ jobs:
           name: updated-packages-worker
           path: .
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node.js with dependencies
+        uses: ./.github/actions/setup-node-deps
         with:
-          node-version: '22'
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: .
+          working-directory: worker
 
       - name: TypeScript check
         run: npx tsc --noEmit
@@ -167,6 +163,9 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Build (dry-run)
+        run: npx wrangler deploy --dry-run
 
   create-pr:
     name: Create PR
@@ -188,7 +187,7 @@ jobs:
           path: .
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           commit-message: 'chore(worker): update npm dependencies'
@@ -209,6 +208,7 @@ jobs:
             - Lint
             - Security audit
             - Tests
+            - Build (dry-run)
           branch: chore/update-worker-deps
           delete-branch: true
           labels: |

--- a/.github/workflows/update-deps-worker.yml
+++ b/.github/workflows/update-deps-worker.yml
@@ -1,0 +1,216 @@
+name: Update Dependencies (Worker)
+
+on:
+  # Run weekly on Mondays at 8:00 UTC (offset from web/mobile, before Dependabot at 9:00 UTC)
+  schedule:
+    - cron: '0 8 * * 1'
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      update_type:
+        description: 'Update type'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: 'Dry run (check updates and validate without creating PR)'
+        required: false
+        default: false
+        type: boolean
+
+# =============================================================================
+# Worker Dependency Update Workflow
+# =============================================================================
+#
+# This workflow automatically updates npm dependencies for the worker,
+# runs full validation, and creates a PR if successful.
+#
+# Flow:
+#   1. Check for updates using npm-check-updates
+#   2. If updates found, install and run validation
+#   3. Run lint, test, and typecheck
+#   4. Create PR with changes if all validations pass
+#
+# =============================================================================
+
+concurrency:
+  group: update-deps-worker
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update Dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      has_updates: ${{ steps.check-updates.outputs.has_updates }}
+      updates_summary: ${{ steps.check-updates.outputs.updates_summary }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install npm-check-updates
+        run: npm install -g npm-check-updates@17
+
+      - name: Determine update target
+        id: update-target
+        run: |
+          UPDATE_TYPE="${{ github.event.inputs.update_type || 'minor' }}"
+          case "$UPDATE_TYPE" in
+            patch) NCU_TARGET="patch" ;;
+            minor) NCU_TARGET="minor" ;;
+            major) NCU_TARGET="latest" ;;
+          esac
+          echo "ncu_target=$NCU_TARGET" >> "$GITHUB_OUTPUT"
+          echo "Update target: $NCU_TARGET"
+
+      - name: Check for updates
+        id: check-updates
+        run: |
+          NCU_TARGET="${{ steps.update-target.outputs.ncu_target }}"
+          echo "Checking for updates with target: $NCU_TARGET"
+
+          # Check worker updates
+          cd worker
+          WORKER_UPDATES=$(ncu --target "$NCU_TARGET" --format lines 2>/dev/null || true)
+          cd ..
+
+          if [ -n "$WORKER_UPDATES" ]; then
+            echo "has_updates=true" >> "$GITHUB_OUTPUT"
+            # Escape for multiline output
+            {
+              echo "updates_summary<<EOF"
+              echo "**worker:**"
+              echo "$WORKER_UPDATES"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "Updates found:"
+            echo "$WORKER_UPDATES"
+          else
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+            echo "No updates available"
+          fi
+
+      - name: Apply updates
+        if: steps.check-updates.outputs.has_updates == 'true'
+        run: |
+          NCU_TARGET="${{ steps.update-target.outputs.ncu_target }}"
+
+          # Update worker dependencies
+          cd worker
+          ncu --target "$NCU_TARGET" -u
+          cd ..
+
+          # Install updated dependencies
+          npm install
+
+          # Regenerate package-lock.json
+          npm install --package-lock-only
+
+      - name: Upload updated files
+        if: steps.check-updates.outputs.has_updates == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: updated-packages-worker
+          path: |
+            package-lock.json
+            worker/package.json
+          retention-days: 1
+
+  validate:
+    name: Validate
+    needs: update
+    if: needs.update.outputs.has_updates == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download updated packages
+        uses: actions/download-artifact@v7
+        with:
+          name: updated-packages-worker
+          path: .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Security audit
+        run: npm audit --audit-level=high --omit=dev
+        working-directory: .
+
+      - name: Test
+        run: npm test
+
+  create-pr:
+    name: Create PR
+    needs: [update, validate]
+    # Note: For scheduled runs, github.event.inputs.dry_run is empty/null, so this evaluates to true (create PR)
+    if: needs.update.outputs.has_updates == 'true' && github.event.inputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download updated packages
+        uses: actions/download-artifact@v7
+        with:
+          name: updated-packages-worker
+          path: .
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          commit-message: 'chore(worker): update npm dependencies'
+          title: 'chore(worker): update npm dependencies'
+          body: |
+            ## Dependency Updates
+
+            This PR was automatically generated by the dependency update workflow.
+
+            ### Updated Packages
+
+            ${{ needs.update.outputs.updates_summary }}
+
+            ### Validation
+
+            All validations passed:
+            - TypeScript check
+            - Lint
+            - Security audit
+            - Tests
+          branch: chore/update-worker-deps
+          delete-branch: true
+          labels: |
+            dependencies
+            automated


### PR DESCRIPTION
## Summary

- Adds `update-deps-worker.yml` workflow for the worker directory (previously only covered by Dependabot)
- Reschedules all custom npm update workflows to Sunday afternoon:
  - 14:00 UTC: update-deps-web.yml
  - 14:30 UTC: update-deps-mobile.yml
  - 15:00 UTC: update-deps-worker.yml
- Moves Dependabot to Monday 07:00 UTC, giving ~17 hours to merge custom PRs first
- Reduces duplicate Dependabot PRs for npm dependencies

## Test plan

- [ ] Verify workflow YAML syntax is valid in GitHub Actions
- [ ] Manually trigger `update-deps-worker.yml` via workflow_dispatch
- [ ] Confirm schedules run as expected on Sunday/Monday

https://claude.ai/code/session_01DLCLzDCch9oMzEMuVHHtSG