### PR TITLE
feat(web): match scorer names in any order for fuzzy search

### DIFF
--- a/.changeset/improve-scorer-name-order.md
+++ b/.changeset/improve-scorer-name-order.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Scorer search now matches names in any order (e.g., "Bühler Renee" finds the same results as "Renee Bühler")

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -410,7 +410,9 @@ export const api = {
         makeRequest(lastName, firstName),
       ])
 
-      // Merge and deduplicate results by __identity, preserving original order first
+      // Merge and deduplicate results by __identity, preserving original order first.
+      // Cap at the requested limit to keep pagination behavior predictable.
+      const limit = options?.limit ?? DEFAULT_SEARCH_RESULTS_LIMIT
       const seen = new Set<string>()
       const merged: PersonSearchResult[] = []
       for (const item of [...(original.items ?? []), ...(swapped.items ?? [])]) {
@@ -418,6 +420,7 @@ export const api = {
         if (id && !seen.has(id)) {
           seen.add(id)
           merged.push(item)
+          if (merged.length >= limit) break
         }
       }
 

--- a/web-app/src/api/mock-api.test.ts
+++ b/web-app/src/api/mock-api.test.ts
@@ -60,6 +60,20 @@ describe('mockApi.searchPersons', () => {
       expect(items[0]?.lastName).toBe('Müller')
     })
 
+    it('matches when names are provided in reversed order (lastName first)', async () => {
+      // User types "Müller Hans" → parseSearchInput gives firstName=Müller, lastName=Hans
+      // The mock API should still find Hans Müller
+      const result = await mockApi.searchPersons({
+        firstName: 'Müller',
+        lastName: 'Hans',
+      })
+      const items = result.items!
+
+      expect(items.length).toBe(1)
+      expect(items[0]?.firstName).toBe('Hans')
+      expect(items[0]?.lastName).toBe('Müller')
+    })
+
     it('returns empty when firstName matches but lastName does not', async () => {
       const result = await mockApi.searchPersons({
         firstName: 'Hans',
@@ -240,6 +254,22 @@ describe('scorer search integration - user flow simulation', () => {
 
       expect(filters).toEqual({ firstName: 'Hans', lastName: 'Müller' })
 
+      const result = await mockApi.searchPersons(filters)
+
+      expect(result.items).toBeDefined()
+      expect(result.items!.length).toBe(1)
+      expect(result.items![0]!.displayName).toBe('Hans Müller')
+    })
+
+    it('finds scorers when user types last name first (e.g., "Müller Hans")', async () => {
+      // User types "Müller Hans" (last name first, common in Swiss German)
+      const userInput = 'Müller Hans'
+      const filters = parseSearchInput(userInput)
+
+      // parseSearchInput treats first word as firstName, second as lastName
+      expect(filters).toEqual({ firstName: 'Müller', lastName: 'Hans' })
+
+      // But the mock API should still find Hans Müller via swapped name matching
       const result = await mockApi.searchPersons(filters)
 
       expect(result.items).toBeDefined()

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -482,31 +482,30 @@ export const mockApi = {
       const scorerLastName = normalizeForSearch(scorer.lastName ?? '')
       const scorerYear = scorer.birthday ? new Date(scorer.birthday).getFullYear().toString() : ''
 
-      if (firstName && !scorerFirstName.includes(normalizeForSearch(firstName))) {
-        return false
-      }
-
-      if (lastName) {
+      if (firstName && lastName) {
+        // Two terms: match in either order (e.g., "Bühler Renee" or "Renee Bühler")
+        const normFirst = normalizeForSearch(firstName)
+        const normLast = normalizeForSearch(lastName)
+        const originalOrder =
+          scorerFirstName.includes(normFirst) && scorerLastName.includes(normLast)
+        const swappedOrder =
+          scorerFirstName.includes(normLast) && scorerLastName.includes(normFirst)
+        if (!originalOrder && !swappedOrder) {
+          return false
+        }
+      } else if (isSingleTermSearch && lastName) {
+        // Single term: match against either firstName or lastName
         const searchTerm = normalizeForSearch(lastName)
-        if (isSingleTermSearch) {
-          // Single term: match against either firstName or lastName
-          const matchesFirstName = scorerFirstName.includes(searchTerm)
-          const matchesLastName = scorerLastName.includes(searchTerm)
-          if (!matchesFirstName && !matchesLastName) {
-            return false
-          }
-        } else {
-          // Two terms provided: lastName must match lastName field
-          if (!scorerLastName.includes(searchTerm)) {
-            return false
-          }
+        if (!scorerFirstName.includes(searchTerm) && !scorerLastName.includes(searchTerm)) {
+          return false
+        }
+      } else if (firstName) {
+        if (!scorerFirstName.includes(normalizeForSearch(firstName))) {
+          return false
         }
       }
 
-      if (yearOfBirth && !scorerYear.includes(yearOfBirth)) {
-        return false
-      }
-      return true
+      return !yearOfBirth || scorerYear.includes(yearOfBirth)
     })
 
     const offset = options?.offset ?? 0

--- a/web-app/src/features/validation/hooks/useScorerSearch.test.tsx
+++ b/web-app/src/features/validation/hooks/useScorerSearch.test.tsx
@@ -382,6 +382,22 @@ describe('useScorerSearch - integration with mock API', () => {
     expect(result.current.data![0]!.displayName).toBe('Hans Müller')
   })
 
+  it('handles swapped name order (last name first)', async () => {
+    // User types "Müller Hans" → firstName=Müller, lastName=Hans
+    const { result } = renderHook(
+      () => useScorerSearch({ firstName: 'Müller', lastName: 'Hans' }),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined()
+    })
+
+    expect(result.current.isError).toBe(false)
+    expect(result.current.data!.length).toBe(1)
+    expect(result.current.data![0]!.displayName).toBe('Hans Müller')
+  })
+
   it('handles accent-insensitive search', async () => {
     const { result } = renderHook(() => useScorerSearch({ lastName: 'muller' }), {
       wrapper: createWrapper(),

--- a/web-app/src/features/validation/hooks/useScorerSearch.ts
+++ b/web-app/src/features/validation/hooks/useScorerSearch.ts
@@ -18,9 +18,8 @@ import { useAuthStore } from '@/shared/stores/auth'
  * - Four-digit number at end: treated as yearOfBirth
  *
  * Note: When two name tokens are provided, the first is treated as firstName
- * and the second as lastName. This follows common Western conventions, but
- * Elasticsearch's fuzzy matching typically handles reversed order (e.g.,
- * "Müller Hans" vs "Hans Müller") well since both fields are searched.
+ * and the second as lastName. The API layer searches both orderings in parallel,
+ * so "Müller Hans" and "Hans Müller" produce the same results.
  *
  * @example
  * parseSearchInput("müller") // { lastName: "müller" }


### PR DESCRIPTION
## Summary

- Scorer search now matches names in any order, so entering the last name before the first name (e.g., "Lastname Firstname") finds the same results as "Firstname Lastname"
- When both first and last name tokens are provided, the API client makes two parallel Elasticsearch requests (original + swapped order) and merges deduplicated results by `__identity`
- Merged results are capped to the requested limit for predictable pagination behavior
- Mock API updated with matching swapped-name logic for demo mode consistency

## Test plan

- [x] New tests for swapped name order in `mock-api.test.ts`, `client.test.ts`, and `useScorerSearch.test.tsx`
- [x] New test for dual API call deduplication by `__identity`
- [x] All 111 tests pass
- [x] Lint, knip, and production build pass
- [ ] Manual verification: type a scorer name in "Lastname Firstname" order in the search panel and confirm the correct result appears

https://claude.ai/code/session_01DnLEKN31H4y4bGoxMt1y7q