### PR TITLE
fix(web): treat undefined paymentDone as unpaid in compensation filter

### DIFF
--- a/.changeset/fix-compensation-tab-filter.md
+++ b/.changeset/fix-compensation-tab-filter.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fixed compensation tab showing empty for pending past items when paymentDone is undefined

--- a/web-app/src/features/compensations/hooks/useCompensations.test.tsx
+++ b/web-app/src/features/compensations/hooks/useCompensations.test.tsx
@@ -237,6 +237,96 @@ describe('useCompensations', () => {
     expect(result.current.data![0]!.__identity).toBe('unpaid-1')
   })
 
+  it('treats undefined paymentDone as unpaid when filtering for unpaid compensations', async () => {
+    const compensations = [
+      createMockCompensation({
+        __identity: 'paid-1',
+        convocationCompensation: {
+          __identity: 'c1',
+          paymentDone: true,
+          gameCompensation: 50,
+          travelExpenses: 20,
+        },
+      }),
+      createMockCompensation({
+        __identity: 'undefined-payment-1',
+        convocationCompensation: {
+          __identity: 'c2',
+          gameCompensation: 50,
+          travelExpenses: 20,
+        },
+      }),
+    ]
+
+    const mockSearchCompensations = vi.fn().mockResolvedValue({
+      items: compensations,
+      totalItemsCount: 2,
+    })
+
+    const { getApiClient } = await import('@/api/client')
+    vi.mocked(getApiClient).mockReturnValue({
+      searchCompensations: mockSearchCompensations,
+      updateCompensation: vi.fn(),
+    } as unknown as ReturnType<typeof getApiClient>)
+
+    const { result } = renderHook(() => useCompensations(false), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    // Should include compensations where paymentDone is undefined (not explicitly paid)
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data![0]!.__identity).toBe('undefined-payment-1')
+  })
+
+  it('excludes undefined paymentDone when filtering for paid compensations', async () => {
+    const compensations = [
+      createMockCompensation({
+        __identity: 'paid-1',
+        convocationCompensation: {
+          __identity: 'c1',
+          paymentDone: true,
+          gameCompensation: 50,
+          travelExpenses: 20,
+        },
+      }),
+      createMockCompensation({
+        __identity: 'undefined-payment-1',
+        convocationCompensation: {
+          __identity: 'c2',
+          gameCompensation: 50,
+          travelExpenses: 20,
+        },
+      }),
+    ]
+
+    const mockSearchCompensations = vi.fn().mockResolvedValue({
+      items: compensations,
+      totalItemsCount: 2,
+    })
+
+    const { getApiClient } = await import('@/api/client')
+    vi.mocked(getApiClient).mockReturnValue({
+      searchCompensations: mockSearchCompensations,
+      updateCompensation: vi.fn(),
+    } as unknown as ReturnType<typeof getApiClient>)
+
+    const { result } = renderHook(() => useCompensations(true), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    // Should only return explicitly paid compensations, not undefined ones
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data![0]!.__identity).toBe('paid-1')
+  })
+
   it('returns empty array when items is null', async () => {
     const mockSearchCompensations = vi.fn().mockResolvedValue({
       items: null,

--- a/web-app/src/features/compensations/hooks/useCompensations.ts
+++ b/web-app/src/features/compensations/hooks/useCompensations.ts
@@ -194,7 +194,13 @@ export function useCompensations(paidFilter?: boolean) {
       if (paidFilter === undefined) {
         return items
       }
-      return items.filter((record) => record.convocationCompensation?.paymentDone === paidFilter)
+      // Use !== instead of === for unpaid filter because paymentDone may be undefined
+      // when not set by the API (the field is optional). For unpaid (paidFilter=false),
+      // we want everything that isn't explicitly paid (true).
+      if (paidFilter) {
+        return items.filter((record) => record.convocationCompensation?.paymentDone === true)
+      }
+      return items.filter((record) => record.convocationCompensation?.paymentDone !== true)
     },
     staleTime: COMPENSATIONS_STALE_TIME_MS,
   })


### PR DESCRIPTION
## Summary

- Fixed the "Pending (Past)" compensation tab showing empty when the API returns `paymentDone` as `undefined` instead of `false`
- Changed `useCompensations` select filter to use `\!== true` for unpaid items instead of `=== false`, so `undefined`/`null`/`false` are all treated as unpaid
- Added 2 test cases covering `undefined` `paymentDone` for both paid and unpaid filter paths

## Test plan

- [x] New test: `treats undefined paymentDone as unpaid when filtering for unpaid compensations`
- [x] New test: `excludes undefined paymentDone when filtering for paid compensations`
- [x] All 166 existing compensation tests pass
- [ ] Manual: verify "Pending (Past)" tab shows compensation records from API

https://claude.ai/code/session_01VNxQwohneAzr6DMtVrDF83