### PR TITLE
fix(web): remove licence type and OCR button from roster validation modal

### DIFF
--- a/.changeset/remove-roster-licence-badge.md
+++ b/.changeset/remove-roster-licence-badge.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Removed licence category badge from player rows in the roster validation modal

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -113,7 +113,6 @@ npm run size
 | Main App Bundle      | 145 KB |
 | Vendor Chunks (each) | 50 KB  |
 | PDF Library (lazy)   | 185 KB |
-| OCR Feature (lazy)   | 12 KB  |
 | Image Cropper (lazy) | 10 KB  |
 | CSS                  | 12 KB  |
 | Total JS             | 520 KB |

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -56,12 +56,6 @@
       "gzip": true
     },
     {
-      "name": "OCR Feature (lazy-loaded)",
-      "path": "dist/assets/chunk-OCRPanel-*.js",
-      "limit": "12 kB",
-      "gzip": true
-    },
-    {
       "name": "Image Cropper (lazy-loaded)",
       "path": "dist/assets/chunk-cropper-*.js",
       "limit": "10 kB",

--- a/web-app/src/features/validation/components/PlayerListItem.test.tsx
+++ b/web-app/src/features/validation/components/PlayerListItem.test.tsx
@@ -9,7 +9,6 @@ function createMockPlayer(overrides: Partial<RosterPlayer> = {}): RosterPlayer {
   return {
     id: 'player-1',
     displayName: 'John Doe',
-    licenseCategory: 'SEN',
     isNewlyAdded: false,
     ...overrides,
   }
@@ -43,23 +42,6 @@ describe('PlayerListItem', () => {
     expect(screen.getByText('Max')).toBeInTheDocument()
     expect(screen.getByText('M.')).toBeInTheDocument()
     expect(screen.getByText('01.01.90')).toBeInTheDocument()
-  })
-
-  it('shows license category badge when provided', () => {
-    const player = createMockPlayer({ licenseCategory: 'JUN' })
-
-    render(
-      <PlayerListItem
-        player={player}
-        displayData={createDisplayData()}
-        maxLastNameWidth={10}
-        isMarkedForRemoval={false}
-        onRemove={vi.fn()}
-        onUndoRemoval={vi.fn()}
-      />
-    )
-
-    expect(screen.getByText('JUN')).toBeInTheDocument()
   })
 
   it('shows newly added badge when isNewlyAdded is true', () => {
@@ -157,9 +139,9 @@ describe('PlayerListItem', () => {
     expect(lastNameElement).toHaveClass('line-through')
   })
 
-  it('hides badges when marked for removal', () => {
+  it('hides newly added badge when marked for removal', () => {
     const player = createMockPlayer({
-      licenseCategory: 'SEN',
+      isNewlyAdded: true,
     })
 
     render(
@@ -173,7 +155,7 @@ describe('PlayerListItem', () => {
       />
     )
 
-    expect(screen.queryByText('SEN')).not.toBeInTheDocument()
+    expect(screen.queryByText('New')).not.toBeInTheDocument()
   })
 
   it('aligns last names based on maxLastNameWidth', () => {

--- a/web-app/src/features/validation/components/PlayerListItem.tsx
+++ b/web-app/src/features/validation/components/PlayerListItem.tsx
@@ -60,18 +60,10 @@ export function PlayerListItem({
           </span>
         </div>
 
-        {/* Badges */}
-        <div className="flex items-center gap-1.5 flex-shrink-0">
-          {/* License category badge */}
-          {player.licenseCategory && !isMarkedForRemoval && (
-            <Badge variant="neutral">{player.licenseCategory}</Badge>
-          )}
-
-          {/* Newly added badge */}
-          {player.isNewlyAdded && !isMarkedForRemoval && (
-            <Badge variant="success">{t('validation.roster.newlyAdded')}</Badge>
-          )}
-        </div>
+        {/* Newly added badge */}
+        {player.isNewlyAdded && !isMarkedForRemoval && (
+          <Badge variant="success">{t('validation.roster.newlyAdded')}</Badge>
+        )}
       </div>
 
       {/* Action button - hidden in read-only mode */}

--- a/web-app/src/features/validation/components/RosterVerificationPanel.tsx
+++ b/web-app/src/features/validation/components/RosterVerificationPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useMemo, lazy, Suspense } from 'react'
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 
 import type { PossibleNomination, NominationList, Schemas } from '@/api/client'
 import type { ValidatedPersonSearchResult } from '@/api/validation'
@@ -10,26 +10,15 @@ import {
   type CoachInfo,
   type CoachModifications,
 } from '@/features/validation/hooks/useNominationList'
-import {
-  UserPlus,
-  AlertCircle,
-  RefreshCw,
-  ChevronDown,
-  ChevronUp,
-  Camera,
-} from '@/shared/components/icons'
+import { UserPlus, AlertCircle, RefreshCw, ChevronDown, ChevronUp } from '@/shared/components/icons'
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner'
 import { useTranslation } from '@/shared/hooks/useTranslation'
-import { useSettingsStore } from '@/shared/stores/settings'
 import { formatRosterEntries, getMaxLastNameWidth } from '@/shared/utils/date-helpers'
 
 import { AddCoachSheet } from './AddCoachSheet'
 import { AddPlayerSheet } from './AddPlayerSheet'
 import { CoachesSection } from './CoachesSection'
 import { PlayerListItem } from './PlayerListItem'
-
-// Lazy load OCR panel to reduce initial bundle size
-const OCRPanel = lazy(() => import('./OCRPanel').then((m) => ({ default: m.OCRPanel })))
 
 type PersonSummary = Schemas['PersonSummary']
 
@@ -114,8 +103,6 @@ export function RosterVerificationPanel({
     team,
     prefetchedData: prefetchedNominationList,
   })
-  const { isOCREnabled } = useSettingsStore()
-
   // Accordion state - players expanded by default as per user request
   const [expandedSection, setExpandedSection] = useState<ExpandedSection>('players')
 
@@ -139,9 +126,6 @@ export function RosterVerificationPanel({
   const [isAddPlayerSheetOpen, setIsAddPlayerSheetOpen] = useState(false)
   const [isAddCoachSheetOpen, setIsAddCoachSheetOpen] = useState(false)
   const [addingCoachRole, setAddingCoachRole] = useState<CoachRole>('head')
-
-  // OCR panel state
-  const [isOCRPanelOpen, setIsOCRPanelOpen] = useState(false)
 
   // Ref for stable callback
   const onModificationsChangeRef = useRef(onModificationsChange)
@@ -262,26 +246,6 @@ export function RosterVerificationPanel({
       return newSet
     })
   }, [])
-
-  // OCR handlers
-  const handleOCRApplyResults = useCallback(
-    (matchedPlayerIds: string[]) => {
-      // In read-only mode, just close the panel without applying changes
-      // (OCR is available for debugging/re-verification purposes only)
-      if (readOnly) {
-        setIsOCRPanelOpen(false)
-        return
-      }
-      // Clear any removed flags for matched players
-      setRemovedPlayerIds((prev) => {
-        const newSet = new Set(prev)
-        matchedPlayerIds.forEach((id) => newSet.delete(id))
-        return newSet
-      })
-      setIsOCRPanelOpen(false)
-    },
-    [readOnly]
-  )
 
   // Compute player data
   const allPlayers = [...players, ...addedPlayers].sort((a, b) => {
@@ -446,30 +410,16 @@ export function RosterVerificationPanel({
             )}
 
             {/* Action buttons */}
-            {(!readOnly || isOCREnabled) && (
+            {!readOnly && (
               <div className="mt-4 flex gap-2">
-                {!readOnly && (
-                  <button
-                    type="button"
-                    onClick={() => setIsAddPlayerSheetOpen(true)}
-                    className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 hover:bg-primary-100 dark:hover:bg-primary-900/50 rounded-lg border border-primary-200 dark:border-primary-800 transition-colors"
-                  >
-                    <UserPlus className="w-4 h-4" aria-hidden="true" />
-                    {t('validation.roster.addPlayer')}
-                  </button>
-                )}
-                {/* OCR button available in read-only mode for debugging/re-verification */}
-                {isOCREnabled && (
-                  <button
-                    type="button"
-                    onClick={() => setIsOCRPanelOpen(true)}
-                    className={`flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/30 hover:bg-gray-100 dark:hover:bg-gray-700/50 rounded-lg border border-gray-200 dark:border-gray-600 transition-colors ${readOnly ? 'flex-1' : ''}`}
-                    title={t('validation.ocr.scanScoresheet')}
-                  >
-                    <Camera className="w-4 h-4" aria-hidden="true" />
-                    <span className="sr-only">{t('validation.ocr.scanScoresheet')}</span>
-                  </button>
-                )}
+                <button
+                  type="button"
+                  onClick={() => setIsAddPlayerSheetOpen(true)}
+                  className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/30 hover:bg-primary-100 dark:hover:bg-primary-900/50 rounded-lg border border-primary-200 dark:border-primary-800 transition-colors"
+                >
+                  <UserPlus className="w-4 h-4" aria-hidden="true" />
+                  {t('validation.roster.addPlayer')}
+                </button>
               </div>
             )}
           </div>
@@ -498,19 +448,6 @@ export function RosterVerificationPanel({
         />
       )}
 
-      {/* OCR Panel - available in read-only mode for debugging/re-verification */}
-      {isOCREnabled && (
-        <Suspense fallback={null}>
-          <OCRPanel
-            isOpen={isOCRPanelOpen}
-            onClose={() => setIsOCRPanelOpen(false)}
-            team={team}
-            teamName={teamName}
-            rosterPlayers={allPlayers}
-            onApplyResults={handleOCRApplyResults}
-          />
-        </Suspense>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Remove the licence category badge (e.g. JUN, SEN) from player rows in the roster verification panel — only name and DOB are shown now
- Remove the per-roster OCR camera button and all associated code (state, handler, lazy import, Suspense wrapper)
- Clean up unused imports (Camera, lazy, Suspense, useSettingsStore)

## Test plan

- [ ] Open the validation modal for a game and verify player rows show only name and DOB (no licence badge)
- [ ] Verify the "newly added" badge still appears when adding a player
- [ ] Confirm the camera icon button is no longer visible next to the add player button
- [ ] Verify add/remove player functionality still works correctly

https://claude.ai/code/session_01DamVU7ZDzFeZ9qQaoxgUoA