### PR TITLE
fix(deps): update @isaacs/brace-expansion to 5.0.1 for security fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5061,9 +5061,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"


### PR DESCRIPTION
## Summary
- Updates @isaacs/brace-expansion from 5.0.0 to 5.0.1 to fix high severity Uncontrolled Resource Consumption vulnerability (GHSA-7h2j-956f-4vf2)

## Test plan
- [x] Verified `npm audit` returns 0 vulnerabilities after the fix

https://claude.ai/code/session_01DEmmj2BH3kHjH2EQ2mWsfY