### PR TITLE
feat(web): add player list and raw JSON display to OCR PoC results

### DIFF
--- a/.changeset/ocr-poc-player-list-json.md
+++ b/.changeset/ocr-poc-player-list-json.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Added player list and raw JSON display to OCR PoC results screen

--- a/ocr-poc/src/components/ResultsScreen.tsx
+++ b/ocr-poc/src/components/ResultsScreen.tsx
@@ -1,25 +1,154 @@
 /**
  * ResultsScreen Component
  *
- * Displays the OCR processing results.
+ * Displays the OCR processing results including extracted text,
+ * detected player lists, and raw Mistral JSON response.
  */
 
 import { useMemo, useState, useEffect } from 'react'
 
-import { CheckCircle, RotateCcw, Copy, Check } from 'lucide-react'
+import {
+  CheckCircle,
+  RotateCcw,
+  Copy,
+  Check,
+  Users,
+  ChevronDown,
+  ChevronRight,
+  AlertTriangle,
+  Code,
+} from 'lucide-react'
 
+import { parseGameSheetWithOCR } from '@/features/ocr/utils/player-list-parser'
 import { useAppStore } from '@/stores/appStore'
+
+import type { ParsedTeam } from '@/features/ocr/types'
 
 /** Duration to show "Copied!" feedback in milliseconds */
 const COPY_FEEDBACK_DURATION_MS = 2000
