### PR TITLE
fix(web): fix OCR manuscript roster detection for sequential tab-separated format

### DIFF
--- a/.changeset/fix-ocr-manuscript-roster-detection.md
+++ b/.changeset/fix-ocr-manuscript-roster-detection.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fix manuscript scoresheet OCR roster detection failing to parse sequential tab-separated format

--- a/web-app/src/features/ocr/types.ts
+++ b/web-app/src/features/ocr/types.ts
@@ -92,8 +92,9 @@ export interface OCREngine {
  * - C: Head Coach
  * - AC, AC2, AC3, AC4: Assistant Coaches
  * - M: Medical Staff (Doctor)
+ * - P: Physiotherapist
  */
-export type OfficialRole = 'C' | 'AC' | 'AC2' | 'AC3' | 'AC4' | 'M'
+export type OfficialRole = 'C' | 'AC' | 'AC2' | 'AC3' | 'AC4' | 'M' | 'P'
 
 /**
  * A player parsed from OCR text

--- a/web-app/src/features/ocr/utils/manuscript-parser.test.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.test.ts
@@ -356,6 +356,21 @@ S. AngeliL. CollierO. Follouier`
 2 WEBER MARIE`
       expect(isSwissTabularFormat(text)).toBe(false)
     })
+
+    it('returns false for sequential tab-separated format with Swiss headers', () => {
+      // This format has Swiss headers and tabs but is sequential (one team per line),
+      // NOT two-column tabular (both teams per line)
+      const text = `Mannschaften/Equipes/Squadre
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+16.05.07\t5\tJ. Klocke
+31.07.07\t2\tN. Christen
+30.07.07\t11\tN. Walser
+LIBEROS («L»)
+13.06.04\t1\tC. Tsang
+Offizielle/Officiels/Ufficiali
+11.08.65\tC\tD. Heynen`
+      expect(isSwissTabularFormat(text)).toBe(false)
+    })
   })
 })
 
@@ -603,6 +618,156 @@ LIBEROS («L»)\tLIBEROS («L»)
 
     const teamBLibero = result.teamB.players.find((p) => p.rawName.includes('Candido'))
     expect(teamBLibero?.birthDate).toBe('10.6.92')
+  })
+})
+
+describe('parseManuscriptSheet with sequential tab-separated format', () => {
+  it('parses VBC Votero Zürich vs Volley Oerlikon scoresheet', () => {
+    // Real OCR output from a manuscript scoresheet scanned sequentially
+    // (left column = Team A, then right column = Team B)
+    const ocrText = `Mannschaften/Equipes/Squadre
+A oder/ou/o B
+A oder/ou/o B
+
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+16.05.07\t5\tJ. Klocke
+31.07.07\t2\tN. Christen
+30.07.07\t11\tN. Walser
+06.04.07\t8\tA. Heinzer
+31.05.07\t6\tI. Pautelić
+25.11.03\t9\tN. Dankelschlep
+10.04.03\t13\tG. Taggin
+16.06.08\t15\tK. Hamnata
+13.06.04\t1\tC. Tsang
+27.01.04\t2\tA. Nuri
+28.03.03\t7\tN. Nausson
+
+LIBEROS («L»)
+
+13.06.04\t1\tC. Tsang
+
+Offizielle/Officiels/Ufficiali
+
+11.08.65\tC\tD. Heynen
+AC1
+AC2
+18.04.05\tP\tN. Fabry
+03.10.08\tM\tY. Zeitov
+
+Unterschrift/Signature/Firma
+
+KapitänCapitaineCapitano
+
+Trainer
+
+EntraineurAllenatore
+
+Volley Oerlikon
+
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+01.10.95\t5\tG. Papadopoulos
+24.02.03\t4\tN. von Loesch
+18.05.96\t8\tI. Kellenberger
+16.09.92\t14\tO. Hartes
+07.08.96\t10\tS. Ward
+26.05.92\t6\tA. Bratschi
+30.07.96\t167\tN. Jegu
+29.10.85\t15\tJ. Risso Gertrude
+24.11.06\t3\tL. Huthäfer
+14.07.06\t11\tL. Zach
+07.04.\tH. Birrer
+
+LIBEROS («L»)
+
+00.07.96\t16\tN. Segu
+29.10.85\t15\tJ. Risso Gertrude
+
+Offizielle/Officiels/Ufficiali
+
+07.04.91\tC\tN. Birrer
+AC1
+AC2
+21.03.97\tP\tN. Chinellato
+M\tY. Zeitler
+
+Unterschrift/Signature/Firma
+
+KapitänCapitaineCapitano
+
+Trainer
+
+EntraineurAllenatore`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // Team A (first column - VBC Votero Zürich)
+    expect(result.teamA.players.length).toBeGreaterThanOrEqual(11)
+
+    // Check specific Team A players
+    const klocke = result.teamA.players.find((p) => p.rawName.includes('Klocke'))
+    expect(klocke).toBeDefined()
+    expect(klocke!.shirtNumber).toBe(5)
+
+    const tsang = result.teamA.players.find((p) => p.rawName.includes('Tsang'))
+    expect(tsang).toBeDefined()
+    expect(tsang!.shirtNumber).toBe(1)
+
+    // Team A officials
+    expect(result.teamA.officials.length).toBeGreaterThanOrEqual(2)
+    const coachA = result.teamA.officials.find((o) => o.role === 'C')
+    expect(coachA).toBeDefined()
+    expect(coachA!.rawName).toContain('Heynen')
+
+    // Team B (second column - Volley Oerlikon)
+    expect(result.teamB.name).toContain('Volley Oerlikon')
+    expect(result.teamB.players.length).toBeGreaterThanOrEqual(10)
+
+    // Check specific Team B players
+    const papadopoulos = result.teamB.players.find((p) => p.rawName.includes('Papadopoulos'))
+    expect(papadopoulos).toBeDefined()
+    expect(papadopoulos!.shirtNumber).toBe(5)
+
+    const ward = result.teamB.players.find((p) => p.rawName.includes('Ward'))
+    expect(ward).toBeDefined()
+    expect(ward!.shirtNumber).toBe(10)
+
+    // Team B officials
+    expect(result.teamB.officials.length).toBeGreaterThanOrEqual(2)
+    const coachB = result.teamB.officials.find((o) => o.role === 'C')
+    expect(coachB).toBeDefined()
+    expect(coachB!.rawName).toContain('Birrer')
+  })
+
+  it('handles tab-separated player lines with birth dates', () => {
+    const ocrText = `Team A VBC Test
+16.05.07\t5\tJ. Klocke
+31.07.07\t2\tN. Christen`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    expect(result.teamA.players).toHaveLength(2)
+    expect(result.teamA.players[0]!.shirtNumber).toBe(5)
+    expect(result.teamA.players[0]!.rawName).toBe('J. Klocke')
+    expect(result.teamA.players[0]!.birthDate).toBe('16.05.07')
+    expect(result.teamA.players[1]!.shirtNumber).toBe(2)
+  })
+
+  it('handles tab-separated officials with birth dates', () => {
+    const ocrText = `Team A VBC Test
+1 MÜLLER ANNA
+Offizielle/Officiels/Ufficiali
+11.08.65\tC\tD. Heynen
+18.04.05\tP\tN. Fabry
+M\tY. Zeitov`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    expect(result.teamA.officials.length).toBeGreaterThanOrEqual(3)
+    expect(result.teamA.officials[0]!.role).toBe('C')
+    expect(result.teamA.officials[0]!.rawName).toContain('Heynen')
+    const physio = result.teamA.officials.find((o) => o.role === 'P')
+    expect(physio).toBeDefined()
+    expect(physio!.rawName).toContain('Fabry')
   })
 })
 

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -40,8 +40,11 @@ const MIN_TEAM_NAME_LENGTH = 3
 /** Minimum ratio of letters in team name */
 const MIN_LETTER_RATIO = 0.6
 
-/** Valid official roles */
-const VALID_ROLES = new Set(['C', 'AC', 'AC2', 'AC3', 'AC4', 'M'])
+/** Maximum tab-separated parts per line in sequential format (date, number, name) */
+const MAX_SEQUENTIAL_PARTS_PER_LINE = 3
+
+/** Valid official roles (C=Coach, AC=Assistant Coach, M=Medical, P=Physiotherapist) */
+const VALID_ROLES = new Set(['C', 'AC', 'AC2', 'AC3', 'AC4', 'M', 'P'])
 
 // =============================================================================
 // OCR Error Correction Maps
@@ -316,7 +319,7 @@ export function isSwissTabularFormat(ocrText: string): boolean {
       const median = sorted[Math.floor(sorted.length / 2)]!
       // Sequential format typically has ≤3 parts per line (date, number, name)
       // Swiss tabular has 4+ parts (data for both teams)
-      if (median <= 3) return false
+      if (median <= MAX_SEQUENTIAL_PARTS_PER_LINE) return false
     }
   }
 
