### PR TITLE
fix(web): fix scoresheet API 500 error on iOS Safari PWA

### DIFF
--- a/.changeset/fix-scoresheet-api-error.md
+++ b/.changeset/fix-scoresheet-api-error.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fix scoresheet API 500 error by explicitly serializing request body to string and sending complete field set matching the real volleymanager site format

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -158,7 +158,10 @@ async function apiRequest<T>(
     method,
     headers,
     credentials: 'include',
-    body: method !== 'GET' && body ? buildFormData(body) : undefined,
+    // Explicitly convert URLSearchParams to string to ensure correct serialization
+    // on iOS Safari PWA where passing URLSearchParams with a non-default Content-Type
+    // (e.g. text/plain) may result in an empty or malformed request body.
+    body: method !== 'GET' && body ? buildFormData(body).toString() : undefined,
   })
 
   // Capture session token from response headers (iOS Safari PWA)
@@ -659,19 +662,38 @@ export const api = {
     isSimpleScoresheet: boolean = false,
     fileResourceId?: string
   ): Promise<Scoresheet> {
+    // Build body matching the real volleymanager site format.
+    // Empty string values for unset fields are required by the TYPO3 Neos/Flow backend;
+    // omitting them causes 500 errors during property mapping.
     const body: Record<string, unknown> = {
       'scoresheet[game][__identity]': gameId,
-      'scoresheet[writerPerson][__identity]': scorerPersonId,
       'scoresheet[isSimpleScoresheet]': isSimpleScoresheet ? 'true' : 'false',
       'scoresheet[hasFile]': fileResourceId ? 'true' : 'false',
+      'scoresheet[closedAt]': '',
+      'scoresheet[closedBy]': '',
+      'scoresheet[emergencySubstituteReferees]': '',
+      'scoresheet[notFoundButNominatedPersons]': '',
+      'scoresheet[lastUpdatedByRealUser]': 'true',
     }
 
+    // scoresheet[__identity] may be undefined for games where the scoresheet
+    // entity hasn't been created yet. The server resolves it from the game identity.
     if (scoresheetId) {
       body['scoresheet[__identity]'] = scoresheetId
     }
 
+    // writerPerson: send [__identity] when set, plain empty field when not set
+    if (scorerPersonId) {
+      body['scoresheet[writerPerson][__identity]'] = scorerPersonId
+    } else {
+      body['scoresheet[writerPerson]'] = ''
+    }
+
+    // file: send [__identity] when set, plain empty field when not set
     if (fileResourceId) {
       body['scoresheet[file][__identity]'] = fileResourceId
+    } else {
+      body['scoresheet[file]'] = ''
     }
 
     return apiRequest<Scoresheet>(

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -678,7 +678,7 @@ export const mockApi = {
   },
 
   async updateScoresheet(
-    scoresheetId: string,
+    scoresheetId: string | undefined,
     gameId: string,
     scorerPersonId: string,
     isSimpleScoresheet: boolean = false
@@ -702,7 +702,7 @@ export const mockApi = {
 
     // In demo mode, return a mock updated scoresheet
     return {
-      __identity: scoresheetId,
+      __identity: scoresheetId ?? `scoresheet-${gameId}`,
       game: { __identity: gameId },
       writerPerson: { __identity: scorerPersonId },
       isSimpleScoresheet,
@@ -711,7 +711,7 @@ export const mockApi = {
   },
 
   async finalizeScoresheet(
-    scoresheetId: string,
+    scoresheetId: string | undefined,
     gameId: string,
     scorerPersonId: string,
     fileResourceId?: string,
@@ -743,7 +743,7 @@ export const mockApi = {
 
     // In demo mode, return a mock finalized scoresheet
     return {
-      __identity: scoresheetId,
+      __identity: scoresheetId ?? `scoresheet-${gameId}`,
       game: { __identity: gameId },
       writerPerson: { __identity: scorerPersonId },
       isSimpleScoresheet,

--- a/web-app/src/features/validation/api/api-helpers.ts
+++ b/web-app/src/features/validation/api/api-helpers.ts
@@ -167,7 +167,7 @@ export async function saveScorerSelection(
     return
   }
 
-  // scoresheet.__identity may be undefined for NLB/NLA games where the scoresheet
+  // scoresheet.__identity may be undefined for games where the scoresheet
   // entity hasn't been created yet. The server resolves it from the game identity.
   await apiClient.updateScoresheet(
     scoresheet?.__identity,
@@ -225,7 +225,7 @@ export async function finalizeScoresheetWithFile(
     return
   }
 
-  // scoresheet.__identity may be undefined for NLB/NLA games where the scoresheet
+  // scoresheet.__identity may be undefined for games where the scoresheet
   // entity hasn't been created yet. The server resolves it from the game identity.
   await apiClient.finalizeScoresheet(
     scoresheet?.__identity,


### PR DESCRIPTION
## Summary

- Fix empty request body on iOS Safari PWA by explicitly calling `.toString()` on `URLSearchParams` before passing to `fetch()`
- Send complete field set in scoresheet PUT body matching the real volleymanager site format (empty string values for unset fields required by TYPO3 Neos/Flow property mapping)
- Allow scoresheet creation when `scoresheet[__identity]` is undefined (server resolves from game identity)

## Test plan

- [ ] Test on iOS Safari PWA: select scorer + upload scoresheet file → Save should not return 500
- [ ] Test on game without existing scoresheet entity → PUT should create scoresheet
- [ ] Test on game with existing scoresheet → PUT should update as before
- [ ] Verify demo mode still works correctly

https://claude.ai/code/session_01XyWS1i3V8apgW5BTfJ9Cip