### PR TITLE
fix(ci): add tar override to fix security vulnerability in mobile deps workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24680,9 +24680,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "@xmldom/xmldom": "^0.8.11",
     "react": "^19.2.3",
     "@expo/vector-icons": "^15.0.3",
-    "react-native-screens": "~4.16.0"
+    "react-native-screens": "~4.16.0",
+    "tar": "^7.5.7"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary

- Added npm override for `tar` package to `^7.5.7` to fix high severity vulnerability (GHSA-34x7-hfp2-rc4v)
- The mobile dependencies update workflow was failing because `@expo/cli` depends on `tar@7.5.6` which has a path traversal vulnerability
- Expo is already at the latest stable version (54.0.32), so the override is necessary until Expo releases an update

## Test plan

- [ ] Verify `npm audit --audit-level=high` passes with 0 vulnerabilities
- [ ] Re-run the Update Dependencies (Mobile) workflow to confirm it passes

https://claude.ai/code/session_01X6Skm26aSuwkYzpyDQpJCy