@@ -615,7 +618,8 @@ const MAX_ROW_NUMBER = 14
 const MIN_LIBERO_LINE_PARTS = 3
 
 /** Date pattern for DD.MM.YY or DD.MM.YYYY format */
-const DATE_PATTERN = /^\d{1,2}\.\d{1,2}\.\d{2,4}$/
+/** Date pattern - DD.MM.YY(YY) or incomplete OCR dates like DD.MM. (trailing dot, no year) */
+const DATE_PATTERN = /^\d{1,2}\.\d{1,2}\.\d{0,4}$/
 
 /** Name pattern - starts with a letter */
 const NAME_START_PATTERN = /^[A-Za-zÀ-ÿ]/
@@ -1141,9 +1145,6 @@ function tryExtractPlayer(line: string): ParsedPlayer | null {
   }
 }
 
-/** Valid official roles including P (physiotherapist) */
-const VALID_ROLES_EXTENDED = new Set([...VALID_ROLES, 'P'])
-
 /**
  * Try to extract an official from a tab-separated line with format: date\trole\tname
  * or role\tname (without date)
@@ -1168,7 +1169,7 @@ function tryExtractOfficialFromTabs(line: string): ParsedOfficial | null {
   // Next should be role
   if (currentIndex >= parts.length) return null
   const role = parts[currentIndex]!.toUpperCase()
-  if (!VALID_ROLES_EXTENDED.has(role)) return null
+  if (!VALID_ROLES.has(role)) return null
   currentIndex++
 
   // Next should be name
@@ -1223,20 +1224,21 @@ function tryExtractOfficial(line: string): ParsedOfficial | null {
 // =============================================================================
 
 /**
- * Check if a line is a Swiss form label that should be skipped
- * (e.g., "Mannschaften/Equipes/Squadre", "A oder/ou/o B")
+ * Check if a line is a Swiss form label or data header that should be skipped.
+ * Covers multilingual form labels ("Mannschaften/Equipes/Squadre", "A oder/ou/o B")
+ * and data header rows ("Lizenz-Nr.Licence-No.Licenza-No.").
  */
