### PR TITLE
test(shared): add integration tests for auth, hooks, and stores

### DIFF
--- a/packages/shared/src/auth/auth-store.integration.test.ts
+++ b/packages/shared/src/auth/auth-store.integration.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Auth Service + Auth Store Integration Tests
+ *
+ * Tests the integration between auth service and auth store:
+ * - Login flow updates store state correctly
+ * - deriveUserFromActiveParty properly sets up user and occupation
+ * - Session check updates store appropriately
+ * - Error states propagate correctly
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createAuthService } from './service'
+import type { AuthServiceConfig } from './types'
+import { useAuthStore } from '../stores/auth'
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('Auth Service + Store Integration', () => {
+  const mockConfig: AuthServiceConfig = {
+    apiBaseUrl: 'https://api.test.com',
+    getSessionHeaders: () => ({ 'X-Session': 'test-session' }),
+    captureSessionToken: vi.fn(),
+    cookieProcessingDelayMs: 0,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    useAuthStore.getState().reset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    useAuthStore.getState().reset()
+  })
+
+  describe('login flow with store update', () => {
+    it('should update auth store on successful login', async () => {
+      const loginPageHtml = `
+        <form>
+          <input name="__trustedProperties" value="trusted-token" />
+          <input name="__referrer[@package]" value="SportManager.Volleyball" />
+        </form>
+      `
+
+      const dashboardHtml = `
+        <div data-csrf-token="csrf-12345">
+          <script>
+            window.activeParty = JSON.parse('${JSON.stringify({
+              __identity: 'user-123',
+              groupedEligibleAttributeValues: [
+                {
+                  __identity: 'occ-referee-sv',
+                  roleIdentifier: 'Indoorvolleyball.RefAdmin:Referee',
+                  inflatedValue: { shortName: 'SV', name: 'SwissVolley' },
+                },
+              ],
+            })}');
+          </script>
+        </div>
+      `
+
+      // Mock fetch responses
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(loginPageHtml),
+        headers: new Headers(),
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 303,
+        type: 'default',
+        headers: new Headers({ Location: '/sportmanager.volleyball/main/dashboard' }),
+        text: () => Promise.resolve(''),
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(dashboardHtml),
+        headers: new Headers(),
+      })
+
+      // Initial state
+      expect(useAuthStore.getState().status).toBe('idle')
+      expect(useAuthStore.getState().user).toBeNull()
+
+      // Set loading state
+      useAuthStore.getState().setStatus('loading')
+      expect(useAuthStore.getState().status).toBe('loading')
+
+      // Execute login
+      const authService = createAuthService(mockConfig)
+      const resultPromise = authService.login('testuser', 'testpass')
+      await vi.runAllTimersAsync()
+      const result = await resultPromise
+
+      expect(result.success).toBe(true)
+
+      // Derive user from activeParty and update store
+      if (result.success && result.dashboardHtml) {
+        const activeParty = authService.extractActivePartyFromHtml(result.dashboardHtml)
+        const { user, activeOccupationId } = authService.deriveUserFromActiveParty(
+          activeParty,
+          null,
+          null
+        )
+
+        useAuthStore.getState().setUser(user)
+        if (activeOccupationId) {
+          useAuthStore.getState().setActiveOccupation(activeOccupationId)
+        }
+      }
+
+      // Verify store state
+      const state = useAuthStore.getState()
+      expect(state.status).toBe('authenticated')
+      expect(state.user).not.toBeNull()
+      expect(state.user?.id).toBe('user-123')
+      expect(state.user?.occupations).toHaveLength(1)
+      expect(state.user?.occupations[0].associationCode).toBe('SV')
+      expect(state.activeOccupationId).toBe('occ-referee-sv')
+    })
+
+    it('should set error state on failed login', async () => {
+      const loginPageHtml = `
+        <form>
+          <input name="__trustedProperties" value="trusted-token" />
+        </form>
+      `
+
+      const errorPageHtml = '<div color="error">Invalid credentials</div>'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(loginPageHtml),
+        headers: new Headers(),
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        type: 'default',
+        headers: new Headers(),
+        text: () => Promise.resolve(errorPageHtml),
+      })
+
+      useAuthStore.getState().setStatus('loading')
+
+      const authService = createAuthService(mockConfig)
+      const result = await authService.login('baduser', 'badpass')
+
+      expect(result.success).toBe(false)
+
+      // Update store with error
+      if (!result.success) {
+        useAuthStore.getState().setError({
+          message: result.error,
+          code: 'invalid_credentials',
+        })
+      }
+
+      const state = useAuthStore.getState()
+      expect(state.status).toBe('error')
+      expect(state.error).not.toBeNull()
+      expect(state.error?.message).toBe('Invalid username or password')
+      expect(state.error?.code).toBe('invalid_credentials')
+      expect(state.user).toBeNull()
+    })
+
+    it('should handle lockout state correctly', async () => {
+      const loginPageHtml = `
+        <form>
+          <input name="__trustedProperties" value="trusted-token" />
+        </form>
+      `
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(loginPageHtml),
+        headers: new Headers(),
+      })
+
+      const lockedUntil = Date.now() + 300000
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 423,
+        json: () =>
+          Promise.resolve({
+            message: 'Account locked for 5 minutes',
+            lockedUntil,
+          }),
+        headers: new Headers(),
+      })
+
+      const authService = createAuthService(mockConfig)
+      const result = await authService.login('user', 'pass')
+
+      expect(result.success).toBe(false)
+
+      if (!result.success) {
+        useAuthStore.getState().setError({
+          message: result.error,
+          code: 'locked',
+          lockedUntilSeconds: result.lockedUntil
+            ? Math.ceil((result.lockedUntil - Date.now()) / 1000)
+            : undefined,
+        })
+      }
+
+      const state = useAuthStore.getState()
+      expect(state.status).toBe('error')
+      expect(state.error?.code).toBe('locked')
+      expect(state.error?.lockedUntilSeconds).toBeDefined()
+    })
+  })
+
+  describe('session check with store update', () => {
+    it('should restore session state on valid session', async () => {
+      const dashboardHtml = `
+        <div data-csrf-token="session-csrf">
+          <script>
+            window.activeParty = JSON.parse('${JSON.stringify({
+              __identity: 'user-456',
+              groupedEligibleAttributeValues: [
+                {
+                  __identity: 'occ-ref-rvno',
+                  roleIdentifier: 'Indoorvolleyball.RefAdmin:Referee',
+                  inflatedValue: { shortName: 'RVNO', name: 'RV Nordostschweiz' },
+                },
+                {
+                  __identity: 'occ-ref-rvsz',
+                  roleIdentifier: 'Indoorvolleyball.RefAdmin:Referee',
+                  inflatedValue: { shortName: 'RVSZ', name: 'RV Zentralschweiz' },
+                },
+              ],
+            })}');
+          </script>
+        </div>
+      `
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(dashboardHtml),
+        headers: new Headers(),
+      })
+
+      // Simulate checking session
+      useAuthStore.getState().setStatus('loading')
+
+      const authService = createAuthService(mockConfig)
+      const result = await authService.checkSession()
+
+      expect(result.valid).toBe(true)
+      expect(result.csrfToken).toBe('session-csrf')
+
+      // Update store based on session check
+      if (result.valid && result.activeParty) {
+        const { user, activeOccupationId } = authService.deriveUserFromActiveParty(
+          result.activeParty,
+          null,
+          null
+        )
+
+        useAuthStore.getState().setUser(user)
+        if (activeOccupationId) {
+          useAuthStore.getState().setActiveOccupation(activeOccupationId)
+        }
+      }
+
+      const state = useAuthStore.getState()
+      expect(state.status).toBe('authenticated')
+      expect(state.user?.id).toBe('user-456')
+      expect(state.user?.occupations).toHaveLength(2)
+      expect(state.hasMultipleAssociations()).toBe(true)
+    })
+
+    it('should handle invalid session', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Headers(),
+      })
+
+      useAuthStore.getState().setStatus('loading')
+
+      const authService = createAuthService(mockConfig)
+      const result = await authService.checkSession()
+
+      expect(result.valid).toBe(false)
+
+      // On invalid session, reset to idle
+      if (!result.valid) {
+        useAuthStore.getState().setStatus('idle')
+      }
+
+      const state = useAuthStore.getState()
+      expect(state.status).toBe('idle')
+      expect(state.user).toBeNull()
+    })
+
+    it('should preserve existing activeOccupationId on session restore', async () => {
+      const dashboardHtml = `
+        <div data-csrf-token="session-csrf">
+          <script>
+            window.activeParty = JSON.parse('${JSON.stringify({
+              __identity: 'user-789',
+              groupedEligibleAttributeValues: [
+                {
+                  __identity: 'occ-1',
+                  roleIdentifier: 'Indoorvolleyball.RefAdmin:Referee',
+                  inflatedValue: { shortName: 'SV' },
+                },
+                {
+                  __identity: 'occ-2',
+                  roleIdentifier: 'Indoorvolleyball.RefAdmin:Referee',
+                  inflatedValue: { shortName: 'RVNO' },
+                },
+              ],
+            })}');
+          </script>
+        </div>
+      `
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(dashboardHtml),
+        headers: new Headers(),
+      })
+
+      // Simulate user had previously selected occ-2
+      const previousActiveOccupationId = 'occ-2'
+
+      const authService = createAuthService(mockConfig)
+      const result = await authService.checkSession()
+
+      if (result.valid && result.activeParty) {
+        const { user, activeOccupationId } = authService.deriveUserFromActiveParty(
+          result.activeParty,
+          null,
+          previousActiveOccupationId // Persisted from storage
+        )
+
+        useAuthStore.getState().setUser(user)
+        if (activeOccupationId) {
+          useAuthStore.getState().setActiveOccupation(activeOccupationId)
+        }
+      }
+
+      // Should preserve the previous selection
+      expect(useAuthStore.getState().activeOccupationId).toBe('occ-2')
+    })
+  })
+
+  describe('logout flow', () => {
+    it('should clear store state on logout', async () => {
+      // Setup authenticated state
+      useAuthStore.getState().setUser({
+        id: 'user-123',
+        firstName: 'John',
+        lastName: 'Doe',
+        occupations: [{ id: 'occ-1', type: 'referee', associationCode: 'SV' }],
+      })
+      useAuthStore.getState().setDataSource('api')
+
+      expect(useAuthStore.getState().status).toBe('authenticated')
+      expect(useAuthStore.getState().user).not.toBeNull()
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+      })
+
+      const authService = createAuthService(mockConfig)
+      await authService.logout()
+
+      // Clear store
+      useAuthStore.getState().logout()
+
+      const state = useAuthStore.getState()
+      expect(state.status).toBe('idle')
+      expect(state.user).toBeNull()
+      expect(state.activeOccupationId).toBeNull()
+      // Data source is preserved on logout
+      expect(state.dataSource).toBe('api')
+    })
+  })
+
+  describe('data source transitions', () => {
+    it('should handle demo mode authentication', () => {
+      // Set demo mode
+      useAuthStore.getState().setDataSource('demo')
+
+      // Set demo user
+      useAuthStore.getState().setUser({
+        id: 'demo-user',
+        firstName: 'Demo',
+        lastName: 'User',
+        occupations: [
+          { id: 'demo-occ-sv', type: 'referee', associationCode: 'SV' },
+          { id: 'demo-occ-rvno', type: 'referee', associationCode: 'RVNO' },
+        ],
+      })
+
+      const state = useAuthStore.getState()
+      expect(state.status).toBe('authenticated')
+      expect(state.dataSource).toBe('demo')
+      expect(state.isDemoMode()).toBe(true)
+      expect(state.getAuthMode()).toBe('demo')
+    })
+
+    it('should handle calendar mode authentication', () => {
+      useAuthStore.getState().setDataSource('calendar')
+      useAuthStore.getState().setCalendarCode('ABC123')
+
+      useAuthStore.getState().setUser({
+        id: 'calendar-user',
+        firstName: 'Calendar',
+        lastName: 'User',
+        occupations: [{ id: 'cal-occ', type: 'referee' }],
+      })
+
+      const state = useAuthStore.getState()
+      expect(state.status).toBe('authenticated')
+      expect(state.dataSource).toBe('calendar')
+      expect(state.isCalendarMode()).toBe(true)
+      expect(state.getAuthMode()).toBe('calendar')
+      expect(state.calendarCode).toBe('ABC123')
+    })
+
+    it('should transition between data sources correctly', () => {
+      // Start with API auth
+      useAuthStore.getState().setUser({
+        id: 'api-user',
+        firstName: 'API',
+        lastName: 'User',
+        occupations: [{ id: 'api-occ', type: 'referee' }],
+      })
+
+      expect(useAuthStore.getState().getAuthMode()).toBe('full')
+
+      // Logout and switch to demo
+      useAuthStore.getState().logout()
+      useAuthStore.getState().setDataSource('demo')
+
+      expect(useAuthStore.getState().getAuthMode()).toBe('none')
+
+      // Auth in demo mode
+      useAuthStore.getState().setUser({
+        id: 'demo-user',
+        firstName: 'Demo',
+        lastName: 'User',
+        occupations: [],
+      })
+
+      expect(useAuthStore.getState().getAuthMode()).toBe('demo')
+    })
+  })
+})

