### PR TITLE
feat(shared): add toggleDemoMode convenience method to demo store

### DIFF
--- a/.changeset/add-toggle-demo-mode.md
+++ b/.changeset/add-toggle-demo-mode.md
@@ -1,0 +1,5 @@
+---
+'@volleykit/shared': patch
+---
+
+Add toggleDemoMode convenience method to demo store

--- a/packages/shared/src/stores/demo.test.ts
+++ b/packages/shared/src/stores/demo.test.ts
@@ -71,4 +71,50 @@ describe('useDemoStore', () => {
       expect(useDemoStore.getState().isDemoMode).toBe(true)
     })
   })
+
+  describe('toggleDemoMode', () => {
+    it('should toggle from false to true', () => {
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+
+      act(() => {
+        useDemoStore.getState().toggleDemoMode()
+      })
+
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+    })
+
+    it('should toggle from true to false', () => {
+      // First set to true
+      act(() => {
+        useDemoStore.getState().setDemoMode(true)
+      })
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+
+      // Toggle should set to false
+      act(() => {
+        useDemoStore.getState().toggleDemoMode()
+      })
+
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+    })
+
+    it('should handle multiple consecutive toggles', () => {
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+
+      act(() => {
+        useDemoStore.getState().toggleDemoMode()
+      })
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+
+      act(() => {
+        useDemoStore.getState().toggleDemoMode()
+      })
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+
+      act(() => {
+        useDemoStore.getState().toggleDemoMode()
+      })
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+    })
+  })
 })

--- a/packages/shared/src/stores/demo.ts
+++ b/packages/shared/src/stores/demo.ts
@@ -10,9 +10,11 @@ import { create } from 'zustand'
 export interface DemoState {
   isDemoMode: boolean
   setDemoMode: (enabled: boolean) => void
+  toggleDemoMode: () => void
 }
 
 export const useDemoStore = create<DemoState>((set) => ({
   isDemoMode: false,
   setDemoMode: (isDemoMode) => set({ isDemoMode }),
+  toggleDemoMode: () => set((state) => ({ isDemoMode: !state.isDemoMode })),
 }))


### PR DESCRIPTION
## Summary

- Add `toggleDemoMode()` convenience method to the shared demo store
- Provides a common pattern for boolean state toggling
- Includes unit tests for the new functionality

## Test plan

- [x] Run `npm test` in packages/shared - all 572 tests pass
- [x] Verify toggleDemoMode toggles state correctly from false to true
- [x] Verify toggleDemoMode toggles state correctly from true to false
- [x] Verify multiple consecutive toggles work correctly

https://claude.ai/code/session_01CUzTLyEfGURh8thTAi5Yyi