### PR TITLE
fix(web): fix validation persistence and API content types

### DIFF
--- a/.changeset/fix-validation-persistence.md
+++ b/.changeset/fix-validation-persistence.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fixed secure validation mode not persisting scorer and scoresheet data to the API. Added scoresheet file upload during save and cache invalidation after saving so reopening a game reflects the saved state.

--- a/docs/api/captures/escoresheet_endpoints.md
+++ b/docs/api/captures/escoresheet_endpoints.md
@@ -47,20 +47,23 @@ Note: The scoresheet identity is NOT sent in the body. The server resolves it fr
 When a field has no value (e.g., writerPerson before scorer selection), the plain field name is used
 without `[__identity]` suffix.
 
-### Example Request (URL-decoded)
+### Example Request (URL-decoded, with scorer and file set)
 
 ```
-scoresheet[game][__identity]=<game-uuid>
-scoresheet[isSimpleScoresheet]=false
-scoresheet[writerPerson]=
-scoresheet[scoresheetValidation]=
-scoresheet[reminderAboutOpenScoresheetSentAt]=
-scoresheet[notFoundButNominatedPersons]=
-scoresheet[emergencySubstituteReferees]=
+scoresheet[__identity]=<scoresheet-uuid>
 scoresheet[closedAt]=
 scoresheet[closedBy]=
+scoresheet[emergencySubstituteReferees]=
 scoresheet[file][__identity]=<file-resource-uuid>
-scoresheet[hasFile]=false
+scoresheet[game][__identity]=<game-uuid>
+scoresheet[hasFile]=true
+scoresheet[isSimpleScoresheet]=false
+scoresheet[lastUpdatedByRealUser]=true
+scoresheet[notFoundButNominatedPersons]=
+scoresheet[persistenceObjectIdentifier]=<scoresheet-uuid>
+scoresheet[reminderAboutOpenScoresheetSentAt]=
+scoresheet[scoresheetValidation][__identity]=<validation-uuid>
+scoresheet[writerPerson][__identity]=<person-uuid>
 __csrfToken=<csrf-token>
 ```
 

--- a/docs/api/captures/escoresheet_endpoints.md
+++ b/docs/api/captures/escoresheet_endpoints.md
@@ -19,41 +19,48 @@ Saves changes to an existing scoresheet.
 ### Endpoint
 
 ```
-PUT /api/sportmanager.indoorvolleyball/api\scoresheet
+POST /api/sportmanager.indoorvolleyball/api\scoresheet
 ```
 
 ### Request
 
-Content-Type: `application/x-www-form-urlencoded`
+Content-Type: `text/plain;charset=UTF-8` (URL-encoded body despite text/plain Content-Type)
 
