### PR TITLE
docs: update Expo and React Native versions across documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ VolleyKit is a multi-platform app suite for Swiss volleyball referee management 
 | Application    | Location           | Description                                         |
 | -------------- | ------------------ | --------------------------------------------------- |
 | Web App (PWA)  | `web-app/`         | React 19 + Vite 7 + Tailwind 4                      |
-| Mobile App     | `packages/mobile/` | React Native 0.79 + Expo 53                         |
+| Mobile App     | `packages/mobile/` | React Native 0.81 + Expo 54                         |
 | Shared Package | `packages/shared/` | API client, hooks, stores, i18n (~70% code sharing) |
 | Help Site      | `help-site/`       | Astro 6 documentation                               |
 | CORS Proxy     | `worker/`          | Cloudflare Worker                                   |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A multi-platform app suite for Swiss volleyball referees, providing an improved 
 | App | Location | Description |
 |-----|----------|-------------|
 | Web App (PWA) | [`web-app/`](./web-app/) | React 19 + Vite 7 + Tailwind 4 |
-| Mobile App | [`packages/mobile/`](./packages/mobile/) | React Native 0.79 + Expo 53 |
+| Mobile App | [`packages/mobile/`](./packages/mobile/) | React Native 0.81 + Expo 54 |
 | Shared Package | [`packages/shared/`](./packages/shared/) | API client, hooks, stores, i18n |
 | Help Site | [`help-site/`](./help-site/) | Astro 6 documentation |
 | CORS Proxy | [`worker/`](./worker/) | Cloudflare Worker |

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -4,7 +4,7 @@ React Native mobile app for iOS and Android.
 
 ## Tech Stack
 
-- React Native 0.79 + Expo 53
+- React Native 0.81 + Expo 54
 - NativeWind (Tailwind for React Native)
 - React Navigation 7
 - TanStack Query 5 (with persistence)


### PR DESCRIPTION
## Summary
- Update mobile tech stack versions from React Native 0.79 + Expo 53 to React Native 0.81 + Expo 54
- Updated files: README.md, CLAUDE.md, packages/mobile/README.md

## Test plan
- [ ] Documentation-only changes, verify versions match package.json

https://claude.ai/code/session_01SQ6vh7DH1axUJxkspNkSvi