### PR TITLE
fix(ci): use --no-frozen-lockfile in update-deps workflows

### DIFF
--- a/.github/workflows/update-deps-mobile.yml
+++ b/.github/workflows/update-deps-mobile.yml
@@ -136,7 +136,7 @@ jobs:
         run: ncu --target minor -u
       - name: Reinstall dependencies
         if: steps.check-updates.outputs.has_updates == 'true'
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
       - name: Run Expo Doctor
         if: steps.check-updates.outputs.has_updates == 'true'
         working-directory: packages/mobile

--- a/.github/workflows/update-deps-web.yml
+++ b/.github/workflows/update-deps-web.yml
@@ -128,11 +128,8 @@ jobs:
           ncu --target "$NCU_TARGET" -u
           cd ..
 
-          # Install updated dependencies
-          pnpm install
-
-          # Regenerate pnpm-lock.yaml
-          pnpm install --lockfile-only
+          # Install updated dependencies (--no-frozen-lockfile needed since ncu modified package.json)
+          pnpm install --no-frozen-lockfile
       - name: Upload updated files
         if: steps.check-updates.outputs.has_updates == 'true'
         uses: actions/upload-artifact@v5

--- a/.github/workflows/update-deps-worker.yml
+++ b/.github/workflows/update-deps-worker.yml
@@ -105,11 +105,8 @@ jobs:
           ncu --target "$NCU_TARGET" -u
           cd ..
 
-          # Install updated dependencies
-          pnpm install
-
-          # Regenerate pnpm-lock.yaml
-          pnpm install --lockfile-only
+          # Install updated dependencies (--no-frozen-lockfile needed since ncu modified package.json)
+          pnpm install --no-frozen-lockfile
       - name: Upload updated files
         if: steps.check-updates.outputs.has_updates == 'true'
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
## Summary
- Fix all three `update-deps` workflows (worker, web, mobile) failing because `pnpm install` defaults to `--frozen-lockfile` in CI
- After `ncu` updates `package.json` versions, the lockfile becomes stale, causing `pnpm install` to fail with `ERR_PNPM_OUTDATED_LOCKFILE`
- Add `--no-frozen-lockfile` flag to the install step in all three workflows
- Remove redundant duplicate `pnpm install --lockfile-only` calls in worker and web workflows

## Test plan
- [ ] Re-run the [failing Update Dependencies (Worker) workflow](https://github.com/Takishima/volleykit/actions/runs/22519511767) to verify it passes
- [ ] Verify web and mobile update-deps workflows also work on next scheduled run