-function isSwissFormLabel(line: string): boolean {
+function isSwissFormLabelOrHeader(line: string): boolean {
   const upper = line.toUpperCase()
   return (
-    /MANNSCHAFT.*EQUIPE.*SQUADR/i.test(line) ||
-    /A\s*ODER\/OU\/O\s*B/i.test(line) ||
-    /ODER\/OU\/O/i.test(line) ||
     upper.includes('LIZENZ-NR') ||
     upper.includes('LICENCE-NO') ||
     upper.includes('LICENZA-NO') ||
+    upper.includes('ODER/OU/O') ||
+    /MANNSCHAFT.*EQUIPE.*SQUADR/i.test(line) ||
     /SPIELER.*JOUEUR.*GIOCATORE/i.test(line) ||
-    /NAME.*NOM.*NOME/i.test(line)
+    /NAME.*NOM.*NOME/i.test(line) ||
+    isSwissDataHeader(line)
   )
 }
 
@@ -1262,8 +1264,7 @@ function extractTeamName(line: string): string | null {
   if (isEndMarker(trimmed)) return null
 
   // Skip Swiss form labels and data headers
-  if (isSwissFormLabel(trimmed)) return null
-  if (isSwissDataHeader(trimmed)) return null
+  if (isSwissFormLabelOrHeader(trimmed)) return null
 
   // Check if it looks like a team name (mostly letters, maybe some spaces/hyphens)
   const letterCount = (trimmed.match(/[A-Za-zÀ-ÿ]/g) ?? []).length
@@ -1340,6 +1341,99 @@ function processTeamMarker(
   return null
 }
 
+/** Mutable state for the team section splitter */
+interface SplitterState {
+  currentTeam: 'A' | 'B' | null
+  teamASectionFound: boolean
+  seenEndMarkerInTeamA: boolean
+  teamAHasContent: boolean
+}
+
+/**
+ * Check if a line looks like team content (player data or section marker)
+ */
+function looksLikeTeamContent(line: string): boolean {
+  return (
+    tryExtractPlayer(line) !== null ||
+    tryExtractOfficial(line) !== null ||
+    isLiberoMarker(line) ||
+    isOfficialsMarker(line)
+  )
+}
+
+/**
+ * Try to detect a team B transition after Team A's end markers.
+ * Returns: 'switch-b' to switch to Team B, 'switch-b-keep' to switch AND process line,
+ * 'skip' to skip noise, or null if this handler doesn't apply.
+ */
+function tryDetectTeamBTransition(
+  trimmed: string,
+  state: SplitterState,
+  result: TeamSections
+): 'switch-b' | 'switch-b-keep' | 'skip' | null {
+  if (!state.seenEndMarkerInTeamA || state.currentTeam !== 'A') return null
+
+  const teamName = extractTeamName(trimmed)
+  if (teamName) {
+    result.teamBName = teamName
+    state.currentTeam = 'B'
+    return 'switch-b'
+  }
+
+  if (looksLikeTeamContent(trimmed)) {
+    state.currentTeam = 'B'
+    return 'switch-b-keep'
+  }
+
+  return 'skip'
+}
+
+/**
+ * Process a team section marker line.
+ * Returns true if the line was consumed (should continue to next line).
+ */
+function handleTeamSectionMarker(
+  trimmed: string,
+  state: SplitterState,
+  result: TeamSections
+): boolean {
+  if (!isTeamSectionMarker(trimmed)) return false
+  const markerResult = processTeamMarker(trimmed, result)
+  if (!markerResult) return false
+  state.currentTeam = markerResult.team
+  if (markerResult.isTeamA) state.teamASectionFound = true
+  return true
+}
+
+/**
+ * Process an end marker line (signature, trainer, captain).
+ * Returns true if the line was consumed.
+ */
+function handleEndMarker(trimmed: string, state: SplitterState): boolean {
+  if (!isEndMarker(trimmed)) return false
+  if (state.currentTeam === 'A' && state.teamAHasContent) {
+    state.seenEndMarkerInTeamA = true
+  }
+  return true
+}
+
+/**
+ * Try to detect Team A's name from a line when no explicit section was found.
+ * Returns true if the line was consumed as a team name.
+ */
+function handleTeamANameDetection(
+  trimmed: string,
+  state: SplitterState,
+  result: TeamSections
+): boolean {
+  if (state.teamASectionFound || result.teamAName) return false
+  const teamName = extractTeamName(trimmed)
+  if (!teamName) return false
+  result.teamAName = teamName
+  state.currentTeam = 'A'
+  return true
+}
+
 function splitIntoTeamSections(lines: string[]): TeamSections {
   const result: TeamSections = {
     teamALines: [],
@@ -1348,86 +1442,30 @@ function splitIntoTeamSections(lines: string[]): TeamSections {
     teamBName: '',
   }
 
-  let currentTeam: 'A' | 'B' | null = null
-  let teamASectionFound = false
-  /** Set to true after we see a signature/trainer end marker while in Team A */
-  let seenEndMarkerInTeamA = false
-  /** Track if Team A has had any content (players/officials) */
-  let teamAHasContent = false
+  const state: SplitterState = {
+    currentTeam: null,
+    teamASectionFound: false,
+    seenEndMarkerInTeamA: false,
+    teamAHasContent: false,
+  }
 
   for (const line of lines) {
     const trimmed = line.trim()
-    if (!trimmed) continue
-
-    // Skip Swiss form labels (e.g., "Mannschaften/Equipes/Squadre", "A oder/ou/o B")
-    if (isSwissFormLabel(trimmed)) continue
-
-    // Skip Swiss data headers (e.g., "Lizenz-Nr.Licence-No.Licenza-No.\t...")
-    if (isSwissDataHeader(trimmed)) continue
-
-    // Check for explicit team section markers (TEAM A, TEAM B, etc.)
-    if (isTeamSectionMarker(trimmed)) {
-      const markerResult = processTeamMarker(trimmed, result)
-      if (markerResult) {
-        currentTeam = markerResult.team
-        if (markerResult.isTeamA) teamASectionFound = true
-        continue
-      }
-    }
-
-    // Detect end markers (signature, trainer, captain) as team boundary
-    if (isEndMarker(trimmed)) {
-      if (currentTeam === 'A' && teamAHasContent) {
-        seenEndMarkerInTeamA = true
-      }
-      // Don't add end marker lines to either team
-      continue
-    }
+    if (!trimmed || isSwissFormLabelOrHeader(trimmed)) continue
+    if (handleTeamSectionMarker(trimmed, state, result)) continue
+    if (handleEndMarker(trimmed, state)) continue
 
     // After seeing end markers in Team A, look for Team B start
-    if (seenEndMarkerInTeamA && currentTeam === 'A') {
-      // Check if this line starts new team content (team name or player data)
-      const teamName = extractTeamName(trimmed)
-      if (teamName) {
-        result.teamBName = teamName
-        currentTeam = 'B'
-        continue
-      }
+    const transition = tryDetectTeamBTransition(trimmed, state, result)
+    if (transition === 'switch-b' || transition === 'skip') continue
 
-      // If we see player-like data or a section marker, it's Team B
-      const looksLikePlayerData =
-        tryExtractPlayer(trimmed) !== null || tryExtractOfficial(trimmed) !== null
-      if (looksLikePlayerData || isLiberoMarker(trimmed) || isOfficialsMarker(trimmed)) {
-        currentTeam = 'B'
-        // Don't continue - let the line be processed below
-      } else {
-        // Skip inter-team noise (empty roles like "AC1", signatures, etc.)
-        continue
-      }
-    }
+    if (handleTeamANameDetection(trimmed, state, result)) continue
 
-    // If we haven't found explicit team sections, try to detect team name
-    if (!teamASectionFound && !result.teamAName) {
-      const teamName = extractTeamName(trimmed)
-      if (teamName) {
-        result.teamAName = teamName
-        currentTeam = 'A'
-        continue
-      }
-    }
-
-    // Default to team A if no team is set
-    if (currentTeam === null) {
-      currentTeam = 'A'
-    }
-
-    // Track that Team A has received content
-    if (currentTeam === 'A') {
-      teamAHasContent = true
-    }
+    if (state.currentTeam === null) state.currentTeam = 'A'
+    if (state.currentTeam === 'A') state.teamAHasContent = true
 
     // Add line to current team
-    if (currentTeam === 'A') {
+    if (state.currentTeam === 'A') {
       result.teamALines.push(trimmed)
     } else {
       result.teamBLines.push(trimmed)

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -276,6 +276,10 @@ function isNoiseLine(line: string): boolean {
 
 /**
  * Detect if the OCR text appears to be from a Swiss tabular manuscript format
+ * (two-column layout with both teams side-by-side).
+ *
+ * Distinguishes from sequential format (Team A section followed by Team B section)
+ * which may also have Swiss headers and tabs but with fewer parts per line.
  */
 export function isSwissTabularFormat(ocrText: string): boolean {
   const lines = ocrText.split('\n')
@@ -292,7 +296,31 @@ export function isSwissTabularFormat(ocrText: string): boolean {
   // Check for concatenated names pattern (e.g., "S. AngeliL. Collier")
   const hasConcatenatedNames = /[A-Z]\.\s*[A-Za-zÀ-ÿ]+[A-Z]\.\s*[A-Za-zÀ-ÿ]+/.test(ocrText)
 
-  return hasSwissHeaders && (hasTabularStructure || hasConcatenatedNames)
+  if (!hasSwissHeaders) return false
+  if (!hasTabularStructure && !hasConcatenatedNames) return false
+
+  // Distinguish from sequential tab-separated format:
+  // Swiss tabular lines contain data for BOTH teams (4+ parts per line),
+  // while sequential format has data for ONE team per line (2-3 parts).
+  // Only apply this check when there are enough non-header data lines to be conclusive.
+  if (hasTabularStructure && !hasConcatenatedNames) {
+    const minDataLinesForCheck = 3
+    const dataLineParts = tabSeparatedLines
+      .filter((line) => !SWISS_HEADER_PATTERNS.some((p) => p.test(line)))
+      .map((line) => line.split('\t').filter((p) => p.trim().length > 0).length)
+      .filter((count) => count > 0)
+
+    if (dataLineParts.length >= minDataLinesForCheck) {
+      // Sort and find median
+      const sorted = [...dataLineParts].sort((a, b) => a - b)
+      const median = sorted[Math.floor(sorted.length / 2)]!
+      // Sequential format typically has ≤3 parts per line (date, number, name)
+      // Swiss tabular has 4+ parts (data for both teams)
+      if (median <= 3) return false
+    }
+  }
+
+  return true
 }
 
 // =============================================================================
@@ -993,22 +1021,96 @@ function isOfficialsMarker(line: string): boolean {
 }
 
 /**
- * Check if a line indicates end of player data
+ * Check if a line indicates end of player data (signature/captain/trainer section)
  */
 function isEndMarker(line: string): boolean {
   const upper = line.toUpperCase()
   return (
     upper.includes('SIGNATURE') ||
+    upper.includes('UNTERSCHRIFT') ||
     upper.includes('CAPTAIN') ||
+    upper.includes('KAPITÄN') ||
+    upper.includes('CAPITAINE') ||
+    upper.includes('CAPITANO') ||
     upper.includes('REFEREE') ||
-    upper.includes('ARBITRE')
+    upper.includes('ARBITRE') ||
+    /^TRAINER\b/i.test(line) ||
+    upper.includes('ENTRAÎNEUR') ||
+    upper.includes('ENTRAINEUR') ||
+    upper.includes('ALLENATORE')
   )
+}
+
+/**
+ * Check if a line is a Swiss multilingual header row (license/player/name headers).
+ * These repeat at the start of each team section in sequential format.
+ */
+function isSwissDataHeader(line: string): boolean {
+  return SWISS_HEADER_PATTERNS.some((pattern) => pattern.test(line))
+}
+
+/**
+ * Try to extract a player from a tab-separated line with format: date\tnumber\tname
+ * This format is common in Swiss sequential manuscript scoresheets.
+ */
+function tryExtractPlayerFromTabs(line: string): ParsedPlayer | null {
+  if (!line.includes('\t')) return null
+
+  const parts = line
+    .split('\t')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  if (parts.length < 2) return null
+
+  let birthDate: string | undefined
+  let jerseyNumber: number | null = null
+  let name = ''
+  let currentIndex = 0
+
+  // First part might be a date (DD.MM.YY or DD.MM.YYYY)
+  if (currentIndex < parts.length && DATE_PATTERN.test(parts[currentIndex]!)) {
+    birthDate = parts[currentIndex]!
+    currentIndex++
+  }
+
+  // Next should be jersey number
+  if (currentIndex < parts.length && JERSEY_NUMBER_PATTERN.test(parts[currentIndex]!)) {
+    const num = parseInt(parts[currentIndex]!, 10)
+    if (num >= 1 && num <= MAX_SHIRT_NUMBER) {
+      jerseyNumber = num
+      currentIndex++
+    }
+  }
+
+  // Next should be name
+  if (currentIndex < parts.length && NAME_START_PATTERN.test(parts[currentIndex]!)) {
+    name = parts[currentIndex]!
+  }
+
+  if (!name || name.length < MIN_NAME_LENGTH) return null
+
+  const parsed = parsePlayerName(name)
+
+  return {
+    shirtNumber: jerseyNumber,
+    lastName: parsed.lastName,
+    firstName: parsed.firstName,
+    displayName: parsed.displayName,
+    rawName: name,
+    licenseStatus: '',
+    birthDate,
+  }
 }
 
 /**
  * Try to extract a player from a line
  */
 function tryExtractPlayer(line: string): ParsedPlayer | null {
+  // Try tab-separated format first (date\tnumber\tname)
+  const tabPlayer = tryExtractPlayerFromTabs(line)
+  if (tabPlayer) return tabPlayer
+
   // Try strict pattern first
   let match = PLAYER_LINE_PATTERN.exec(line)
   if (!match) {
@@ -1039,10 +1141,60 @@ function tryExtractPlayer(line: string): ParsedPlayer | null {
   }
 }
 
+/** Valid official roles including P (physiotherapist) */
+const VALID_ROLES_EXTENDED = new Set([...VALID_ROLES, 'P'])
+
+/**
+ * Try to extract an official from a tab-separated line with format: date\trole\tname
+ * or role\tname (without date)
+ */
+function tryExtractOfficialFromTabs(line: string): ParsedOfficial | null {
+  if (!line.includes('\t')) return null
+
+  const parts = line
+    .split('\t')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+
+  if (parts.length < 2) return null
+
+  let currentIndex = 0
+
+  // First part might be a date - skip it
+  if (currentIndex < parts.length && DATE_PATTERN.test(parts[currentIndex]!)) {
+    currentIndex++
+  }
+
+  // Next should be role
+  if (currentIndex >= parts.length) return null
+  const role = parts[currentIndex]!.toUpperCase()
+  if (!VALID_ROLES_EXTENDED.has(role)) return null
+  currentIndex++
+
+  // Next should be name
+  if (currentIndex >= parts.length) return null
+  const nameStr = parts[currentIndex]!
+  if (!NAME_START_PATTERN.test(nameStr) || nameStr.length < MIN_NAME_LENGTH) return null
+
+  const parsed = parseOfficialName(nameStr)
+
+  return {
+    role: role as OfficialRole,
+    lastName: parsed.lastName,
+    firstName: parsed.firstName,
+    displayName: parsed.displayName,
+    rawName: nameStr,
+  }
+}
+
 /**
  * Try to extract an official from a line
  */
 function tryExtractOfficial(line: string): ParsedOfficial | null {
+  // Try tab-separated format first (date\trole\tname or role\tname)
+  const tabOfficial = tryExtractOfficialFromTabs(line)
+  if (tabOfficial) return tabOfficial
+
   const match = OFFICIAL_LINE_PATTERN.exec(line)
   if (!match) return null
 
@@ -1071,6 +1223,24 @@ function tryExtractOfficial(line: string): ParsedOfficial | null {
 // =============================================================================
 
 /**
+ * Check if a line is a Swiss form label that should be skipped
+ * (e.g., "Mannschaften/Equipes/Squadre", "A oder/ou/o B")
+ */
+function isSwissFormLabel(line: string): boolean {
+  const upper = line.toUpperCase()
+  return (
+    /MANNSCHAFT.*EQUIPE.*SQUADR/i.test(line) ||
+    /A\s*ODER\/OU\/O\s*B/i.test(line) ||
+    /ODER\/OU\/O/i.test(line) ||
+    upper.includes('LIZENZ-NR') ||
+    upper.includes('LICENCE-NO') ||
+    upper.includes('LICENZA-NO') ||
+    /SPIELER.*JOUEUR.*GIOCATORE/i.test(line) ||
+    /NAME.*NOM.*NOME/i.test(line)
+  )
+}
+
+/**
  * Try to extract team name from a line
  */
 function extractTeamName(line: string): string | null {
@@ -1083,10 +1253,17 @@ function extractTeamName(line: string): string | null {
   if (PLAYER_LINE_PATTERN.test(trimmed)) return null
   if (PLAYER_LINE_LENIENT.test(trimmed)) return null
 
+  // Skip tab-separated player data (date\tnumber\tname)
+  if (trimmed.includes('\t') && DATE_PATTERN.test(trimmed.split('\t')[0]!.trim())) return null
+
   // Skip section markers
   if (isLiberoMarker(trimmed)) return null
   if (isOfficialsMarker(trimmed)) return null
   if (isEndMarker(trimmed)) return null
+
+  // Skip Swiss form labels and data headers
+  if (isSwissFormLabel(trimmed)) return null
+  if (isSwissDataHeader(trimmed)) return null
 
   // Check if it looks like a team name (mostly letters, maybe some spaces/hyphens)
   const letterCount = (trimmed.match(/[A-Za-zÀ-ÿ]/g) ?? []).length
@@ -1173,17 +1350,58 @@ function splitIntoTeamSections(lines: string[]): TeamSections {
 
   let currentTeam: 'A' | 'B' | null = null
   let teamASectionFound = false
+  /** Set to true after we see a signature/trainer end marker while in Team A */
+  let seenEndMarkerInTeamA = false
+  /** Track if Team A has had any content (players/officials) */
+  let teamAHasContent = false
 
   for (const line of lines) {
     const trimmed = line.trim()
     if (!trimmed) continue
 
-    // Check for team section markers
+    // Skip Swiss form labels (e.g., "Mannschaften/Equipes/Squadre", "A oder/ou/o B")
+    if (isSwissFormLabel(trimmed)) continue
+
+    // Skip Swiss data headers (e.g., "Lizenz-Nr.Licence-No.Licenza-No.\t...")
+    if (isSwissDataHeader(trimmed)) continue
+
+    // Check for explicit team section markers (TEAM A, TEAM B, etc.)
     if (isTeamSectionMarker(trimmed)) {
       const markerResult = processTeamMarker(trimmed, result)
       if (markerResult) {
         currentTeam = markerResult.team
         if (markerResult.isTeamA) teamASectionFound = true
+        continue
+      }
+    }
+
+    // Detect end markers (signature, trainer, captain) as team boundary
+    if (isEndMarker(trimmed)) {
+      if (currentTeam === 'A' && teamAHasContent) {
+        seenEndMarkerInTeamA = true
+      }
+      // Don't add end marker lines to either team
+      continue
+    }
+
+    // After seeing end markers in Team A, look for Team B start
+    if (seenEndMarkerInTeamA && currentTeam === 'A') {
+      // Check if this line starts new team content (team name or player data)
+      const teamName = extractTeamName(trimmed)
+      if (teamName) {
+        result.teamBName = teamName
+        currentTeam = 'B'
+        continue
+      }
+
+      // If we see player-like data or a section marker, it's Team B
+      const looksLikePlayerData =
+        tryExtractPlayer(trimmed) !== null || tryExtractOfficial(trimmed) !== null
+      if (looksLikePlayerData || isLiberoMarker(trimmed) || isOfficialsMarker(trimmed)) {
+        currentTeam = 'B'
+        // Don't continue - let the line be processed below
+      } else {
+        // Skip inter-team noise (empty roles like "AC1", signatures, etc.)
         continue
       }
     }
@@ -1201,6 +1419,11 @@ function splitIntoTeamSections(lines: string[]): TeamSections {
     // Default to team A if no team is set
     if (currentTeam === null) {
       currentTeam = 'A'
+    }
+
+    // Track that Team A has received content
+    if (currentTeam === 'A') {
+      teamAHasContent = true
     }
 
     // Add line to current team

--- a/web-app/src/features/ocr/utils/player-list-parser.ts
+++ b/web-app/src/features/ocr/utils/player-list-parser.ts
@@ -370,7 +370,7 @@ function isLiberoSection(line: string, parts: string[]): boolean {
 }
 
 /** Valid official roles */
-const VALID_ROLES = new Set(['C', 'AC', 'AC2', 'AC3', 'AC4', 'M'])
+const VALID_ROLES = new Set(['C', 'AC', 'AC2', 'AC3', 'AC4', 'M', 'P'])
 
 function isOfficialRole(role: string): role is OfficialRole {
   return VALID_ROLES.has(role.toUpperCase().trim())


### PR DESCRIPTION
## Summary

- Fix manuscript scoresheet OCR roster detection that incorrectly classified sequential tab-separated scoresheets as Swiss tabular format, causing almost all players and officials to be missed
- Add support for parsing `date\tnumber\tname` tab-separated player lines and `date\trole\tname` official lines common in Swiss sequential manuscript scoresheets
- Improve team boundary detection using signature/trainer end markers instead of requiring explicit "Team B" labels
- Add `P` (physiotherapist) to `OfficialRole` type for Swiss scoresheets
- Skip Swiss form labels ("Mannschaften/Equipes/Squadre", "A oder/ou/o B") during team name extraction

## Test plan

- [x] All 151 existing OCR tests pass (manuscript-parser, player-list-parser, roster-comparison, useOCRScoresheet, useEasterEggDetection)
- [x] New test: real-world VBC Votero Zürich vs Volley Oerlikon scoresheet parses both teams with all players and officials
- [x] New test: `isSwissTabularFormat` returns false for sequential tab-separated format with Swiss headers
- [x] New test: tab-separated player lines extract birth dates correctly
- [x] New test: tab-separated officials with P/M roles parse correctly
- [ ] Manual test with the scoresheet image from the issue

https://claude.ai/code/session_01PR947bh5r2JqrtyjDYfWiW