-| Parameter                                      | Type     | Description                          |
-| ---------------------------------------------- | -------- | ------------------------------------ |
-| scoresheet[\_\_identity]                       | UUID     | The scoresheet identifier            |
-| scoresheet[game][\_\_identity]                 | UUID     | The game identifier                  |
-| scoresheet[isSimpleScoresheet]                 | boolean  | Whether using simplified scoresheet  |
-| scoresheet[writerPerson][\_\_identity]         | UUID     | Person filling out the scoresheet    |
-| scoresheet[file][\_\_identity]                 | UUID     | Reference to uploaded PDF (optional) |
-| scoresheet[hasFile]                            | boolean  | Whether a PDF is attached            |
-| scoresheet[scoresheetValidation][\_\_identity] | UUID     | Validation record reference          |
-| scoresheet[closedAt]                           | datetime | When closed (empty if open)          |
-| scoresheet[closedBy]                           | string   | Who closed it (empty if open)        |
-| scoresheet[emergencySubstituteReferees]        | string   | Emergency referees (empty if none)   |
-| scoresheet[notFoundButNominatedPersons]        | string   | Unmatched persons (empty if none)    |
-| \_\_csrfToken                                  | string   | CSRF protection token                |
+| Parameter                                        | Type     | Description                                  |
+| ------------------------------------------------ | -------- | -------------------------------------------- |
+| scoresheet[game][\_\_identity]                   | UUID     | The game identifier                          |
+| scoresheet[isSimpleScoresheet]                   | boolean  | Whether using simplified scoresheet          |
+| scoresheet[writerPerson][\_\_identity]           | UUID     | Person filling out the scoresheet (optional) |
+| scoresheet[writerPerson]                         | string   | Empty string when no scorer set              |
+| scoresheet[file][\_\_identity]                   | UUID     | Reference to uploaded file (optional)        |
+| scoresheet[hasFile]                              | boolean  | Whether a file is attached                   |
+| scoresheet[scoresheetValidation][\_\_identity]   | UUID     | Validation record reference (optional)       |
+| scoresheet[scoresheetValidation]                 | string   | Empty string when no validation yet          |
+| scoresheet[reminderAboutOpenScoresheetSentAt]    | string   | Reminder timestamp (empty if not sent)       |
+| scoresheet[closedAt]                             | datetime | When closed (empty if open)                  |
+| scoresheet[closedBy]                             | string   | Who closed it (empty if open)                |
+| scoresheet[emergencySubstituteReferees]          | string   | Emergency referees (empty if none)           |
+| scoresheet[notFoundButNominatedPersons]          | string   | Unmatched persons (empty if none)            |
+| \_\_csrfToken                                    | string   | CSRF protection token                        |
+
+Note: The scoresheet identity is NOT sent in the body. The server resolves it from the game identity.
+When a field has no value (e.g., writerPerson before scorer selection), the plain field name is used
+without `[__identity]` suffix.
 
 ### Example Request (URL-decoded)
 
 ```
-scoresheet[__identity]=<scoresheet-uuid>
 scoresheet[game][__identity]=<game-uuid>
 scoresheet[isSimpleScoresheet]=false
-scoresheet[writerPerson][__identity]=<person-uuid>
-scoresheet[hasFile]=false
+scoresheet[writerPerson]=
+scoresheet[scoresheetValidation]=
+scoresheet[reminderAboutOpenScoresheetSentAt]=
+scoresheet[notFoundButNominatedPersons]=
+scoresheet[emergencySubstituteReferees]=
 scoresheet[closedAt]=
 scoresheet[closedBy]=
-scoresheet[scoresheetValidation][__identity]=<validation-uuid>
-scoresheet[emergencySubstituteReferees]=
-scoresheet[notFoundButNominatedPersons]=
+scoresheet[file][__identity]=<file-resource-uuid>
+scoresheet[hasFile]=false
 __csrfToken=<csrf-token>
 ```
 
@@ -159,9 +166,9 @@ Common validation issues include:
 
 ---
 
-## 3. Upload Scoresheet PDF
+## 3. Upload Scoresheet File
 
-Uploads the signed scoresheet PDF file.
+Uploads the signed scoresheet file (JPEG, PNG, or PDF).
 
 ### Endpoint
 
@@ -173,10 +180,13 @@ POST /api/sportmanager.resourcemanagement/api\persistentresource/upload
 
 Content-Type: `multipart/form-data`
 
-| Parameter     | Type   | Description            |
-| ------------- | ------ | ---------------------- |
-| resource      | file   | The PDF file to upload |
-| \_\_csrfToken | string | CSRF protection token  |
+| Parameter          | Type   | Description                       |
+| ------------------ | ------ | --------------------------------- |
+| scoresheetFile[]   | file   | The scoresheet file to upload     |
+| \_\_csrfToken      | string | CSRF protection token (optional)  |
+
+Note: The volleymanager website does not include a CSRF token in the upload request body.
+The field name uses array notation (`scoresheetFile[]`).
 
 ### Response
 

--- a/docs/api/captures/escoresheet_endpoints.md
+++ b/docs/api/captures/escoresheet_endpoints.md
@@ -19,7 +19,7 @@ Saves changes to an existing scoresheet.
 ### Endpoint
 
 ```
-POST /api/sportmanager.indoorvolleyball/api\scoresheet
+PUT /api/sportmanager.indoorvolleyball/api\scoresheet
 ```
 
 ### Request

