### PR TITLE
fix(mobile): use i18n translation for LoadingScreen loading text

### DIFF
--- a/.changeset/fix-loading-screen-i18n.md
+++ b/.changeset/fix-loading-screen-i18n.md
@@ -1,0 +1,7 @@
+---
+'@volleykit/mobile': patch
+---
+
+Use i18n translation for LoadingScreen loading text
+
+Replace hardcoded "Loading..." text with `t('common.loading')` to support all 4 languages (de, en, fr, it).

--- a/packages/mobile/src/screens/LoadingScreen.tsx
+++ b/packages/mobile/src/screens/LoadingScreen.tsx
@@ -4,15 +4,19 @@
 
 import { View, Text, ActivityIndicator } from 'react-native'
 
+import { useTranslation } from '@volleykit/shared/i18n'
+
 import type { RootStackScreenProps } from '../navigation/types'
 
 type Props = RootStackScreenProps<'Loading'>
 
 export function LoadingScreen(_props: Props) {
+  const { t } = useTranslation()
+
   return (
     <View className="flex-1 bg-white items-center justify-center">
       <ActivityIndicator size="large" color="#0ea5e9" />
-      <Text className="text-gray-600 mt-4">Loading...</Text>
+      <Text className="text-gray-600 mt-4">{t('common.loading')}</Text>
     </View>
   )
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded "Loading..." text with `t('common.loading')` in mobile LoadingScreen
- Enables proper localization for all 4 supported languages (de, en, fr, it)
- The translation key already exists in the shared i18n package

## Test plan

- [x] Mobile typecheck passes
- [x] Mobile lint passes
- [x] Mobile tests pass (54 tests)

https://claude.ai/code/session_01J1Q2MPk2AUBn6hQ15oLqc4