### PR TITLE
fix(mobile): use dynamic dates in demo mode mock API client

### DIFF
--- a/.changeset/dynamic-mock-dates.md
+++ b/.changeset/dynamic-mock-dates.md
@@ -1,0 +1,7 @@
+---
+'@volleykit/mobile': patch
+---
+
+Use dynamic dates in mock API client for demo mode
+
+The mobile app's mock API client now generates dates relative to the current date instead of using hardcoded dates. This ensures demo mode always shows realistic "upcoming" and "past" assignments, exchanges, and compensations.

--- a/packages/mobile/src/api/client.ts
+++ b/packages/mobile/src/api/client.ts
@@ -29,257 +29,289 @@ function delay(ms: number): Promise<void> {
 }
 
 /**
- * Mock assignment data.
+ * Helper to generate a date relative to today.
+ * @param daysFromNow - Number of days from today (positive = future, negative = past)
+ * @param hour - Hour of the day (0-23)
+ * @returns ISO 8601 formatted date string with timezone
+ */
+function getRelativeDate(daysFromNow: number, hour: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() + daysFromNow)
+  date.setHours(hour, 0, 0, 0)
+  return date.toISOString()
+}
+
+/**
+ * Generate mock assignment data with dynamic dates.
+ * Uses dates relative to today so demo data is always relevant.
  * Matches the API Assignment schema structure.
  */
