### PR TITLE
fix(web): disable distance editing when hasFlexibleTravelExpenses is false

### DIFF
--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -249,6 +249,7 @@ export const api = {
     query.append('propertyRenderConfiguration[]', 'correctionReason')
     query.append('propertyRenderConfiguration[]', 'distanceInMetres')
     query.append('propertyRenderConfiguration[]', 'distanceFormatted')
+    query.append('propertyRenderConfiguration[]', 'hasFlexibleTravelExpenses')
 
     return apiRequest<ConvocationCompensationDetailed>(
       `/indoorvolleyball.refadmin/api%5cconvocationcompensation/showWithNestedObjects?${query}`

--- a/web-app/src/features/compensations/components/EditCompensationModal.test.tsx
+++ b/web-app/src/features/compensations/components/EditCompensationModal.test.tsx
@@ -364,6 +364,88 @@ describe('EditCompensationModal', () => {
       const reasonInput = screen.getByLabelText('Reason')
       expect(reasonInput).toHaveValue('Detour due to road closure')
     })
+
+    it('disables distance field when hasFlexibleTravelExpenses is false', async () => {
+      mockGetCompensationDetails.mockResolvedValue({
+        convocationCompensation: {
+          distanceInMetres: 112120,
+          correctionReason: '',
+          hasFlexibleTravelExpenses: false,
+        },
+      })
+
+      render(
+        <EditCompensationModal
+          compensation={createMockCompensation()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        const kmInput = screen.getByLabelText('Kilometers')
+        expect(kmInput).toBeDisabled()
+      })
+
+      // Should show the explanation hint
+      expect(
+        screen.getByText('Distance is calculated automatically and cannot be changed.')
+      ).toBeInTheDocument()
+    })
+
+    it('enables distance field when hasFlexibleTravelExpenses is true', async () => {
+      mockGetCompensationDetails.mockResolvedValue({
+        convocationCompensation: {
+          distanceInMetres: 50000,
+          correctionReason: '',
+          hasFlexibleTravelExpenses: true,
+        },
+      })
+
+      render(
+        <EditCompensationModal
+          compensation={createMockCompensation()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        const kmInput = screen.getByLabelText('Kilometers')
+        expect(kmInput).not.toBeDisabled()
+      })
+
+      // Should NOT show the explanation hint
+      expect(
+        screen.queryByText('Distance is calculated automatically and cannot be changed.')
+      ).not.toBeInTheDocument()
+    })
+
+    it('enables distance field by default when hasFlexibleTravelExpenses is undefined', async () => {
+      mockGetCompensationDetails.mockResolvedValue({
+        convocationCompensation: {
+          distanceInMetres: 50000,
+          correctionReason: '',
+          // hasFlexibleTravelExpenses not set (undefined)
+        },
+      })
+
+      render(
+        <EditCompensationModal
+          compensation={createMockCompensation()}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        const kmInput = screen.getByLabelText('Kilometers')
+        expect(kmInput).not.toBeDisabled()
+      })
+    })
   })
 
   describe('form validation', () => {

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -314,6 +314,7 @@ const de: Translations = {
       'Entschädigungseintrag hat keine Kennung. Bitte versuchen Sie es später erneut.',
     saveError: 'Entschädigung konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.',
     saveSuccess: 'Entschädigung erfolgreich gespeichert.',
+    distanceNotEditable: 'Die Distanz wird automatisch berechnet und kann nicht geändert werden.',
     unavailableInCalendarModeTitle: 'Im Kalender-Modus nicht verfügbar',
     unavailableInCalendarModeDescription:
       'Entschädigungsdaten sind im Kalender-Modus nicht verfügbar. Verwenden Sie die vollständige Anmeldung, um auf Entschädigungsdetails zuzugreifen.',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -306,6 +306,7 @@ const en: Translations = {
     compensationMissingId: 'Compensation record is missing an identifier. Please try again later.',
     saveError: 'Failed to save compensation. Please try again.',
     saveSuccess: 'Compensation saved successfully.',
+    distanceNotEditable: 'Distance is calculated automatically and cannot be changed.',
     unavailableInCalendarModeTitle: 'Not available in Calendar Mode',
     unavailableInCalendarModeDescription:
       'Compensation data is not available in calendar mode. Use full login to access compensation details.',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -314,6 +314,7 @@ const fr: Translations = {
       "L'enregistrement d'indemnité n'a pas d'identifiant. Veuillez réessayer plus tard.",
     saveError: "Échec de l'enregistrement de l'indemnité. Veuillez réessayer.",
     saveSuccess: 'Indemnité enregistrée avec succès.',
+    distanceNotEditable: 'La distance est calculée automatiquement et ne peut pas être modifiée.',
     unavailableInCalendarModeTitle: 'Non disponible en mode calendrier',
     unavailableInCalendarModeDescription:
       "Les données d'indemnités ne sont pas disponibles en mode calendrier. Utilisez la connexion complète pour accéder aux détails des indemnités.",

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -312,6 +312,7 @@ const it: Translations = {
     compensationMissingId: 'Il record di compenso non ha un identificatore. Riprova più tardi.',
     saveError: 'Impossibile salvare il compenso. Riprova.',
     saveSuccess: 'Compenso salvato con successo.',
+    distanceNotEditable: 'La distanza viene calcolata automaticamente e non può essere modificata.',
     unavailableInCalendarModeTitle: 'Non disponibile in modalità calendario',
     unavailableInCalendarModeDescription:
       "I dati dei compensi non sono disponibili in modalità calendario. Usa l'accesso completo per accedere ai dettagli dei compensi.",

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -197,6 +197,7 @@ export interface Translations {
     compensationMissingId: string
     saveError: string
     saveSuccess: string
+    distanceNotEditable: string
     unavailableInCalendarModeTitle: string
     unavailableInCalendarModeDescription: string
   }


### PR DESCRIPTION
## Summary

- Fetch `hasFlexibleTravelExpenses` in the `getCompensationDetails` API call
- Disable the kilometers input field when distance editing is not allowed
- Show an explanatory hint message when the field is disabled
- Add translations for the hint in all 4 languages (de/en/fr/it)

Regional associations (non-SV) have distance calculated automatically by the backend and do not allow manual editing. Previously, the distance field appeared editable but changes would fail silently on the backend.

## Test plan

- [ ] Open edit compensation modal for a regional association compensation (hasFlexibleTravelExpenses: false)
- [ ] Verify the kilometers field is disabled and shows the hint message
- [ ] Open edit compensation modal for an SV compensation (hasFlexibleTravelExpenses: true)
- [ ] Verify the kilometers field is enabled and editable
- [ ] Run unit tests: `npm test -- --run EditCompensationModal`
- [ ] Build succeeds: `npm run build`

https://claude.ai/code/session_0136CJiJjEtMDum1PNzsoSuq