### PR TITLE
fix(web): support 6-column Swiss tabular OCR format from Mistral

### DIFF
--- a/.changeset/fix-ocr-6column-tabular-parsing.md
+++ b/.changeset/fix-ocr-6column-tabular-parsing.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fix 6-column Swiss tabular OCR parsing: detect multilingual officials headers, preserve tab column alignment, and skip header rows in tabular format

--- a/web-app/src/features/ocr/services/mistral-ocr.ts
+++ b/web-app/src/features/ocr/services/mistral-ocr.ts
@@ -142,7 +142,10 @@ export class MistralOCR implements OCREngine {
    */
   #parseHtmlTable(html: string): string[] {
     const parser = new DOMParser()
-    const doc = parser.parseFromString(html, 'text/html')
+    // Replace <br> tags with spaces before parsing to preserve word boundaries
+    // (e.g., "A<br/>Oder/ou/o" → "A Oder/ou/o" instead of "AOder/ou/o")
+    const cleanedHtml = html.replace(/<br\s*\/?>/gi, ' ')
+    const doc = parser.parseFromString(cleanedHtml, 'text/html')
     const table = doc.querySelector('table')
 
     if (!table) {
@@ -154,11 +157,11 @@ export class MistralOCR implements OCREngine {
 
     for (const row of rows) {
       const cells = row.querySelectorAll('th, td')
-      const cellTexts = Array.from(cells)
-        .map((cell) => cell.textContent?.trim() ?? '')
-        .filter((text) => text.length > 0)
+      // Preserve empty cells to maintain column alignment for tabular formats
+      const cellTexts = Array.from(cells).map((cell) => cell.textContent?.trim() ?? '')
 
-      if (cellTexts.length > 0) {
+      // Only skip rows where ALL cells are empty
+      if (cellTexts.some((text) => text.length > 0)) {
         // Join cells with tab separator for structured output
         lines.push(cellTexts.join('\t'))
       }

--- a/web-app/src/features/ocr/utils/manuscript-parser.test.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.test.ts
@@ -801,3 +801,239 @@ TrainerEntraîneurAllenatore\tTrainerEntraîneurAllenatore`
     expect(result.teamA.name).not.toBe('4 8 4 8 . 4 8 4 8 4 8 4 8 4 8 4 8 .')
   })
 })
+
+// =============================================================================
+// 6-Column Swiss Tabular Format Tests (Mistral OCR HTML table output)
+// =============================================================================
+
+describe('parseManuscriptSheet with 6-column tabular format', () => {
+  it('parses 6-column player rows with DOB, jersey number, and name for both teams', () => {
+    const ocrText = `A Oder/ou/o B VBC Test\tVölley Opponent A Oder/ou/o B
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome\tLizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+16.05.07\t5\tJ. Klocke\t01.10.95\t5\tG. Papadopoulos
+31.07.07\t2\tN. Christen\t24.02.03\t4\tN. von Loesch
+30.07.07\t11\tN. Walser\t18.05.96\t8\tI. Kellenberger`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // Team A
+    expect(result.teamA.players).toHaveLength(3)
+    expect(result.teamA.players[0]!.shirtNumber).toBe(5)
+    expect(result.teamA.players[0]!.rawName).toBe('J. Klocke')
+    expect(result.teamA.players[0]!.birthDate).toBe('16.05.07')
+    expect(result.teamA.players[1]!.shirtNumber).toBe(2)
+    expect(result.teamA.players[1]!.rawName).toBe('N. Christen')
+    expect(result.teamA.players[1]!.birthDate).toBe('31.07.07')
+    expect(result.teamA.players[2]!.shirtNumber).toBe(11)
+
+    // Team B
+    expect(result.teamB.players).toHaveLength(3)
+    expect(result.teamB.players[0]!.shirtNumber).toBe(5)
+    expect(result.teamB.players[0]!.rawName).toBe('G. Papadopoulos')
+    expect(result.teamB.players[0]!.birthDate).toBe('01.10.95')
+    expect(result.teamB.players[1]!.shirtNumber).toBe(4)
+    expect(result.teamB.players[2]!.shirtNumber).toBe(8)
+  })
+
+  it('handles partial rows where one team has empty columns', () => {
+    const ocrText = `A Oder/ou/o B VBC Test\tVC Opponent A Oder/ou/o B
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome\tLizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+28.03.03\t7\tN. Nausson\t07.04.\t\tH. Birrer
+\t\t\t29.10.85\t15\tJ. Risso Gertrude`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // Row 1: Team A has player, Team B has player with incomplete DOB and no jersey
+    expect(result.teamA.players.length).toBeGreaterThanOrEqual(1)
+    const nausson = result.teamA.players.find((p) => p.rawName.includes('Nausson'))
+    expect(nausson).toBeDefined()
+    expect(nausson!.shirtNumber).toBe(7)
+    expect(nausson!.birthDate).toBe('28.03.03')
+
+    const birrer = result.teamB.players.find((p) => p.rawName.includes('Birrer'))
+    expect(birrer).toBeDefined()
+    expect(birrer!.shirtNumber).toBeNull()
+    expect(birrer!.birthDate).toBe('07.04.')
+
+    // Row 2: Only Team B has data (Team A columns are empty)
+    const risso = result.teamB.players.find((p) => p.rawName.includes('Risso'))
+    expect(risso).toBeDefined()
+    expect(risso!.shirtNumber).toBe(15)
+    expect(risso!.birthDate).toBe('29.10.85')
+  })
+
+  it('parses officials with DOB prefix in 6-column format', () => {
+    const ocrText = `A Oder/ou/o B VBC Test\tVC Opponent A Oder/ou/o B
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome\tLizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+16.05.07\t5\tJ. Klocke\t01.10.95\t5\tG. Papadopoulos
+Offizielle/Officiels/Ufficiali\tOffizielle/Officiels/Ufficiali
+11.08.65\tC\tD. Heynen\t07.04.71\tC\tN. Birrer
+18.04.05\tP\tN. Fabry\t21.03.97\tP\tN. Chinellato
+03.10.08\tM\tY. Zeitov\t\tM\tY. Zeitler`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // Team A officials
+    expect(result.teamA.officials.length).toBeGreaterThanOrEqual(3)
+    const coachA = result.teamA.officials.find((o) => o.role === 'C')
+    expect(coachA).toBeDefined()
+    expect(coachA!.rawName).toContain('Heynen')
+    const physioA = result.teamA.officials.find((o) => o.role === 'P')
+    expect(physioA).toBeDefined()
+    expect(physioA!.rawName).toContain('Fabry')
+    const medicalA = result.teamA.officials.find((o) => o.role === 'M')
+    expect(medicalA).toBeDefined()
+    expect(medicalA!.rawName).toContain('Zeitov')
+
+    // Team B officials
+    expect(result.teamB.officials.length).toBeGreaterThanOrEqual(3)
+    const coachB = result.teamB.officials.find((o) => o.role === 'C')
+    expect(coachB).toBeDefined()
+    expect(coachB!.rawName).toContain('Birrer')
+    const physioB = result.teamB.officials.find((o) => o.role === 'P')
+    expect(physioB).toBeDefined()
+    expect(physioB!.rawName).toContain('Chinellato')
+    const medicalB = result.teamB.officials.find((o) => o.role === 'M')
+    expect(medicalB).toBeDefined()
+    expect(medicalB!.rawName).toContain('Zeitler')
+  })
+
+  it('normalizes AC1 role to AC', () => {
+    const ocrText = `A Oder/ou/o B VBC Test\tVC Opponent A Oder/ou/o B
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome\tLizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+16.05.07\t5\tJ. Klocke\t01.10.95\t5\tG. Papadopoulos
+Offizielle/Officiels/Ufficiali\tOffizielle/Officiels/Ufficiali
+C\tM. Lorentz\tC\tA. Zbinden
+15.03.80\tAC1\tS. Helper\t22.06.85\tAC1\tR. Assistent`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // AC1 should be normalized to AC
+    const acA = result.teamA.officials.find((o) => o.role === 'AC')
+    expect(acA).toBeDefined()
+    expect(acA!.rawName).toContain('Helper')
+
+    const acB = result.teamB.officials.find((o) => o.role === 'AC')
+    expect(acB).toBeDefined()
+    expect(acB!.rawName).toContain('Assistent')
+  })
+
+  it('parses libero section in 6-column format', () => {
+    const ocrText = `A Oder/ou/o B VBC Test\tVC Opponent A Oder/ou/o B
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome\tLizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+16.05.07\t5\tJ. Klocke\t01.10.95\t5\tG. Papadopoulos
+LIBEROS («L»)\tLIBEROS («L»)
+13.06.04\t1\tC. Tsang\t30.07.96\t16\tN. Jegu
+\t\t\t29.10.85\t15\tJ. Risso Gertrude`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // Team A libero
+    const tsang = result.teamA.players.find((p) => p.rawName.includes('Tsang'))
+    expect(tsang).toBeDefined()
+    expect(tsang!.shirtNumber).toBe(1)
+    expect(tsang!.birthDate).toBe('13.06.04')
+
+    // Team B liberos
+    const jegu = result.teamB.players.find((p) => p.rawName.includes('Jegu'))
+    expect(jegu).toBeDefined()
+    expect(jegu!.shirtNumber).toBe(16)
+    expect(jegu!.birthDate).toBe('30.07.96')
+
+    // Team B second libero (only on Team B side)
+    const risso = result.teamB.players.find((p) => p.rawName.includes('Risso'))
+    expect(risso).toBeDefined()
+    expect(risso!.shirtNumber).toBe(15)
+    expect(risso!.birthDate).toBe('29.10.85')
+  })
+
+  it('parses full Mistral OCR output from VBC Votero Zürich vs Volley Oerlikon', () => {
+    // Simulates the tab-separated output from #parseHtmlTable after processing
+    // Mistral's 6-column HTML table with <br> → space conversion and preserved empty cells
+    const ocrText = `A Oder/ou/o B VBC Votero Zürich\tVölley Oerlikon A Oder/ou/o B
+Lizenz-Nr. Licence-No. Licenza-No.\tSpieler Nr. Joueur No. Giocatore No.\tName Nom Nome\tLizenz-Nr. Licence-No. Licenza-No.\tSpieler Nr. Joueur No. Giocatore No.\tName Nom Nome
+16.05.07\t5\tJ. Klocke\t01.10.95\t5\tG. Papadopoulos
+31.07.07\t2\tN. Christen\t24.02.03\t4\tN. von Loesch
+30.07.07\t11\tN. Walser\t18.05.96\t8\tI. Kellenberger
+06.04.07\t8\tA. Heinzer\t16.09.92\t14\tO. Hartes
+31.05.07\t6\tI. Pautelić\t07.08.96\t10\tS. Ward
+25.11.03\t9\tN. Dankelschlep\t26.05.92\t6\tA. Bratschi
+10.04.03\t13\tG. Taggin\t30.07.96\t16\tN. Jegu
+16.06.08\t15\tK. Hamnata\t29.10.85\t15\tJ. Risso Gertrude
+13.06.04\t1\tC. Tsang\t24.11.06\t3\tL. Huthäfer
+27.01.04\t12\tA. Nuri\t14.07.06\t11\tL. Zach
+28.03.03\t7\tN. Nausson\t07.04.\t\tH. Birrer
+LIBEROS («L»)\tLIBEROS («L»)
+13.06.04\t1\tC. Tsang\t30.07.96\t16\tN. Jegu
+\t\t\t29.10.85\t15\tJ. Risso Gertrude
+Offizielle/Officiels/Ufficiali\tOffizielle/Officiels/Ufficiali
+11.08.65\tC\tD. Heynen\t07.04.71\tC\tN. Birrer
+\tAC1\t\t\tAC1\t
+\tAC2\t\t\tAC2\t
+18.04.05\tP\tN. Fabry\t21.03.97\tP\tN. Chinellato
+03.10.08\tM\tY. Zeitov\t\tM\tY. Zeitler`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // ---- Team A (VBC Votero Zürich) ----
+    // 11 regular players + 1 libero (duplicate of C. Tsang)
+    expect(result.teamA.players.length).toBeGreaterThanOrEqual(11)
+
+    // Check specific players with DOB
+    const klocke = result.teamA.players.find((p) => p.rawName.includes('Klocke'))
+    expect(klocke).toBeDefined()
+    expect(klocke!.shirtNumber).toBe(5)
+    expect(klocke!.birthDate).toBe('16.05.07')
+
+    const tsang = result.teamA.players.find((p) => p.rawName.includes('Tsang'))
+    expect(tsang).toBeDefined()
+    expect(tsang!.shirtNumber).toBe(1)
+
+    const dankelschlep = result.teamA.players.find((p) => p.rawName.includes('Dankelschlep'))
+    expect(dankelschlep).toBeDefined()
+    expect(dankelschlep!.shirtNumber).toBe(9)
+    expect(dankelschlep!.birthDate).toBe('25.11.03')
+
+    // Team A officials
+    expect(result.teamA.officials.length).toBeGreaterThanOrEqual(3)
+    const coachA = result.teamA.officials.find((o) => o.role === 'C')
+    expect(coachA).toBeDefined()
+    expect(coachA!.rawName).toContain('Heynen')
+    const physioA = result.teamA.officials.find((o) => o.role === 'P')
+    expect(physioA).toBeDefined()
+    expect(physioA!.rawName).toContain('Fabry')
+    const medicalA = result.teamA.officials.find((o) => o.role === 'M')
+    expect(medicalA).toBeDefined()
+    expect(medicalA!.rawName).toContain('Zeitov')
+
+    // ---- Team B (Volley Oerlikon) ----
+    expect(result.teamB.players.length).toBeGreaterThanOrEqual(11)
+
+    const papadopoulos = result.teamB.players.find((p) => p.rawName.includes('Papadopoulos'))
+    expect(papadopoulos).toBeDefined()
+    expect(papadopoulos!.shirtNumber).toBe(5)
+    expect(papadopoulos!.birthDate).toBe('01.10.95')
+
+    const ward = result.teamB.players.find((p) => p.rawName.includes('Ward'))
+    expect(ward).toBeDefined()
+    expect(ward!.shirtNumber).toBe(10)
+
+    // H. Birrer has incomplete DOB and no jersey number
+    const birrerPlayer = result.teamB.players.find((p) => p.rawName.includes('Birrer'))
+    expect(birrerPlayer).toBeDefined()
+    expect(birrerPlayer!.shirtNumber).toBeNull()
+    expect(birrerPlayer!.birthDate).toBe('07.04.')
+
+    // Team B officials
+    expect(result.teamB.officials.length).toBeGreaterThanOrEqual(3)
+    const coachB = result.teamB.officials.find((o) => o.role === 'C')
+    expect(coachB).toBeDefined()
+    expect(coachB!.rawName).toContain('Birrer')
+    const physioB = result.teamB.officials.find((o) => o.role === 'P')
+    expect(physioB).toBeDefined()
+    expect(physioB!.rawName).toContain('Chinellato')
+    const medicalB = result.teamB.officials.find((o) => o.role === 'M')
+    expect(medicalB).toBeDefined()
+    expect(medicalB!.rawName).toContain('Zeitler')
+  })
+})

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -43,6 +43,12 @@ const MIN_LETTER_RATIO = 0.6
 /** Maximum tab-separated parts per line in sequential format (date, number, name) */
 const MAX_SEQUENTIAL_PARTS_PER_LINE = 3
 
+/** Total columns in 6-column Swiss tabular format (3 per team × 2 teams) */
+const TABULAR_TOTAL_COLUMNS = 6
+
+/** Columns per team in 6-column Swiss tabular format (date, number, name) */
+const TABULAR_COLUMNS_PER_TEAM = 3
+
 /** Valid official roles (C=Coach, AC=Assistant Coach, M=Medical, P=Physiotherapist) */
 const VALID_ROLES = new Set(['C', 'AC', 'AC2', 'AC3', 'AC4', 'M', 'P'])
 
@@ -247,7 +253,7 @@ const SWISS_HEADER_PATTERNS = [
   /offizielle.*officiels.*ufficiali/i, // Officials header (DE/FR/IT)
   /kapitän.*capitaine.*capitano/i, // Captain header (DE/FR/IT)
   /trainer.*entraîneur.*allenatore/i, // Trainer header (DE/FR/IT)
-  /aader\/ou\/o/i, // Common marker for "and/or" in Swiss forms
+  /oder\/ou\/o/i, // Common marker for "and/or" in Swiss forms (A oder/ou/o B)
 ]
 
 /**
@@ -494,7 +500,7 @@ const MIN_VALID_TEAM_NAME_LENGTH = 3
  */
 function cleanSwissMarkers(text: string): string {
   return text
-    .replace(/aader\/ou\/o\s*B?\s*/gi, ' ')
+    .replace(/A? ?oder\/ou\/o ?B? ?/gi, ' ')
     .replace(/punkte[\s\S]*?punti\s*/i, ' ')
     .replace(/\s+/g, ' ')
     .trim()
@@ -686,10 +692,25 @@ function parseSwissLiberoLine(line: string): {
   teamA: ParsedPlayer | null
   teamB: ParsedPlayer | null
 } {
-  const parts = line
-    .split('\t')
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0)
+  const rawParts = line.split('\t')
+
+  // If we have exactly 6 columns, use column-based parsing to preserve team alignment
+  if (rawParts.length === TABULAR_TOTAL_COLUMNS) {
+    const teamA = parsePlayerFromColumns(
+      rawParts[0]!.trim(),
+      rawParts[1]!.trim(),
+      rawParts[2]!.trim()
+    )
+    const teamB = parsePlayerFromColumns(
+      rawParts[3]!.trim(),
+      rawParts[4]!.trim(),
+      rawParts[5]!.trim()
+    )
+    return { teamA, teamB }
+  }
+
+  // Fallback: sequential parsing for non-6-column lines
+  const parts = rawParts.map((p) => p.trim()).filter((p) => p.length > 0)
 
   if (parts.length < MIN_LIBERO_LINE_PARTS) {
     return { teamA: null, teamB: null }
@@ -713,63 +734,182 @@ function parseSwissLiberoLine(line: string): {
 }
 
 /**
+ * Parse a 6-column tab-separated player line from Swiss tabular format.
+ * Format: "date_A\tnumber_A\tname_A\tdate_B\tnumber_B\tname_B"
+ * Columns may be empty (preserved as empty strings from HTML table conversion).
+ * Returns true if the line was successfully parsed as player data.
+ */
+function parseSwissTabularPlayerLine(line: string, teamA: ParsedTeam, teamB: ParsedTeam): boolean {
+  // Split keeping all parts (including empty) to preserve column alignment
+  const parts = line.split('\t')
+
+  // Need exactly 6 columns for the two-team tabular format
+  if (parts.length !== TABULAR_TOTAL_COLUMNS) return false
+
+  const teamACols = [parts[0]!.trim(), parts[1]!.trim(), parts[2]!.trim()]
+  const teamBCols = [parts[3]!.trim(), parts[4]!.trim(), parts[5]!.trim()]
+
+  let parsedAny = false
+
+  // Parse Team A (columns 0-2)
+  const playerA = parsePlayerFromColumns(teamACols[0]!, teamACols[1]!, teamACols[2]!)
+  if (playerA) {
+    teamA.players.push(playerA)
+    parsedAny = true
+  }
+
+  // Parse Team B (columns 3-5)
+  const playerB = parsePlayerFromColumns(teamBCols[0]!, teamBCols[1]!, teamBCols[2]!)
+  if (playerB) {
+    teamB.players.push(playerB)
+    parsedAny = true
+  }
+
+  return parsedAny
+}
+
+/**
+ * Parse a player from 3 columns: date (DOB), jersey number, and name.
+ * Any column may be empty. Returns null if no valid name is found.
+ */
+function parsePlayerFromColumns(col0: string, col1: string, col2: string): ParsedPlayer | null {
+  let birthDate: string | undefined
+  let jerseyNumber: number | null = null
+  let name = ''
+
+  // Column 0: expect DOB (DD.MM.YY or DD.MM.YYYY)
+  if (DATE_PATTERN.test(col0)) {
+    birthDate = col0
+  }
+
+  // Column 1: expect jersey number (1-2 digits, 1-99)
+  if (JERSEY_NUMBER_PATTERN.test(col1)) {
+    const num = parseInt(col1, 10)
+    if (num >= 1 && num <= MAX_SHIRT_NUMBER) {
+      jerseyNumber = num
+    }
+  }
+
+  // Column 2: expect player name
+  if (col2 && NAME_START_PATTERN.test(col2) && col2.length >= MIN_NAME_LENGTH) {
+    name = col2
+  }
+
+  // Must have at least a name to count as a valid player
+  if (!name) return null
+
+  const parsed = parsePlayerName(name)
+  return {
+    shirtNumber: jerseyNumber,
+    lastName: parsed.lastName,
+    firstName: parsed.firstName,
+    displayName: parsed.displayName,
+    rawName: name,
+    licenseStatus: '',
+    birthDate,
+  }
+}
+
+/**
+ * Normalize official role strings from Swiss forms.
+ * AC1 → AC (Swiss forms use AC1 for first assistant coach, AC2 for second)
+ */
+function normalizeRole(role: string): string | null {
+  const upper = role.toUpperCase()
+  if (VALID_ROLES.has(upper)) return upper
+  // AC1 → AC (Swiss form convention)
+  if (upper === 'AC1') return 'AC'
+  return null
+}
+
+/**
+ * Parse one official from parts starting at currentIndex.
+ * Handles optional date prefix: [date]\trole\tname
+ */
+function parseOneOfficial(
+  parts: string[],
+  startIndex: number
+): { official: ParsedOfficial | null; nextIndex: number } {
+  let currentIndex = startIndex
+
+  // Skip date prefix if present (DOB for officials)
+  if (currentIndex < parts.length && DATE_PATTERN.test(parts[currentIndex]!)) {
+    currentIndex++
+  }
+
+  // Expect role
+  if (currentIndex >= parts.length) {
+    return { official: null, nextIndex: currentIndex }
+  }
+
+  const normalizedRole = normalizeRole(parts[currentIndex]!)
+  if (!normalizedRole) {
+    return { official: null, nextIndex: currentIndex }
+  }
+  currentIndex++
+
+  // Expect name
+  if (currentIndex >= parts.length || !NAME_START_PATTERN.test(parts[currentIndex]!)) {
+    return { official: null, nextIndex: currentIndex }
+  }
+
+  const name = parts[currentIndex]!
+  currentIndex++
+  const parsed = parseOfficialName(name)
+
+  return {
+    official: {
+      role: normalizedRole as OfficialRole,
+      lastName: parsed.lastName,
+      firstName: parsed.firstName,
+      displayName: parsed.displayName,
+      rawName: name,
+    },
+    nextIndex: currentIndex,
+  }
+}
+
+/**
  * Parse a tab-separated officials line from Swiss format
- * Format: "C\tM. Lorentz\tC\tA. Zbinden"
+ * Supports formats:
+ *   "C\tM. Lorentz\tC\tA. Zbinden"             (without dates)
+ *   "11.08.65\tC\tD. Heynen\t07.04.71\tC\tN. Birrer"  (with DOB prefix)
  */
 function parseSwissOfficialsLine(line: string): {
   teamA: ParsedOfficial | null
   teamB: ParsedOfficial | null
 } {
-  const parts = line
-    .split('\t')
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0)
+  const rawParts = line.split('\t')
 
-  let teamAOfficial: ParsedOfficial | null = null
-  let teamBOfficial: ParsedOfficial | null = null
+  // If we have exactly 6 columns, use column-based parsing to preserve team alignment
+  if (rawParts.length === TABULAR_TOTAL_COLUMNS) {
+    const teamACols = rawParts.slice(0, TABULAR_COLUMNS_PER_TEAM).map((p) => p.trim())
+    const teamBCols = rawParts
+      .slice(TABULAR_COLUMNS_PER_TEAM, TABULAR_TOTAL_COLUMNS)
+      .map((p) => p.trim())
 
-  let currentIndex = 0
+    const teamAFiltered = teamACols.filter((p) => p.length > 0)
+    const teamBFiltered = teamBCols.filter((p) => p.length > 0)
 
-  // Parse Team A official
-  if (currentIndex < parts.length) {
-    const role = parts[currentIndex]!.toUpperCase()
-    if (VALID_ROLES.has(role)) {
-      currentIndex++
-      if (currentIndex < parts.length && /^[A-Za-zÀ-ÿ]/.test(parts[currentIndex]!)) {
-        const name = parts[currentIndex]!
-        const parsed = parseOfficialName(name)
-        teamAOfficial = {
-          role: role as OfficialRole,
-          lastName: parsed.lastName,
-          firstName: parsed.firstName,
-          displayName: parsed.displayName,
-          rawName: name,
-        }
-        currentIndex++
-      }
+    const teamAResult = teamAFiltered.length > 0 ? parseOneOfficial(teamAFiltered, 0) : null
+    const teamBResult = teamBFiltered.length > 0 ? parseOneOfficial(teamBFiltered, 0) : null
+
+    return {
+      teamA: teamAResult?.official ?? null,
+      teamB: teamBResult?.official ?? null,
     }
   }
 
-  // Parse Team B official
-  if (currentIndex < parts.length) {
-    const role = parts[currentIndex]!.toUpperCase()
-    if (VALID_ROLES.has(role)) {
-      currentIndex++
-      if (currentIndex < parts.length && /^[A-Za-zÀ-ÿ]/.test(parts[currentIndex]!)) {
-        const name = parts[currentIndex]!
-        const parsed = parseOfficialName(name)
-        teamBOfficial = {
-          role: role as OfficialRole,
-          lastName: parsed.lastName,
-          firstName: parsed.firstName,
-          displayName: parsed.displayName,
-          rawName: name,
-        }
-      }
-    }
-  }
+  // Fallback: sequential parsing for non-6-column lines
+  const parts = rawParts.map((p) => p.trim()).filter((p) => p.length > 0)
 
-  return { teamA: teamAOfficial, teamB: teamBOfficial }
+  // Parse Team A official (skips leading date if present)
+  const teamAResult = parseOneOfficial(parts, 0)
+
+  // Parse Team B official (continues from where Team A left off)
+  const teamBResult = parseOneOfficial(parts, teamAResult.nextIndex)
+
+  return { teamA: teamAResult.official, teamB: teamBResult.official }
 }
 
 /** Concatenated names pattern (e.g., "S. AngeliL. Collier") */
@@ -881,7 +1021,7 @@ function processStructuredLine(
  */
 function shouldSkipLine(line: string): boolean {
   if (isNoiseLine(line)) return true
-  if (SWISS_HEADER_PATTERNS.some((pattern) => pattern.test(line)) && !line.includes('\t')) {
+  if (SWISS_HEADER_PATTERNS.some((pattern) => pattern.test(line))) {
     return true
   }
   return false
@@ -922,7 +1062,9 @@ function generateTeamWarnings(teamA: ParsedTeam, teamB: ParsedTeam): string[] {
  * This format has both teams side-by-side with OCR reading horizontally
  */
 function parseSwissTabularSheet(ocrText: string): ParsedGameSheet {
-  const lines = ocrText.split('\n').map((l) => l.trim())
+  // Keep raw lines (don't trim) to preserve tab-based column alignment
+  // Lines like "\t\t\t29.10.85\t15\tName" need leading tabs for 6-column parsing
+  const rawLines = ocrText.split('\n')
   const teamNames = extractSwissTeamNames(ocrText)
 
   const teamA: ParsedTeam = { name: teamNames.teamA, players: [], officials: [] }
@@ -931,9 +1073,12 @@ function parseSwissTabularSheet(ocrText: string): ParsedGameSheet {
   let inLiberoSection = false
   let inOfficialsSection = false
 
-  for (const line of lines) {
-    if (shouldSkipLine(line)) continue
+  for (const rawLine of rawLines) {
+    const line = rawLine.trim()
 
+    // Check section markers first (before skip) so multilingual headers
+    // like "Offizielle/Officiels/Ufficiali" are detected as section markers
+    // rather than skipped as Swiss header patterns
     const sectionMarker = detectSectionMarker(line)
     if (sectionMarker === 'end') break
     if (sectionMarker === 'libero') {
@@ -947,13 +1092,23 @@ function parseSwissTabularSheet(ocrText: string): ParsedGameSheet {
       continue
     }
 
+    if (shouldSkipLine(line)) continue
+
     if (!line.includes('\t')) continue
 
-    if (processStructuredLine(line, inOfficialsSection, inLiberoSection, teamA, teamB)) {
+    // Use rawLine for tab-based parsing to preserve column alignment
+    if (processStructuredLine(rawLine, inOfficialsSection, inLiberoSection, teamA, teamB)) {
       continue
     }
 
-    // Process concatenated player data
+    // Try parsing as 6-column tab-separated player row (date\tnum\tname per team)
+    if (!inOfficialsSection && !inLiberoSection) {
+      if (parseSwissTabularPlayerLine(rawLine, teamA, teamB)) {
+        continue
+      }
+    }
+
+    // Process concatenated player data (fallback for OCR that runs names together)
     const parts = line.split('\t')
     const data = extractConcatenatedData(parts)
     addPlayersFromExtractedData(teamA, data.firstHalfNames, data.firstHalfDates)
@@ -1019,9 +1174,16 @@ function isLiberoMarker(line: string): boolean {
  */
 function isOfficialsMarker(line: string): boolean {
   const upper = line.toUpperCase()
-  // Must contain 'OFFICIAL' or specific section headers
+  // Must contain 'OFFICIAL' or multilingual equivalents, or specific section headers
   // Avoid matching lines like "C Hans Trainer" which contain 'TRAINER'
-  return upper.includes('OFFICIAL') || upper.startsWith('COACH') || /^TRAINER\b/.test(upper)
+  return (
+    upper.includes('OFFICIAL') ||
+    upper.includes('OFFICIEL') ||
+    upper.includes('OFFIZIEL') ||
+    upper.includes('UFFICIALI') ||
+    upper.startsWith('COACH') ||
+    /^TRAINER\b/.test(upper)
+  )
 }
 
 /**
@@ -1166,10 +1328,10 @@ function tryExtractOfficialFromTabs(line: string): ParsedOfficial | null {
     currentIndex++
   }
 
-  // Next should be role
+  // Next should be role (with AC1 → AC normalization)
   if (currentIndex >= parts.length) return null
-  const role = parts[currentIndex]!.toUpperCase()
-  if (!VALID_ROLES.has(role)) return null
+  const role = normalizeRole(parts[currentIndex]!)
+  if (!role) return null
   currentIndex++
 
   // Next should be name

--- a/web-app/src/features/validation/components/ValidateGameModal.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.tsx
@@ -303,18 +303,16 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
           </div>
         )}
 
-        {!wizard.isValidated &&
-          wizard.isLastStep &&
-          !wizard.allPreviousRequiredStepsDone && (
-            <div
-              role="status"
-              className="mt-4 p-3 bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-800 rounded-lg"
-            >
-              <p className="text-sm text-warning-700 dark:text-warning-400">
-                {t('validation.wizard.stepsIncomplete')}
-              </p>
-            </div>
-          )}
+        {!wizard.isValidated && wizard.isLastStep && !wizard.allPreviousRequiredStepsDone && (
+          <div
+            role="status"
+            className="mt-4 p-3 bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-800 rounded-lg"
+          >
+            <p className="text-sm text-warning-700 dark:text-warning-400">
+              {t('validation.wizard.stepsIncomplete')}
+            </p>
+          </div>
+        )}
 
         <div className="flex justify-between gap-3 pt-4 border-t border-border-default dark:border-border-default-dark mt-4">
           {wizard.isValidated ? (


### PR DESCRIPTION
## Summary

- Fix Mistral OCR HTML table parsing to properly handle `<br>` tags and preserve empty cells for column alignment
- Add 6-column tab-separated player/official/libero parsing that handles empty Team A columns (data only on Team B side)
- Fix officials section detection for multilingual headers (DE/FR/IT variants: Offizielle/Officiels/Ufficiali)
- Fix header row pollution: skip Swiss header lines in tabular format even when tab-separated
- Preserve raw line tabs in `parseSwissTabularSheet` to maintain column alignment
- Normalize AC1 role to AC for Swiss form convention
- Add comprehensive test coverage for 6-column format (6 new tests)
- Apply formatter to ValidateGameModal

## Test plan

- [ ] Verify new manuscript-parser tests pass (`npm test` in web-app)
- [ ] Verify OCR parsing works for 6-column Swiss tabular format with empty Team A columns
- [ ] Verify officials parsing detects multilingual headers correctly
- [ ] Verify header row lines are properly skipped in tabular format
- [ ] Verify web-app builds successfully

https://claude.ai/code/session_01VqasqkvKnu2w6YopRU3Wx9