### PR TITLE
fix(web): show validated state in modal when game validated externally

### DIFF
--- a/.changeset/fix-validation-modal-stale-state.md
+++ b/.changeset/fix-validation-modal-stale-state.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fixed validation modal showing editable state for already-validated games when validation was completed externally on volleymanager


### PR DESCRIPTION
## Summary

- Fixed validation modal showing editable "to be validated" state for games already validated externally on volleymanager
- The wizard hook now checks both the assignment list data (`closedAt`) and the game details query to determine validated state, providing immediate correct UI even when the game details cache is stale
- Game details cache is invalidated when the modal opens to ensure fresh data loads

## Test plan

- [x] Added test: modal shows validated mode when assignment has `closedAt` even if game details query is stale
- [x] All 405 validation tests pass
- [x] TypeScript type check passes
- [x] Lint, format, knip, build all pass

https://claude.ai/code/session_01TJvYt4oeqZiosPxyJmj2U4