### PR TITLE
fix(shared): resolve eslint errors and warnings in shared package

### DIFF
--- a/packages/shared/src/auth/service.test.ts
+++ b/packages/shared/src/auth/service.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createAuthService } from './service'
-import type { AuthServiceConfig, LoginFormFields } from './types'
+import type { AuthServiceConfig } from './types'
 
 // Mock fetch globally
 const mockFetch = vi.fn()

--- a/packages/shared/src/hooks/useAssignments.test.ts
+++ b/packages/shared/src/hooks/useAssignments.test.ts
@@ -17,7 +17,6 @@ import {
   THIS_WEEK_DAYS,
   NEXT_MONTH_DAYS,
   type AssignmentsApiClient,
-  type DatePeriod,
 } from './useAssignments'
 
 /** Small delay for tests that need to wait a tick without triggering queries */
@@ -330,6 +329,7 @@ describe('useAssignments', () => {
 
   it('should return empty array when API returns null items', async () => {
     vi.mocked(mockApiClient.searchAssignments).mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing edge case: API returns undefined instead of array
       items: undefined as any,
       totalItemsCount: 0,
     })
@@ -386,6 +386,7 @@ describe('useAssignmentDetails', () => {
       },
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial mock object for testing
     vi.mocked(mockApiClient.getAssignmentDetails!).mockResolvedValue(mockAssignment as any)
 
     const { result } = renderHook(() => useAssignmentDetails('assign-123', mockApiClient), {

--- a/packages/shared/src/hooks/useCompensations.test.ts
+++ b/packages/shared/src/hooks/useCompensations.test.ts
@@ -12,7 +12,6 @@ import {
   COMPENSATIONS_STALE_TIME_MS,
   DEFAULT_PAGE_SIZE,
   type CompensationsApiClient,
-  type CompensationStatus,
 } from './useCompensations'
 import type { CompensationRecord } from '../api/validation'
 
@@ -171,6 +170,7 @@ describe('useCompensations', () => {
 
   it('should return empty array when items is undefined', async () => {
     vi.mocked(mockApiClient.searchCompensations).mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing edge case: API returns undefined instead of array
       items: undefined as any,
       totalItemsCount: 0,
     })
@@ -274,6 +274,7 @@ describe('calculateTotalCompensation', () => {
       {
         __identity: '1',
         convocationCompensation: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing edge case: API returns null instead of number
           gameCompensation: null as any,
           travelExpenses: 20,
         },

--- a/packages/shared/src/hooks/useExchanges.test.ts
+++ b/packages/shared/src/hooks/useExchanges.test.ts
@@ -12,7 +12,6 @@ import {
   EXCHANGES_STALE_TIME_MS,
   DEFAULT_PAGE_SIZE,
   type ExchangesApiClient,
-  type ExchangeStatusFilter,
 } from './useExchanges'
 import type { GameExchange } from '../api/validation'
 
@@ -272,6 +271,7 @@ describe('useExchanges', () => {
 
   it('should return empty array when items is undefined', async () => {
     vi.mocked(mockApiClient.searchExchanges).mockResolvedValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing edge case: API returns undefined instead of array
       items: undefined as any,
       totalItemsCount: 0,
     })

--- a/packages/shared/src/stores/settings.ts
+++ b/packages/shared/src/stores/settings.ts
@@ -160,7 +160,7 @@ const initialState = {
  * Platform-agnostic store for user preferences.
  * Persistence is handled by platform-specific adapters.
  */
-export const useSettingsStore = create<SettingsState>((set, get) => ({
+export const useSettingsStore = create<SettingsState>((set) => ({
   ...initialState,
 
   setLanguage: (language) => set({ language }),

--- a/packages/shared/src/utils/date-helpers.test.ts
+++ b/packages/shared/src/utils/date-helpers.test.ts
@@ -20,7 +20,6 @@ import {
   formatRosterEntries,
   getMaxLastNameWidth,
   getSeasonDateRange,
-  type WeekGroup,
   type RosterPlayerData,
 } from './date-helpers'
 


### PR DESCRIPTION
## Summary

- Remove unused imports from test files (LoginFormFields, DatePeriod, CompensationStatus, ExchangeStatusFilter, WeekGroup)
- Remove unused 'get' parameter from settings store create callback
- Add eslint-disable comments for intentional 'any' usage in test edge cases

## Test plan

- [x] All 447 tests pass in shared package
- [x] Lint passes with 0 errors and 0 warnings
- [x] Pre-commit validation completed successfully

https://claude.ai/code/session_01MVr6PBr3rYNJ8NUeiyc1Ka