-const MOCK_ASSIGNMENTS: Assignment[] = [
-  {
-    __identity: '1',
-    refereeGame: {
-      __identity: 'rg1',
-      game: {
-        __identity: 'g1',
-        gameNumber: 'G001',
-        startingDateTime: '2026-01-20T14:00:00.000+01:00',
-        teamHome: { __identity: 'th1', name: 'VC Zürich' },
-        teamAway: { __identity: 'ta1', name: 'Volley Luzern' },
-        hall: {
-          __identity: 'h1',
-          name: 'Sports Hall A',
-          primaryPostalAddress: {
-            combinedAddress: 'Sportstrasse 1, 8000 Zürich',
-            city: 'Zürich',
+function getMockAssignments(): Assignment[] {
+  return [
+    {
+      __identity: '1',
+      refereeGame: {
+        __identity: 'rg1',
+        game: {
+          __identity: 'g1',
+          gameNumber: 'G001',
+          startingDateTime: getRelativeDate(3, 14), // 3 days from now at 14:00
+          teamHome: { __identity: 'th1', name: 'VC Zürich' },
+          teamAway: { __identity: 'ta1', name: 'Volley Luzern' },
+          hall: {
+            __identity: 'h1',
+            name: 'Sports Hall A',
+            primaryPostalAddress: {
+              combinedAddress: 'Sportstrasse 1, 8000 Zürich',
+              city: 'Zürich',
+            },
           },
         },
       },
+      refereeConvocationStatus: 'active',
+      refereePosition: '1SR',
+      isOpenEntryInRefereeGameExchange: false,
+      hasLastMessageToReferee: false,
+      hasLinkedDoubleConvocation: false,
     },
-    refereeConvocationStatus: 'active',
-    refereePosition: '1SR',
-    isOpenEntryInRefereeGameExchange: false,
-    hasLastMessageToReferee: false,
-    hasLinkedDoubleConvocation: false,
-  },
-  {
-    __identity: '2',
-    refereeGame: {
-      __identity: 'rg2',
-      game: {
-        __identity: 'g2',
-        gameNumber: 'G002',
-        startingDateTime: '2026-01-25T16:00:00.000+01:00',
-        teamHome: { __identity: 'th2', name: 'VBC Therwil' },
-        teamAway: { __identity: 'ta2', name: 'VC Kanti' },
-        hall: {
-          __identity: 'h2',
-          name: 'Sports Hall B',
-          primaryPostalAddress: {
-            combinedAddress: 'Hauptstrasse 10, 4106 Therwil',
-            city: 'Therwil',
+    {
+      __identity: '2',
+      refereeGame: {
+        __identity: 'rg2',
+        game: {
+          __identity: 'g2',
+          gameNumber: 'G002',
+          startingDateTime: getRelativeDate(7, 16), // 7 days from now at 16:00
+          teamHome: { __identity: 'th2', name: 'VBC Therwil' },
+          teamAway: { __identity: 'ta2', name: 'VC Kanti' },
+          hall: {
+            __identity: 'h2',
+            name: 'Sports Hall B',
+            primaryPostalAddress: {
+              combinedAddress: 'Hauptstrasse 10, 4106 Therwil',
+              city: 'Therwil',
+            },
           },
         },
       },
+      refereeConvocationStatus: 'active',
+      refereePosition: '2SR',
+      isOpenEntryInRefereeGameExchange: false,
+      hasLastMessageToReferee: false,
+      hasLinkedDoubleConvocation: false,
     },
-    refereeConvocationStatus: 'active',
-    refereePosition: '2SR',
-    isOpenEntryInRefereeGameExchange: false,
-    hasLastMessageToReferee: false,
-    hasLinkedDoubleConvocation: false,
-  },
-  {
-    __identity: '3',
-    refereeGame: {
-      __identity: 'rg3',
-      game: {
-        __identity: 'g3',
-        gameNumber: 'G003',
-        startingDateTime: '2026-02-01T18:00:00.000+01:00',
-        teamHome: { __identity: 'th3', name: 'Volley Amriswil' },
-        teamAway: { __identity: 'ta3', name: 'VC Schönenwerd' },
-        hall: {
-          __identity: 'h3',
-          name: 'Sports Hall C',
-          primaryPostalAddress: {
-            combinedAddress: 'Sportweg 5, 8580 Amriswil',
-            city: 'Amriswil',
+    {
+      __identity: '3',
+      refereeGame: {
+        __identity: 'rg3',
+        game: {
+          __identity: 'g3',
+          gameNumber: 'G003',
+          startingDateTime: getRelativeDate(14, 18), // 14 days from now at 18:00
+          teamHome: { __identity: 'th3', name: 'Volley Amriswil' },
+          teamAway: { __identity: 'ta3', name: 'VC Schönenwerd' },
+          hall: {
+            __identity: 'h3',
+            name: 'Sports Hall C',
+            primaryPostalAddress: {
+              combinedAddress: 'Sportweg 5, 8580 Amriswil',
+              city: 'Amriswil',
+            },
           },
         },
       },
+      refereeConvocationStatus: 'cancelled',
+      refereePosition: '1SR',
+      isOpenEntryInRefereeGameExchange: false,
+      hasLastMessageToReferee: false,
+      hasLinkedDoubleConvocation: false,
     },
-    refereeConvocationStatus: 'cancelled',
-    refereePosition: '1SR',
-    isOpenEntryInRefereeGameExchange: false,
-    hasLastMessageToReferee: false,
-    hasLinkedDoubleConvocation: false,
-  },
-]
+  ]
+}
 
 /**
- * Mock exchange data.
+ * Generate mock exchange data with dynamic dates.
+ * Uses dates relative to today so demo data is always relevant.
  * Matches the API GameExchange schema structure.
  */
-const MOCK_EXCHANGES: GameExchange[] = [
-  {
-    __identity: '1',
-    refereeGame: {
-      __identity: 'rg1',
-      game: {
-        __identity: 'g1',
-        gameNumber: 'G004',
-        startingDateTime: '2026-01-22T19:00:00.000+01:00',
-        teamHome: { __identity: 'th4', name: 'VC Zürich' },
-        teamAway: { __identity: 'ta4', name: 'Volley Düdingen' },
-        hall: {
-          __identity: 'h4',
-          name: 'Sporthalle Hardau',
-          primaryPostalAddress: {
-            combinedAddress: 'Hardaustrasse 10, 8004 Zürich',
-            city: 'Zürich',
+function getMockExchanges(): GameExchange[] {
+  return [
+    {
+      __identity: '1',
+      refereeGame: {
+        __identity: 'rg1',
+        game: {
+          __identity: 'g1',
+          gameNumber: 'G004',
+          startingDateTime: getRelativeDate(5, 19), // 5 days from now at 19:00
+          teamHome: { __identity: 'th4', name: 'VC Zürich' },
+          teamAway: { __identity: 'ta4', name: 'Volley Düdingen' },
+          hall: {
+            __identity: 'h4',
+            name: 'Sporthalle Hardau',
+            primaryPostalAddress: {
+              combinedAddress: 'Hardaustrasse 10, 8004 Zürich',
+              city: 'Zürich',
+            },
           },
         },
       },
+      status: 'open',
+      refereePosition: '1SR',
+      submittedByPerson: { __identity: 'p1', displayName: 'Max Muster' },
+      exchangeReason: 'Konflikt mit anderem Termin',
     },
-    status: 'open',
-    refereePosition: '1SR',
-    submittedByPerson: { __identity: 'p1', displayName: 'Max Muster' },
-    exchangeReason: 'Konflikt mit anderem Termin',
-  },
-  {
-    __identity: '2',
-    refereeGame: {
-      __identity: 'rg2',
-      game: {
-        __identity: 'g2',
-        gameNumber: 'G005',
-        startingDateTime: '2026-01-28T17:00:00.000+01:00',
-        teamHome: { __identity: 'th5', name: 'VBC Therwil' },
-        teamAway: { __identity: 'ta5', name: "Sm'Aesch Pfeffingen" },
-        hall: {
-          __identity: 'h5',
-          name: 'Sporthalle Therwil',
-          primaryPostalAddress: {
-            combinedAddress: 'Benkenstrasse 5, 4106 Therwil',
-            city: 'Therwil',
+    {
+      __identity: '2',
+      refereeGame: {
+        __identity: 'rg2',
+        game: {
+          __identity: 'g2',
+          gameNumber: 'G005',
+          startingDateTime: getRelativeDate(10, 17), // 10 days from now at 17:00
+          teamHome: { __identity: 'th5', name: 'VBC Therwil' },
+          teamAway: { __identity: 'ta5', name: "Sm'Aesch Pfeffingen" },
+          hall: {
+            __identity: 'h5',
+            name: 'Sporthalle Therwil',
+            primaryPostalAddress: {
+              combinedAddress: 'Benkenstrasse 5, 4106 Therwil',
+              city: 'Therwil',
+            },
           },
         },
       },
+      status: 'applied',
+      refereePosition: '2SR',
+      submittedByPerson: { __identity: 'p2', displayName: 'Anna Beispiel' },
     },
-    status: 'applied',
-    refereePosition: '2SR',
-    submittedByPerson: { __identity: 'p2', displayName: 'Anna Beispiel' },
-  },
-  {
-    __identity: '3',
-    refereeGame: {
-      __identity: 'rg3',
-      game: {
-        __identity: 'g3',
-        gameNumber: 'G006',
-        startingDateTime: '2026-02-05T15:00:00.000+01:00',
-        teamHome: { __identity: 'th6', name: 'Volley Luzern' },
-        teamAway: { __identity: 'ta6', name: 'VC Kanti' },
-        hall: {
-          __identity: 'h6',
-          name: 'Sporthalle Utenberg',
-          primaryPostalAddress: {
-            combinedAddress: 'Utenbergstrasse 24, 6006 Luzern',
-            city: 'Luzern',
+    {
+      __identity: '3',
+      refereeGame: {
+        __identity: 'rg3',
+        game: {
+          __identity: 'g3',
+          gameNumber: 'G006',
+          startingDateTime: getRelativeDate(21, 15), // 21 days from now at 15:00
+          teamHome: { __identity: 'th6', name: 'Volley Luzern' },
+          teamAway: { __identity: 'ta6', name: 'VC Kanti' },
+          hall: {
+            __identity: 'h6',
+            name: 'Sporthalle Utenberg',
+            primaryPostalAddress: {
+              combinedAddress: 'Utenbergstrasse 24, 6006 Luzern',
+              city: 'Luzern',
+            },
           },
         },
       },
+      status: 'open',
+      refereePosition: '1SR',
+      submittedByPerson: { __identity: 'p3', displayName: 'Peter Test' },
+      exchangeReason: 'Krankheit',
     },
-    status: 'open',
-    refereePosition: '1SR',
-    submittedByPerson: { __identity: 'p3', displayName: 'Peter Test' },
-    exchangeReason: 'Krankheit',
-  },
-]
+  ]
+}
 
 /**
- * Mock compensation data.
+ * Helper to format a date as YYYY-MM-DD for payment value dates.
+ */
+function formatPaymentDate(daysFromNow: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() + daysFromNow)
+  return date.toISOString().split('T')[0]
+}
+
+/**
+ * Generate mock compensation data with dynamic dates.
+ * Uses dates relative to today so demo data is always relevant.
+ * Shows a mix of paid (past) and unpaid (recent) compensations.
  * Matches the API CompensationRecord schema structure.
  */
-const MOCK_COMPENSATIONS: CompensationRecord[] = [
-  {
-    __identity: '1',
-    refereeGame: {
-      __identity: 'rg1',
-      game: {
-        __identity: 'g1',
-        gameNumber: 'G010',
-        startingDateTime: '2026-01-10T14:00:00.000+01:00',
-        teamHome: { __identity: 'th7', name: 'VC Zürich' },
-        teamAway: { __identity: 'ta7', name: 'Volley Luzern' },
-        hall: { __identity: 'h7', name: 'Sports Hall A' },
+function getMockCompensations(): CompensationRecord[] {
+  return [
+    {
+      __identity: '1',
+      refereeGame: {
+        __identity: 'rg1',
+        game: {
+          __identity: 'g1',
+          gameNumber: 'G010',
+          startingDateTime: getRelativeDate(-7, 14), // 7 days ago at 14:00
+          teamHome: { __identity: 'th7', name: 'VC Zürich' },
+          teamAway: { __identity: 'ta7', name: 'Volley Luzern' },
+          hall: { __identity: 'h7', name: 'Sports Hall A' },
+        },
+      },
+      refereeConvocationStatus: 'active',
+      refereePosition: '1SR',
+      compensationDate: getRelativeDate(-7, 14),
+      convocationCompensation: {
+        __identity: 'cc1',
+        paymentDone: true,
+        gameCompensation: 120,
+        travelExpenses: 25,
+        gameCompensationFormatted: 'CHF 120.00',
+        travelExpensesFormatted: 'CHF 25.00',
+        costFormatted: 'CHF 145.00',
+        paymentValueDate: formatPaymentDate(-2), // Paid 2 days ago
       },
     },
-    refereeConvocationStatus: 'active',
-    refereePosition: '1SR',
-    compensationDate: '2026-01-10T14:00:00.000+01:00',
-    convocationCompensation: {
-      __identity: 'cc1',
-      paymentDone: true,
-      gameCompensation: 120,
-      travelExpenses: 25,
-      gameCompensationFormatted: 'CHF 120.00',
-      travelExpensesFormatted: 'CHF 25.00',
-      costFormatted: 'CHF 145.00',
-      paymentValueDate: '2026-01-15',
-    },
-  },
-  {
-    __identity: '2',
-    refereeGame: {
-      __identity: 'rg2',
-      game: {
-        __identity: 'g2',
-        gameNumber: 'G011',
-        startingDateTime: '2026-01-05T16:00:00.000+01:00',
-        teamHome: { __identity: 'th8', name: 'VBC Therwil' },
-        teamAway: { __identity: 'ta8', name: 'VC Kanti' },
-        hall: { __identity: 'h8', name: 'Sports Hall B' },
+    {
+      __identity: '2',
+      refereeGame: {
+        __identity: 'rg2',
+        game: {
+          __identity: 'g2',
+          gameNumber: 'G011',
+          startingDateTime: getRelativeDate(-3, 16), // 3 days ago at 16:00
+          teamHome: { __identity: 'th8', name: 'VBC Therwil' },
+          teamAway: { __identity: 'ta8', name: 'VC Kanti' },
+          hall: { __identity: 'h8', name: 'Sports Hall B' },
+        },
+      },
+      refereeConvocationStatus: 'active',
+      refereePosition: '2SR',
+      compensationDate: getRelativeDate(-3, 16),
+      convocationCompensation: {
+        __identity: 'cc2',
+        paymentDone: false, // Recent game, not yet paid
+        gameCompensation: 95,
+        travelExpenses: 30,
+        gameCompensationFormatted: 'CHF 95.00',
+        travelExpensesFormatted: 'CHF 30.00',
+        costFormatted: 'CHF 125.00',
       },
     },
-    refereeConvocationStatus: 'active',
-    refereePosition: '2SR',
-    compensationDate: '2026-01-05T16:00:00.000+01:00',
-    convocationCompensation: {
-      __identity: 'cc2',
-      paymentDone: false,
-      gameCompensation: 95,
-      travelExpenses: 30,
-      gameCompensationFormatted: 'CHF 95.00',
-      travelExpensesFormatted: 'CHF 30.00',
-      costFormatted: 'CHF 125.00',
-    },
-  },
-  {
-    __identity: '3',
-    refereeGame: {
-      __identity: 'rg3',
-      game: {
-        __identity: 'g3',
-        gameNumber: 'G012',
-        startingDateTime: '2025-12-20T18:00:00.000+01:00',
-        teamHome: { __identity: 'th9', name: 'Volley Amriswil' },
-        teamAway: { __identity: 'ta9', name: 'VC Schönenwerd' },
-        hall: { __identity: 'h9', name: 'Sports Hall C' },
+    {
+      __identity: '3',
+      refereeGame: {
+        __identity: 'rg3',
+        game: {
+          __identity: 'g3',
+          gameNumber: 'G012',
+          startingDateTime: getRelativeDate(-21, 18), // 21 days ago at 18:00
+          teamHome: { __identity: 'th9', name: 'Volley Amriswil' },
+          teamAway: { __identity: 'ta9', name: 'VC Schönenwerd' },
+          hall: { __identity: 'h9', name: 'Sports Hall C' },
+        },
+      },
+      refereeConvocationStatus: 'active',
+      refereePosition: '1SR',
+      compensationDate: getRelativeDate(-21, 18),
+      convocationCompensation: {
+        __identity: 'cc3',
+        paymentDone: true,
+        gameCompensation: 110,
+        travelExpenses: 40,
+        gameCompensationFormatted: 'CHF 110.00',
+        travelExpensesFormatted: 'CHF 40.00',
+        costFormatted: 'CHF 150.00',
+        paymentValueDate: formatPaymentDate(-14), // Paid 14 days ago
       },
     },
-    refereeConvocationStatus: 'active',
-    refereePosition: '1SR',
-    compensationDate: '2025-12-20T18:00:00.000+01:00',
-    convocationCompensation: {
-      __identity: 'cc3',
-      paymentDone: true,
-      gameCompensation: 110,
-      travelExpenses: 40,
-      gameCompensationFormatted: 'CHF 110.00',
-      travelExpensesFormatted: 'CHF 40.00',
-      costFormatted: 'CHF 150.00',
-      paymentValueDate: '2025-12-28',
-    },
-  },
-]
+  ]
+}
 
 /**
  * Mobile API client.
@@ -295,9 +327,10 @@ export const mobileApiClient = {
     _config: SearchConfiguration = {}
   ): Promise<{ items: Assignment[]; totalItemsCount: number }> {
     await delay(MOCK_NETWORK_DELAY_MS)
+    const assignments = getMockAssignments()
     return {
-      items: MOCK_ASSIGNMENTS,
-      totalItemsCount: MOCK_ASSIGNMENTS.length,
+      items: assignments,
+      totalItemsCount: assignments.length,
     }
   },
 
@@ -306,7 +339,8 @@ export const mobileApiClient = {
    */
   async getAssignmentDetails(id: string): Promise<Assignment> {
     await delay(MOCK_NETWORK_DELAY_MS)
-    const assignment = MOCK_ASSIGNMENTS.find((a) => a.__identity === id)
+    const assignments = getMockAssignments()
+    const assignment = assignments.find((a) => a.__identity === id)
     if (!assignment) {
       throw new Error(`Assignment not found: ${id}`)
     }
@@ -320,9 +354,10 @@ export const mobileApiClient = {
     _config: SearchConfiguration = {}
   ): Promise<{ items: GameExchange[]; totalItemsCount: number }> {
     await delay(MOCK_NETWORK_DELAY_MS)
+    const exchanges = getMockExchanges()
     return {
-      items: MOCK_EXCHANGES,
-      totalItemsCount: MOCK_EXCHANGES.length,
+      items: exchanges,
+      totalItemsCount: exchanges.length,
     }
   },
 
@@ -333,9 +368,10 @@ export const mobileApiClient = {
     _config: SearchConfiguration = {}
   ): Promise<{ items: CompensationRecord[]; totalItemsCount: number }> {
     await delay(MOCK_NETWORK_DELAY_MS)
+    const compensations = getMockCompensations()
     return {
-      items: MOCK_COMPENSATIONS,
-      totalItemsCount: MOCK_COMPENSATIONS.length,
+      items: compensations,
+      totalItemsCount: compensations.length,
     }
   },
 


### PR DESCRIPTION
## Summary

- Updated mobile app's mock API client to generate dates relative to the current date instead of using hardcoded dates from 2025/2026
- Demo mode now always shows realistic "upcoming" and "past" assignments, exchanges, and compensations
- Added helper functions for generating relative dates and payment dates

## Test plan

- [ ] Run mobile app in demo mode and verify assignments show future dates (3, 7, 14 days from now)
- [ ] Verify compensations show past dates (3, 7, 21 days ago) with appropriate payment statuses
- [ ] Verify exchanges show future dates (5, 10, 21 days from now)

https://claude.ai/code/session_01B41fiNTyiSyJngkiAtaHFV