+
+/**
+ * Collapsible section wrapper for result panels
+ */
+function CollapsibleSection({
+  title,
+  icon: Icon,
+  badge,
+  defaultOpen = false,
+  children,
+}: {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  badge?: string
+  defaultOpen?: boolean
+  children: React.ReactNode
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full px-4 py-2 bg-slate-50 border-b border-slate-200 flex items-center gap-2 hover:bg-slate-100 transition-colors"
+      >
+        {isOpen ? (
+          <ChevronDown className="w-4 h-4 text-slate-500 flex-shrink-0" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-slate-500 flex-shrink-0" />
+        )}
+        <Icon className="w-4 h-4 text-slate-600 flex-shrink-0" />
+        <h3 className="font-medium text-slate-700 flex-1 text-left">{title}</h3>
+        {badge && (
+          <span className="text-xs text-slate-500 bg-slate-200 px-2 py-0.5 rounded-full">
+            {badge}
+          </span>
+        )}
+      </button>
+      {isOpen && children}
+    </div>
+  )
+}
+
+/**
+ * Displays a single team's player list
+ */
+function TeamPlayerList({ team, label }: { team: ParsedTeam; label: string }) {
+  return (
+    <div>
+      <div className="px-4 py-2 bg-slate-50 border-b border-slate-100">
+        <span className="text-sm font-medium text-slate-600">
+          {label}: {team.name || 'Unknown'}
+        </span>
+        <span className="text-xs text-slate-400 ml-2">
+          ({team.players.length} players, {team.officials.length} officials)
+        </span>
+      </div>
+
+      {/* Players */}
+      {team.players.length > 0 ? (
+        <div className="divide-y divide-slate-100">
+          {team.players.map((player, idx) => (
+            <div
+              key={`${idx}-${player.rawName}`}
+              className="px-4 py-1.5 flex items-center gap-3"
+            >
+              <span className="text-xs font-mono text-slate-400 w-6 text-right flex-shrink-0">
+                {player.shirtNumber ?? '-'}
+              </span>
+              <span className="text-sm text-slate-700 flex-1">{player.displayName}</span>
+              <span
+                className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+                  player.licenseStatus === 'OK'
+                    ? 'bg-green-100 text-green-700'
+                    : player.licenseStatus === 'NOT'
+                      ? 'bg-red-100 text-red-700'
+                      : 'bg-amber-100 text-amber-700'
+                }`}
+              >
+                {player.licenseStatus || '?'}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="px-4 py-2 text-sm text-slate-400 italic">No players detected</div>
+      )}
+
+      {/* Officials */}
+      {team.officials.length > 0 && (
+        <>
+          <div className="px-4 py-1 bg-slate-50 border-t border-slate-100">
+            <span className="text-xs font-medium text-slate-500 uppercase">Officials</span>
+          </div>
+          <div className="divide-y divide-slate-100">
+            {team.officials.map((official, idx) => (
+              <div
+                key={`${idx}-${official.rawName}`}
+                className="px-4 py-1.5 flex items-center gap-3"
+              >
+                <span className="text-xs font-mono text-slate-400 w-6 text-right flex-shrink-0">
+                  {official.role}
+                </span>
+                <span className="text-sm text-slate-700 flex-1">{official.displayName}</span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
 
 export function ResultsScreen() {
   const ocrResult = useAppStore((s) => s.ocrResult)
   const croppedImage = useAppStore((s) => s.croppedImage)
   const capturedImage = useAppStore((s) => s.capturedImage)
+  const sheetType = useAppStore((s) => s.sheetType)
   const reset = useAppStore((s) => s.reset)
 
   const [copied, setCopied] = useState(false)
+  const [copiedJson, setCopiedJson] = useState(false)
 
   // Create preview URL for the processed image
   const imageUrl = useMemo(() => {
@@ -39,6 +168,19 @@ export function ResultsScreen() {
     }
   }, [imageUrl])
 
+  // Parse the OCR result into structured player data
+  const parsedGameSheet = useMemo(() => {
+    if (!ocrResult) return null
+    try {
+      return parseGameSheetWithOCR(ocrResult, {
+        type: sheetType === 'manuscript' ? 'manuscript' : 'electronic',
+      })
+    } catch (err) {
+      console.error('Failed to parse game sheet:', err)
+      return null
+    }
+  }, [ocrResult, sheetType])
+
   const handleCopy = async () => {
     if (!ocrResult?.fullText) {
       return
@@ -53,6 +195,20 @@ export function ResultsScreen() {
     }
   }
 
+  const handleCopyJson = async () => {
+    if (!ocrResult?.rawResponse) {
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(ocrResult.rawResponse)
+      setCopiedJson(true)
+      setTimeout(() => setCopiedJson(false), COPY_FEEDBACK_DURATION_MS)
+    } catch (err) {
+      console.error('Failed to copy JSON:', err)
+    }
+  }
+
   if (!ocrResult) {
     return (
       <div className="flex-1 flex items-center justify-center p-6">
@@ -60,6 +216,9 @@ export function ResultsScreen() {
       </div>
     )
   }
+
+  const totalPlayers =
+    (parsedGameSheet?.teamA.players.length ?? 0) + (parsedGameSheet?.teamB.players.length ?? 0)
 
   return (
     <div className="flex-1 flex flex-col">
@@ -95,10 +254,36 @@ export function ResultsScreen() {
           </div>
         )}
 
+        {/* Detected Players */}
+        {parsedGameSheet && (
+          <CollapsibleSection
+            title="Detected Players"
+            icon={Users}
+            badge={`${totalPlayers} players`}
+            defaultOpen
+          >
+            <div className="divide-y divide-slate-200">
+              <TeamPlayerList team={parsedGameSheet.teamA} label="Team A" />
+              <TeamPlayerList team={parsedGameSheet.teamB} label="Team B" />
+            </div>
+
+            {/* Warnings */}
+            {parsedGameSheet.warnings.length > 0 && (
+              <div className="px-4 py-2 bg-amber-50 border-t border-amber-100">
+                {parsedGameSheet.warnings.map((warning, idx) => (
+                  <div key={idx} className="flex items-start gap-2 text-xs text-amber-700">
+                    <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
+                    <span>{warning}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CollapsibleSection>
+        )}
+
         {/* OCR Text */}
-        <div className="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden">
-          <div className="px-4 py-2 bg-slate-50 border-b border-slate-200 flex items-center justify-between">
-            <h3 className="font-medium text-slate-700">Extracted Text</h3>
+        <CollapsibleSection title="Extracted Text" icon={Copy} defaultOpen={false}>
+          <div className="px-4 py-2 flex justify-end border-b border-slate-100">
             <button
               type="button"
               onClick={handleCopy}
@@ -122,14 +307,46 @@ export function ResultsScreen() {
               {ocrResult.fullText}
             </pre>
           </div>
-        </div>
+        </CollapsibleSection>
+
+        {/* Raw JSON Response */}
+        {ocrResult.rawResponse && (
+          <CollapsibleSection title="Raw Mistral JSON" icon={Code} defaultOpen={false}>
+            <div className="px-4 py-2 flex justify-end border-b border-slate-100">
+              <button
+                type="button"
+                onClick={handleCopyJson}
+                className="flex items-center gap-1 px-2 py-1 text-sm text-slate-600 hover:text-slate-900 hover:bg-slate-100 rounded transition-colors"
+              >
+                {copiedJson ? (
+                  <>
+                    <Check className="w-4 h-4 text-green-600" />
+                    <span className="text-green-600">Copied!</span>
+                  </>
+                ) : (
+                  <>
+                    <Copy className="w-4 h-4" />
+                    <span>Copy</span>
+                  </>
+                )}
+              </button>
+            </div>
+            <div className="p-4">
+              <pre className="whitespace-pre-wrap text-xs text-slate-600 font-mono bg-slate-50 p-3 rounded border border-slate-200 max-h-96 overflow-auto">
+                {ocrResult.rawResponse}
+              </pre>
+            </div>
+          </CollapsibleSection>
+        )}
 
         {/* Line-by-line results */}
         {ocrResult.lines.length > 0 && (
-          <div className="bg-white rounded-lg shadow-sm border border-slate-200 overflow-hidden">
-            <div className="px-4 py-2 bg-slate-50 border-b border-slate-200">
-              <h3 className="font-medium text-slate-700">Lines ({ocrResult.lines.length})</h3>
-            </div>
+          <CollapsibleSection
+            title="Lines"
+            icon={Copy}
+            badge={`${ocrResult.lines.length}`}
+            defaultOpen={false}
+          >
             <div className="divide-y divide-slate-100">
               {ocrResult.lines.map((line, index) => (
                 <div
@@ -146,7 +363,7 @@ export function ResultsScreen() {
                 </div>
               ))}
             </div>
-          </div>
+          </CollapsibleSection>
         )}
       </div>
 

--- a/ocr-poc/src/components/ResultsScreen.tsx
+++ b/ocr-poc/src/components/ResultsScreen.tsx
@@ -50,6 +50,7 @@ function CollapsibleSection({
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
         className="w-full px-4 py-2 bg-slate-50 border-b border-slate-200 flex items-center gap-2 hover:bg-slate-100 transition-colors"
       >
         {isOpen ? (
@@ -88,9 +89,9 @@ function TeamPlayerList({ team, label }: { team: ParsedTeam; label: string }) {
       {/* Players */}
       {team.players.length > 0 ? (
         <div className="divide-y divide-slate-100">
-          {team.players.map((player, idx) => (
+          {team.players.map((player) => (
             <div
-              key={`${idx}-${player.rawName}`}
+              key={`${player.shirtNumber ?? 'x'}-${player.rawName}`}
               className="px-4 py-1.5 flex items-center gap-3"
             >
               <span className="text-xs font-mono text-slate-400 w-6 text-right flex-shrink-0">
@@ -122,9 +123,9 @@ function TeamPlayerList({ team, label }: { team: ParsedTeam; label: string }) {
             <span className="text-xs font-medium text-slate-500 uppercase">Officials</span>
           </div>
           <div className="divide-y divide-slate-100">
-            {team.officials.map((official, idx) => (
+            {team.officials.map((official) => (
               <div
-                key={`${idx}-${official.rawName}`}
+                key={`${official.role}-${official.rawName}`}
                 className="px-4 py-1.5 flex items-center gap-3"
               >
                 <span className="text-xs font-mono text-slate-400 w-6 text-right flex-shrink-0">
@@ -170,7 +171,9 @@ export function ResultsScreen() {
 
   // Parse the OCR result into structured player data
   const parsedGameSheet = useMemo(() => {
-    if (!ocrResult) return null
+    if (!ocrResult) {
+      return null
+    }
     try {
       return parseGameSheetWithOCR(ocrResult, {
         type: sheetType === 'manuscript' ? 'manuscript' : 'electronic',
@@ -270,8 +273,8 @@ export function ResultsScreen() {
             {/* Warnings */}
             {parsedGameSheet.warnings.length > 0 && (
               <div className="px-4 py-2 bg-amber-50 border-t border-amber-100">
-                {parsedGameSheet.warnings.map((warning, idx) => (
-                  <div key={idx} className="flex items-start gap-2 text-xs text-amber-700">
+                {parsedGameSheet.warnings.map((warning) => (
+                  <div key={warning} className="flex items-start gap-2 text-xs text-amber-700">
                     <AlertTriangle className="w-3 h-3 flex-shrink-0 mt-0.5" />
                     <span>{warning}</span>
                   </div>

--- a/web-app/src/features/ocr/services/mistral-ocr.ts
+++ b/web-app/src/features/ocr/services/mistral-ocr.ts
@@ -294,7 +294,9 @@ export class MistralOCR implements OCREngine {
 
       this.#reportProgress('Processing complete', PROGRESS_COMPLETE)
 
-      return this.#convertResponse(mistralResponse)
+      const result = this.#convertResponse(mistralResponse)
+      result.rawResponse = JSON.stringify(mistralResponse, null, 2)
+      return result
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         throw new Error('OCR cancelled', { cause: error })

--- a/web-app/src/features/ocr/types.ts
+++ b/web-app/src/features/ocr/types.ts
@@ -54,6 +54,8 @@ export interface OCRResult {
   words: OCRWord[]
   /** Whether bounding boxes are precise pixel coordinates (false = estimated) */
   hasPreciseBoundingBoxes: boolean
+  /** Raw JSON response from the OCR service (for debugging/inspection) */
+  rawResponse?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

- Parse OCR text into structured player data using `parseGameSheetWithOCR` and display detected players (Team A / Team B) with shirt numbers, names, license status badges, and officials
- Show raw Mistral JSON response in a collapsible panel with copy-to-clipboard for debugging
- Refactor all result sections into collapsible panels (Detected Players open by default, others collapsed)
- Add optional `rawResponse` field to `OCRResult` type and capture it in `MistralOCR.recognize()`

## Test plan

- [ ] Scan an electronic scoresheet and verify players are listed correctly with names, shirt numbers, and license statuses
- [ ] Scan a manuscript scoresheet and verify the manuscript parser is used
- [ ] Verify Raw Mistral JSON section shows valid pretty-printed JSON
- [ ] Verify copy buttons work for both extracted text and raw JSON
- [ ] Verify collapsible sections expand/collapse correctly
- [ ] Verify web-app still builds and type-checks (shared type was modified)

https://claude.ai/code/session_018jQLt8bj2YpJzcJe1SjPUN