--- a/packages/shared/src/hooks/hooks-store.integration.test.ts
+++ b/packages/shared/src/hooks/hooks-store.integration.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Hooks + Store Coordination Integration Tests
+ *
+ * Tests the integration between TanStack Query hooks and Zustand stores:
+ * - Query key changes when store values change
+ * - Hook behavior when auth state transitions
+ * - useAuth hook correctly reflects store state
+ * - Query enabling/disabling based on auth state
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement, type ReactNode } from 'react'
+
+import { useAuthStore } from '../stores/auth'
+import { useAuth } from './useAuth'
+import { useAssignments, type AssignmentsApiClient } from './useAssignments'
+import { useCompensations, type CompensationsApiClient } from './useCompensations'
+
+/** Small delay for tests that need to wait a tick */
+const TEST_TICK_MS = 50
+
+// Helper to create a wrapper with QueryClient
+function createWrapper(queryClient?: QueryClient) {
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0,
+        },
+      },
+    })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children)
+  }
+}
+
+describe('useAuth + Store Integration', () => {
+  beforeEach(() => {
+    useAuthStore.getState().reset()
+  })
+
+  afterEach(() => {
+    useAuthStore.getState().reset()
+  })
+
+  it('should reflect store state changes', () => {
+    const { result, rerender } = renderHook(() => useAuth())
+
+    // Initial state
+    expect(result.current.isAuthenticated).toBe(false)
+    expect(result.current.status).toBe('idle')
+    expect(result.current.user).toBeNull()
+
+    // Update store
+    act(() => {
+      useAuthStore.getState().setUser({
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+        occupations: [{ id: 'occ-1', type: 'referee' }],
+      })
+    })
+
+    rerender()
+
+    expect(result.current.isAuthenticated).toBe(true)
+    expect(result.current.status).toBe('authenticated')
+    expect(result.current.user?.firstName).toBe('John')
+  })
+
+  it('should handle loading state', () => {
+    const { result, rerender } = renderHook(() => useAuth())
+
+    act(() => {
+      useAuthStore.getState().setStatus('loading')
+    })
+
+    rerender()
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.isAuthenticated).toBe(false)
+  })
+
+  it('should handle error state', () => {
+    const { result, rerender } = renderHook(() => useAuth())
+
+    act(() => {
+      useAuthStore.getState().setError({
+        message: 'Invalid credentials',
+        code: 'invalid_credentials',
+      })
+    })
+
+    rerender()
+
+    expect(result.current.error?.message).toBe('Invalid credentials')
+    expect(result.current.status).toBe('error')
+  })
+
+  it('should logout and clear state', () => {
+    const { result, rerender } = renderHook(() => useAuth())
+
+    // First authenticate
+    act(() => {
+      useAuthStore.getState().setUser({
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+        occupations: [],
+      })
+    })
+
+    rerender()
+    expect(result.current.isAuthenticated).toBe(true)
+
+    // Then logout
+    act(() => {
+      result.current.logout()
+    })
+
+    rerender()
+
+    expect(result.current.isAuthenticated).toBe(false)
+    expect(result.current.user).toBeNull()
+  })
+})
+
+describe('useAssignments + Store Integration', () => {
+  const mockApiClient: AssignmentsApiClient = {
+    searchAssignments: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.getState().reset()
+  })
+
+  afterEach(() => {
+    useAuthStore.getState().reset()
+  })
+
+  it('should use different query keys for different associations', async () => {
+    vi.mocked(mockApiClient.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    })
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+      },
+    })
+
+    // Render with association key SV
+    const { result: result1, unmount: unmount1 } = renderHook(
+      () =>
+        useAssignments({
+          apiClient: mockApiClient,
+          associationKey: 'SV',
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await waitFor(() => {
+      expect(result1.current.isSuccess).toBe(true)
+    })
+
+    const callCount1 = vi.mocked(mockApiClient.searchAssignments).mock.calls.length
+    expect(callCount1).toBe(1)
+
+    unmount1()
+
+    // Render with different association key
+    const { result: result2 } = renderHook(
+      () =>
+        useAssignments({
+          apiClient: mockApiClient,
+          associationKey: 'RVNO',
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await waitFor(() => {
+      expect(result2.current.isSuccess).toBe(true)
+    })
+
+    // Should have made a new API call because query key changed
+    expect(vi.mocked(mockApiClient.searchAssignments).mock.calls.length).toBe(2)
+  })
+
+  it('should disable queries when not authenticated', async () => {
+    const { result } = renderHook(
+      () =>
+        useAssignments({
+          apiClient: mockApiClient,
+          enabled: false, // Simulating unauthenticated state
+        }),
+      { wrapper: createWrapper() }
+    )
+
+    // Wait a tick to ensure no fetch
+    await new Promise((r) => setTimeout(r, TEST_TICK_MS))
+
+    expect(mockApiClient.searchAssignments).not.toHaveBeenCalled()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+
+  it('should enable queries when auth state changes', async () => {
+    vi.mocked(mockApiClient.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    })
+
+    // Start disabled
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useAssignments({
+          apiClient: mockApiClient,
+          enabled,
+        }),
+      {
+        wrapper: createWrapper(),
+        initialProps: { enabled: false },
+      }
+    )
+
+    await new Promise((r) => setTimeout(r, TEST_TICK_MS))
+    expect(mockApiClient.searchAssignments).not.toHaveBeenCalled()
+
+    // Simulate auth state change - enable queries
+    rerender({ enabled: true })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockApiClient.searchAssignments).toHaveBeenCalled()
+  })
+})
+
+describe('useCompensations + Store Integration', () => {
+  const mockApiClient: CompensationsApiClient = {
+    searchCompensations: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.getState().reset()
+  })
+
+  afterEach(() => {
+    useAuthStore.getState().reset()
+  })
+
+  it('should refetch with new association key', async () => {
+    vi.mocked(mockApiClient.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    })
+
+    const { result, rerender } = renderHook(
+      ({ associationKey }) =>
+        useCompensations({
+          apiClient: mockApiClient,
+          associationKey,
+        }),
+      {
+        wrapper: createWrapper(),
+        initialProps: { associationKey: 'SV' },
+      }
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockApiClient.searchCompensations).toHaveBeenCalledTimes(1)
+
+    // Change association
+    rerender({ associationKey: 'RVNO' })
+
+    await waitFor(() => {
+      expect(vi.mocked(mockApiClient.searchCompensations).mock.calls.length).toBe(2)
+    })
+  })
+})
+
+describe('Multiple hooks with shared auth state', () => {
+  const mockAssignmentsApi: AssignmentsApiClient = {
+    searchAssignments: vi.fn(),
+  }
+
+  const mockCompensationsApi: CompensationsApiClient = {
+    searchCompensations: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAuthStore.getState().reset()
+  })
+
+  afterEach(() => {
+    useAuthStore.getState().reset()
+  })
+
+  it('should coordinate multiple hooks based on auth store', async () => {
+    vi.mocked(mockAssignmentsApi.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    })
+
+    vi.mocked(mockCompensationsApi.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    })
+
+    // Setup auth state
+    act(() => {
+      useAuthStore.getState().setUser({
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+        occupations: [
+          { id: 'occ-1', type: 'referee', associationCode: 'SV' },
+          { id: 'occ-2', type: 'referee', associationCode: 'RVNO' },
+        ],
+      })
+    })
+
+    const activeOccupation = useAuthStore.getState().getActiveOccupation()
+    expect(activeOccupation).not.toBeNull()
+
+    // Both hooks should use the same association key
+    const wrapper = createWrapper()
+
+    const { result: assignmentsResult } = renderHook(
+      () =>
+        useAssignments({
+          apiClient: mockAssignmentsApi,
+          associationKey: activeOccupation?.associationCode,
+        }),
+      { wrapper }
+    )
+
+    const { result: compensationsResult } = renderHook(
+      () =>
+        useCompensations({
+          apiClient: mockCompensationsApi,
+          associationKey: activeOccupation?.associationCode,
+        }),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(assignmentsResult.current.isSuccess).toBe(true)
+      expect(compensationsResult.current.isSuccess).toBe(true)
+    })
+
+    // Both should have been called
+    expect(mockAssignmentsApi.searchAssignments).toHaveBeenCalled()
+    expect(mockCompensationsApi.searchCompensations).toHaveBeenCalled()
+  })
+
+  it('should handle association switching across hooks', async () => {
+    vi.mocked(mockAssignmentsApi.searchAssignments).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    })
+
+    vi.mocked(mockCompensationsApi.searchCompensations).mockResolvedValue({
+      items: [],
+      totalItemsCount: 0,
+    })
+
+    // Setup with multiple associations
+    act(() => {
+      useAuthStore.getState().setUser({
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+        occupations: [
+          { id: 'occ-sv', type: 'referee', associationCode: 'SV' },
+          { id: 'occ-rvno', type: 'referee', associationCode: 'RVNO' },
+        ],
+      })
+    })
+
+    expect(useAuthStore.getState().hasMultipleAssociations()).toBe(true)
+
+    const getAssociationCode = () =>
+      useAuthStore.getState().getActiveOccupation()?.associationCode ?? 'SV'
+
+    const wrapper = createWrapper()
+
+    const { result, rerender } = renderHook(
+      ({ associationKey }) => ({
+        assignments: useAssignments({
+          apiClient: mockAssignmentsApi,
+          associationKey,
+        }),
+        compensations: useCompensations({
+          apiClient: mockCompensationsApi,
+          associationKey,
+        }),
+      }),
+      {
+        wrapper,
+        initialProps: { associationKey: getAssociationCode() },
+      }
+    )
+
+    await waitFor(() => {
+      expect(result.current.assignments.isSuccess).toBe(true)
+      expect(result.current.compensations.isSuccess).toBe(true)
+    })
+
+    const initialCallCount = {
+      assignments: vi.mocked(mockAssignmentsApi.searchAssignments).mock.calls.length,
+      compensations: vi.mocked(mockCompensationsApi.searchCompensations).mock.calls.length,
+    }
+
+    // Switch association
+    act(() => {
+      useAuthStore.getState().setActiveOccupation('occ-rvno')
+    })
+
+    rerender({ associationKey: getAssociationCode() })
+
+    await waitFor(() => {
+      // Should have refetched both
+      expect(vi.mocked(mockAssignmentsApi.searchAssignments).mock.calls.length).toBeGreaterThan(
+        initialCallCount.assignments
+      )
+      expect(vi.mocked(mockCompensationsApi.searchCompensations).mock.calls.length).toBeGreaterThan(
+        initialCallCount.compensations
+      )
+    })
+  })
+})

