### PR TITLE
feat(mobile): show alert notifications for sync failures

### DIFF
--- a/.changeset/sync-failure-alerts.md
+++ b/.changeset/sync-failure-alerts.md
@@ -1,0 +1,10 @@
+---
+'@volleykit/mobile': patch
+'@volleykit/shared': patch
+---
+
+Show alert notifications when offline sync fails
+
+- Display alert dialog when some changes fail to sync after reconnecting
+- Display alert dialog for critical sync errors (unexpected exceptions)
+- Add `offline.syncError` translation key for critical sync failure messages

--- a/packages/mobile/src/components/PendingActionsIndicator.tsx
+++ b/packages/mobile/src/components/PendingActionsIndicator.tsx
@@ -11,7 +11,7 @@
 import type { JSX } from 'react'
 import { useEffect, useRef } from 'react'
 
-import { View, Text, Animated } from 'react-native'
+import { View, Text, Animated, Alert } from 'react-native'
 
 import { Feather } from '@expo/vector-icons'
 
@@ -38,6 +38,7 @@ const BADGE_ICON_MARGIN = 4
  * Uses refs to prevent race conditions during sync operations.
  */
 function useAutoSync() {
+  const { t } = useTranslation()
   const { isOnline, isKnown } = useNetwork()
   const wasOnlineRef = useRef(isOnline)
   const syncTriggeredRef = useRef(false)
@@ -78,8 +79,10 @@ function useAutoSync() {
               console.info('[PendingActionsIndicator] Sync complete:', result.succeeded)
             }
             if (result.failed > 0) {
-              // TODO: Consider surfacing failed syncs to user via toast notification
               console.warn('[PendingActionsIndicator] Sync failed:', result.failed)
+              Alert.alert(t('common.error'), t('offline.syncFailed', { count: result.failed }), [
+                { text: t('common.close') },
+              ])
             }
             if (result.requiresReauth) {
               console.warn('[PendingActionsIndicator] Session expired during sync')
@@ -87,11 +90,11 @@ function useAutoSync() {
           }
         })
         .catch((error) => {
-          // TODO: Consider surfacing critical sync failures to user
           console.error('[PendingActionsIndicator] Failed to sync pending actions:', error)
+          Alert.alert(t('common.error'), t('offline.syncError'), [{ text: t('common.close') }])
         })
     }
-  }, [isOnline, isKnown, pendingCount, sync, isSyncing])
+  }, [isOnline, isKnown, pendingCount, sync, isSyncing, t])
 
   return { isSyncing }
 }

--- a/packages/mobile/src/components/PendingActionsIndicator.tsx
+++ b/packages/mobile/src/components/PendingActionsIndicator.tsx
@@ -86,6 +86,9 @@ function useAutoSync() {
             }
             if (result.requiresReauth) {
               console.warn('[PendingActionsIndicator] Session expired during sync')
+              Alert.alert(t('common.error'), t('offline.sessionExpired'), [
+                { text: t('common.close') },
+              ])
             }
           }
         })

--- a/packages/shared/src/i18n/locales/de.ts
+++ b/packages/shared/src/i18n/locales/de.ts
@@ -302,6 +302,7 @@ const de: Translations = {
     syncing: 'Synchronisieren...',
     syncComplete: '{count} Änderungen erfolgreich synchronisiert',
     syncFailed: '{count} Änderungen konnten nicht synchronisiert werden',
+    syncError: 'Synchronisierung fehlgeschlagen. Bitte versuchen Sie es später erneut.',
     sessionExpired: 'Sitzung abgelaufen. Bitte melden Sie sich erneut an, um Änderungen zu synchronisieren.',
     actions: {
       updateCompensation: 'Entschädigung aktualisieren',

--- a/packages/shared/src/i18n/locales/en.ts
+++ b/packages/shared/src/i18n/locales/en.ts
@@ -298,6 +298,7 @@ const en: Translations = {
     syncing: 'Syncing...',
     syncComplete: '{count} changes synced successfully',
     syncFailed: '{count} changes failed to sync',
+    syncError: 'Failed to sync changes. Please try again later.',
     sessionExpired: 'Session expired. Please log in again to sync changes.',
     actions: {
       updateCompensation: 'Update compensation',

--- a/packages/shared/src/i18n/locales/fr.ts
+++ b/packages/shared/src/i18n/locales/fr.ts
@@ -303,6 +303,7 @@ const fr: Translations = {
     syncing: 'Synchronisation...',
     syncComplete: '{count} modifications synchronisées avec succès',
     syncFailed: '{count} modifications ont échoué lors de la synchronisation',
+    syncError: 'Échec de la synchronisation. Veuillez réessayer plus tard.',
     sessionExpired: 'Session expirée. Veuillez vous reconnecter pour synchroniser les modifications.',
     actions: {
       updateCompensation: 'Mettre à jour l\'indemnisation',

--- a/packages/shared/src/i18n/locales/it.ts
+++ b/packages/shared/src/i18n/locales/it.ts
@@ -302,6 +302,7 @@ const it: Translations = {
     syncing: 'Sincronizzazione...',
     syncComplete: '{count} modifiche sincronizzate con successo',
     syncFailed: '{count} modifiche non sono state sincronizzate',
+    syncError: 'Sincronizzazione fallita. Riprova più tardi.',
     sessionExpired: 'Sessione scaduta. Accedi nuovamente per sincronizzare le modifiche.',
     actions: {
       updateCompensation: 'Aggiorna compenso',

--- a/packages/shared/src/i18n/types.ts
+++ b/packages/shared/src/i18n/types.ts
@@ -307,6 +307,7 @@ export interface Translations {
     syncing: string
     syncComplete: string
     syncFailed: string
+    syncError: string
     sessionExpired: string
     actions: {
       updateCompensation: string


### PR DESCRIPTION
## Summary

- Display alert dialogs when offline sync fails to notify users
- Alert when some changes fail to sync after reconnecting
- Alert for critical/unexpected sync errors
- Add `offline.syncError` translation key in all 4 languages (de/en/fr/it)

## Test plan

- [x] TypeScript compilation passes (`npm run typecheck`)
- [x] ESLint passes with no warnings (`npm run lint`)
- [x] All mobile tests pass (`npm test`)
- [ ] Manual test: Go offline, make changes, reconnect - verify alert shows on sync failure

https://claude.ai/code/session_013aLc7FJqVAdmLtgW4zxYVR