### PR TITLE
fix(web,docs): align game validation API with OpenAPI spec

### DIFF
--- a/.changeset/align-game-validation-api.md
+++ b/.changeset/align-game-validation-api.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Align game validation API with OpenAPI spec: make finalizeScoresheet required fields strict, add validateScoresheet call before finalization, and update NominationListFinalizeRequest spec

--- a/docs/api/volleymanager-openapi.yaml
+++ b/docs/api/volleymanager-openapi.yaml
@@ -6307,6 +6307,9 @@ components:
         "nominationList[firstAssistantCoachPerson][__identity]":
           type: string
           format: uuid
+        "nominationList[secondAssistantCoachPerson]":
+          type: string
+          description: Empty string to clear, or use [__identity] suffix with UUID to set
         "nominationList[indoorPlayerNominations][0][__identity]":
           type: string
           format: uuid

--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -1006,13 +1006,13 @@ describe('API Client', () => {
         })
       )
 
-      await api.finalizeScoresheet('ss-1', 'game-1', 'scorer-1')
+      await api.finalizeScoresheet('ss-1', 'game-1', 'scorer-1', 'file-res-1')
 
       expect(capturedUrl).toContain('scoresheet/finalize')
       expect(capturedMethod).toBe('POST')
     })
 
-    it('includes file resource ID when provided', async () => {
+    it('includes file resource ID and sets hasFile to true', async () => {
       let capturedBody: URLSearchParams | null = null
 
       server.use(
@@ -1029,6 +1029,22 @@ describe('API Client', () => {
       expect(capturedBody?.get('scoresheet[hasFile]')).toBe('true')
     })
 
+    it('includes scoresheet identity in body', async () => {
+      let capturedBody: URLSearchParams | null = null
+
+      server.use(
+        http.post('*/api%5cscoresheet/finalize', async ({ request }) => {
+          const text = await request.text()
+          capturedBody = new URLSearchParams(text)
+          return HttpResponse.json({})
+        })
+      )
+
+      await api.finalizeScoresheet('ss-1', 'game-1', 'scorer-1', 'file-res-1')
+
+      expect(capturedBody?.get('scoresheet[__identity]')).toBe('ss-1')
+    })
+
     it('includes validation ID when provided', async () => {
       let capturedBody: URLSearchParams | null = null
 
@@ -1040,25 +1056,9 @@ describe('API Client', () => {
         })
       )
 
-      await api.finalizeScoresheet('ss-1', 'game-1', 'scorer-1', undefined, 'val-1')
+      await api.finalizeScoresheet('ss-1', 'game-1', 'scorer-1', 'file-res-1', 'val-1')
 
       expect(capturedBody?.get('scoresheet[scoresheetValidation][__identity]')).toBe('val-1')
-    })
-
-    it('sets hasFile to false when no file provided', async () => {
-      let capturedBody: URLSearchParams | null = null
-
-      server.use(
-        http.post('*/api%5cscoresheet/finalize', async ({ request }) => {
-          const text = await request.text()
-          capturedBody = new URLSearchParams(text)
-          return HttpResponse.json({})
-        })
-      )
-
-      await api.finalizeScoresheet('ss-1', 'game-1', 'scorer-1')
-
-      expect(capturedBody?.get('scoresheet[hasFile]')).toBe('false')
     })
   })
 

--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -993,6 +993,61 @@ describe('API Client', () => {
     })
   })
 