--- a/packages/shared/src/stores/stores.integration.test.ts
+++ b/packages/shared/src/stores/stores.integration.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Store Cross-Interactions Integration Tests
+ *
+ * Tests the coordination between multiple Zustand stores:
+ * - Auth + Demo store interactions
+ * - Store reset coordination during logout
+ * - Demo mode activation flows
+ * - Settings store interactions (if applicable)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act } from '@testing-library/react'
+
+import { useAuthStore } from './auth'
+import { useDemoStore } from './demo'
+import { useSettingsStore } from './settings'
+
+describe('Auth + Demo Store Integration', () => {
+  beforeEach(() => {
+    useAuthStore.getState().reset()
+    useDemoStore.getState().setDemoMode(false)
+    useSettingsStore.getState().reset()
+  })
+
+  afterEach(() => {
+    useAuthStore.getState().reset()
+    useDemoStore.getState().setDemoMode(false)
+    useSettingsStore.getState().reset()
+  })
+
+  describe('demo mode activation flow', () => {
+    it('should coordinate auth and demo stores when entering demo mode', () => {
+      // Step 1: Enable demo mode in demo store
+      act(() => {
+        useDemoStore.getState().setDemoMode(true)
+      })
+
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+
+      // Step 2: Set auth store data source to demo
+      act(() => {
+        useAuthStore.getState().setDataSource('demo')
+      })
+
+      expect(useAuthStore.getState().dataSource).toBe('demo')
+      expect(useAuthStore.getState().isDemoMode()).toBe(true)
+
+      // Step 3: Set demo user in auth store
+      act(() => {
+        useAuthStore.getState().setUser({
+          id: 'demo-user',
+          firstName: 'Demo',
+          lastName: 'User',
+          occupations: [
+            { id: 'demo-occ-sv', type: 'referee', associationCode: 'SV' },
+            { id: 'demo-occ-rvno', type: 'referee', associationCode: 'RVNO' },
+          ],
+        })
+      })
+
+      // Verify coordinated state
+      expect(useAuthStore.getState().status).toBe('authenticated')
+      expect(useAuthStore.getState().getAuthMode()).toBe('demo')
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+    })
+
+    it('should toggle demo mode correctly', () => {
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+
+      act(() => {
+        useDemoStore.getState().toggleDemoMode()
+      })
+
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+
+      act(() => {
+        useDemoStore.getState().toggleDemoMode()
+      })
+
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+    })
+  })
+
+  describe('logout flow coordination', () => {
+    it('should coordinate store resets on logout', () => {
+      // Setup authenticated demo state
+      act(() => {
+        useDemoStore.getState().setDemoMode(true)
+        useAuthStore.getState().setDataSource('demo')
+        useAuthStore.getState().setUser({
+          id: 'demo-user',
+          firstName: 'Demo',
+          lastName: 'User',
+          occupations: [{ id: 'occ-1', type: 'referee', associationCode: 'SV' }],
+        })
+      })
+
+      expect(useAuthStore.getState().status).toBe('authenticated')
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+
+      // Logout from auth store
+      act(() => {
+        useAuthStore.getState().logout()
+      })
+
+      // Auth should be cleared but dataSource preserved
+      expect(useAuthStore.getState().status).toBe('idle')
+      expect(useAuthStore.getState().user).toBeNull()
+      expect(useAuthStore.getState().dataSource).toBe('demo') // Preserved
+
+      // Demo store should be cleared separately (by the app)
+      act(() => {
+        useDemoStore.getState().setDemoMode(false)
+      })
+
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+    })
+
+    it('should handle full reset across stores', () => {
+      // Setup state across stores
+      act(() => {
+        useAuthStore.getState().setUser({
+          id: 'user-1',
+          firstName: 'John',
+          lastName: 'Doe',
+          occupations: [{ id: 'occ-1', type: 'referee' }],
+        })
+        useDemoStore.getState().setDemoMode(true)
+        useSettingsStore.getState().setLanguage('fr')
+      })
+
+      // Full reset
+      act(() => {
+        useAuthStore.getState().reset()
+        useDemoStore.getState().setDemoMode(false)
+        useSettingsStore.getState().reset()
+      })
+
+      expect(useAuthStore.getState().status).toBe('idle')
+      expect(useAuthStore.getState().user).toBeNull()
+      expect(useAuthStore.getState().dataSource).toBe('api')
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+      expect(useSettingsStore.getState().language).toBe('de')
+    })
+  })
+
+  describe('data source transitions', () => {
+    it('should transition from API to demo mode', () => {
+      // Start in API mode (authenticated)
+      act(() => {
+        useAuthStore.getState().setUser({
+          id: 'api-user',
+          firstName: 'Real',
+          lastName: 'User',
+          occupations: [{ id: 'api-occ', type: 'referee', associationCode: 'SV' }],
+        })
+      })
+
+      expect(useAuthStore.getState().dataSource).toBe('api')
+      expect(useAuthStore.getState().getAuthMode()).toBe('full')
+
+      // Logout and switch to demo
+      act(() => {
+        useAuthStore.getState().logout()
+      })
+
+      expect(useAuthStore.getState().status).toBe('idle')
+
+      // Switch to demo mode
+      act(() => {
+        useDemoStore.getState().setDemoMode(true)
+        useAuthStore.getState().setDataSource('demo')
+        useAuthStore.getState().setUser({
+          id: 'demo-user',
+          firstName: 'Demo',
+          lastName: 'User',
+          occupations: [{ id: 'demo-occ', type: 'referee', associationCode: 'SV' }],
+        })
+      })
+
+      expect(useAuthStore.getState().getAuthMode()).toBe('demo')
+      expect(useDemoStore.getState().isDemoMode).toBe(true)
+    })
+
+    it('should transition from demo to calendar mode', () => {
+      // Start in demo mode
+      act(() => {
+        useDemoStore.getState().setDemoMode(true)
+        useAuthStore.getState().setDataSource('demo')
+        useAuthStore.getState().setUser({
+          id: 'demo-user',
+          firstName: 'Demo',
+          lastName: 'User',
+          occupations: [],
+        })
+      })
+
+      expect(useAuthStore.getState().getAuthMode()).toBe('demo')
+
+      // Logout from demo
+      act(() => {
+        useAuthStore.getState().logout()
+        useDemoStore.getState().setDemoMode(false)
+      })
+
+      // Switch to calendar mode
+      act(() => {
+        useAuthStore.getState().setDataSource('calendar')
+        useAuthStore.getState().setCalendarCode('ABC123')
+        useAuthStore.getState().setUser({
+          id: 'calendar-user',
+          firstName: 'Calendar',
+          lastName: 'User',
+          occupations: [{ id: 'cal-occ', type: 'referee' }],
+        })
+      })
+
+      expect(useAuthStore.getState().getAuthMode()).toBe('calendar')
+      expect(useAuthStore.getState().calendarCode).toBe('ABC123')
+      expect(useDemoStore.getState().isDemoMode).toBe(false)
+    })
+  })
+})
+
+describe('Auth + Settings Store Integration', () => {
+  beforeEach(() => {
+    useAuthStore.getState().reset()
+    useSettingsStore.getState().reset()
+  })
+
+  afterEach(() => {
+    useAuthStore.getState().reset()
+    useSettingsStore.getState().reset()
+  })
+
+  it('should preserve settings across auth state changes', () => {
+    // Set language preference
+    act(() => {
+      useSettingsStore.getState().setLanguage('fr')
+    })
+
+    expect(useSettingsStore.getState().language).toBe('fr')
+
+    // Authenticate
+    act(() => {
+      useAuthStore.getState().setUser({
+        id: 'user-1',
+        firstName: 'Jean',
+        lastName: 'Dupont',
+        occupations: [{ id: 'occ-1', type: 'referee' }],
+      })
+    })
+
+    expect(useAuthStore.getState().status).toBe('authenticated')
+    expect(useSettingsStore.getState().language).toBe('fr') // Preserved
+
+    // Logout
+    act(() => {
+      useAuthStore.getState().logout()
+    })
+
+    expect(useAuthStore.getState().status).toBe('idle')
+    expect(useSettingsStore.getState().language).toBe('fr') // Still preserved
+  })
+
+  it('should allow independent settings updates while authenticated', () => {
+    // Authenticate
+    act(() => {
+      useAuthStore.getState().setUser({
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+        occupations: [{ id: 'occ-1', type: 'referee' }],
+      })
+    })
+
+    // Change settings while authenticated
+    act(() => {
+      useSettingsStore.getState().setLanguage('it')
+      useSettingsStore.getState().setBiometricEnabled(true)
+    })
+
+    expect(useSettingsStore.getState().language).toBe('it')
+    expect(useSettingsStore.getState().biometricEnabled).toBe(true)
+
+    // Auth state unchanged
+    expect(useAuthStore.getState().status).toBe('authenticated')
+    expect(useAuthStore.getState().user?.firstName).toBe('John')
+  })
+})
+
+describe('Association switching coordination', () => {
+  beforeEach(() => {
+    useAuthStore.getState().reset()
+  })
+
+  afterEach(() => {
+    useAuthStore.getState().reset()
+  })
+
+  it('should set association switching flag during switch', () => {
+    act(() => {
+      useAuthStore.getState().setUser({
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+        occupations: [
+          { id: 'occ-sv', type: 'referee', associationCode: 'SV' },
+          { id: 'occ-rvno', type: 'referee', associationCode: 'RVNO' },
+        ],
+      })
+    })
+
+    expect(useAuthStore.getState().isAssociationSwitching).toBe(false)
+
+    // Start switching
+    act(() => {
+      useAuthStore.getState().setAssociationSwitching(true)
+    })
+
+    expect(useAuthStore.getState().isAssociationSwitching).toBe(true)
+
+    // Change occupation
+    act(() => {
+      useAuthStore.getState().setActiveOccupation('occ-rvno')
+    })
+
+    expect(useAuthStore.getState().activeOccupationId).toBe('occ-rvno')
+    expect(useAuthStore.getState().getActiveOccupation()?.associationCode).toBe('RVNO')
+
+    // Finish switching
+    act(() => {
+      useAuthStore.getState().setAssociationSwitching(false)
+    })
+
+    expect(useAuthStore.getState().isAssociationSwitching).toBe(false)
+  })
+
+  it('should update active occupation and reflect in getters', () => {
+    act(() => {
+      useAuthStore.getState().setUser({
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+        occupations: [
+          { id: 'occ-1', type: 'referee', associationCode: 'SV', level: 'National' },
+          { id: 'occ-2', type: 'referee', associationCode: 'RVNO', level: 'Regional' },
+        ],
+      })
+    })
+
+    // First occupation selected by default (referee type)
+    let activeOcc = useAuthStore.getState().getActiveOccupation()
+    expect(activeOcc?.id).toBe('occ-1')
+    expect(activeOcc?.associationCode).toBe('SV')
+
+    // Switch occupation
+    act(() => {
+      useAuthStore.getState().setActiveOccupation('occ-2')
+    })
+
+    activeOcc = useAuthStore.getState().getActiveOccupation()
+    expect(activeOcc?.id).toBe('occ-2')
+    expect(activeOcc?.associationCode).toBe('RVNO')
+    expect(activeOcc?.level).toBe('Regional')
+  })
+})


### PR DESCRIPTION
## Summary

- Add 30 new integration tests for the shared package covering cross-module interactions
- Auth service + store coordination tests (login flow, session check, logout, data source transitions)
- Hooks + store integration tests (query key changes, auth state transitions, multiple hooks coordination)
- Store cross-interactions tests (auth + demo, auth + settings, association switching)

## Test plan

- [x] All 602 tests pass (572 existing + 30 new integration tests)
- [x] Tests verify cross-module state coordination
- [x] Tests cover error states and edge cases

https://claude.ai/code/session_01W7Gfkn69Y6ipKfwiMJcMD1