### PR TITLE
fix(mobile): wire departure reminder cleanup into app lifecycle hooks

### DIFF
--- a/.changeset/wire-departure-reminder-cleanup.md
+++ b/.changeset/wire-departure-reminder-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@volleykit/mobile': patch
+---
+
+Wire departure reminder cleanup into app lifecycle hooks

--- a/packages/mobile/src/contexts/SessionMonitorContext.tsx
+++ b/packages/mobile/src/contexts/SessionMonitorContext.tsx
@@ -76,7 +76,9 @@ export function SessionMonitorProvider({ children }: SessionMonitorProviderProps
     const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
       if (nextAppState === 'active') {
         checkBiometricStatus()
-        onAppForeground()
+        onAppForeground().catch(() => {
+          // Ignore cleanup errors on foreground
+        })
       }
     })
 

--- a/packages/mobile/src/contexts/SessionMonitorContext.tsx
+++ b/packages/mobile/src/contexts/SessionMonitorContext.tsx
@@ -14,6 +14,7 @@ import { useStorage } from '@volleykit/shared/adapters'
 
 import { BIOMETRIC_ENABLED_KEY } from '../constants'
 import { biometrics } from '../platform/biometrics'
+import { onAppForeground } from '../services/departure-reminder'
 
 export interface SessionMonitorState {
   /** Whether the session has expired */
@@ -75,6 +76,7 @@ export function SessionMonitorProvider({ children }: SessionMonitorProviderProps
     const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
       if (nextAppState === 'active') {
         checkBiometricStatus()
+        onAppForeground()
       }
     })
 

--- a/packages/mobile/src/screens/DepartureReminderSettingsScreen.tsx
+++ b/packages/mobile/src/screens/DepartureReminderSettingsScreen.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from '@volleykit/shared/i18n'
 import { COLORS, SETTINGS_ICON_SIZE } from '../constants'
 import { location } from '../platform/location'
 import { notifications } from '../platform/notifications'
+import { onFeatureDisabled } from '../services/departure-reminder'
 import { departureReminderSettingsStore } from '../stores/departureReminderSettings'
 import {
   DEFAULT_DEPARTURE_REMINDER_SETTINGS,
@@ -126,9 +127,9 @@ export function DepartureReminderSettingsScreen(_props: Props) {
         const updated = await departureReminderSettingsStore.disable(storage)
         setSettings(updated)
 
-        // Stop background tracking
+        // Clean up: cancel notifications, stop tracking, clear reminder data
         try {
-          await location.stopBackgroundTracking()
+          await onFeatureDisabled()
         } catch {
           // Ignore errors
         }

--- a/packages/mobile/src/services/authService.ts
+++ b/packages/mobile/src/services/authService.ts
@@ -14,6 +14,7 @@ import { useAuthStore } from '@volleykit/shared/stores'
 
 import { setSessionToken, setCsrfToken, clearTokens, getSessionToken } from '../api'
 import { SESSION_TOKEN_HEADER } from '../constants'
+import { onUserLogout as cleanupDepartureReminders } from './departure-reminder'
 import { secureStorage } from '../platform/secureStorage'
 import { useActionQueueStore } from './offline/action-queue-store'
 
@@ -203,6 +204,14 @@ export async function logout(): Promise<void> {
     logger.info('Offline action queue cleared')
   } catch (error) {
     logger.warn('Failed to clear offline action queue:', error)
+  }
+
+  // Clean up departure reminders (cancel notifications, stop tracking, clear data)
+  try {
+    await cleanupDepartureReminders()
+    logger.info('Departure reminders cleaned up')
+  } catch (error) {
+    logger.warn('Failed to clean up departure reminders:', error)
   }
 
   // Clear auth store

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -76,7 +76,6 @@ function normalizeForSearch(str: string): string {
     .replace(/[\u0300-\u036f]/g, '')
 }
 
-
 /**
  * Get a nested property value from an object using dot notation.
  * @example getNestedValue({ a: { b: 1 } }, "a.b") // returns 1


### PR DESCRIPTION
## Summary

- Wire the departure-reminder cleanup functions (`onAppForeground`, `onUserLogout`, `onFeatureDisabled`) into their corresponding app lifecycle hooks — these were implemented but never called
- `onAppForeground`: cleans up past reminders when app becomes active (SessionMonitorContext)
- `onUserLogout`: cancels notifications, stops tracking, and resets store on logout (authService)
- `onFeatureDisabled`: full cleanup replacing bare `stopBackgroundTracking()` when user disables departure reminders (DepartureReminderSettingsScreen)
- Ensures compliance with FR-026a (no location history retained)

## Test plan

- [x] Mobile typecheck passes (`npm run typecheck`)
- [x] Mobile lint passes (`npm run lint`)
- [x] Mobile tests pass (`npm test` — 54 tests)
- [ ] Manual: enable departure reminders, then disable — confirm notifications are cancelled
- [ ] Manual: log out while reminders are active — confirm all reminder data is cleared

https://claude.ai/code/session_01CabUSYP8mPeiUnkuKwjrWK