### PR TITLE
fix(ci): add dependency to prevent gh-pages squash race condition

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -172,6 +172,7 @@ jobs:
   # Runs monthly (1st of month) or on manual trigger with squash_history=true
   squash-history:
     runs-on: ubuntu-latest
+    needs: cleanup
     # Run on monthly schedule (second cron) or manual trigger with squash_history
     if: github.event.schedule == '0 4 1 * *' || inputs.squash_history == true
     steps:


### PR DESCRIPTION
## Summary
- Fixed race condition in gh-pages cleanup workflow when `squash_history` is enabled
- The `squash-history` job now depends on the `cleanup` job, ensuring they run sequentially instead of in parallel

## Test plan
- [ ] Manually trigger the cleanup-pr-preview workflow with `squash_history=true`
- [ ] Verify the `squash-history` job waits for `cleanup` to complete before running

https://claude.ai/code/session_012Wverjb22boLHBJ5qn42Nj