### PR TITLE
refactor(worker): extract CORS preflight max-age to named constant

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -42,6 +42,7 @@ import {
   AUTH_LOCKOUT_MAX_DURATION_SECONDS,
   type AuthLockoutKV,
   type AuthLockoutState,
+  CORS_PREFLIGHT_MAX_AGE_SECONDS,
   KILL_SWITCH_RETRY_AFTER_SECONDS,
   OCR_MAX_FILE_SIZE_BYTES,
   VOLLEYKIT_USER_AGENT,
@@ -470,7 +471,7 @@ describe('CORS Headers', () => {
     'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Accept',
     'Access-Control-Allow-Credentials': 'true',
-    'Access-Control-Max-Age': '86400',
+    'Access-Control-Max-Age': String(CORS_PREFLIGHT_MAX_AGE_SECONDS),
   })
 
   it('sets correct Allow-Origin header', () => {
@@ -490,7 +491,7 @@ describe('CORS Headers', () => {
 
   it('sets max age for preflight caching', () => {
     const headers = corsHeaders('https://example.com')
-    expect(headers['Access-Control-Max-Age']).toBe('86400')
+    expect(headers['Access-Control-Max-Age']).toBe(String(CORS_PREFLIGHT_MAX_AGE_SECONDS))
   })
 })
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -16,6 +16,7 @@ import type { HeadersWithCookies } from './types'
 import {
   AUTH_ENDPOINT,
   CAPTURE_SESSION_TOKEN_HEADER,
+  CORS_PREFLIGHT_MAX_AGE_SECONDS,
   KILL_SWITCH_RETRY_AFTER_SECONDS,
   OCR_MAX_FILE_SIZE_BYTES,
   VOLLEYKIT_USER_AGENT,
@@ -103,7 +104,7 @@ function corsHeaders(origin: string): HeadersInit {
     // Expose X-Session-Token so JavaScript can read the session cookie relay
     'Access-Control-Expose-Headers': 'X-Session-Token',
     'Access-Control-Allow-Credentials': 'true',
-    'Access-Control-Max-Age': '86400',
+    'Access-Control-Max-Age': String(CORS_PREFLIGHT_MAX_AGE_SECONDS),
   }
 }
 

--- a/worker/src/utils.ts
+++ b/worker/src/utils.ts
@@ -64,6 +64,9 @@ export const CAPTURE_SESSION_TOKEN_HEADER = 'X-Capture-Session-Token'
 /** Retry-After duration when service is unavailable (kill switch enabled) */
 export const KILL_SWITCH_RETRY_AFTER_SECONDS = 86400 // 24 hours
 
+/** CORS preflight cache duration in seconds (24 hours) */
+export const CORS_PREFLIGHT_MAX_AGE_SECONDS = 86400
+
 /** Maximum file size for OCR requests (Mistral API limit) */
 export const OCR_MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024 // 50MB
 


### PR DESCRIPTION
## Summary

- Replace hardcoded magic number `86400` with `CORS_PREFLIGHT_MAX_AGE_SECONDS` constant
- Improves code readability and maintainability
- The value represents 24 hours in seconds for CORS preflight cache duration

## Test plan

- [x] Worker tests pass (279 tests)
- [x] Lint passes
- [x] Web-app build verified

https://claude.ai/code/session_01SR5qb2UUypYU562hApexTr