--- a/docs/api/captures/escoresheet_endpoints.md
+++ b/docs/api/captures/escoresheet_endpoints.md
@@ -231,7 +231,7 @@ POST /api/sportmanager.indoorvolleyball/api\scoresheet/finalize
 
 ### Request
 
-Content-Type: `application/x-www-form-urlencoded`
+Content-Type: `text/plain;charset=UTF-8` (URL-encoded body despite text/plain Content-Type)
 
 | Parameter                                      | Type    | Description                              |
 | ---------------------------------------------- | ------- | ---------------------------------------- |

--- a/docs/api/captures/nomination_list_endpoints.md
+++ b/docs/api/captures/nomination_list_endpoints.md
@@ -18,7 +18,7 @@ Updates an existing nomination list with player nominations and coach assignment
 ### Endpoint
 
 ```
-PUT /api/sportmanager.indoorvolleyball/api\nominationlist
+POST /api/sportmanager.indoorvolleyball/api\nominationlist
 ```
 
 ### Request

--- a/docs/api/captures/nomination_list_endpoints.md
+++ b/docs/api/captures/nomination_list_endpoints.md
@@ -154,7 +154,7 @@ POST /api/sportmanager.indoorvolleyball/api\nominationlist/finalize
 
 ### Request
 
-Content-Type: `application/x-www-form-urlencoded`
+Content-Type: `text/plain;charset=UTF-8` (URL-encoded body despite text/plain Content-Type)
 
 Same parameters as update, with:
 

--- a/docs/api/captures/nomination_list_endpoints.md
+++ b/docs/api/captures/nomination_list_endpoints.md
@@ -23,44 +23,57 @@ PUT /api/sportmanager.indoorvolleyball/api\nominationlist
 
 ### Request
 
-Content-Type: `application/x-www-form-urlencoded`
+Content-Type: `text/plain;charset=UTF-8` (URL-encoded body despite text/plain Content-Type)
 
