### PR TITLE
fix(mobile): remove debug console.log statements from background-task

### DIFF
--- a/.changeset/remove-debug-logs-mobile.md
+++ b/.changeset/remove-debug-logs-mobile.md
@@ -1,0 +1,5 @@
+---
+'@volleykit/mobile': patch
+---
+
+Remove debug console.log statements from background-task.ts

--- a/packages/mobile/src/services/departure-reminder/background-task.ts
+++ b/packages/mobile/src/services/departure-reminder/background-task.ts
@@ -89,26 +89,22 @@ export async function startBackgroundTask(): Promise<void> {
   // Check if feature is enabled
   const settings = await departureReminderSettingsStore.loadSettings(storage)
   if (!settings.enabled) {
-    console.log('Departure reminders disabled, not starting task')
     return
   }
 
   // Check for assignments
   if (!assignmentProvider) {
-    console.log('No assignment provider registered')
     return
   }
 
   const assignments = await assignmentProvider.getUpcomingAssignments(LOOKAHEAD_WINDOW_MS)
   if (assignments.length === 0) {
-    console.log('No upcoming assignments, not starting task')
     return
   }
 
   // Check permissions
   const hasBgPermissions = await location.hasBackgroundPermissions()
   if (!hasBgPermissions) {
-    console.log('No background location permissions')
     return
   }
 
@@ -144,7 +140,6 @@ export async function runDepartureReminderCheck(): Promise<void> {
   try {
     const currentLocation = await location.getCurrentLocation()
     if (!currentLocation) {
-      console.log('Could not get current location')
       // Fallback behavior: schedule time-based reminders without route info
       await scheduleTimeBasedReminders()
       return


### PR DESCRIPTION
## Summary
- Remove 5 debug console.log statements from the departure reminder background task
- These were logging informational messages about early returns, which are not appropriate for production code
- Console.error statements for actual error handling are retained

## Test plan
- [x] TypeScript type checking passes
- [x] ESLint passes with 0 warnings
- [x] No dedicated tests for this file (background task with external dependencies)

https://claude.ai/code/session_01CWzyZqvofr98ms1CMoFrkQ