### PR TITLE
fix(web,worker): add session token auth to PDF download

### DIFF
--- a/.changeset/fix-pdf-download-auth.md
+++ b/.changeset/fix-pdf-download-auth.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fix compensation PDF download by adding session token authentication headers

--- a/web-app/src/features/compensations/utils/compensation-actions.ts
+++ b/web-app/src/features/compensations/utils/compensation-actions.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react'
 
 import type { Assignment, CompensationRecord } from '@/api/client'
+import { captureSessionToken, getSessionHeaders } from '@/api/client'
 import { isFromCalendarMode } from '@/features/assignments/utils/assignment-helpers'
 import { Wallet, FileText } from '@/shared/components/icons'
 import { type SwipeAction, SWIPE_ACTION_ICON_SIZE } from '@/types/swipe'
@@ -161,7 +162,12 @@ export async function downloadCompensationPDF(compensationId: string): Promise<v
     const response = await fetch(url, {
       method: 'GET',
       credentials: 'include',
+      headers: {
+        ...getSessionHeaders(),
+      },
     })
+
+    captureSessionToken(response)
 
     if (!response.ok) {
       throw new Error(`Failed to download PDF: ${response.statusText}`)

--- a/web-app/src/features/validation/components/RosterVerificationPanel.tsx
+++ b/web-app/src/features/validation/components/RosterVerificationPanel.tsx
@@ -447,7 +447,6 @@ export function RosterVerificationPanel({
           onSelectCoach={handleSelectCoach}
         />
       )}
-
     </div>
   )
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -102,7 +102,7 @@ function corsHeaders(origin: string): HeadersInit {
     // These headers bypass iOS Safari's ITP which blocks third-party cookies in PWA mode
     'Access-Control-Allow-Headers': `Content-Type, Accept, X-Session-Token, ${CAPTURE_SESSION_TOKEN_HEADER}`,
     // Expose X-Session-Token so JavaScript can read the session cookie relay
-    'Access-Control-Expose-Headers': 'X-Session-Token',
+    'Access-Control-Expose-Headers': 'X-Session-Token, Content-Disposition',
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Max-Age': String(CORS_PREFLIGHT_MAX_AGE_SECONDS),
   }


### PR DESCRIPTION
## Summary

- Fix compensation PDF download failing on iOS Safari PWA due to missing `X-Session-Token` authentication header
- Add `getSessionHeaders()` to include session token in PDF download requests, matching the pattern used by all other API calls
- Add `captureSessionToken(response)` to refresh session tokens from PDF download responses
- Expose `Content-Disposition` in CORS proxy `Access-Control-Expose-Headers` so the browser can read the server-provided PDF filename

## Test plan

- [ ] Verify PDF download works on iOS Safari PWA (primary fix — ITP blocks third-party cookies)
- [ ] Verify PDF download still works on desktop browsers (Chrome, Firefox, Safari)
- [ ] Verify downloaded PDF filename matches server-provided name instead of generic "compensation.pdf"
- [ ] Run compensation-actions tests (42 passing)
- [ ] Run worker tests (279 passing)

https://claude.ai/code/session_01PM5w2xPE5NCm8bgPukcjRa