-| Parameter                                                | Type     | Description                      |
-| -------------------------------------------------------- | -------- | -------------------------------- |
-| nominationList[\_\_identity]                             | UUID     | The nomination list identifier   |
-| nominationList[game][\_\_identity]                       | UUID     | The game identifier              |
-| nominationList[team][\_\_identity]                       | UUID     | The team identifier              |
-| nominationList[coachPerson][\_\_identity]                | UUID     | Head coach person ID             |
-| nominationList[firstAssistantCoachPerson][\_\_identity]  | UUID     | First assistant coach (optional) |
-| nominationList[secondAssistantCoachPerson]               | string   | Second assistant coach or empty  |
-| nominationList[indoorPlayerNominations][N][\_\_identity] | UUID     | Player nomination IDs (array)    |
-| nominationList[closed]                                   | boolean  | Whether the list is closed       |
-| nominationList[closedAt]                                 | datetime | When closed (empty if open)      |
-| nominationList[closedBy]                                 | string   | Who closed it (empty if open)    |
-| nominationList[checked]                                  | boolean  | Whether checked by referee       |
-| nominationList[isClosedForTeam]                          | boolean  | Whether team can still edit      |
-| nominationList[nominationListValidation][\_\_identity]   | UUID     | Validation record                |
-| \_\_csrfToken                                            | string   | CSRF protection token            |
+| Parameter                                                                    | Type     | Description                                  |
+| ---------------------------------------------------------------------------- | -------- | -------------------------------------------- |
+| nominationList[\_\_identity]                                                 | UUID     | The nomination list identifier               |
+| nominationList[game][\_\_identity]                                           | UUID     | The game identifier                          |
+| nominationList[team][\_\_identity]                                           | UUID     | The team identifier                          |
+| nominationList[coachPerson][\_\_identity]                                    | UUID     | Head coach person ID                         |
+| nominationList[firstAssistantCoachPerson][\_\_identity]                      | UUID     | First assistant coach (optional)             |
+| nominationList[firstAssistantCoachPerson]                                    | string   | Empty string when no assistant coach         |
+| nominationList[secondAssistantCoachPerson]                                   | string   | Second assistant coach UUID or empty         |
+| nominationList[indoorPlayerNominations][N][\_\_identity]                     | UUID     | Player nomination IDs (array)                |
+| nominationList[closed]                                                       | boolean  | Whether the list is closed                   |
+| nominationList[closedAt]                                                     | datetime | When closed (empty if open)                  |
+| nominationList[closedBy]                                                     | string   | Who closed it (empty if open)                |
+| nominationList[checked]                                                      | boolean  | Whether checked by referee                   |
+| nominationList[checkedAt]                                                    | datetime | When checked (empty if not checked)          |
+| nominationList[checkedBy]                                                    | string   | Who checked it (empty if not checked)        |
+| nominationList[isClosedForTeam]                                              | boolean  | Whether team can still edit                  |
+| nominationList[isSubsequentGameForTeamInTournamentGroup]                     | boolean  | Whether second/third game in tournament      |
+| nominationList[lastUpdatedByRealUser]                                        | boolean  | Marks update as user-initiated               |
+| nominationList[nominationListValidation][\_\_identity]                       | UUID     | Validation record                            |
+| nominationList[notFoundButNominatedPersons]                                  | string   | Unmatched persons (empty if none)            |
+| nominationList[persistenceObjectIdentifier]                                  | UUID     | Same as \_\_identity (Neos Flow internal)    |
+| \_\_csrfToken                                                                | string   | CSRF protection token                        |
 
 ### Example Request (URL-decoded)
 
 ```
 nominationList[__identity]=<nomination-list-uuid>
-nominationList[game][__identity]=<game-uuid>
-nominationList[team][__identity]=<team-uuid>
+nominationList[checked]=false
+nominationList[checkedAt]=
+nominationList[checkedBy]=
+nominationList[closed]=false
+nominationList[closedAt]=
+nominationList[closedBy]=
 nominationList[coachPerson][__identity]=<coach-person-uuid>
-nominationList[firstAssistantCoachPerson][__identity]=<assistant-coach-uuid>
-nominationList[secondAssistantCoachPerson]=
+nominationList[firstAssistantCoachPerson]=
+nominationList[game][__identity]=<game-uuid>
 nominationList[indoorPlayerNominations][0][__identity]=<player-nomination-0-uuid>
 nominationList[indoorPlayerNominations][1][__identity]=<player-nomination-1-uuid>
 nominationList[indoorPlayerNominations][2][__identity]=<player-nomination-2-uuid>
 ...
-nominationList[closed]=false
-nominationList[closedAt]=
-nominationList[closedBy]=
-nominationList[checked]=false
 nominationList[isClosedForTeam]=true
+nominationList[isSubsequentGameForTeamInTournamentGroup]=false
+nominationList[lastUpdatedByRealUser]=true
 nominationList[nominationListValidation][__identity]=<validation-uuid>
+nominationList[notFoundButNominatedPersons]=
+nominationList[persistenceObjectIdentifier]=<nomination-list-uuid>
+nominationList[secondAssistantCoachPerson]=
+nominationList[team][__identity]=<team-uuid>
 __csrfToken=<csrf-token>
 ```
 

--- a/docs/api/captures/nomination_list_endpoints.md
+++ b/docs/api/captures/nomination_list_endpoints.md
@@ -18,7 +18,7 @@ Updates an existing nomination list with player nominations and coach assignment
 ### Endpoint
 
 ```
-POST /api/sportmanager.indoorvolleyball/api\nominationlist
+PUT /api/sportmanager.indoorvolleyball/api\nominationlist
 ```
 
 ### Request

--- a/docs/api/captures/search_and_resources_endpoints.md
+++ b/docs/api/captures/search_and_resources_endpoints.md
@@ -118,10 +118,10 @@ POST /api/sportmanager.resourcemanagement/api\persistentresource/upload
 
 Content-Type: `multipart/form-data`
 
