### PR TITLE
fix(worker): resolve TypeScript errors for dependency updates

### DIFF
--- a/worker/src/types.d.ts
+++ b/worker/src/types.d.ts
@@ -18,4 +18,6 @@ export type HeadersWithCookies = Headers & {
  * Used for version tracking - the web app checks this to determine if
  * session tokens need to be invalidated (worker auth logic changed).
  */
-declare const __WORKER_GIT_HASH__: string
+declare global {
+  const __WORKER_GIT_HASH__: string
+}


### PR DESCRIPTION
## Summary

- Fix `__WORKER_GIT_HASH__` global declaration by wrapping in `declare global` block (required when file has exports)
- Add proper type assertions for `response.json()` calls in tests
- Add `JsonBody` interface with index signature for flexible test assertions
- Add non-null assertions for services property access in health tests

This enables the automatic dependency update workflow to complete successfully when `@cloudflare/workers-types` is updated.

## Test plan

- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] All 279 tests pass (`npm test`)

https://claude.ai/code/session_01SkgqXCz4zGHQ1wLyNWfEac