### PR TITLE
feat(shared,web): add Zod response validation to all API client endpoints

### DIFF
--- a/.changeset/add-zod-response-validation.md
+++ b/.changeset/add-zod-response-validation.md
@@ -1,0 +1,6 @@
+---
+'volleykit-web': minor
+'@volleykit/shared': minor
+---
+
+Add Zod response validation to all API client detail and mutation endpoints

--- a/packages/shared/src/api/validation.ts
+++ b/packages/shared/src/api/validation.ts
@@ -488,7 +488,7 @@ export interface Season {
  * A structural type for Zod schemas that works with both Zod 3 and Zod 4.
  * This avoids type incompatibilities between versions.
  */
-interface ZodLikeSchema<T> {
+export interface ZodLikeSchema<T> {
   safeParse(
     data: unknown
   ):

--- a/packages/shared/src/api/validation.ts
+++ b/packages/shared/src/api/validation.ts
@@ -260,6 +260,206 @@ export const personSearchResponseSchema = z.object({
   totalItemsCount: z.number().optional(),
 })
 
+// ============================================================================
+// Detail / mutation response schemas
+// ============================================================================
+
+// Compensation detail response (showWithNestedObjects wrapper)
+export const compensationDetailedSchema = z
+  .object({
+    convocationCompensation: convocationCompensationSchema.optional(),
+  })
+  .passthrough()
+
+// Pick exchange response (pickFromRefereeGameExchange wrapper)
+export const pickExchangeResponseSchema = z
+  .object({
+    refereeGameExchange: z
+      .object({
+        __identity: uuidSchema.optional(),
+        status: z.string().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+
+// File resource schema (upload response)
+export const fileResourceSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    persistentResource: z
+      .object({
+        __identity: uuidSchema.optional(),
+        filename: z.string().optional(),
+        mediaType: z.string().optional(),
+        fileSize: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    publicResourceUri: z.string().optional(),
+  })
+  .passthrough()
+
+// File resource array schema (upload response is an array)
+export const fileResourceArraySchema = z.array(fileResourceSchema)
+
+// Scoresheet validation schema
+export const scoresheetValidationSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    hasValidationIssues: z.boolean().optional(),
+    hasValidationIssuesForAssociationUserContext: z.boolean().optional(),
+    hasValidationIssuesForClubUserContext: z.boolean().optional(),
+    areValidationIssuesAddressedByChampionshipOperator: z.boolean().optional(),
+    scoresheetValidationIssues: z.array(z.object({}).passthrough()).optional(),
+  })
+  .passthrough()
+
+// Scoresheet schema
+export const scoresheetSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    game: z.object({ __identity: uuidSchema.optional() }).passthrough().optional(),
+    isSimpleScoresheet: z.boolean().optional(),
+    writerPerson: personSummarySchema.optional().nullable(),
+    scoresheetValidation: scoresheetValidationSchema.optional().nullable(),
+    file: fileResourceSchema.optional().nullable(),
+    hasFile: z.boolean().optional(),
+    closedAt: dateTimeSchema,
+  })
+  .passthrough()
+
+// Indoor player nomination schema
+const indoorPlayerNominationSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    indoorPlayer: z
+      .object({
+        __identity: uuidSchema.optional(),
+        person: personSummarySchema.optional(),
+      })
+      .passthrough()
+      .optional(),
+    indoorPlayerLicenseCategory: z
+      .object({
+        __identity: uuidSchema.optional(),
+        shortName: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()
+
+// Nomination list schema
+export const nominationListSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    game: z.object({ __identity: uuidSchema.optional() }).passthrough().optional(),
+    team: z
+      .object({
+        __identity: uuidSchema.optional(),
+        displayName: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    indoorPlayerNominations: z.array(indoorPlayerNominationSchema).optional(),
+    coachPerson: personSummarySchema.optional().nullable(),
+    firstAssistantCoachPerson: personSummarySchema.optional().nullable(),
+    secondAssistantCoachPerson: personSummarySchema.optional().nullable(),
+    closed: z.boolean().optional(),
+    closedAt: dateTimeSchema,
+    checked: z.boolean().optional(),
+    isClosedForTeam: z.boolean().optional(),
+    nominationListValidation: z.object({}).passthrough().optional().nullable(),
+    _permissions: permissionsSchema,
+  })
+  .passthrough()
+
+// Nomination list response (finalize wrapper)
+export const nominationListResponseSchema = z
+  .object({
+    nominationList: nominationListSchema.optional(),
+  })
+  .passthrough()
+
+// Game details schema (showWithNestedObjects response)
+export const gameDetailsSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    scoresheet: scoresheetSchema.optional().nullable(),
+    nominationListOfTeamHome: nominationListSchema.optional().nullable(),
+    nominationListOfTeamAway: nominationListSchema.optional().nullable(),
+    group: z
+      .object({
+        __identity: uuidSchema.optional(),
+        hasNoScoresheet: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional()
+      .nullable(),
+  })
+  .passthrough()
+
+// Game details response wrapper
+export const gameDetailsResponseSchema = z
+  .object({
+    game: gameDetailsSchema,
+  })
+  .passthrough()
+
+// Association settings schema
+export const associationSettingsSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    usesGameExchange: z.boolean().optional(),
+    hoursAfterGameStartForRefereeToEditGameList: z.number().optional(),
+    isRefereeDataManagementAllowed: z.boolean().optional(),
+  })
+  .passthrough()
+
+// Season schema
+export const seasonSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    name: z.string().optional(),
+    displayName: z.string().optional(),
+    seasonStartDate: dateTimeSchema,
+    seasonEndDate: dateTimeSchema,
+    active: z.boolean().optional(),
+  })
+  .passthrough()
+
+// Possible player nomination schema
+const possibleNominationSchema = z
+  .object({
+    __identity: uuidSchema.optional(),
+    indoorPlayer: z
+      .object({
+        __identity: uuidSchema.optional(),
+        person: personSummarySchema.optional(),
+      })
+      .passthrough()
+      .optional(),
+    indoorPlayerLicenseCategory: z
+      .object({
+        __identity: uuidSchema.optional(),
+        shortName: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    teamDisplayName: z.string().optional(),
+    isInSameTeam: z.boolean().optional(),
+    isInSameClub: z.boolean().optional(),
+    isInSameGender: z.boolean().optional(),
+  })
+  .passthrough()
+
+// Possible nominations response schema
+export const possibleNominationsResponseSchema = z.object({
+  items: z.array(possibleNominationSchema).optional(),
+  totalItemsCount: z.number().optional(),
+})
+
 // Type exports inferred from Zod schemas
 export type Assignment = z.infer<typeof assignmentSchema>
 export type CompensationRecord = z.infer<typeof compensationRecordSchema>

--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -12,11 +12,17 @@ import { server } from '@/test/msw/server'
 
 import { api, setCsrfToken, clearSession } from './client'
 
+// Valid UUIDs for mock data that passes Zod validation
+const UUID1 = 'a1111111-1111-4111-a111-111111111111'
+const UUID2 = 'a2222222-2222-4222-a222-222222222222'
+const UUID3 = 'a3333333-3333-4333-a333-333333333333'
+
 // Valid mock response structures that pass Zod validation
 const mockAssignmentsResponse = { items: [], totalItemsCount: 0 }
 const mockCompensationsResponse = { items: [], totalItemsCount: 0 }
 const mockExchangesResponse = { items: [], totalItemsCount: 0 }
 const mockPersonSearchResponse = { items: [], totalItemsCount: 0 }
+const mockPossibleNominationsResponse = { items: [], totalItemsCount: 0 }
 
 describe('API Client', () => {
   beforeEach(() => {
@@ -237,7 +243,7 @@ describe('API Client', () => {
       let capturedMethod: string | null = null
       const mockDetailsResponse = {
         convocationCompensation: {
-          __identity: 'comp-123',
+          __identity: UUID1,
           distanceInMetres: 48000,
           correctionReason: 'Test reason',
         },
@@ -275,7 +281,7 @@ describe('API Client', () => {
     it('returns detailed compensation data', async () => {
       const mockDetailsResponse = {
         convocationCompensation: {
-          __identity: 'comp-123',
+          __identity: UUID1,
           distanceInMetres: 48000,
           distanceFormatted: '48.0',
           correctionReason: 'Ich wohne in Oberengstringen',
@@ -381,7 +387,7 @@ describe('API Client', () => {
           capturedBody = new URLSearchParams(text)
           return HttpResponse.json({
             refereeGameExchange: {
-              __identity: 'exchange-123',
+              __identity: UUID1,
               status: 'applied',
               appliedAt: new Date().toISOString(),
             },
@@ -389,12 +395,12 @@ describe('API Client', () => {
         })
       )
 
-      const result = await api.applyForExchange('exchange-123')
+      const result = await api.applyForExchange(UUID1)
 
       expect(capturedMethod).toBe('PUT')
       expect(capturedUrl).toContain('pickFromRefereeGameExchange')
-      expect(capturedBody?.get('refereeGameExchange[__identity]')).toBe('exchange-123')
-      expect(result.refereeGameExchange.__identity).toBe('exchange-123')
+      expect(capturedBody?.get('refereeGameExchange[__identity]')).toBe(UUID1)
+      expect(result.refereeGameExchange.__identity).toBe(UUID1)
       expect(result.refereeGameExchange.status).toBe('applied')
     })
   })
@@ -650,12 +656,12 @@ describe('API Client', () => {
 
       server.use(
         http.post('*/api%5cpersistentresource/upload', () => {
-          return HttpResponse.json([{ __identity: 'res-1' }])
+          return HttpResponse.json([{ __identity: UUID1 }])
         })
       )
 
       const result = await api.uploadResource(pdfFile)
-      expect(result).toEqual([{ __identity: 'res-1' }])
+      expect(result).toEqual([{ __identity: UUID1 }])
     })
 
     it('accepts JPEG files', async () => {
@@ -663,12 +669,12 @@ describe('API Client', () => {
 
       server.use(
         http.post('*/api%5cpersistentresource/upload', () => {
-          return HttpResponse.json([{ __identity: 'res-1' }])
+          return HttpResponse.json([{ __identity: UUID1 }])
         })
       )
 
       const result = await api.uploadResource(jpegFile)
-      expect(result).toEqual([{ __identity: 'res-1' }])
+      expect(result).toEqual([{ __identity: UUID1 }])
     })
 
     it('accepts PNG files', async () => {
@@ -676,12 +682,12 @@ describe('API Client', () => {
 
       server.use(
         http.post('*/api%5cpersistentresource/upload', () => {
-          return HttpResponse.json([{ __identity: 'res-1' }])
+          return HttpResponse.json([{ __identity: UUID1 }])
         })
       )
 
       const result = await api.uploadResource(pngFile)
-      expect(result).toEqual([{ __identity: 'res-1' }])
+      expect(result).toEqual([{ __identity: UUID1 }])
     })
 
     it('sends POST request with FormData', async () => {
@@ -692,7 +698,7 @@ describe('API Client', () => {
         http.post('*/api%5cpersistentresource/upload', ({ request }) => {
           capturedMethod = request.method
           capturedContentType = request.headers.get('Content-Type')
-          return HttpResponse.json([{ __identity: 'res-1' }])
+          return HttpResponse.json([{ __identity: UUID1 }])
         })
       )
 
@@ -712,7 +718,7 @@ describe('API Client', () => {
       server.use(
         http.post('*/api%5cpersistentresource/upload', async ({ request }) => {
           capturedFormData = await request.formData()
-          return HttpResponse.json([{ __identity: 'res-1' }])
+          return HttpResponse.json([{ __identity: UUID1 }])
         })
       )
 
@@ -750,6 +756,13 @@ describe('API Client', () => {
   })
 
   describe('getAssignmentDetails', () => {
+    const validAssignment = {
+      __identity: UUID1,
+      refereeGame: { __identity: UUID2 },
+      refereeConvocationStatus: 'active',
+      refereePosition: 'head-one',
+    }
+
     it('sends GET request with convocation ID', async () => {
       let capturedUrl: string | null = null
       let capturedMethod: string | null = null
@@ -758,7 +771,7 @@ describe('API Client', () => {
         http.get('*/api%5crefereeconvocation/showWithNestedObjects', ({ request }) => {
           capturedUrl = request.url
           capturedMethod = request.method
-          return HttpResponse.json({})
+          return HttpResponse.json(validAssignment)
         })
       )
 
@@ -774,7 +787,7 @@ describe('API Client', () => {
       server.use(
         http.get('*/api%5crefereeconvocation/showWithNestedObjects', ({ request }) => {
           capturedUrl = request.url
-          return HttpResponse.json({})
+          return HttpResponse.json(validAssignment)
         })
       )
 
@@ -1002,7 +1015,7 @@ describe('API Client', () => {
         http.post('*/api%5cscoresheet/validateScoresheet', ({ request }) => {
           capturedUrl = request.url
           capturedMethod = request.method
-          return HttpResponse.json({ __identity: 'val-1', hasValidationIssues: false })
+          return HttpResponse.json({ __identity: UUID1, hasValidationIssues: false })
         })
       )
 
@@ -1019,7 +1032,7 @@ describe('API Client', () => {
         http.post('*/api%5cscoresheet/validateScoresheet', async ({ request }) => {
           const text = await request.text()
           capturedBody = new URLSearchParams(text)
-          return HttpResponse.json({ __identity: 'val-1', hasValidationIssues: false })
+          return HttpResponse.json({ __identity: UUID1, hasValidationIssues: false })
         })
       )
 
@@ -1034,16 +1047,16 @@ describe('API Client', () => {
       server.use(
         http.post('*/api%5cscoresheet/validateScoresheet', () => {
           return HttpResponse.json({
-            __identity: 'val-123',
+            __identity: UUID1,
             hasValidationIssues: true,
-            scoresheetValidationIssues: [{ __identity: 'issue-1' }],
+            scoresheetValidationIssues: [{ __identity: UUID2 }],
           })
         })
       )
 
       const result = await api.validateScoresheet('game-1', 'scorer-1')
 
-      expect(result.__identity).toBe('val-123')
+      expect(result.__identity).toBe(UUID1)
       expect(result.hasValidationIssues).toBe(true)
     })
   })
@@ -1124,7 +1137,7 @@ describe('API Client', () => {
       server.use(
         http.get('*/api%5cgame/showWithNestedObjects', ({ request }) => {
           capturedUrl = request.url
-          return HttpResponse.json({ game: { __identity: 'game-1' } })
+          return HttpResponse.json({ game: { __identity: UUID1 } })
         })
       )
 
@@ -1138,10 +1151,10 @@ describe('API Client', () => {
 
     it('returns the game object from the response wrapper', async () => {
       const gameData = {
-        __identity: 'game-1',
-        scoresheet: { __identity: 'ss-1', closedAt: null },
-        nominationListOfTeamHome: { __identity: 'nl-home' },
-        nominationListOfTeamAway: { __identity: 'nl-away' },
+        __identity: UUID1,
+        scoresheet: { __identity: UUID2, closedAt: null },
+        nominationListOfTeamHome: { __identity: UUID3 },
+        nominationListOfTeamAway: { __identity: 'a4444444-4444-4444-a444-444444444444' },
       }
 
       server.use(
@@ -1196,6 +1209,220 @@ describe('API Client', () => {
 
       expect(capturedUrl).toContain('getActiveIndoorSeason')
       expect(capturedMethod).toBe('GET')
+    })
+  })
+
+  describe('response validation', () => {
+    it('getAssignmentDetails validates response against assignmentSchema', async () => {
+      server.use(
+        http.get('*/api%5crefereeconvocation/showWithNestedObjects', () => {
+          return HttpResponse.json({ __identity: 'not-a-uuid' })
+        })
+      )
+
+      await expect(api.getAssignmentDetails('conv-1', [])).rejects.toThrow(
+        /Invalid API response for getAssignmentDetails/
+      )
+    })
+
+    it('getAssignmentDetails accepts valid assignment response', async () => {
+      server.use(
+        http.get('*/api%5crefereeconvocation/showWithNestedObjects', () => {
+          return HttpResponse.json({
+            __identity: UUID1,
+            refereeGame: { __identity: UUID2 },
+            refereeConvocationStatus: 'active',
+            refereePosition: 'head-one',
+          })
+        })
+      )
+
+      const result = await api.getAssignmentDetails('conv-1', [])
+
+      expect(result.__identity).toBe(UUID1)
+    })
+
+    it('getCompensationDetails validates response', async () => {
+      server.use(
+        http.get('*/api%5cconvocationcompensation/showWithNestedObjects', () => {
+          return HttpResponse.json({
+            convocationCompensation: { __identity: UUID1, distanceInMetres: 48000 },
+          })
+        })
+      )
+
+      const result = await api.getCompensationDetails(UUID1)
+
+      expect(result.convocationCompensation?.distanceInMetres).toBe(48000)
+    })
+
+    it('applyForExchange validates response', async () => {
+      server.use(
+        http.put('*/api%5crefereegameexchange/pickFromRefereeGameExchange', () => {
+          return HttpResponse.json({
+            refereeGameExchange: { __identity: UUID1, status: 'applied' },
+          })
+        })
+      )
+
+      const result = await api.applyForExchange(UUID1)
+
+      expect(result.refereeGameExchange.status).toBe('applied')
+    })
+
+    it('searchPersons validates response', async () => {
+      server.use(
+        http.get('*/api%5celasticsearchperson/search', () => {
+          return HttpResponse.json(mockPersonSearchResponse)
+        })
+      )
+
+      const result = await api.searchPersons({ lastName: 'test' })
+
+      expect(result.items).toEqual([])
+    })
+
+    it('getGameWithScoresheet validates response', async () => {
+      server.use(
+        http.get('*/api%5cgame/showWithNestedObjects', () => {
+          return HttpResponse.json({ game: { __identity: UUID1 } })
+        })
+      )
+
+      const result = await api.getGameWithScoresheet('game-1')
+
+      expect(result.__identity).toBe(UUID1)
+    })
+
+    it('getGameWithScoresheet rejects response missing game wrapper', async () => {
+      server.use(
+        http.get('*/api%5cgame/showWithNestedObjects', () => {
+          return HttpResponse.json({ notGame: {} })
+        })
+      )
+
+      await expect(api.getGameWithScoresheet('game-1')).rejects.toThrow(
+        /Invalid API response for getGameWithScoresheet/
+      )
+    })
+
+    it('updateNominationList validates response', async () => {
+      server.use(
+        http.put('*/api%5cnominationlist', () => {
+          return HttpResponse.json({ __identity: UUID1 })
+        })
+      )
+
+      const result = await api.updateNominationList('nl-1', 'game-1', 'team-1', [])
+
+      expect(result.__identity).toBe(UUID1)
+    })
+
+    it('finalizeNominationList validates response', async () => {
+      server.use(
+        http.post('*/api%5cnominationlist/finalize', () => {
+          return HttpResponse.json({ nominationList: { __identity: UUID1 } })
+        })
+      )
+
+      const result = await api.finalizeNominationList('nl-1', 'game-1', 'team-1', [])
+
+      expect(result.nominationList?.__identity).toBe(UUID1)
+    })
+
+    it('updateScoresheet validates response', async () => {
+      server.use(
+        http.put('*/api%5cscoresheet', () => {
+          return HttpResponse.json({ __identity: UUID1, hasFile: false })
+        })
+      )
+
+      const result = await api.updateScoresheet('ss-1', 'game-1', 'scorer-1', false)
+
+      expect(result.__identity).toBe(UUID1)
+    })
+
+    it('validateScoresheet validates response', async () => {
+      server.use(
+        http.post('*/api%5cscoresheet/validateScoresheet', () => {
+          return HttpResponse.json({ __identity: UUID1, hasValidationIssues: false })
+        })
+      )
+
+      const result = await api.validateScoresheet('game-1', 'scorer-1')
+
+      expect(result.hasValidationIssues).toBe(false)
+    })
+
+    it('finalizeScoresheet validates response', async () => {
+      server.use(
+        http.post('*/api%5cscoresheet/finalize', () => {
+          return HttpResponse.json({ __identity: UUID1, hasFile: true })
+        })
+      )
+
+      const result = await api.finalizeScoresheet('ss-1', 'game-1', 'scorer-1', 'file-1')
+
+      expect(result.__identity).toBe(UUID1)
+    })
+
+    it('uploadResource validates response', async () => {
+      server.use(
+        http.post('*/api%5cpersistentresource/upload', () => {
+          return HttpResponse.json([{ __identity: UUID1 }])
+        })
+      )
+
+      function createMockFile(name: string, type: string, size: number = 1024): File {
+        const content = new Uint8Array(size)
+        return new File([content], name, { type })
+      }
+
+      const result = await api.uploadResource(createMockFile('test.pdf', 'application/pdf'))
+
+      expect(result[0].__identity).toBe(UUID1)
+    })
+
+    it('getAssociationSettings validates response', async () => {
+      server.use(
+        http.get(
+          '*/api%5crefereeassociationsettings/getRefereeAssociationSettingsOfActiveParty',
+          () => {
+            return HttpResponse.json({ __identity: UUID1, usesGameExchange: true })
+          }
+        )
+      )
+
+      const result = await api.getAssociationSettings()
+
+      expect(result.usesGameExchange).toBe(true)
+    })
+
+    it('getActiveSeason validates response', async () => {
+      server.use(
+        http.get('*/api%5cindoorseason/getActiveIndoorSeason', () => {
+          return HttpResponse.json({ __identity: UUID1, name: '2025', active: true })
+        })
+      )
+
+      const result = await api.getActiveSeason()
+
+      expect(result.name).toBe('2025')
+    })
+
+    it('getPossiblePlayerNominations validates response', async () => {
+      server.use(
+        http.post(
+          '*/api%5cnominationlist/getPossibleIndoorPlayerNominationsForNominationList',
+          () => {
+            return HttpResponse.json(mockPossibleNominationsResponse)
+          }
+        )
+      )
+
+      const result = await api.getPossiblePlayerNominations('nl-1')
+
+      expect(result.items).toEqual([])
     })
   })
 })

--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -1410,6 +1410,62 @@ describe('API Client', () => {
       expect(result.name).toBe('2025')
     })
 
+    it('searchCompensations rejects response with non-array items', async () => {
+      server.use(
+        http.post('*/api%5crefereeconvocationcompensation/search', () => {
+          return HttpResponse.json({ items: 'not-an-array', totalItemsCount: 0 })
+        })
+      )
+
+      await expect(api.searchCompensations({})).rejects.toThrow(
+        /Invalid API response for searchCompensations/
+      )
+    })
+
+    it('searchExchanges rejects response with non-array items', async () => {
+      server.use(
+        http.post('*/api%5crefereegameexchange/search', () => {
+          return HttpResponse.json({ items: 'not-an-array', totalItemsCount: 0 })
+        })
+      )
+
+      await expect(api.searchExchanges({})).rejects.toThrow(
+        /Invalid API response for searchExchanges/
+      )
+    })
+
+    it('getPossiblePlayerNominations rejects response with non-array items', async () => {
+      server.use(
+        http.post(
+          '*/api%5cnominationlist/getPossibleIndoorPlayerNominationsForNominationList',
+          () => {
+            return HttpResponse.json({ items: 'not-an-array', totalItemsCount: 0 })
+          }
+        )
+      )
+
+      await expect(api.getPossiblePlayerNominations('nl-1')).rejects.toThrow(
+        /Invalid API response for getPossiblePlayerNominations/
+      )
+    })
+
+    it('uploadResource rejects non-array response', async () => {
+      server.use(
+        http.post('*/api%5cpersistentresource/upload', () => {
+          return HttpResponse.json({ __identity: UUID1 })
+        })
+      )
+
+      function createMockFile(name: string, type: string, size: number = 1024): File {
+        const content = new Uint8Array(size)
+        return new File([content], name, { type })
+      }
+
+      await expect(
+        api.uploadResource(createMockFile('test.pdf', 'application/pdf'))
+      ).rejects.toThrow(/Invalid API response for uploadResource/)
+    })
+
     it('getPossiblePlayerNominations validates response', async () => {
       server.use(
         http.post(

--- a/web-app/src/api/real-api.ts
+++ b/web-app/src/api/real-api.ts
@@ -174,8 +174,11 @@ export const api = {
         propertyRenderConfiguration: ASSIGNMENT_PROPERTIES,
       }
     )
-    validateResponse(data, assignmentsResponseSchema, 'searchAssignments')
-    return data as AssignmentsResponse
+    return validateResponse(
+      data,
+      assignmentsResponseSchema,
+      'searchAssignments'
+    ) as AssignmentsResponse
   },
 
   async getAssignmentDetails(convocationId: string, properties: string[]): Promise<Assignment> {
@@ -186,8 +189,7 @@ export const api = {
     const data = await apiRequest<unknown>(
       `/indoorvolleyball.refadmin/api%5crefereeconvocation/showWithNestedObjects?${query}`
     )
-    validateResponse(data, assignmentSchema, 'getAssignmentDetails')
-    return data as Assignment
+    return validateResponse(data, assignmentSchema, 'getAssignmentDetails') as Assignment
   },
 
   // Compensations
@@ -200,8 +202,11 @@ export const api = {
         propertyRenderConfiguration: COMPENSATION_PROPERTIES,
       }
     )
-    validateResponse(data, compensationsResponseSchema, 'searchCompensations')
-    return data as CompensationsResponse
+    return validateResponse(
+      data,
+      compensationsResponseSchema,
+      'searchCompensations'
+    ) as CompensationsResponse
   },
 
   async getCompensationDetails(compensationId: string): Promise<ConvocationCompensationDetailed> {
@@ -215,8 +220,11 @@ export const api = {
     const data = await apiRequest<unknown>(
       `/indoorvolleyball.refadmin/api%5cconvocationcompensation/showWithNestedObjects?${query}`
     )
-    validateResponse(data, compensationDetailedSchema, 'getCompensationDetails')
-    return data as ConvocationCompensationDetailed
+    return validateResponse(
+      data,
+      compensationDetailedSchema,
+      'getCompensationDetails'
+    ) as ConvocationCompensationDetailed
   },
 
   async updateCompensation(
@@ -251,8 +259,7 @@ export const api = {
         propertyRenderConfiguration: EXCHANGE_PROPERTIES,
       }
     )
-    validateResponse(data, exchangesResponseSchema, 'searchExchanges')
-    return data as ExchangesResponse
+    return validateResponse(data, exchangesResponseSchema, 'searchExchanges') as ExchangesResponse
   },
 
   async applyForExchange(exchangeId: string): Promise<PickExchangeResponse> {
@@ -263,8 +270,11 @@ export const api = {
         'refereeGameExchange[__identity]': exchangeId,
       }
     )
-    validateResponse(data, pickExchangeResponseSchema, 'applyForExchange')
-    return data as PickExchangeResponse
+    return validateResponse(
+      data,
+      pickExchangeResponseSchema,
+      'applyForExchange'
+    ) as PickExchangeResponse
   },
 
   /**
@@ -306,16 +316,18 @@ export const api = {
     const data = await apiRequest<unknown>(
       '/indoorvolleyball.refadmin/api%5crefereeassociationsettings/getRefereeAssociationSettingsOfActiveParty'
     )
-    validateResponse(data, associationSettingsSchema, 'getAssociationSettings')
-    return data as Schemas['AssociationSettings']
+    return validateResponse(
+      data,
+      associationSettingsSchema,
+      'getAssociationSettings'
+    ) as Schemas['AssociationSettings']
   },
 
   async getActiveSeason(): Promise<Schemas['Season']> {
     const data = await apiRequest<unknown>(
       '/sportmanager.indoorvolleyball/api%5cindoorseason/getActiveIndoorSeason'
     )
-    validateResponse(data, seasonSchema, 'getActiveSeason')
-    return data as Schemas['Season']
+    return validateResponse(data, seasonSchema, 'getActiveSeason') as Schemas['Season']
   },
 
   // Nominations
@@ -332,8 +344,11 @@ export const api = {
         onlyRelevantGender: options?.onlyRelevantGender ?? true,
       }
     )
-    validateResponse(data, possibleNominationsResponseSchema, 'getPossiblePlayerNominations')
-    return data as PossibleNominationsResponse
+    return validateResponse(
+      data,
+      possibleNominationsResponseSchema,
+      'getPossiblePlayerNominations'
+    ) as PossibleNominationsResponse
   },
 
   // Person search
@@ -366,8 +381,11 @@ export const api = {
             propertyRenderConfiguration: PERSON_SEARCH_PROPERTIES,
           }
         )
-        validateResponse(data, personSearchResponseSchema, 'searchPersons')
-        return data as PersonSearchResponse
+        return validateResponse(
+          data,
+          personSearchResponseSchema,
+          'searchPersons'
+        ) as PersonSearchResponse
       }
 
       const [original, swapped] = await Promise.all([
@@ -432,8 +450,11 @@ export const api = {
         propertyRenderConfiguration: PERSON_SEARCH_PROPERTIES,
       }
     )
-    validateResponse(data, personSearchResponseSchema, 'searchPersons')
-    return data as PersonSearchResponse
+    return validateResponse(
+      data,
+      personSearchResponseSchema,
+      'searchPersons'
+    ) as PersonSearchResponse
   },
 
   // Game details and scoresheet
@@ -522,8 +543,8 @@ export const api = {
         propertyRenderConfiguration: properties,
       }
     )
-    validateResponse(data, gameDetailsResponseSchema, 'getGameWithScoresheet')
-    return (data as { game: Schemas['GameDetails'] }).game
+    const validated = validateResponse(data, gameDetailsResponseSchema, 'getGameWithScoresheet')
+    return (validated as { game: Schemas['GameDetails'] }).game
   },
 
   async updateNominationList(
@@ -567,8 +588,7 @@ export const api = {
       body,
       'text/plain;charset=UTF-8'
     )
-    validateResponse(data, nominationListSchema, 'updateNominationList')
-    return data as NominationList
+    return validateResponse(data, nominationListSchema, 'updateNominationList') as NominationList
   },
 
   async finalizeNominationList(
@@ -617,8 +637,11 @@ export const api = {
       body,
       'text/plain;charset=UTF-8'
     )
-    validateResponse(data, nominationListResponseSchema, 'finalizeNominationList')
-    return data as NominationListResponse
+    return validateResponse(
+      data,
+      nominationListResponseSchema,
+      'finalizeNominationList'
+    ) as NominationListResponse
   },
 
   async updateScoresheet(
@@ -670,8 +693,7 @@ export const api = {
       body,
       'text/plain;charset=UTF-8'
     )
-    validateResponse(data, scoresheetSchema, 'updateScoresheet')
-    return data as Scoresheet
+    return validateResponse(data, scoresheetSchema, 'updateScoresheet') as Scoresheet
   },
 
   async validateScoresheet(
@@ -699,8 +721,11 @@ export const api = {
       'POST',
       body
     )
-    validateResponse(data, scoresheetValidationSchema, 'validateScoresheet')
-    return data as ScoresheetValidation
+    return validateResponse(
+      data,
+      scoresheetValidationSchema,
+      'validateScoresheet'
+    ) as ScoresheetValidation
   },
 
   async finalizeScoresheet(
@@ -730,8 +755,7 @@ export const api = {
       body,
       'text/plain;charset=UTF-8'
     )
-    validateResponse(data, scoresheetSchema, 'finalizeScoresheet')
-    return data as Scoresheet
+    return validateResponse(data, scoresheetSchema, 'finalizeScoresheet') as Scoresheet
   },
 
   async uploadResource(file: File): Promise<FileResource[]> {
@@ -775,8 +799,7 @@ export const api = {
     }
 
     const data: unknown = await response.json()
-    validateResponse(data, fileResourceArraySchema, 'uploadResource')
-    return data as FileResource[]
+    return validateResponse(data, fileResourceArraySchema, 'uploadResource') as FileResource[]
   },
 
   /**
@@ -852,8 +875,11 @@ export const api = {
         propertyRenderConfiguration: REFEREE_BACKUP_PROPERTIES,
       }
     )
-    validateResponse(data, refereeBackupResponseSchema, 'searchRefereeBackups')
-    return data as RefereeBackupSearchResponse
+    return validateResponse(
+      data,
+      refereeBackupResponseSchema,
+      'searchRefereeBackups'
+    ) as RefereeBackupSearchResponse
   },
 }
 

--- a/web-app/src/api/real-api.ts
+++ b/web-app/src/api/real-api.ts
@@ -12,9 +12,22 @@
 import type { components } from './schema'
 
 import {
+  assignmentSchema,
   assignmentsResponseSchema,
   compensationsResponseSchema,
   exchangesResponseSchema,
+  personSearchResponseSchema,
+  compensationDetailedSchema,
+  pickExchangeResponseSchema,
+  fileResourceArraySchema,
+  scoresheetValidationSchema,
+  scoresheetSchema,
+  nominationListSchema,
+  nominationListResponseSchema,
+  gameDetailsResponseSchema,
+  associationSettingsSchema,
+  seasonSchema,
+  possibleNominationsResponseSchema,
   refereeBackupResponseSchema,
   validateResponse,
 } from './validation'
@@ -170,9 +183,11 @@ export const api = {
     query.set('convocation', convocationId)
     properties.forEach((prop, i) => query.set(`nestedPropertyNames[${i}]`, prop))
 
-    return apiRequest<Assignment>(
+    const data = await apiRequest<unknown>(
       `/indoorvolleyball.refadmin/api%5crefereeconvocation/showWithNestedObjects?${query}`
     )
+    validateResponse(data, assignmentSchema, 'getAssignmentDetails')
+    return data as Assignment
   },
 
   // Compensations
@@ -197,9 +212,11 @@ export const api = {
     query.append('propertyRenderConfiguration[]', 'distanceFormatted')
     query.append('propertyRenderConfiguration[]', 'hasFlexibleTravelExpenses')
 
-    return apiRequest<ConvocationCompensationDetailed>(
+    const data = await apiRequest<unknown>(
       `/indoorvolleyball.refadmin/api%5cconvocationcompensation/showWithNestedObjects?${query}`
     )
+    validateResponse(data, compensationDetailedSchema, 'getCompensationDetails')
+    return data as ConvocationCompensationDetailed
   },
 
   async updateCompensation(
@@ -239,13 +256,15 @@ export const api = {
   },
 
   async applyForExchange(exchangeId: string): Promise<PickExchangeResponse> {
-    return apiRequest<PickExchangeResponse>(
+    const data = await apiRequest<unknown>(
       '/indoorvolleyball.refadmin/api%5crefereegameexchange/pickFromRefereeGameExchange',
       'PUT',
       {
         'refereeGameExchange[__identity]': exchangeId,
       }
     )
+    validateResponse(data, pickExchangeResponseSchema, 'applyForExchange')
+    return data as PickExchangeResponse
   },
 
   /**
@@ -284,13 +303,19 @@ export const api = {
 
   // Settings
   async getAssociationSettings(): Promise<Schemas['AssociationSettings']> {
-    return apiRequest(
+    const data = await apiRequest<unknown>(
       '/indoorvolleyball.refadmin/api%5crefereeassociationsettings/getRefereeAssociationSettingsOfActiveParty'
     )
+    validateResponse(data, associationSettingsSchema, 'getAssociationSettings')
+    return data as Schemas['AssociationSettings']
   },
 
   async getActiveSeason(): Promise<Schemas['Season']> {
-    return apiRequest('/sportmanager.indoorvolleyball/api%5cindoorseason/getActiveIndoorSeason')
+    const data = await apiRequest<unknown>(
+      '/sportmanager.indoorvolleyball/api%5cindoorseason/getActiveIndoorSeason'
+    )
+    validateResponse(data, seasonSchema, 'getActiveSeason')
+    return data as Schemas['Season']
   },
 
   // Nominations
@@ -298,7 +323,7 @@ export const api = {
     nominationListId: string,
     options?: { onlyFromMyTeam?: boolean; onlyRelevantGender?: boolean }
   ): Promise<PossibleNominationsResponse> {
-    return apiRequest(
+    const data = await apiRequest<unknown>(
       '/sportmanager.indoorvolleyball/api%5cnominationlist/getPossibleIndoorPlayerNominationsForNominationList',
       'POST',
       {
@@ -307,6 +332,8 @@ export const api = {
         onlyRelevantGender: options?.onlyRelevantGender ?? true,
       }
     )
+    validateResponse(data, possibleNominationsResponseSchema, 'getPossiblePlayerNominations')
+    return data as PossibleNominationsResponse
   },
 
   // Person search
@@ -319,7 +346,7 @@ export const api = {
     // When both firstName and lastName are provided, search both orderings
     // in parallel so "Bühler Renee" finds the same results as "Renee Bühler".
     if (firstName && lastName) {
-      const makeRequest = (fn: string, ln: string) => {
+      const makeRequest = async (fn: string, ln: string) => {
         const propertyFilters: Array<{ propertyName: string; text: string }> = [
           { propertyName: 'firstName', text: fn },
           { propertyName: 'lastName', text: ln },
@@ -327,7 +354,7 @@ export const api = {
         if (yearOfBirth) {
           propertyFilters.push({ propertyName: 'yearOfBirth', text: yearOfBirth })
         }
-        return apiRequest<PersonSearchResponse>(
+        const data = await apiRequest<unknown>(
           '/sportmanager.core/api%5celasticsearchperson/search',
           'GET',
           {
@@ -339,6 +366,8 @@ export const api = {
             propertyRenderConfiguration: PERSON_SEARCH_PROPERTIES,
           }
         )
+        validateResponse(data, personSearchResponseSchema, 'searchPersons')
+        return data as PersonSearchResponse
       }
 
       const [original, swapped] = await Promise.all([
@@ -395,7 +424,7 @@ export const api = {
       limit: options?.limit ?? DEFAULT_SEARCH_RESULTS_LIMIT,
     }
 
-    return apiRequest<PersonSearchResponse>(
+    const data = await apiRequest<unknown>(
       '/sportmanager.core/api%5celasticsearchperson/search',
       'GET',
       {
@@ -403,6 +432,8 @@ export const api = {
         propertyRenderConfiguration: PERSON_SEARCH_PROPERTIES,
       }
     )
+    validateResponse(data, personSearchResponseSchema, 'searchPersons')
+    return data as PersonSearchResponse
   },
 
   // Game details and scoresheet
@@ -483,7 +514,7 @@ export const api = {
       'group.phase.league.leagueCategory.writersCanUseSimpleScoresheetForThisLeagueCategory',
     ]
 
-    const response = await apiRequest<{ game: Schemas['GameDetails'] }>(
+    const data = await apiRequest<unknown>(
       '/sportmanager.indoorvolleyball/api%5cgame/showWithNestedObjects',
       'GET',
       {
@@ -491,8 +522,8 @@ export const api = {
         propertyRenderConfiguration: properties,
       }
     )
-
-    return response.game
+    validateResponse(data, gameDetailsResponseSchema, 'getGameWithScoresheet')
+    return (data as { game: Schemas['GameDetails'] }).game
   },
 
   async updateNominationList(
@@ -530,12 +561,14 @@ export const api = {
       }
     }
 
-    return apiRequest<NominationList>(
+    const data = await apiRequest<unknown>(
       '/sportmanager.indoorvolleyball/api%5cnominationlist',
       'PUT',
       body,
       'text/plain;charset=UTF-8'
     )
+    validateResponse(data, nominationListSchema, 'updateNominationList')
+    return data as NominationList
   },
 
   async finalizeNominationList(
@@ -578,12 +611,14 @@ export const api = {
       }
     }
 
-    return apiRequest<NominationListResponse>(
+    const data = await apiRequest<unknown>(
       '/sportmanager.indoorvolleyball/api%5cnominationlist/finalize',
       'POST',
       body,
       'text/plain;charset=UTF-8'
     )
+    validateResponse(data, nominationListResponseSchema, 'finalizeNominationList')
+    return data as NominationListResponse
   },
 
   async updateScoresheet(
@@ -629,12 +664,14 @@ export const api = {
       body['scoresheet[file]'] = ''
     }
 
-    return apiRequest<Scoresheet>(
+    const data = await apiRequest<unknown>(
       '/sportmanager.indoorvolleyball/api%5cscoresheet',
       method,
       body,
       'text/plain;charset=UTF-8'
     )
+    validateResponse(data, scoresheetSchema, 'updateScoresheet')
+    return data as Scoresheet
   },
 
   async validateScoresheet(
@@ -657,11 +694,13 @@ export const api = {
       'scoresheet[hasFile]': 'false',
     }
 
-    return apiRequest<ScoresheetValidation>(
+    const data = await apiRequest<unknown>(
       '/sportmanager.indoorvolleyball/api%5cscoresheet/validateScoresheet',
       'POST',
       body
     )
+    validateResponse(data, scoresheetValidationSchema, 'validateScoresheet')
+    return data as ScoresheetValidation
   },
 
   async finalizeScoresheet(
@@ -685,12 +724,14 @@ export const api = {
       body['scoresheet[scoresheetValidation][__identity]'] = validationId
     }
 
-    return apiRequest<Scoresheet>(
+    const data = await apiRequest<unknown>(
       '/sportmanager.indoorvolleyball/api%5cscoresheet/finalize',
       'POST',
       body,
       'text/plain;charset=UTF-8'
     )
+    validateResponse(data, scoresheetSchema, 'finalizeScoresheet')
+    return data as Scoresheet
   },
 
   async uploadResource(file: File): Promise<FileResource[]> {
@@ -733,7 +774,9 @@ export const api = {
       throw new Error(`POST ${url}: ${errorMessage}`)
     }
 
-    return response.json()
+    const data: unknown = await response.json()
+    validateResponse(data, fileResourceArraySchema, 'uploadResource')
+    return data as FileResource[]
   },
 
   /**

--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -26,6 +26,8 @@
  */
 import { z } from 'zod'
 
+import type { ZodLikeSchema } from '@volleykit/shared/api'
+
 import { logger } from '@/shared/utils/logger'
 
 // Re-export all base schemas from shared package
@@ -65,6 +67,7 @@ export {
   type AssignmentsResponse,
   type CompensationsResponse,
   type ExchangesResponse,
+  type ZodLikeSchema,
 } from '@volleykit/shared/api'
 
 // Common field schemas for web-specific extensions
@@ -162,18 +165,6 @@ export const refereeBackupResponseSchema = z.object({
 // ============================================================================
 // Validation helper (re-exported from shared with web-specific logging)
 // ============================================================================
-
-/**
- * A structural type for Zod schemas that works with both Zod 3 and Zod 4.
- * This avoids type incompatibilities between versions.
- */
-interface ZodLikeSchema<T> {
-  safeParse(
-    data: unknown
-  ):
-    | { success: true; data: T }
-    | { success: false; error: { issues: Array<{ path: PropertyKey[]; message: string }> } }
-}
 
 /**
  * Validates API response data against a Zod schema.

--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -26,9 +26,9 @@
  */
 import { z } from 'zod'
 
-import type { ZodLikeSchema } from '@volleykit/shared/api'
-
 import { logger } from '@/shared/utils/logger'
+
+import type { ZodLikeSchema } from '@volleykit/shared/api'
 
 // Re-export all base schemas from shared package
 export {

--- a/web-app/src/api/validation.ts
+++ b/web-app/src/api/validation.ts
@@ -45,6 +45,18 @@ export {
   compensationsResponseSchema,
   exchangesResponseSchema,
   personSearchResponseSchema,
+  // Detail / mutation schemas
+  compensationDetailedSchema,
+  pickExchangeResponseSchema,
+  fileResourceArraySchema,
+  scoresheetValidationSchema,
+  scoresheetSchema,
+  nominationListSchema,
+  nominationListResponseSchema,
+  gameDetailsResponseSchema,
+  associationSettingsSchema,
+  seasonSchema,
+  possibleNominationsResponseSchema,
   // Types
   type Assignment,
   type CompensationRecord,


### PR DESCRIPTION
## Summary

- Add Zod runtime validation schemas for all API detail and mutation endpoints in `@volleykit/shared` (13 new schemas: `compensationDetailedSchema`, `pickExchangeResponseSchema`, `fileResourceArraySchema`, `scoresheetValidationSchema`, `scoresheetSchema`, `nominationListSchema`, `nominationListResponseSchema`, `gameDetailsResponseSchema`, `associationSettingsSchema`, `seasonSchema`, `possibleNominationsResponseSchema`, and supporting schemas)
- Wire up `validateResponse()` in `real-api.ts` for all 14+ endpoints that previously returned unvalidated data
- Add 16 response validation contract tests to `client.test.ts` ensuring each endpoint correctly validates against its schema
- Update mock data with valid UUIDs to pass Zod validation

## Test plan

- [x] All 3829 existing unit tests pass (182 test files)
- [x] 16 new response validation contract tests added and passing
- [x] Pre-commit validation passes (format, lint, knip, test, build)
- [ ] Verify no runtime regressions in staging with real API responses

Closes #948

https://claude.ai/code/session_014hrJEHHkkreTMj1B7qEdrx