-| Parameter     | Type   | Description           |
-| ------------- | ------ | --------------------- |
-| resource      | file   | The file to upload    |
-| \_\_csrfToken | string | CSRF protection token |
+| Parameter          | Type   | Description           |
+| ------------------ | ------ | --------------------- |
+| scoresheetFile[]   | file   | The file to upload    |
+| \_\_csrfToken      | string | CSRF protection token |
 
 ### Example (using cURL)
 
@@ -129,7 +129,7 @@ Content-Type: `multipart/form-data`
 curl -X POST \
   'https://volleymanager.volleyball.ch/api/sportmanager.resourcemanagement/api\persistentresource/upload' \
   -H 'Cookie: Neos_Flow_Session=<session-id>' \
-  -F 'resource=@/path/to/scoresheet.pdf' \
+  -F 'scoresheetFile[]=@/path/to/scoresheet.pdf' \
   -F '__csrfToken=<csrf-token>'
 ```
 

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -1066,18 +1066,18 @@ paths:
           $ref: '#/components/responses/Unauthorized'
   # ==================== eScoresheet Endpoints ====================
   /sportmanager.indoorvolleyball/api\scoresheet:
-    post:
+    put:
       tags: [eScoresheet]
       summary: Update scoresheet
       description: |
         Updates an existing scoresheet. Used to save scoresheet data before finalization.
         The scoresheet must already exist (created when accessing the eScoresheet interface).
-        Note: Uses POST method (not PUT) matching the actual volleymanager behavior.
+        Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
       operationId: updateScoresheet
       requestBody:
         required: true
         content:
-          application/x-www-form-urlencoded:
+          text/plain:
             schema:
               $ref: '#/components/schemas/ScoresheetUpdateRequest'
       responses:
@@ -1142,18 +1142,18 @@ paths:
           $ref: '#/components/responses/Forbidden'
   # ==================== Nomination List Endpoints ====================
   /sportmanager.indoorvolleyball/api\nominationlist:
-    post:
+    put:
       tags: [NominationList]
       summary: Update nomination list
       description: |
         Updates an existing nomination list with player nominations, coach assignments, etc.
         Used by team responsibles and referees to manage the team lineup for a game.
-        Note: Uses POST method (not PUT) matching the actual volleymanager behavior.
+        Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
       operationId: updateNominationList
       requestBody:
         required: true
         content:
-          application/x-www-form-urlencoded:
+          text/plain:
             schema:
               $ref: '#/components/schemas/NominationListUpdateRequest'
       responses:

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -6,7 +6,8 @@ info:
     Captured from observing production behavior at volleymanager.volleyball.ch
 
     ## Request Format
-    All POST endpoints use `application/x-www-form-urlencoded` with nested bracket notation:
+    Most POST endpoints use `application/x-www-form-urlencoded` with nested bracket notation.
+    However, PUT endpoints and some POST endpoints (finalize) use `text/plain;charset=UTF-8` with the same bracket notation body:
     ```
     searchConfiguration[propertyFilters][0][propertyName]=refereeGame.game.startingDateTime
     searchConfiguration[propertyFilters][0][dateRange][from]=2025-12-07T23:00:00.000Z
@@ -1125,6 +1126,9 @@ paths:
       operationId: finalizeScoresheet
       requestBody:
         required: true
+        description: |
+          Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
+          The body is still URL-encoded bracket notation despite the text/plain Content-Type.
         content:
           application/x-www-form-urlencoded:
             schema:
@@ -1177,6 +1181,9 @@ paths:
       operationId: finalizeNominationList
       requestBody:
         required: true
+        description: |
+          Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
+          The body is still URL-encoded bracket notation despite the text/plain Content-Type.
         content:
           application/x-www-form-urlencoded:
             schema:

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -1130,7 +1130,7 @@ paths:
           Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
           The body is still URL-encoded bracket notation despite the text/plain Content-Type.
         content:
-          application/x-www-form-urlencoded:
+          text/plain:
             schema:
               $ref: '#/components/schemas/ScoresheetFinalizeRequest'
       responses:
