### PR TITLE
docs: update main README and add sub-project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,121 +3,43 @@
 [![CI](https://github.com/Takishima/volleykit/actions/workflows/ci.yml/badge.svg)](https://github.com/Takishima/volleykit/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A mobile-friendly Progressive Web App (PWA) for Swiss volleyball referees, providing an improved interface to [volleymanager.volleyball.ch](https://volleymanager.volleyball.ch).
+A multi-platform app suite for Swiss volleyball referees, providing an improved interface to [volleymanager.volleyball.ch](https://volleymanager.volleyball.ch).
 
-## Features
+## Applications
 
-### Assignment Management
-
-- View upcoming match assignments with detailed game information
-- Swipe gestures for quick actions (validate, exchange, edit compensation)
-- Game validation wizard with roster verification and scorer assignment
-- Generate sports hall reports for NLA/NLB games
-- Full address display with navigation buttons (Apple/Google Maps)
-
-### Compensation Tracking
-
-- View all referee compensations including game fees and travel expenses
-- Edit compensation details directly from the app
-- Export compensation reports as PDF
-
-### Game Exchange
-
-- Browse the game exchange marketplace
-- Filter by distance, travel time, and game level
-- Take over games from other referees with confirmation flow
-- Put your assignments up for exchange
-
-### Swiss Public Transport Integration
-
-- Real-time travel time calculations via OJP SDK
-- Filter assignments by reachability from your home location
-- Direct SBB deep links for route planning
-
-### Progressive Web App
-
-- Works offline with service worker caching
-- Installable on mobile devices
-- Auto-updating with reload prompts
-- Multi-language support (German, English, French, Italian)
-- Interactive guided tour for new users
-
-## Tech Stack
-
-| Category   | Technology                                    |
-| ---------- | --------------------------------------------- |
-| Framework  | React 19 with TypeScript 5.9                  |
-| Build      | Vite 7                                        |
-| Styling    | Tailwind CSS 4                                |
-| State      | Zustand 5 (client), TanStack Query 5 (server) |
-| Routing    | React Router 7                                |
-| Validation | Zod 4                                         |
-| Testing    | Vitest 4, React Testing Library, Playwright   |
-| CORS Proxy | Cloudflare Workers                            |
-| Transport  | OJP SDK (Swiss public transport)              |
-
-## Project Structure
-
-```
-volleykit/
-├── web-app/          # React PWA
-├── worker/           # Cloudflare Worker CORS proxy
-└── docs/             # API documentation and guides
-```
+| App | Location | Description |
+|-----|----------|-------------|
+| Web App (PWA) | [`web-app/`](./web-app/) | React 19 + Vite 7 + Tailwind 4 |
+| Mobile App | [`packages/mobile/`](./packages/mobile/) | React Native 0.79 + Expo 53 |
+| Shared Package | [`packages/shared/`](./packages/shared/) | API client, hooks, stores, i18n |
+| Help Site | [`help-site/`](./help-site/) | Astro 6 documentation |
+| CORS Proxy | [`worker/`](./worker/) | Cloudflare Worker |
 
 ## Quick Start
 
-### With devenv (Recommended)
-
 ```bash
-devenv shell    # Enter development environment
-dev             # Start dev server
-```
-
-### Without Nix
-
-```bash
-cd web-app && npm install && npm run dev
-```
-
-Then open http://localhost:5173
-
-## Development Commands
-
-```bash
-# Web App (from web-app/)
-npm run dev           # Start dev server
-npm run build         # Production build
-npm run lint          # ESLint check
-npm test              # Run unit tests
-npm run test:e2e      # Run E2E tests
-
-# Worker (from worker/)
-npm run dev           # Local worker dev
-npx wrangler deploy   # Deploy to Cloudflare
+npm install                        # Install all dependencies
+cd web-app && npm run dev          # Start web dev server (localhost:5173)
+cd packages/mobile && npm start    # Start Expo dev server
 ```
 
 ## Documentation
 
-- [Development Guide](./CLAUDE.md) - Detailed development guidelines and conventions
-- [API Documentation](./docs/api/README.md) - OpenAPI spec and API details
-- [Security Checklist](./docs/SECURITY_CHECKLIST.md) - Security review guide
-- [Code Patterns](./docs/CODE_PATTERNS.md) - Code examples and patterns
+| Document | Description |
+|----------|-------------|
+| [CLAUDE.md](./CLAUDE.md) | Development guide and conventions |
+| [API Docs](./docs/api/README.md) | OpenAPI spec and endpoints |
+| [Code Patterns](./docs/CODE_PATTERNS.md) | Code examples and best practices |
+| [Testing Strategy](./docs/TESTING_STRATEGY.md) | Testing guidelines |
+| [Security Checklist](./docs/SECURITY_CHECKLIST.md) | Security review guide |
+| [Validation](./docs/VALIDATION.md) | Build validation and bundle limits |
 
-## Legal Notice & Data Ownership
+## Legal & Privacy
 
-**This is an unofficial application** for personal use. It is not affiliated with or endorsed by Swiss Volley.
+**Unofficial application** - not affiliated with Swiss Volley. All volleyball data is property of Swiss Volley.
 
-- All data is property of **Swiss Volley**
-- No Swiss Volley logos or trademarks are used
-- For official information, visit [volleymanager.volleyball.ch](https://volleymanager.volleyball.ch)
-
-## Privacy
-
-- **No data collection** - VolleyKit does not collect or store personal data
-- **Direct communication** - All data flows directly to Swiss Volley's servers
-- **No analytics** - No tracking or telemetry
+No data collection, no analytics. All data flows directly to Swiss Volley's servers.
 
 ## License
 
-MIT - applies to the application code only. All volleyball data is property of Swiss Volley.
+MIT - applies to application code only.

--- a/help-site/README.md
+++ b/help-site/README.md
@@ -1,0 +1,43 @@
+# VolleyKit Help Site
+
+Documentation and help pages built with Astro.
+
+## Tech Stack
+
+- Astro 6
+- Tailwind CSS 4
+- Pagefind (search)
+
+## Development
+
+```bash
+npm run dev           # Start dev server
+npm run build         # Build static site
+npm run preview       # Preview production build
+```
+
+## Project Structure
+
+```
+src/
+├── pages/            # Markdown/Astro pages
+├── components/       # Astro components
+├── layouts/          # Page layouts
+└── i18n/             # Translations
+public/
+└── images/           # Screenshots and assets
+```
+
+## Adding Content
+
+1. Create a new `.md` or `.astro` file in `src/pages/`
+2. Add frontmatter with title and description
+3. Build to regenerate search index
+
+## Search
+
+Search is powered by Pagefind and generated at build time:
+
+```bash
+npm run build  # Runs astro build && pagefind
+```

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -1,0 +1,55 @@
+# VolleyKit Mobile
+
+React Native mobile app for iOS and Android.
+
+## Tech Stack
+
+- React Native 0.79 + Expo 53
+- NativeWind (Tailwind for React Native)
+- React Navigation 7
+- TanStack Query 5 (with persistence)
+- @volleykit/shared (shared business logic)
+
+## Features
+
+- Assignment list with pull-to-refresh
+- Biometric authentication (Face ID / fingerprint)
+- Push notifications for new assignments
+- Calendar integration
+- iOS widgets (WidgetKit)
+- Offline support with query persistence
+
+## Development
+
+```bash
+npm start             # Start Expo dev server
+npm run ios           # Run on iOS simulator
+npm run android       # Run on Android emulator
+npm run prebuild      # Generate native projects
+```
+
+## Project Structure
+
+```
+src/
+├── screens/          # Screen components
+├── components/       # Shared UI components
+├── navigation/       # Navigation configuration
+├── hooks/            # Mobile-specific hooks
+├── services/         # Native services (notifications, etc.)
+├── stores/           # Mobile-specific stores
+└── platform/         # Platform-specific code
+```
+
+## Building
+
+```bash
+# Development builds
+eas build --profile development --platform ios
+eas build --profile development --platform android
+
+# Production builds
+eas build --profile production --platform all
+```
+
+See `eas.json` for build profiles.

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,40 @@
+# @volleykit/shared
+
+Shared code between VolleyKit web and mobile apps (~70% code sharing).
+
+## Exports
+
+```typescript
+import { useAssignments } from '@volleykit/shared/hooks'
+import { useAuthStore } from '@volleykit/shared/stores'
+import { apiClient } from '@volleykit/shared/api'
+import { formatDate } from '@volleykit/shared/utils'
+import { t } from '@volleykit/shared/i18n'
+```
+
+| Export | Contents |
+|--------|----------|
+| `/api` | API client, query keys, generated types |
+| `/hooks` | TanStack Query hooks for all endpoints |
+| `/stores` | Zustand stores (auth, settings, etc.) |
+| `/i18n` | Translations (de, en, fr, it) |
+| `/utils` | Date formatting, validation helpers |
+| `/types` | Shared TypeScript types |
+| `/adapters` | Platform-specific adapters |
+
+## Development
+
+```bash
+npm run dev           # Watch mode
+npm run build         # Build with tsup
+npm test              # Run tests
+npm run typecheck     # TypeScript check
+```
+
+## API Types
+
+Generated from OpenAPI spec. Regenerate with:
+
+```bash
+cd ../web-app && npm run generate:api
+```

--- a/web-app/README.md
+++ b/web-app/README.md
@@ -1,0 +1,53 @@
+# VolleyKit Web App
+
+A Progressive Web App (PWA) for Swiss volleyball referee management.
+
+## Tech Stack
+
+- React 19 + TypeScript 5.9
+- Vite 7 (build)
+- Tailwind CSS 4 (styling)
+- Zustand 5 (client state)
+- TanStack Query 5 (server state)
+- React Router 7 (routing)
+- Zod 4 (validation)
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| Assignments | View/validate match assignments with swipe gestures |
+| Compensations | Track fees, expenses, export PDF reports |
+| Game Exchange | Browse marketplace, filter by distance/level |
+| Transport | Swiss public transport integration (OJP SDK) |
+| OCR | Receipt scanning for expense entry |
+| Offline | Service worker caching, installable PWA |
+
+## Development
+
+```bash
+npm install
+npm run dev           # Start dev server (localhost:5173)
+npm run build         # Production build
+npm run lint          # ESLint check
+npm test              # Unit tests (Vitest)
+npm run test:e2e      # E2E tests (Playwright)
+```
+
+## Project Structure
+
+```
+src/
+├── features/         # Feature modules (assignments, auth, compensations, etc.)
+├── shared/           # Shared components, hooks, utils
+├── api/              # API client and generated types
+├── i18n/             # Translations (de, en, fr, it)
+└── contexts/         # React contexts
+e2e/
+├── pages/            # Page Object Models
+└── *.spec.ts         # E2E test specs
+```
+
+## Bundle Limits
+
+See [VALIDATION.md](../docs/VALIDATION.md) for size limits and build checks.


### PR DESCRIPTION
## Summary
- Simplify main README with applications table and documentation links
- Add web-app/README.md with PWA tech stack and features
- Add packages/shared/README.md with exports and usage examples
- Add packages/mobile/README.md with React Native setup
- Add help-site/README.md with Astro docs info

## Test plan
- [ ] Verify all links in READMEs work correctly
- [ ] Check table formatting renders properly on GitHub

https://claude.ai/code/session_01E5FqKcDeP2cbtpFV6bs41U