### PR TITLE
fix(web): use localized naming pattern for sports hall report filenames

### DIFF
--- a/.changeset/fix-sports-hall-report-naming.md
+++ b/.changeset/fix-sports-hall-report-naming.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Use localized naming pattern for sports hall report filenames (e.g., nlb_hallenrapport_20260214_123456.pdf)

--- a/web-app/src/shared/utils/pdf-form-filler.test.ts
+++ b/web-app/src/shared/utils/pdf-form-filler.test.ts
@@ -286,32 +286,46 @@ describe('pdf-form-filler', () => {
   })
 
   describe('buildReportFilename', () => {
-    it('builds German NLB filename with date', () => {
+    it('builds German NLB filename with date and game number', () => {
+      expect(buildReportFilename('NLB', 'de', '2026-02-14T19:30:00.000Z', '123456')).toBe(
+        'nlb_hallenrapport_20260214_123456.pdf'
+      )
+    })
+
+    it('builds French NLB filename with date and game number', () => {
+      expect(buildReportFilename('NLB', 'fr', '2026-02-14T19:30:00.000Z', '789')).toBe(
+        'nlb_rapport_salle_20260214_789.pdf'
+      )
+    })
+
+    it('builds German NLA filename with date and game number', () => {
+      expect(buildReportFilename('NLA', 'de', '2025-12-15T19:30:00.000Z', '456')).toBe(
+        'nla_hallenrapport_20251215_456.pdf'
+      )
+    })
+
+    it('builds French NLA filename with date and game number', () => {
+      expect(buildReportFilename('NLA', 'fr', '2025-12-15T19:30:00.000Z', '789')).toBe(
+        'nla_rapport_salle_20251215_789.pdf'
+      )
+    })
+
+    it('uses "unknown" when startingDateTime is undefined', () => {
+      expect(buildReportFilename('NLB', 'de', undefined, '123')).toBe(
+        'nlb_hallenrapport_unknown_123.pdf'
+      )
+    })
+
+    it('omits game number suffix when gameNumber is undefined', () => {
       expect(buildReportFilename('NLB', 'de', '2026-02-14T19:30:00.000Z')).toBe(
         'nlb_hallenrapport_20260214.pdf'
       )
     })
 
-    it('builds French NLB filename with date', () => {
-      expect(buildReportFilename('NLB', 'fr', '2026-02-14T19:30:00.000Z')).toBe(
-        'nlb_rapport_salle_20260214.pdf'
+    it('falls back to "unknown" date for invalid date string', () => {
+      expect(buildReportFilename('NLA', 'de', 'invalid-date', '123')).toBe(
+        'nla_hallenrapport_unknown_123.pdf'
       )
-    })
-
-    it('builds German NLA filename with date', () => {
-      expect(buildReportFilename('NLA', 'de', '2025-12-15T19:30:00.000Z')).toBe(
-        'nla_hallenrapport_20251215.pdf'
-      )
-    })
-
-    it('builds French NLA filename with date', () => {
-      expect(buildReportFilename('NLA', 'fr', '2025-12-15T19:30:00.000Z')).toBe(
-        'nla_rapport_salle_20251215.pdf'
-      )
-    })
-
-    it('uses "unknown" when startingDateTime is undefined', () => {
-      expect(buildReportFilename('NLB', 'de', undefined)).toBe('nlb_hallenrapport_unknown.pdf')
     })
   })
 

--- a/web-app/src/shared/utils/pdf-form-filler.test.ts
+++ b/web-app/src/shared/utils/pdf-form-filler.test.ts
@@ -9,6 +9,7 @@ import {
   mapAppLocaleToPdfLanguage,
   downloadPdf,
   fillSportsHallReportForm,
+  buildReportFilename,
   type SportsHallReportData,
 } from './pdf-form-filler'
 
@@ -99,6 +100,7 @@ describe('pdf-form-filler', () => {
         hallName: 'Sporthalle Hardau',
         location: 'Zürich',
         date: '15.12.25',
+        startingDateTime: '2025-12-15T19:30:00.000Z',
         firstRefereeName: 'Max Mustermann',
         secondRefereeName: 'Anna Schmidt',
       })
@@ -283,6 +285,36 @@ describe('pdf-form-filler', () => {
     })
   })
 
+  describe('buildReportFilename', () => {
+    it('builds German NLB filename with date', () => {
+      expect(buildReportFilename('NLB', 'de', '2026-02-14T19:30:00.000Z')).toBe(
+        'nlb_hallenrapport_20260214.pdf'
+      )
+    })
+
+    it('builds French NLB filename with date', () => {
+      expect(buildReportFilename('NLB', 'fr', '2026-02-14T19:30:00.000Z')).toBe(
+        'nlb_rapport_salle_20260214.pdf'
+      )
+    })
+
+    it('builds German NLA filename with date', () => {
+      expect(buildReportFilename('NLA', 'de', '2025-12-15T19:30:00.000Z')).toBe(
+        'nla_hallenrapport_20251215.pdf'
+      )
+    })
+
+    it('builds French NLA filename with date', () => {
+      expect(buildReportFilename('NLA', 'fr', '2025-12-15T19:30:00.000Z')).toBe(
+        'nla_rapport_salle_20251215.pdf'
+      )
+    })
+
+    it('uses "unknown" when startingDateTime is undefined', () => {
+      expect(buildReportFilename('NLB', 'de', undefined)).toBe('nlb_hallenrapport_unknown.pdf')
+    })
+  })
+
   describe('downloadPdf', () => {
     let mockCreateObjectURL: ReturnType<typeof vi.fn>
     let mockRevokeObjectURL: ReturnType<typeof vi.fn>
@@ -349,6 +381,7 @@ describe('pdf-form-filler', () => {
       hallName: 'Test Hall',
       location: 'Test City',
       date: '15.12.25',
+      startingDateTime: '2025-12-15T19:30:00.000Z',
       firstRefereeName: 'First Ref',
       secondRefereeName: 'Second Ref',
     }

--- a/web-app/src/shared/utils/pdf-form-filler.ts
+++ b/web-app/src/shared/utils/pdf-form-filler.ts
@@ -242,12 +242,21 @@ const REPORT_NAME: Record<Language, string> = {
 export function buildReportFilename(
   leagueCategory: LeagueCategory,
   language: Language,
-  startingDateTime?: string
+  startingDateTime?: string,
+  gameNumber?: string
 ): string {
   const league = leagueCategory.toLowerCase()
   const reportName = REPORT_NAME[language]
-  const datePart = startingDateTime ? format(new Date(startingDateTime), 'yyyyMMdd') : 'unknown'
-  return `${league}_${reportName}_${datePart}.pdf`
+  let datePart = 'unknown'
+  if (startingDateTime) {
+    try {
+      datePart = format(new Date(startingDateTime), 'yyyyMMdd')
+    } catch {
+      logger.warn('Failed to parse date for report filename:', startingDateTime)
+    }
+  }
+  const suffix = gameNumber ? `_${gameNumber}` : ''
+  return `${league}_${reportName}_${datePart}${suffix}.pdf`
 }
 
 export async function generateAndDownloadSportsHallReport(
@@ -256,6 +265,11 @@ export async function generateAndDownloadSportsHallReport(
   language: Language
 ): Promise<void> {
   const pdfBytes = await fillSportsHallReportForm(data, leagueCategory, language)
-  const filename = buildReportFilename(leagueCategory, language, data.startingDateTime)
+  const filename = buildReportFilename(
+    leagueCategory,
+    language,
+    data.startingDateTime,
+    data.gameNumber
+  )
   downloadPdf(pdfBytes, filename)
 }

--- a/web-app/src/shared/utils/pdf-form-filler.ts
+++ b/web-app/src/shared/utils/pdf-form-filler.ts
@@ -22,6 +22,7 @@ export interface SportsHallReportData {
   hallName: string
   location: string
   date: string
+  startingDateTime?: string
   firstRefereeName?: string
   secondRefereeName?: string
 }
@@ -81,6 +82,7 @@ export function extractSportsHallReportData(assignment: Assignment): SportsHallR
     hallName: game.hall?.name ?? '',
     location: game.hall?.primaryPostalAddress?.city ?? '',
     date: formatDateForReport(game.startingDateTime),
+    startingDateTime: game.startingDateTime,
     firstRefereeName: firstReferee,
     secondRefereeName: secondReferee,
   }
@@ -232,12 +234,28 @@ export function downloadPdf(pdfBytes: Uint8Array, filename: string): void {
   URL.revokeObjectURL(url)
 }
 
+const REPORT_NAME: Record<Language, string> = {
+  de: 'hallenrapport',
+  fr: 'rapport_salle',
+}
+
+export function buildReportFilename(
+  leagueCategory: LeagueCategory,
+  language: Language,
+  startingDateTime?: string
+): string {
+  const league = leagueCategory.toLowerCase()
+  const reportName = REPORT_NAME[language]
+  const datePart = startingDateTime ? format(new Date(startingDateTime), 'yyyyMMdd') : 'unknown'
+  return `${league}_${reportName}_${datePart}.pdf`
+}
+
 export async function generateAndDownloadSportsHallReport(
   data: SportsHallReportData,
   leagueCategory: LeagueCategory,
   language: Language
 ): Promise<void> {
   const pdfBytes = await fillSportsHallReportForm(data, leagueCategory, language)
-  const filename = `sports-hall-report-${data.gameNumber}-${language}.pdf`
+  const filename = buildReportFilename(leagueCategory, language, data.startingDateTime)
   downloadPdf(pdfBytes, filename)
 }


### PR DESCRIPTION
## Summary

- Sports hall report filenames now follow the pattern `{league}_{report_name}_{date}_{gameNumber}.pdf`
- German: `nlb_hallenrapport_20260214_123456.pdf`
- French: `nlb_rapport_salle_20260214_123456.pdf`
- Added `buildReportFilename` helper with error handling for invalid dates
- Added `startingDateTime` to `SportsHallReportData` interface
- Includes game number for download uniqueness across same-day games

## Test plan

- [x] 7 unit tests for `buildReportFilename` (NLA/NLB x de/fr, missing date, missing game number, invalid date)
- [x] All 33 tests pass
- [ ] Manual test: generate NLB report in German → filename is `nlb_hallenrapport_YYYYMMDD_NNNNNN.pdf`
- [ ] Manual test: generate NLA report in French → filename is `nla_rapport_salle_YYYYMMDD_NNNNNN.pdf`

https://claude.ai/code/session_018SM7poYM5HYc4z3xByAGu9