@@ -1185,7 +1185,7 @@ paths:
           Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
           The body is still URL-encoded bracket notation despite the text/plain Content-Type.
         content:
-          application/x-www-form-urlencoded:
+          text/plain:
             schema:
               $ref: '#/components/schemas/NominationListFinalizeRequest'
       responses:

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -1066,12 +1066,13 @@ paths:
           $ref: '#/components/responses/Unauthorized'
   # ==================== eScoresheet Endpoints ====================
   /sportmanager.indoorvolleyball/api\scoresheet:
-    put:
+    post:
       tags: [eScoresheet]
       summary: Update scoresheet
       description: |
         Updates an existing scoresheet. Used to save scoresheet data before finalization.
         The scoresheet must already exist (created when accessing the eScoresheet interface).
+        Note: Uses POST method (not PUT) matching the actual volleymanager behavior.
       operationId: updateScoresheet
       requestBody:
         required: true
@@ -1141,12 +1142,13 @@ paths:
           $ref: '#/components/responses/Forbidden'
   # ==================== Nomination List Endpoints ====================
   /sportmanager.indoorvolleyball/api\nominationlist:
-    put:
+    post:
       tags: [NominationList]
       summary: Update nomination list
       description: |
         Updates an existing nomination list with player nominations, coach assignments, etc.
         Used by team responsibles and referees to manage the team lineup for a game.
+        Note: Uses POST method (not PUT) matching the actual volleymanager behavior.
       operationId: updateNominationList
       requestBody:
         required: true
@@ -1346,10 +1348,10 @@ paths:
             schema:
               type: object
               properties:
-                resource:
+                scoresheetFile[]:
                   type: string
                   format: binary
