### PR TITLE
fix(ci): fix mobile CI generate:api step failing when caches are warm

### DIFF
--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate API types
         if: steps.api-cache.outputs.cache-hit != 'true'
-        run: npx --yes openapi-typescript docs/api/volleymanager-openapi.yaml -o packages/shared/src/api/schema.ts
+        run: npm exec -w web-app -- openapi-typescript ../docs/api/volleymanager-openapi.yaml -o ../packages/shared/src/api/schema.ts
 
   typecheck:
     name: TypeScript Check

--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate API types
         if: steps.api-cache.outputs.cache-hit != 'true'
-        run: npx openapi-typescript docs/api/volleymanager-openapi.yaml -o packages/shared/src/api/schema.ts
+        run: npx --yes openapi-typescript docs/api/volleymanager-openapi.yaml -o packages/shared/src/api/schema.ts
 
   typecheck:
     name: TypeScript Check

--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate API types
         if: steps.api-cache.outputs.cache-hit != 'true'
-        run: npm run generate:api
+        run: npx openapi-typescript docs/api/volleymanager-openapi.yaml -o packages/shared/src/api/schema.ts
 
   typecheck:
     name: TypeScript Check


### PR DESCRIPTION
## Summary

- Fixed `CI Mobile` workflow failing at "Generate API types" step with `openapi-typescript: not found`
- **Root cause:** `setup-node-deps` action (with `working-directory: packages/mobile`) only caches root and `packages/mobile/node_modules`. When caches are warm, `npm ci` is skipped and `web-app/node_modules` (where `openapi-typescript` lives) is never created. Even when `npm ci` does run, `npx` from root cannot resolve binaries in `web-app/node_modules/.bin/`.
- **Fix:** Replaced `npm run generate:api` with `npm exec -w web-app -- openapi-typescript` which uses the `-w` workspace flag to properly resolve the binary from `web-app/node_modules/.bin/`. Only generates the shared schema (`packages/shared/src/api/schema.ts`) that mobile CI actually needs.

## Test plan

- [x] Verify CI Mobile workflow passes on this PR
- [x] Confirm `packages/shared/src/api/schema.ts` is correctly generated

https://claude.ai/code/session_016Rn9MgH6g8mSG6Mida3ay6