+  describe('validateScoresheet', () => {
+    it('sends POST request to validateScoresheet endpoint', async () => {
+      let capturedUrl: string | null = null
+      let capturedMethod: string | null = null
+
+      server.use(
+        http.post('*/api%5cscoresheet/validateScoresheet', ({ request }) => {
+          capturedUrl = request.url
+          capturedMethod = request.method
+          return HttpResponse.json({ __identity: 'val-1', hasValidationIssues: false })
+        })
+      )
+
+      await api.validateScoresheet('game-1', 'scorer-1')
+
+      expect(capturedUrl).toContain('scoresheet/validateScoresheet')
+      expect(capturedMethod).toBe('POST')
+    })
+
+    it('includes game and scorer in request body', async () => {
+      let capturedBody: URLSearchParams | null = null
+
+      server.use(
+        http.post('*/api%5cscoresheet/validateScoresheet', async ({ request }) => {
+          const text = await request.text()
+          capturedBody = new URLSearchParams(text)
+          return HttpResponse.json({ __identity: 'val-1', hasValidationIssues: false })
+        })
+      )
+
+      await api.validateScoresheet('game-1', 'scorer-1', true)
+
+      expect(capturedBody?.get('scoresheet[game][__identity]')).toBe('game-1')
+      expect(capturedBody?.get('scoresheet[writerPerson][__identity]')).toBe('scorer-1')
+      expect(capturedBody?.get('scoresheet[isSimpleScoresheet]')).toBe('true')
+    })
+
+    it('returns validation result with identity', async () => {
+      server.use(
+        http.post('*/api%5cscoresheet/validateScoresheet', () => {
+          return HttpResponse.json({
+            __identity: 'val-123',
+            hasValidationIssues: true,
+            scoresheetValidationIssues: [{ __identity: 'issue-1' }],
+          })
+        })
+      )
+
+      const result = await api.validateScoresheet('game-1', 'scorer-1')
+
+      expect(result.__identity).toBe('val-123')
+      expect(result.hasValidationIssues).toBe(true)
+    })
+  })
+
   describe('finalizeScoresheet', () => {
     it('sends POST request to finalize endpoint', async () => {
       let capturedUrl: string | null = null

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -48,6 +48,7 @@ export type PossibleNomination = Schemas['PossibleNomination']
 export type PossibleNominationsResponse = Schemas['PossibleNominationsResponse']
 export type NominationListResponse = Schemas['NominationListResponse']
 export type Scoresheet = Schemas['Scoresheet']
+export type ScoresheetValidation = Schemas['ScoresheetValidation']
 export type FileResource = Schemas['FileResource']
 export type GameDetails = Schemas['GameDetails']
 export type PersonSearchResult = Schemas['PersonSearchResult']
@@ -703,6 +704,34 @@ export const api = {
       method,
       body,
       'text/plain;charset=UTF-8'
+    )
+  },
+
+  async validateScoresheet(
+    gameId: string,
+    scorerPersonId: string,
+    isSimpleScoresheet: boolean = false
+  ): Promise<ScoresheetValidation> {
+    const body: Record<string, unknown> = {
+      'scoresheet[game][__identity]': gameId,
+      'scoresheet[isSimpleScoresheet]': isSimpleScoresheet ? 'true' : 'false',
+      'scoresheet[scoresheetValidation]': '',
+      'scoresheet[notFoundButNominatedPersons]': '',
+      'scoresheet[emergencySubstituteReferees]': '',
+      'scoresheet[closedAt]': '',
+      'scoresheet[closedBy]': '',
+      'scoresheet[file]': '',
+      'scoresheet[hasFile]': 'false',
+    }
+
+    if (scorerPersonId) {
+      body['scoresheet[writerPerson][__identity]'] = scorerPersonId
+    }
+
+    return apiRequest<ScoresheetValidation>(
+      '/sportmanager.indoorvolleyball/api%5cscoresheet/validateScoresheet',
+      'POST',
+      body
     )
   },
 

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -712,8 +712,11 @@ export const api = {
     scorerPersonId: string,
     isSimpleScoresheet: boolean = false
   ): Promise<ScoresheetValidation> {
+    // Empty-string fields are required by the Neos Flow backend to clear server-side state
+    // during validation. Omitting them causes 500 errors during property mapping.
     const body: Record<string, unknown> = {
       'scoresheet[game][__identity]': gameId,
+      'scoresheet[writerPerson][__identity]': scorerPersonId,
       'scoresheet[isSimpleScoresheet]': isSimpleScoresheet ? 'true' : 'false',
       'scoresheet[scoresheetValidation]': '',
       'scoresheet[notFoundButNominatedPersons]': '',
@@ -722,10 +725,6 @@ export const api = {
       'scoresheet[closedBy]': '',
       'scoresheet[file]': '',
       'scoresheet[hasFile]': 'false',
-    }
-
-    if (scorerPersonId) {
-      body['scoresheet[writerPerson][__identity]'] = scorerPersonId
     }
 
     return apiRequest<ScoresheetValidation>(

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -707,26 +707,20 @@ export const api = {
   },
 
   async finalizeScoresheet(
-    scoresheetId: string | undefined,
+    scoresheetId: string,
     gameId: string,
     scorerPersonId: string,
-    fileResourceId?: string,
+    fileResourceId: string,
     validationId?: string,
     isSimpleScoresheet: boolean = false
   ): Promise<Scoresheet> {
     const body: Record<string, unknown> = {
+      'scoresheet[__identity]': scoresheetId,
       'scoresheet[game][__identity]': gameId,
       'scoresheet[writerPerson][__identity]': scorerPersonId,
-      'scoresheet[hasFile]': fileResourceId ? 'true' : 'false',
+      'scoresheet[file][__identity]': fileResourceId,
+      'scoresheet[hasFile]': 'true',
       'scoresheet[isSimpleScoresheet]': isSimpleScoresheet ? 'true' : 'false',
-    }
-
-    if (scoresheetId) {
-      body['scoresheet[__identity]'] = scoresheetId
-    }
-
-    if (fileResourceId) {
-      body['scoresheet[file][__identity]'] = fileResourceId
     }
 
     if (validationId) {

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -711,10 +711,10 @@ export const mockApi = {
   },
 
   async finalizeScoresheet(
-    scoresheetId: string | undefined,
+    scoresheetId: string,
     gameId: string,
     scorerPersonId: string,
-    fileResourceId?: string,
+    fileResourceId: string,
     _validationId?: string,
     isSimpleScoresheet: boolean = false
   ): Promise<Scoresheet> {

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -36,6 +36,7 @@ import type {
   NominationList,
   NominationListResponse,
   Scoresheet,
+  ScoresheetValidation,
   FileResource,
   GameDetails,
   PossibleNominationsResponse,
@@ -707,6 +708,20 @@ export const mockApi = {
       writerPerson: { __identity: scorerPersonId },
       isSimpleScoresheet,
       hasFile: false,
+    }
+  },
+
+  async validateScoresheet(
+    _gameId: string,
+    _scorerPersonId: string,
+    _isSimpleScoresheet: boolean = false
+  ): Promise<ScoresheetValidation> {
+    await delay(MOCK_MUTATION_DELAY_MS)
+
+    return {
+      __identity: crypto.randomUUID(),
+      hasValidationIssues: false,
+      scoresheetValidationIssues: [],
     }
   },
 

--- a/web-app/src/api/schema.ts
+++ b/web-app/src/api/schema.ts
@@ -4342,6 +4342,8 @@ export interface components {
             "nominationList[coachPerson][__identity]"?: string;
             /** Format: uuid */
             "nominationList[firstAssistantCoachPerson][__identity]"?: string;
+            /** @description Empty string to clear, or use [__identity] suffix with UUID to set */
+            "nominationList[secondAssistantCoachPerson]"?: string;
             /** Format: uuid */
             "nominationList[indoorPlayerNominations][0][__identity]"?: string;
             /**

--- a/web-app/src/features/assignments/api/calendar-client.ts
+++ b/web-app/src/features/assignments/api/calendar-client.ts
@@ -45,6 +45,7 @@ import type {
   NominationList,
   NominationListResponse,
   Scoresheet,
+  ScoresheetValidation,
   FileResource,
   GameDetails,
   PossibleNominationsResponse,
@@ -285,6 +286,10 @@ export const calendarApi = {
 
   async updateScoresheet(): Promise<Scoresheet> {
     throw new CalendarModeNotSupportedError('Scoresheet updates')
+  },
+
+  async validateScoresheet(): Promise<ScoresheetValidation> {
+    throw new CalendarModeNotSupportedError('Scoresheet validation')
   },
 
   async finalizeScoresheet(): Promise<Scoresheet> {

--- a/web-app/src/features/validation/Validation.integration.test.tsx
+++ b/web-app/src/features/validation/Validation.integration.test.tsx
@@ -402,7 +402,7 @@ describe('Validation Integration', () => {
         ],
       })
 
-      await mockApi.finalizeScoresheet('scoresheet-1', gameId, scorerId)
+      await mockApi.finalizeScoresheet('scoresheet-1', gameId, scorerId, 'resource-123')
 
       // Game should be marked as validated
       const validatedData = useDemoStore.getState().validatedGames[gameId]

--- a/web-app/src/features/validation/api/api-helpers.ts
+++ b/web-app/src/features/validation/api/api-helpers.ts
@@ -208,7 +208,22 @@ export async function finalizeRoster(
   )
 }
 
-/** Finalizes scoresheet with file upload. */
+/** Validates scoresheet on the server and returns the validation identity. */
+export async function validateScoresheetBeforeFinalize(
+  apiClient: ReturnType<typeof getApiClient>,
+  gameId: string,
+  scorerId: string,
+  isSimpleScoresheet: boolean
+): Promise<string | undefined> {
+  const validation = await apiClient.validateScoresheet(gameId, scorerId, isSimpleScoresheet)
+  logger.debug('[VS] scoresheet validated', {
+    validationId: validation.__identity,
+    hasIssues: validation.hasValidationIssues,
+  })
+  return validation.__identity
+}
+
+/** Finalizes scoresheet with file upload. Validates on the server first. */
 export async function finalizeScoresheetWithFile(
   apiClient: ReturnType<typeof getApiClient>,
   gameId: string,
@@ -233,12 +248,23 @@ export async function finalizeScoresheetWithFile(
     return
   }
 
+  const isSimple = scoresheet.isSimpleScoresheet ?? false
+
+  // Validate scoresheet on the server to get a fresh validation identity.
+  // The volleymanager workflow requires this step before finalization.
+  const validationId = await validateScoresheetBeforeFinalize(
+    apiClient,
+    gameId,
+    scorerId,
+    isSimple
+  )
+
   await apiClient.finalizeScoresheet(
     scoresheet.__identity,
     gameId,
     scorerId,
     fileResourceId,
-    scoresheet.scoresheetValidation?.__identity,
-    scoresheet.isSimpleScoresheet ?? false
+    validationId,
+    isSimple
   )
 }

--- a/web-app/src/features/validation/api/api-helpers.ts
+++ b/web-app/src/features/validation/api/api-helpers.ts
@@ -208,7 +208,7 @@ export async function finalizeRoster(
   )
 }
 
-/** Finalizes scoresheet with optional file upload. */
+/** Finalizes scoresheet with file upload. */
 export async function finalizeScoresheetWithFile(
   apiClient: ReturnType<typeof getApiClient>,
   gameId: string,
@@ -224,15 +224,21 @@ export async function finalizeScoresheetWithFile(
     logger.debug('[VS] skip scoresheet finalize: scoresheet already closed')
     return
   }
+  if (!scoresheet?.__identity) {
+    logger.debug('[VS] skip scoresheet finalize: no scoresheet identity (save first)')
+    return
+  }
+  if (!fileResourceId) {
+    logger.debug('[VS] skip scoresheet finalize: no file uploaded')
+    return
+  }
 
-  // scoresheet.__identity may be undefined for games where the scoresheet
-  // entity hasn't been created yet. The server resolves it from the game identity.
   await apiClient.finalizeScoresheet(
-    scoresheet?.__identity,
+    scoresheet.__identity,
     gameId,
     scorerId,
     fileResourceId,
-    scoresheet?.scoresheetValidation?.__identity,
-    scoresheet?.isSimpleScoresheet ?? false
+    scoresheet.scoresheetValidation?.__identity,
+    scoresheet.isSimpleScoresheet ?? false
   )
 }

--- a/web-app/src/features/validation/hooks/useValidationState.test.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.test.ts
@@ -66,6 +66,7 @@ describe('useValidationState', () => {
   const mockGetGameWithScoresheet = vi.fn()
   const mockUpdateNominationList = vi.fn()
   const mockUpdateScoresheet = vi.fn()
+  const mockValidateScoresheet = vi.fn()
   const mockFinalizeNominationList = vi.fn()
   const mockFinalizeScoresheet = vi.fn()
   const mockUploadResource = vi.fn()
@@ -77,10 +78,17 @@ describe('useValidationState', () => {
       selector({ dataSource: 'api' } as ReturnType<typeof authStore.useAuthStore.getState>)
     )
 
+    mockValidateScoresheet.mockResolvedValue({
+      __identity: 'fresh-validation-id',
+      hasValidationIssues: false,
+      scoresheetValidationIssues: [],
+    })
+
     vi.mocked(apiClient.getApiClient).mockReturnValue({
       getGameWithScoresheet: mockGetGameWithScoresheet,
       updateNominationList: mockUpdateNominationList,
       updateScoresheet: mockUpdateScoresheet,
+      validateScoresheet: mockValidateScoresheet,
       finalizeNominationList: mockFinalizeNominationList,
       finalizeScoresheet: mockFinalizeScoresheet,
       uploadResource: mockUploadResource,


### PR DESCRIPTION
## Summary

- **Spec fix**: Add `secondAssistantCoachPerson` to `NominationListFinalizeRequest` in OpenAPI spec (was present in update schema but missing from finalize)
- **Client fix**: Make `scoresheetId` and `fileResourceId` required in `finalizeScoresheet()` per spec, with early-return guards in the `finalizeScoresheetWithFile` helper
- **New feature**: Implement `validateScoresheet` API call before finalization, matching the real volleymanager workflow (validate → upload → finalize) documented in `docs/api/captures/escoresheet_endpoints.md`
- Add client, mock API, and calendar stub implementations + tests
- Regenerate API types from updated OpenAPI spec

## Test plan

- [x] All 63 client tests pass (including 3 new `validateScoresheet` tests)
- [x] All 62 contract + integration tests pass
- [x] All 38 calendar client tests pass
- [x] `useValidationState` tests pass with mock `validateScoresheet`
- [ ] Verify finalize flow in demo mode end-to-end

https://claude.ai/code/session_01TpufzNTCAqmxDbwk7cMzAZ