### PR TITLE
fix(web): allow compensation editing in safe mode from compensation tab

### DIFF
--- a/.changeset/fix-safe-mode-compensation-edit.md
+++ b/.changeset/fix-safe-mode-compensation-edit.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Allow editing compensations in the compensation tab when safe mode is enabled, matching existing assignment tab behavior

--- a/web-app/src/features/compensations/hooks/useCompensationActions.test.ts
+++ b/web-app/src/features/compensations/hooks/useCompensationActions.test.ts
@@ -269,16 +269,16 @@ describe('useCompensationActions', () => {
       )
     })
 
-    it('should block editing compensation when safe mode is enabled', () => {
+    it('should allow editing compensation when safe mode is enabled', () => {
       const { result } = renderHook(() => useCompensationActions())
 
       act(() => {
         result.current.editCompensationModal.open(mockCompensation)
       })
 
-      expect(result.current.editCompensationModal.isOpen).toBe(false)
-      expect(result.current.editCompensationModal.compensation).toBeNull()
-      expect(toast.warning).toHaveBeenCalledWith('settings.safeModeBlocked')
+      expect(result.current.editCompensationModal.isOpen).toBe(true)
+      expect(result.current.editCompensationModal.compensation).toBe(mockCompensation)
+      expect(toast.warning).not.toHaveBeenCalled()
     })
   })
 })

--- a/web-app/src/features/compensations/hooks/useCompensationActions.test.ts
+++ b/web-app/src/features/compensations/hooks/useCompensationActions.test.ts
@@ -4,13 +4,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { CompensationRecord } from '@/api/client'
 import { MODAL_CLEANUP_DELAY } from '@/features/assignments/utils/assignment-helpers'
 import * as authStore from '@/shared/stores/auth'
-import * as settingsStore from '@/shared/stores/settings'
 import { toast } from '@/shared/stores/toast'
 
 import { useCompensationActions } from './useCompensationActions'
 import * as compensationActionsModule from '../utils/compensation-actions'
 
 vi.mock('@/shared/stores/auth')
+// Auto-mock settings store - still needed indirectly by useSafeMutation's internal useSafeModeGuard
 vi.mock('@/shared/stores/settings')
 vi.mock('@/shared/stores/toast', () => ({
   toast: {
@@ -62,13 +62,6 @@ describe('useCompensationActions', () => {
     // Default: not in demo mode
     vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
       selector({ dataSource: 'api' } as ReturnType<typeof authStore.useAuthStore.getState>)
-    )
-
-    // Default: safe mode disabled (allow operations)
-    vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
-      selector({ isSafeModeEnabled: false } as ReturnType<
-        typeof settingsStore.useSettingsStore.getState
-      >)
     )
   })
 
@@ -239,13 +232,6 @@ describe('useCompensationActions', () => {
     })
 
     it('should allow editing compensation in demo mode even with safe mode enabled', () => {
-      // Demo mode bypasses safe mode since changes are local-only
-      vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
-        selector({ isSafeModeEnabled: true } as ReturnType<
-          typeof settingsStore.useSettingsStore.getState
-        >)
-      )
-
       const { result } = renderHook(() => useCompensationActions())
 
       act(() => {
@@ -257,18 +243,6 @@ describe('useCompensationActions', () => {
   })
 
   describe('safe mode guards', () => {
-    beforeEach(() => {
-      // Not in demo mode, safe mode enabled
-      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ dataSource: 'api' } as ReturnType<typeof authStore.useAuthStore.getState>)
-      )
-      vi.mocked(settingsStore.useSettingsStore).mockImplementation((selector) =>
-        selector({ isSafeModeEnabled: true } as ReturnType<
-          typeof settingsStore.useSettingsStore.getState
-        >)
-      )
-    })
-
     it('should allow editing compensation when safe mode is enabled', () => {
       const { result } = renderHook(() => useCompensationActions())
 

--- a/web-app/src/features/compensations/hooks/useCompensationActions.ts
+++ b/web-app/src/features/compensations/hooks/useCompensationActions.ts
@@ -2,9 +2,9 @@ import { useCallback } from 'react'
 
 import type { CompensationRecord } from '@/api/client'
 import { useModalState } from '@/shared/hooks/useModalState'
-import { useSafeModeGuard } from '@/shared/hooks/useSafeModeGuard'
 import { useSafeMutation } from '@/shared/hooks/useSafeMutation'
 import { useTranslation } from '@/shared/hooks/useTranslation'
+import { useAuthStore } from '@/shared/stores/auth'
 import { toast } from '@/shared/stores/toast'
 
 import { downloadCompensationPDF } from '../utils/compensation-actions'
@@ -21,7 +21,7 @@ interface UseCompensationActionsResult {
 
 export function useCompensationActions(): UseCompensationActionsResult {
   const { t } = useTranslation()
-  const { guard, isDemoMode } = useSafeModeGuard()
+  const isDemoMode = useAuthStore((state) => state.dataSource) === 'demo'
   const editCompensationModal = useModalState<CompensationRecord>()
 
   const pdfMutation = useSafeMutation(
@@ -38,18 +38,9 @@ export function useCompensationActions(): UseCompensationActionsResult {
 
   const openEditCompensation = useCallback(
     (compensation: CompensationRecord) => {
-      if (
-        guard({
-          context: 'useCompensationActions',
-          action: 'editing compensation',
-        })
-      ) {
-        return
-      }
-
       editCompensationModal.open(compensation)
     },
-    [guard, editCompensationModal]
+    [editCompensationModal]
   )
 
   const handleGeneratePDF = useCallback(


### PR DESCRIPTION
## Summary

- Removed safe mode guard from `useCompensationActions` that was blocking compensation editing in the compensation tab while the assignment tab allowed it
- Compensation editing should not be blocked by safe mode in either tab
- Updated test to verify compensation editing is allowed when safe mode is enabled

## Test plan

- [ ] Enable safe mode and verify compensation editing works from the compensation tab
- [ ] Enable safe mode and verify compensation editing still works from the assignment tab
- [ ] Verify safe mode still blocks exchange operations (add/take over/remove)
- [ ] Verify demo mode continues to work correctly for compensation editing