### PR TITLE
fix(web): sync association context before setting auth state on login

### DIFF
--- a/.changeset/fix-compensation-games-display.md
+++ b/.changeset/fix-compensation-games-display.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fixed compensation games not displaying on initial login by ensuring server-side association context is synced before setting authenticated state

--- a/web-app/src/shared/stores/auth.ts
+++ b/web-app/src/shared/stores/auth.ts
@@ -284,6 +284,20 @@ async function handleSuccessfulLoginResult(
     return rejectNonRefereeUser(set)
   }
 
+  // Sync server-side active association with client's selection BEFORE
+  // setting authenticated state. This ensures the API returns data for
+  // the correct association when React re-renders and queries fire after
+  // the state update. Without this ordering, queries race with the
+  // switchRoleAndAttribute call and may return data for the wrong association.
+  if (activeOccupationId) {
+    try {
+      await apiClient.switchRoleAndAttribute(activeOccupationId)
+    } catch (error) {
+      // Log but don't fail login - user can manually switch if needed
+      logger.warn('Failed to sync active association after login:', error)
+    }
+  }
+
   set({
     status: 'authenticated',
     csrfToken: result.csrfToken,
@@ -294,19 +308,6 @@ async function handleSuccessfulLoginResult(
     activeOccupationId,
     _lastAuthTimestamp: Date.now(),
   })
-
-  // Sync server-side active association with client's selection.
-  // This ensures the API returns data for the correct association,
-  // especially after logout/re-login when the server's default
-  // may differ from the client's chosen occupation.
-  if (activeOccupationId) {
-    try {
-      await apiClient.switchRoleAndAttribute(activeOccupationId)
-    } catch (error) {
-      // Log but don't fail login - user can manually switch if needed
-      logger.warn('Failed to sync active association after login:', error)
-    }
-  }
 
   // Extract calendar code from dashboard HTML if not already stored.
   // The calendar code is unique per referee and doesn't change, so we only
@@ -521,6 +522,20 @@ export const useAuthStore = create<AuthState>()(
               return rejectNonRefereeUser(set)
             }
 
+            // Sync server-side active association with client's selection BEFORE
+            // setting authenticated state. This ensures the API returns data for
+            // the correct association when React re-renders and queries fire after
+            // the state update. Without this ordering, queries race with the
+            // switchRoleAndAttribute call and may return data for the wrong association.
+            if (activeOccupationId) {
+              try {
+                await apiClient.switchRoleAndAttribute(activeOccupationId)
+              } catch (error) {
+                // Log but don't fail login - user can manually switch if needed
+                logger.warn('Failed to sync active association after login:', error)
+              }
+            }
+
             set({
               status: 'authenticated',
               csrfToken: existingCsrfToken,
@@ -531,19 +546,6 @@ export const useAuthStore = create<AuthState>()(
               activeOccupationId,
               _lastAuthTimestamp: Date.now(),
             })
-
-            // Sync server-side active association with client's selection.
-            // This ensures the API returns data for the correct association,
-            // especially after logout/re-login when the server's default
-            // may differ from the client's chosen occupation.
-            if (activeOccupationId) {
-              try {
-                await apiClient.switchRoleAndAttribute(activeOccupationId)
-              } catch (error) {
-                // Log but don't fail login - user can manually switch if needed
-                logger.warn('Failed to sync active association after login:', error)
-              }
-            }
 
             // Extract calendar code from dashboard HTML if not already stored
             if (!currentState.calendarCode && dashboardHtml) {


### PR DESCRIPTION
## Summary

- Fixed a race condition in `auth.ts` where `set({ status: "authenticated" })` was called **before** `switchRoleAndAttribute()` completed
- This caused compensation queries to fire against the server while it was still in the wrong/default association context, resulting in empty "past but not closed" section on initial login
- Moved `switchRoleAndAttribute()` before the state update in both login paths, aligning with the correct pattern already used in AppShell's association switcher

## Test plan

- [ ] Log in with a multi-association account, navigate to Compensations tab, verify "past but not closed" shows games immediately
- [ ] Log out and log back in, verify compensations display correctly without needing to switch associations
- [ ] Switch associations via dropdown, verify it still works as before
- [ ] Existing auth store tests pass (57/57 verified locally)

https://claude.ai/code/session_01Ceuy42cCoGkberGK6oVuRX