### PR TITLE
fix(web): handle surname particles in scorer name search

### DIFF
--- a/.changeset/fix-fuzzy-name-particles.md
+++ b/.changeset/fix-fuzzy-name-particles.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fixed fuzzy name matching for scorer names with surname particles (e.g. "di martino", "von Berg", "de la Cruz"). Previously, particles like "di" were incorrectly treated as a first name, splitting "di martino" into firstName:"di" + lastName:"martino". Now the parser recognizes common surname particles and keeps them as part of the lastName for accurate search results.

--- a/web-app/src/features/validation/hooks/useScorerSearch.test.tsx
+++ b/web-app/src/features/validation/hooks/useScorerSearch.test.tsx
@@ -143,6 +143,44 @@ describe('parseSearchInput', () => {
       lastName: 'dupont',
     })
   })
+
+  it('treats leading surname particles as part of lastName', () => {
+    // "di martino" should not be split into firstName:"di" + lastName:"martino"
+    expect(parseSearchInput('di martino')).toEqual({
+      lastName: 'di martino',
+    })
+    expect(parseSearchInput('von Berg')).toEqual({
+      lastName: 'von Berg',
+    })
+    expect(parseSearchInput('de la cruz')).toEqual({
+      lastName: 'de la cruz',
+    })
+    expect(parseSearchInput('van der Heyde')).toEqual({
+      lastName: 'van der Heyde',
+    })
+  })
+
+  it('treats leading surname particles with year as lastName + year', () => {
+    expect(parseSearchInput('di martino 1990')).toEqual({
+      lastName: 'di martino',
+      yearOfBirth: '1990',
+    })
+    expect(parseSearchInput('von Berg 1985')).toEqual({
+      lastName: 'von Berg',
+      yearOfBirth: '1985',
+    })
+  })
+
+  it('keeps particles as part of lastName when preceded by a first name', () => {
+    expect(parseSearchInput('marco di martino')).toEqual({
+      firstName: 'marco',
+      lastName: 'di martino',
+    })
+    expect(parseSearchInput('emma von Berg')).toEqual({
+      firstName: 'emma',
+      lastName: 'von Berg',
+    })
+  })
 })
 
 describe('useScorerSearch', () => {

--- a/web-app/src/features/validation/hooks/useScorerSearch.ts
+++ b/web-app/src/features/validation/hooks/useScorerSearch.ts
@@ -11,11 +11,38 @@ import { ASSIGNMENTS_STALE_TIME_MS } from '@/shared/hooks/usePaginatedQuery'
 import { useAuthStore } from '@/shared/stores/auth'
 
 /**
+ * Common surname particles that indicate the token is part of a compound
+ * surname rather than a standalone first name (e.g. "di Martino", "von Berg").
+ */
+const SURNAME_PARTICLES = new Set([
+  'de',
+  'del',
+  'della',
+  'di',
+  'du',
+  'von',
+  'van',
+  'den',
+  'der',
+  'la',
+  'le',
+  'las',
+  'los',
+  'dos',
+  'da',
+  'das',
+])
+
+/**
  * Parses a search input string into search filters.
  * Supports flexible token parsing:
  * - Single word: treated as lastName
  * - Two words: treated as firstName and lastName
  * - Four-digit number at end: treated as yearOfBirth
+ *
+ * When the first token is a surname particle (e.g. "di", "von", "de"),
+ * the entire name is treated as a lastName to preserve compound surnames
+ * like "di Martino" or "de la Cruz".
  *
  * Note: When two name tokens are provided, the first is treated as firstName
  * and the second as lastName. The API layer searches both orderings in parallel,
@@ -24,6 +51,7 @@ import { useAuthStore } from '@/shared/stores/auth'
  * @example
  * parseSearchInput("müller") // { lastName: "müller" }
  * parseSearchInput("hans müller") // { firstName: "hans", lastName: "müller" }
+ * parseSearchInput("di martino") // { lastName: "di martino" }
  * parseSearchInput("müller 1985") // { lastName: "müller", yearOfBirth: "1985" }
  * parseSearchInput("hans müller 1985") // { firstName: "hans", lastName: "müller", yearOfBirth: "1985" }
  */
@@ -47,9 +75,16 @@ export function parseSearchInput(input: string): PersonSearchFilter {
   if (tokens.length === 1) {
     result.lastName = tokens[0]
   } else if (tokens.length >= 2) {
-    // First token as firstName, rest as lastName
-    result.firstName = tokens[0]
-    result.lastName = tokens.slice(1).join(' ')
+    // If the first token is a surname particle (e.g. "di", "von", "de"),
+    // treat the entire input as a lastName to preserve compound surnames
+    // like "di Martino", "von Berg", "de la Cruz".
+    if (SURNAME_PARTICLES.has(tokens[0]!.toLowerCase())) {
+      result.lastName = tokens.join(' ')
+    } else {
+      // First token as firstName, rest as lastName
+      result.firstName = tokens[0]
+      result.lastName = tokens.slice(1).join(' ')
+    }
   }
 
   return result


### PR DESCRIPTION
## Summary

- Fixed scorer name search for names with surname particles (e.g. "di martino", "von Berg", "de la Cruz")
- Previously, `parseSearchInput("di martino")` incorrectly split into `firstName:"di"` + `lastName:"martino"`, missing compound surnames
- Added a `SURNAME_PARTICLES` set (16 common particles: di, de, von, van, del, della, etc.) to detect when the first token is part of a compound surname
- When a leading particle is detected, the entire name is kept as `lastName` for accurate single-term API search

## Test plan

- [x] Unit tests for leading surname particles (`di martino`, `von Berg`, `de la cruz`, `van der Heyde`)
- [x] Unit tests for particles with year (`di martino 1990`, `von Berg 1985`)
- [x] Unit tests for first name + particle surname (`marco di martino`, `emma von Berg`)
- [x] Existing tests unchanged and passing (e.g. `maria de la cruz 1990` still correctly parsed)
- [x] All 182 test files / 3836 tests pass

https://claude.ai/code/session_01PLwJtQSxqYtKyyJGtkWbMZ