### PR TITLE
fix(web): deduplicate libero players in scoresheet parsing and fix POC crop button visibility

### DIFF
--- a/.changeset/fix-libero-deduplication.md
+++ b/.changeset/fix-libero-deduplication.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fixed duplicate libero players in scoresheet parsing and crop button visibility on iOS

--- a/ocr-poc/src/index.css
+++ b/ocr-poc/src/index.css
@@ -1,5 +1,8 @@
 @import 'tailwindcss';
 
+/* Scan web-app components imported via aliases (ImageCropEditor, etc.) */
+@source "../../web-app/src/features";
+
 /* Tailwind 4 theme customization */
 @theme {
   --color-primary-500: #1e40af;

--- a/web-app/src/features/ocr/utils/dedup-players.ts
+++ b/web-app/src/features/ocr/utils/dedup-players.ts
@@ -1,0 +1,33 @@
+/**
+ * Player Deduplication Utility
+ *
+ * Removes duplicate players from a team's roster. Manuscript scoresheets
+ * typically list libero players twice: once in the main player list and
+ * again in a separate LIBERO section. This utility keeps the first
+ * occurrence of each player.
+ */
+
+import type { ParsedPlayer, ParsedTeam } from '../types'
+
+/**
+ * Deduplicate players in a team's roster.
+ *
+ * Two players are considered duplicates if they share the same rawName
+ * (case-insensitive). Shirt numbers are NOT used for deduplication because
+ * OCR errors can assign the same number to different players.
+ */
+export function deduplicatePlayers(team: ParsedTeam): void {
+  const seenNames = new Set<string>()
+  const deduped: ParsedPlayer[] = []
+
+  for (const player of team.players) {
+    const nameKey = player.rawName.toLowerCase().trim()
+
+    if (!nameKey || !seenNames.has(nameKey)) {
+      deduped.push(player)
+      if (nameKey) seenNames.add(nameKey)
+    }
+  }
+
+  team.players = deduped
+}

--- a/web-app/src/features/ocr/utils/manuscript-parser.test.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.test.ts
@@ -701,7 +701,8 @@ EntraineurAllenatore`
     const result = parseManuscriptSheet(ocrText)
 
     // Team A (first column - VBC Votero Zürich)
-    expect(result.teamA.players.length).toBeGreaterThanOrEqual(11)
+    // 11 unique players (libero C. Tsang deduplicated)
+    expect(result.teamA.players).toHaveLength(11)
 
     // Check specific Team A players
     const klocke = result.teamA.players.find((p) => p.rawName.includes('Klocke'))
@@ -976,8 +977,8 @@ Offizielle/Officiels/Ufficiali\tOffizielle/Officiels/Ufficiali
     const result = parseManuscriptSheet(ocrText)
 
     // ---- Team A (VBC Votero Zürich) ----
-    // 11 regular players + 1 libero (duplicate of C. Tsang)
-    expect(result.teamA.players.length).toBeGreaterThanOrEqual(11)
+    // 11 unique players (libero C. Tsang deduplicated - appears in both player list and LIBERO section)
+    expect(result.teamA.players).toHaveLength(11)
 
     // Check specific players with DOB
     const klocke = result.teamA.players.find((p) => p.rawName.includes('Klocke'))
@@ -1007,7 +1008,8 @@ Offizielle/Officiels/Ufficiali\tOffizielle/Officiels/Ufficiali
     expect(medicalA!.rawName).toContain('Zeitov')
 
     // ---- Team B (Volley Oerlikon) ----
-    expect(result.teamB.players.length).toBeGreaterThanOrEqual(11)
+    // 11 unique players (liberos N. Jegu and J. Risso Gertrude deduplicated)
+    expect(result.teamB.players).toHaveLength(11)
 
     const papadopoulos = result.teamB.players.find((p) => p.rawName.includes('Papadopoulos'))
     expect(papadopoulos).toBeDefined()
@@ -1035,5 +1037,64 @@ Offizielle/Officiels/Ufficiali\tOffizielle/Officiels/Ufficiali
     const medicalB = result.teamB.officials.find((o) => o.role === 'M')
     expect(medicalB).toBeDefined()
     expect(medicalB!.rawName).toContain('Zeitler')
+  })
+})
+
+// =============================================================================
+// Libero Deduplication Tests
+// =============================================================================
+
+describe('Libero deduplication', () => {
+  it('deduplicates libero players that appear in both player list and LIBERO section (6-column)', () => {
+    const ocrText = `A Oder/ou/o B VBC Test\tVC Opponent A Oder/ou/o B
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome\tLizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+16.05.07\t5\tJ. Klocke\t01.10.95\t5\tG. Papadopoulos
+13.06.04\t1\tC. Tsang\t30.07.96\t16\tN. Jegu
+LIBEROS («L»)\tLIBEROS («L»)
+13.06.04\t1\tC. Tsang\t30.07.96\t16\tN. Jegu`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // Each team should have exactly 2 players (no duplicates from libero section)
+    expect(result.teamA.players).toHaveLength(2)
+    expect(result.teamB.players).toHaveLength(2)
+
+    // C. Tsang should appear only once
+    const tsangCount = result.teamA.players.filter((p) => p.rawName.includes('Tsang')).length
+    expect(tsangCount).toBe(1)
+
+    // N. Jegu should appear only once
+    const jeguCount = result.teamB.players.filter((p) => p.rawName.includes('Jegu')).length
+    expect(jeguCount).toBe(1)
+  })
+
+  it('deduplicates libero players in sequential format', () => {
+    const ocrText = `Team A VBC Test
+16.05.07\t5\tJ. Klocke
+13.06.04\t1\tC. Tsang
+LIBEROS («L»)
+13.06.04\t1\tC. Tsang`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // Should have 2 players, not 3
+    expect(result.teamA.players).toHaveLength(2)
+
+    const tsangCount = result.teamA.players.filter((p) => p.rawName.includes('Tsang')).length
+    expect(tsangCount).toBe(1)
+  })
+
+  it('keeps libero-only players that are not in the regular list', () => {
+    const ocrText = `A Oder/ou/o B VBC Test\tVC Opponent A Oder/ou/o B
+Lizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome\tLizenz-Nr.Licence-No.Licenza-No.\tSpieler Nr.Joueur No.Giocatore No.\tNameNomNome
+16.05.07\t5\tJ. Klocke\t01.10.95\t5\tG. Papadopoulos
+LIBEROS («L»)\tLIBEROS («L»)
+13.06.04\t1\tC. Tsang\t30.07.96\t16\tN. Jegu`
+
+    const result = parseManuscriptSheet(ocrText)
+
+    // Liberos not in regular list should still be added
+    expect(result.teamA.players).toHaveLength(2) // Klocke + Tsang
+    expect(result.teamB.players).toHaveLength(2) // Papadopoulos + Jegu
   })
 })

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -24,6 +24,8 @@ import type {
   OfficialRole,
 } from '../types'
 
+import { deduplicatePlayers } from './dedup-players'
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -1036,33 +1038,6 @@ function detectSectionMarker(line: string): 'libero' | 'officials' | 'end' | nul
   if (isOfficialsMarker(line)) return 'officials'
   if (isEndMarker(line)) return 'end'
   return null
-}
-
-/**
- * Deduplicate players in a team's roster.
- *
- * Manuscript scoresheets typically list libero players twice:
- * once in the main player list and again in a separate LIBERO section.
- * This function removes duplicates, keeping the first occurrence.
- *
- * Two players are considered duplicates if they share the same rawName
- * (case-insensitive). Shirt numbers are NOT used for deduplication because
- * OCR errors can assign the same number to different players.
- */
-function deduplicatePlayers(team: ParsedTeam): void {
-  const seenNames = new Set<string>()
-  const deduped: ParsedPlayer[] = []
-
-  for (const player of team.players) {
-    const nameKey = player.rawName.toLowerCase().trim()
-
-    if (!nameKey || !seenNames.has(nameKey)) {
-      deduped.push(player)
-      if (nameKey) seenNames.add(nameKey)
-    }
-  }
-
-  team.players = deduped
 }
 
 /**

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -16,6 +16,8 @@
  *    where OCR reads horizontally concatenating data from both columns
  */
 
+import { deduplicatePlayers } from './dedup-players'
+
 import type {
   ParsedPlayer,
   ParsedOfficial,
@@ -23,8 +25,6 @@ import type {
   ParsedGameSheet,
   OfficialRole,
 } from '../types'
-
-import { deduplicatePlayers } from './dedup-players'
 
 // =============================================================================
 // Constants

--- a/web-app/src/features/ocr/utils/manuscript-parser.ts
+++ b/web-app/src/features/ocr/utils/manuscript-parser.ts
@@ -1039,6 +1039,33 @@ function detectSectionMarker(line: string): 'libero' | 'officials' | 'end' | nul
 }
 
 /**
+ * Deduplicate players in a team's roster.
+ *
+ * Manuscript scoresheets typically list libero players twice:
+ * once in the main player list and again in a separate LIBERO section.
+ * This function removes duplicates, keeping the first occurrence.
+ *
+ * Two players are considered duplicates if they share the same rawName
+ * (case-insensitive). Shirt numbers are NOT used for deduplication because
+ * OCR errors can assign the same number to different players.
+ */
+function deduplicatePlayers(team: ParsedTeam): void {
+  const seenNames = new Set<string>()
+  const deduped: ParsedPlayer[] = []
+
+  for (const player of team.players) {
+    const nameKey = player.rawName.toLowerCase().trim()
+
+    if (!nameKey || !seenNames.has(nameKey)) {
+      deduped.push(player)
+      if (nameKey) seenNames.add(nameKey)
+    }
+  }
+
+  team.players = deduped
+}
+
+/**
  * Generate warnings for parsed teams
  */
 function generateTeamWarnings(teamA: ParsedTeam, teamB: ParsedTeam): string[] {
@@ -1114,6 +1141,10 @@ function parseSwissTabularSheet(ocrText: string): ParsedGameSheet {
     addPlayersFromExtractedData(teamA, data.firstHalfNames, data.firstHalfDates)
     addPlayersFromExtractedData(teamB, data.secondHalfNames, data.secondHalfDates)
   }
+
+  // Deduplicate players (liberos often appear in both the main list and LIBERO section)
+  deduplicatePlayers(teamA)
+  deduplicatePlayers(teamB)
 
   const warnings = generateTeamWarnings(teamA, teamB)
   return { teamA, teamB, warnings }
@@ -1745,6 +1776,10 @@ export function parseManuscriptSheet(ocrText: string): ParsedGameSheet {
   // Parse each team
   const teamAResult = parseTeamLines(sections.teamALines, sections.teamAName)
   const teamBResult = parseTeamLines(sections.teamBLines, sections.teamBName)
+
+  // Deduplicate players (liberos often appear in both the main list and LIBERO section)
+  deduplicatePlayers(teamAResult.team)
+  deduplicatePlayers(teamBResult.team)
 
   // Collect warnings
   warnings.push(...teamAResult.warnings)

--- a/web-app/src/features/ocr/utils/player-list-parser.ts
+++ b/web-app/src/features/ocr/utils/player-list-parser.ts
@@ -15,6 +15,7 @@
  * For manuscript scoresheets, use parseGameSheet with type: 'manuscript' option.
  */
 
+import { deduplicatePlayers } from './dedup-players'
 import { parseManuscriptSheet } from './manuscript-parser'
 
 import type { ScoresheetType } from './scoresheet-detector'
@@ -805,37 +806,6 @@ function processLine(line: string, state: ParserState): void {
       processOfficialsLine(parts, state)
       break
   }
-}
-
-// =============================================================================
-// Player Deduplication
-// =============================================================================
-
-/**
- * Deduplicate players in a team's roster.
- *
- * Scoresheets typically list libero players twice:
- * once in the main player list and again in a separate LIBERO section.
- * This function removes duplicates, keeping the first occurrence.
- *
- * Two players are considered duplicates if they share the same rawName
- * (case-insensitive). Shirt numbers are NOT used for deduplication because
- * OCR errors can assign the same number to different players.
- */
-function deduplicatePlayers(team: ParsedTeam): void {
-  const seenNames = new Set<string>()
-  const deduped: ParsedPlayer[] = []
-
-  for (const player of team.players) {
-    const nameKey = player.rawName.toLowerCase().trim()
-
-    if (!nameKey || !seenNames.has(nameKey)) {
-      deduped.push(player)
-      if (nameKey) seenNames.add(nameKey)
-    }
-  }
-
-  team.players = deduped
 }
 
 // =============================================================================

--- a/web-app/src/features/ocr/utils/player-list-parser.ts
+++ b/web-app/src/features/ocr/utils/player-list-parser.ts
@@ -808,6 +808,37 @@ function processLine(line: string, state: ParserState): void {
 }
 
 // =============================================================================
+// Player Deduplication
+// =============================================================================
+
+/**
+ * Deduplicate players in a team's roster.
+ *
+ * Scoresheets typically list libero players twice:
+ * once in the main player list and again in a separate LIBERO section.
+ * This function removes duplicates, keeping the first occurrence.
+ *
+ * Two players are considered duplicates if they share the same rawName
+ * (case-insensitive). Shirt numbers are NOT used for deduplication because
+ * OCR errors can assign the same number to different players.
+ */
+function deduplicatePlayers(team: ParsedTeam): void {
+  const seenNames = new Set<string>()
+  const deduped: ParsedPlayer[] = []
+
+  for (const player of team.players) {
+    const nameKey = player.rawName.toLowerCase().trim()
+
+    if (!nameKey || !seenNames.has(nameKey)) {
+      deduped.push(player)
+      if (nameKey) seenNames.add(nameKey)
+    }
+  }
+
+  team.players = deduped
+}
+
+// =============================================================================
 // Main Parser
 // =============================================================================
 
@@ -863,6 +894,10 @@ export function parseGameSheet(ocrText: string): ParsedGameSheet {
   for (const line of lines) {
     processLine(line, state)
   }
+
+  // Deduplicate players (liberos often appear in both the main list and LIBERO section)
+  deduplicatePlayers(state.teamA)
+  deduplicatePlayers(state.teamB)
 
   // Add warnings
   if (state.teamA.players.length === 0) {
@@ -1396,6 +1431,10 @@ export function parseGameSheetWithOCR(
     const ocrLine = lineToOCRLine.get(line)
     processLineWithOCR(line, state, ocrLine)
   }
+
+  // Deduplicate players (liberos often appear in both the main list and LIBERO section)
+  deduplicatePlayers(state.teamA)
+  deduplicatePlayers(state.teamB)
 
   // Add warnings
   if (state.teamA.players.length === 0) {

--- a/web-app/src/features/validation/components/ImageCropEditor.tsx
+++ b/web-app/src/features/validation/components/ImageCropEditor.tsx
@@ -170,8 +170,8 @@ export function ImageCropEditor({
         </div>
       </div>
 
-      {/* Controls */}
-      <div className="flex-shrink-0 flex gap-4 p-4 bg-white dark:bg-gray-800">
+      {/* Controls - pb accounts for iOS safe area behind home indicator */}
+      <div className="flex-shrink-0 flex gap-4 p-4 pb-[max(1rem,env(safe-area-inset-bottom))] bg-white dark:bg-gray-800">
         <button
           type="button"
           onClick={onCancel}


### PR DESCRIPTION
## Summary

- **Libero deduplication**: Manuscript scoresheets list libero players in both the regular player roster and a separate LIBERO section, causing duplicates. Added name-based deduplication to both manuscript and electronic parsers, keeping the first occurrence.
- **Crop button visibility**: Fixed the confirm button in ImageCropEditor being hidden behind the iOS home indicator by adding safe-area-inset-bottom padding to the controls container.
- **POC CSS source scanning**: Added `@source` directive to the OCR PoC CSS so Tailwind 4 scans shared web-app component classes (e.g. `bg-primary-500`).

## Test plan

- [x] All 160 OCR tests pass (75 manuscript + 31 electronic + others)
- [x] 3 new deduplication-specific tests added (6-column, sequential, libero-only)
- [ ] Verify crop confirm button visible on iOS device with home indicator
- [ ] Verify POC crop screen renders button with correct primary color

https://claude.ai/code/session_01Ny92RojtMajG6b8pPJymC2