-                  description: The file to upload
+                  description: The file to upload (field name uses array notation)
                 __csrfToken:
                   type: string
       responses:

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -603,15 +603,26 @@ export const api = {
     scoresheetId: string,
     gameId: string,
     scorerPersonId: string,
-    isSimpleScoresheet: boolean = false
+    isSimpleScoresheet: boolean = false,
+    fileResourceId?: string
   ): Promise<Scoresheet> {
-    return apiRequest<Scoresheet>('/sportmanager.indoorvolleyball/api%5cscoresheet', 'PUT', {
+    const body: Record<string, unknown> = {
       'scoresheet[__identity]': scoresheetId,
       'scoresheet[game][__identity]': gameId,
       'scoresheet[writerPerson][__identity]': scorerPersonId,
       'scoresheet[isSimpleScoresheet]': isSimpleScoresheet ? 'true' : 'false',
-      'scoresheet[hasFile]': 'false',
-    })
+      'scoresheet[hasFile]': fileResourceId ? 'true' : 'false',
+    }
+
+    if (fileResourceId) {
+      body['scoresheet[file][__identity]'] = fileResourceId
+    }
+
+    return apiRequest<Scoresheet>(
+      '/sportmanager.indoorvolleyball/api%5cscoresheet',
+      'PUT',
+      body
+    )
   },
 
   async finalizeScoresheet(

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -547,7 +547,7 @@ export const api = {
 
     return apiRequest<NominationList>(
       '/sportmanager.indoorvolleyball/api%5cnominationlist',
-      'PUT',
+      'POST',
       body
     )
   },
@@ -620,7 +620,7 @@ export const api = {
 
     return apiRequest<Scoresheet>(
       '/sportmanager.indoorvolleyball/api%5cscoresheet',
-      'PUT',
+      'POST',
       body
     )
   },
@@ -669,7 +669,7 @@ export const api = {
     }
 
     const formData = new FormData()
-    formData.append('resource', file)
+    formData.append('scoresheetFile[]', file)
     const csrfToken = getCsrfToken()
     if (csrfToken) {
       formData.append('__csrfToken', csrfToken)

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -597,7 +597,8 @@ export const api = {
     return apiRequest<NominationListFinalizeResponse>(
       '/sportmanager.indoorvolleyball/api%5cnominationlist/finalize',
       'POST',
-      body
+      body,
+      'text/plain;charset=UTF-8'
     )
   },
 
@@ -655,7 +656,8 @@ export const api = {
     return apiRequest<Scoresheet>(
       '/sportmanager.indoorvolleyball/api%5cscoresheet/finalize',
       'POST',
-      body
+      body,
+      'text/plain;charset=UTF-8'
     )
   },
 

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -134,7 +134,8 @@ export function clearSession() {
 async function apiRequest<T>(
   endpoint: string,
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' = 'GET',
-  body?: Record<string, unknown>
+  body?: Record<string, unknown>,
+  requestContentType?: string
 ): Promise<T> {
   let url = `${API_BASE}${endpoint}`
 
@@ -149,7 +150,7 @@ async function apiRequest<T>(
   }
 
   if (method !== 'GET' && body) {
-    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    headers['Content-Type'] = requestContentType ?? 'application/x-www-form-urlencoded'
   }
 
   const response = await fetch(url, {
@@ -547,8 +548,9 @@ export const api = {
 
     return apiRequest<NominationList>(
       '/sportmanager.indoorvolleyball/api%5cnominationlist',
-      'POST',
-      body
+      'PUT',
+      body,
+      'text/plain;charset=UTF-8'
     )
   },
 
@@ -620,8 +622,9 @@ export const api = {
 
     return apiRequest<Scoresheet>(
       '/sportmanager.indoorvolleyball/api%5cscoresheet',
-      'POST',
-      body
+      'PUT',
+      body,
+      'text/plain;charset=UTF-8'
     )
   },
 

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -722,6 +722,7 @@ export interface paths {
          * Update scoresheet
          * @description Updates an existing scoresheet. Used to save scoresheet data before finalization.
          *     The scoresheet must already exist (created when accessing the eScoresheet interface).
+         *     Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
          */
         put: operations["updateScoresheet"];
         post?: never;
@@ -786,6 +787,7 @@ export interface paths {
          * Update nomination list
          * @description Updates an existing nomination list with player nominations, coach assignments, etc.
          *     Used by team responsibles and referees to manage the team lineup for a game.
+         *     Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
          */
         put: operations["updateNominationList"];
         post?: never;
@@ -5621,7 +5623,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/x-www-form-urlencoded": components["schemas"]["ScoresheetUpdateRequest"];
+                "text/plain": components["schemas"]["ScoresheetUpdateRequest"];
             };
         };
         responses: {
@@ -5670,6 +5672,10 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
+        /**
+         * @description Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
+         *     The body is still URL-encoded bracket notation despite the text/plain Content-Type.
+         */
         requestBody: {
             content: {
                 "application/x-www-form-urlencoded": components["schemas"]["ScoresheetFinalizeRequest"];
@@ -5698,7 +5704,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/x-www-form-urlencoded": components["schemas"]["NominationListUpdateRequest"];
+                "text/plain": components["schemas"]["NominationListUpdateRequest"];
             };
         };
         responses: {
@@ -5722,6 +5728,10 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
+        /**
+         * @description Note: Content-Type must be text/plain;charset=UTF-8 (not application/x-www-form-urlencoded).
+         *     The body is still URL-encoded bracket notation despite the text/plain Content-Type.
+         */
         requestBody: {
             content: {
                 "application/x-www-form-urlencoded": components["schemas"]["NominationListFinalizeRequest"];
@@ -5860,9 +5870,9 @@ export interface operations {
                 "multipart/form-data": {
                     /**
                      * Format: binary
-                     * @description The file to upload
+                     * @description The file to upload (field name uses array notation)
                      */
-                    resource?: string;
+                    "scoresheetFile[]"?: string;
                     __csrfToken?: string;
                 };
             };

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -5678,7 +5678,7 @@ export interface operations {
          */
         requestBody: {
             content: {
-                "application/x-www-form-urlencoded": components["schemas"]["ScoresheetFinalizeRequest"];
+                "text/plain": components["schemas"]["ScoresheetFinalizeRequest"];
             };
         };
         responses: {
@@ -5734,7 +5734,7 @@ export interface operations {
          */
         requestBody: {
             content: {
-                "application/x-www-form-urlencoded": components["schemas"]["NominationListFinalizeRequest"];
+                "text/plain": components["schemas"]["NominationListFinalizeRequest"];
             };
         };
         responses: {

--- a/web-app/src/features/validation/api/api-helpers.ts
+++ b/web-app/src/features/validation/api/api-helpers.ts
@@ -142,12 +142,13 @@ export async function saveRosterModifications(
   )
 }
 
-/** Saves scoresheet with scorer selection. */
+/** Saves scoresheet with scorer selection and optional file reference. */
 export async function saveScorerSelection(
   apiClient: ReturnType<typeof getApiClient>,
   gameId: string,
   scoresheet: ScoresheetForApi | undefined,
-  scorerId: string | undefined
+  scorerId: string | undefined,
+  fileResourceId?: string
 ): Promise<void> {
   if (!scorerId || !scoresheet?.__identity) {
     logger.debug('[VS] skip scorer save: no scorer or scoresheet ID')
@@ -158,7 +159,8 @@ export async function saveScorerSelection(
     scoresheet.__identity,
     gameId,
     scorerId,
-    scoresheet.isSimpleScoresheet ?? false
+    scoresheet.isSimpleScoresheet ?? false,
+    fileResourceId
   )
 }
 

--- a/web-app/src/features/validation/hooks/useValidationState.test.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.test.ts
@@ -454,7 +454,8 @@ describe('useValidationState', () => {
         'scoresheet-1',
         'game-123',
         'scorer-1',
-        false
+        false,
+        undefined
       )
     })
 

--- a/web-app/src/features/validation/hooks/useValidationState.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.ts
@@ -206,6 +206,14 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
         return
       }
 
+      // Upload scoresheet file if present
+      let fileResourceId: string | undefined
+      if (state.scoresheet.file) {
+        const uploadResult = await apiClient.uploadResource(state.scoresheet.file)
+        fileResourceId = uploadResult[0]?.__identity
+        logger.debug('[VS] PDF uploaded:', fileResourceId)
+      }
+
       await saveRosterModifications(
         apiClient,
         gameId,
@@ -224,8 +232,12 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
         apiClient,
         gameId,
         gameDetails.scoresheet,
-        state.scorer.selected?.__identity
+        state.scorer.selected?.__identity,
+        fileResourceId
       )
+
+      // Invalidate cache so reopening shows the saved data
+      await queryClient.invalidateQueries({ queryKey: queryKeys.validation.gameDetail(gameId) })
       logger.debug('[VS] save done')
     } catch (error) {
       logger.error('[VS] save failed:', error)
@@ -234,7 +246,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
       isSavingRef.current = false
       setIsSaving(false)
     }
-  }, [gameId, gameDetailsQuery.data, state, apiClient])
+  }, [gameId, gameDetailsQuery.data, state, apiClient, queryClient])
 
   const finalizeValidation = useCallback(async (): Promise<void> => {
     if (isFinalizingRef.current) {


### PR DESCRIPTION
## Summary

- Fixed secure validation mode not persisting scorer and scoresheet data to the VolleyManager API
- Added scoresheet file upload during save progress (was only done during finalize)
- Fixed Content-Type for all PUT/POST endpoints to use `text/plain;charset=UTF-8` matching VolleyManager's Neos Flow backend requirements
- Fixed upload field name from `resource` to `scoresheetFile[]`
- Added React Query cache invalidation after save so reopening a game reflects saved state
- Updated API documentation, OpenAPI spec, and capture docs with correct content types

## Test plan

- [x] All 3790 unit tests pass
- [x] Production build succeeds
- [ ] Manual test: enable secure validation, validate a game, verify scorer and scoresheet persist in VolleyManager
- [ ] Manual test: normal (non-secure) finalize flow still works correctly

https://claude.ai/code/session_01LXg6bi6wLo3HT5ayFfnN2C