### PR TITLE
fix(mobile): distinguish iOS Touch ID from Android fingerprint in biometric auth

### DIFF
--- a/.changeset/biometric-platform-detection.md
+++ b/.changeset/biometric-platform-detection.md
@@ -1,0 +1,5 @@
+---
+'@volleykit/mobile': patch
+---
+
+Fix biometric type mapping to correctly distinguish iOS Touch ID from Android fingerprint using platform detection

--- a/packages/mobile/src/platform/biometrics.ts
+++ b/packages/mobile/src/platform/biometrics.ts
@@ -5,6 +5,8 @@
  * Used for quick re-authentication after session expiry.
  */
 
+import { Platform } from 'react-native'
+
 import * as LocalAuthentication from 'expo-local-authentication'
 
 import type { BiometricAdapter } from '@volleykit/shared/types/platform'
@@ -19,10 +21,8 @@ function mapAuthenticationType(
     return 'faceId'
   }
   if (types.includes(LocalAuthentication.AuthenticationType.FINGERPRINT)) {
-    // iOS Touch ID or Android fingerprint
-    // We can't distinguish between iOS Touch ID and Android fingerprint easily,
-    // but we'll use 'fingerprint' for Android and 'touchId' for iOS
-    return 'fingerprint'
+    // Use platform detection to distinguish iOS Touch ID from Android fingerprint
+    return Platform.OS === 'ios' ? 'touchId' : 'fingerprint'
   }
   if (types.includes(LocalAuthentication.AuthenticationType.IRIS)) {
     // Treat iris as fingerprint for simplicity


### PR DESCRIPTION
## Summary
- Use Platform.OS to correctly return 'touchId' on iOS and 'fingerprint' on Android when fingerprint authentication is detected
- Improves the accuracy of biometric type detection for platform-specific UI labels

## Test plan
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] All 54 mobile tests pass (`npm test`)

https://claude.ai/code/session_013Yg4vS7SfWi1vFYKUmuZ53