### PR TITLE
refactor(web,shared): consolidate API transport and unify search types

### DIFF
--- a/.changeset/refactor-api-dependencies.md
+++ b/.changeset/refactor-api-dependencies.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Refactored API transport layer to consolidate duplicated fetch logic

--- a/packages/shared/src/api/queryKeys.ts
+++ b/packages/shared/src/api/queryKeys.ts
@@ -28,17 +28,53 @@
  */
 
 /**
+ * Property filter for Neos Flow API search endpoints.
+ * Supports value matching, enum matching, and date range filtering.
+ */
+export interface PropertyFilter {
+  propertyName: string
+  values?: string[]
+  enumValues?: string[]
+  dateRange?: { from: string; to: string }
+}
+
+/**
+ * Property ordering for Neos Flow API search endpoints.
+ */
+export interface PropertyOrdering {
+  propertyName: string
+  descending: boolean
+  isSetByUser?: boolean
+}
+
+/**
  * Search configuration for list queries.
- * Matches the API's expected filter format.
+ *
+ * Supports two usage patterns:
+ * - **Simplified** (shared hooks / mobile): Uses `fromDate`, `toDate`, `sortField`, `sortDirection`
+ * - **Neos Flow** (web-app API calls): Uses `propertyFilters` and `propertyOrderings`
+ *
+ * Both patterns can coexist; the API client implementation decides which fields to use.
  */
 export interface SearchConfiguration {
-  fromDate?: string
-  toDate?: string
-  status?: string
-  sortField?: string
-  sortDirection?: 'asc' | 'desc'
-  limit?: number
+  /** Starting index for pagination */
   offset?: number
+  /** Number of items to return */
+  limit?: number
+  /** Neos Flow property filters for complex queries */
+  propertyFilters?: PropertyFilter[]
+  /** Neos Flow property orderings for sorting */
+  propertyOrderings?: PropertyOrdering[]
+  /** Simplified date filter (used by shared hooks) */
+  fromDate?: string
+  /** Simplified date filter (used by shared hooks) */
+  toDate?: string
+  /** Simplified status filter (used by shared hooks) */
+  status?: string
+  /** Simplified sort field (used by shared hooks) */
+  sortField?: string
+  /** Simplified sort direction (used by shared hooks) */
+  sortDirection?: 'asc' | 'desc'
 }
 
 /**

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -46,25 +46,8 @@ export interface PersonSearchFilter {
   yearOfBirth?: string
 }
 
-export interface SearchConfiguration {
-  offset?: number
-  limit?: number
-  propertyFilters?: PropertyFilter[]
-  propertyOrderings?: PropertyOrdering[]
-}
-
-export interface PropertyFilter {
-  propertyName: string
-  values?: string[]
-  enumValues?: string[]
-  dateRange?: { from: string; to: string }
-}
-
-export interface PropertyOrdering {
-  propertyName: string
-  descending: boolean
-  isSetByUser?: boolean
-}
+// Re-export search types from shared package (single source of truth)
+export type { SearchConfiguration, PropertyFilter, PropertyOrdering } from '@volleykit/shared/api'
 
 // Session management — re-export from dedicated module
 export {

--- a/web-app/src/api/queryKeys.ts
+++ b/web-app/src/api/queryKeys.ts
@@ -6,4 +6,9 @@
  */
 
 export { queryKeys } from '@volleykit/shared/api'
-export type { SearchConfiguration, PersonSearchFilter } from '@volleykit/shared/api'
+export type {
+  SearchConfiguration,
+  PropertyFilter,
+  PropertyOrdering,
+  PersonSearchFilter,
+} from '@volleykit/shared/api'

--- a/web-app/src/api/real-api.ts
+++ b/web-app/src/api/real-api.ts
@@ -34,17 +34,10 @@ import {
 import { scoreNameMatch } from './search-utils'
 
 import { getCsrfToken } from './form-serialization'
-import { captureSessionToken, getSessionHeaders, clearSession } from './session'
 
-import { HttpStatus, BYTES_PER_KB } from '@/shared/utils/constants'
-import {
-  API_BASE_URL,
-  MAX_FILE_SIZE_BYTES,
-  ALLOWED_FILE_TYPES,
-  DEFAULT_SEARCH_RESULTS_LIMIT,
-} from './constants'
-import { parseErrorResponse } from './error-handling'
-import { apiRequest } from './transport'
+import { BYTES_PER_KB } from '@/shared/utils/constants'
+import { MAX_FILE_SIZE_BYTES, ALLOWED_FILE_TYPES, DEFAULT_SEARCH_RESULTS_LIMIT } from './constants'
+import { apiRequest, apiRequestFormData, apiRequestVoid } from './transport'
 import {
   ASSIGNMENT_PROPERTIES,
   EXCHANGE_PROPERTIES,
@@ -697,28 +690,10 @@ export const api = {
       formData.append('__csrfToken', csrfToken)
     }
 
-    const url = `${API_BASE_URL}/sportmanager.resourcemanagement/api%5cpersistentresource/upload`
-
-    const response = await fetch(url, {
-      method: 'POST',
-      credentials: 'include',
-      headers: getSessionHeaders(),
-      body: formData,
-    })
-
-    // Capture session token from response headers (iOS Safari PWA)
-    captureSessionToken(response)
-
-    if (!response.ok) {
-      if (response.status === HttpStatus.UNAUTHORIZED || response.status === HttpStatus.FORBIDDEN) {
-        clearSession()
-        throw new Error('Session expired. Please log in again.')
-      }
-      const errorMessage = await parseErrorResponse(response)
-      throw new Error(`POST ${url}: ${errorMessage}`)
-    }
-
-    const data: unknown = await response.json()
+    const data = await apiRequestFormData<unknown>(
+      '/sportmanager.resourcemanagement/api%5cpersistentresource/upload',
+      formData
+    )
     return validateResponse(data, fileResourceArraySchema, 'uploadResource') as FileResource[]
   },
 
@@ -740,37 +715,13 @@ export const api = {
       body.append('__csrfToken', csrfToken)
     }
 
-    const response = await fetch(
-      `${API_BASE_URL}/sportmanager.security/api%5cparty/switchRoleAndAttribute`,
-      {
-        method: 'PUT',
-        headers: {
-          Accept: 'application/json',
-          // The real site uses text/plain, not application/x-www-form-urlencoded
-          'Content-Type': 'text/plain;charset=UTF-8',
-          ...getSessionHeaders(),
-        },
-        credentials: 'include',
-        body: body.toString(),
-      }
+    return apiRequestVoid(
+      '/sportmanager.security/api%5cparty/switchRoleAndAttribute',
+      'PUT',
+      body.toString(),
+      // The real site uses text/plain, not application/x-www-form-urlencoded
+      'text/plain;charset=UTF-8'
     )
-
-    // Capture session token from response headers (iOS Safari PWA)
-    captureSessionToken(response)
-
-    if (!response.ok) {
-      // 406 indicates session expiry in TYPO3 Neos/Flow (same as apiRequest)
-      if (
-        response.status === HttpStatus.UNAUTHORIZED ||
-        response.status === HttpStatus.FORBIDDEN ||
-        response.status === HttpStatus.NOT_ACCEPTABLE
-      ) {
-        clearSession()
-        throw new Error('Session expired. Please log in again.')
-      }
-      const errorMessage = await parseErrorResponse(response)
-      throw new Error(`PUT switchRoleAndAttribute: ${errorMessage}`)
-    }
   },
 
   // Referee Backup (Pikett)
@@ -802,6 +753,3 @@ export const api = {
     ) as RefereeBackupSearchResponse
   },
 }
-
-// Re-export ApiClient from shared for backwards compatibility
-export type { ApiClient } from '@volleykit/shared/api'

--- a/web-app/src/api/transport.ts
+++ b/web-app/src/api/transport.ts
@@ -4,6 +4,9 @@
  * Encapsulates the generic fetch logic, session management, and error handling
  * used by the real API client. Separated from endpoint definitions to improve
  * testability and make the transport mechanism independently configurable.
+ *
+ * All API requests should flow through these functions to ensure consistent
+ * session token capture, error handling, and stale-session detection.
  */
 
 import { HttpStatus } from '@/shared/utils/constants'
@@ -18,7 +21,58 @@ if (!import.meta.env.DEV && !API_BASE_URL) {
 }
 
 /**
- * Generic fetch wrapper for API requests.
+ * Shared error handling for all transport functions.
+ * Handles session expiry detection, error parsing, and session token capture.
+ */
+async function handleResponse(response: Response, method: string, endpoint: string): Promise<void> {
+  // Capture session token from response headers (iOS Safari PWA)
+  captureSessionToken(response)
+
+  if (!response.ok) {
+    if (
+      response.status === HttpStatus.UNAUTHORIZED ||
+      response.status === HttpStatus.FORBIDDEN ||
+      response.status === HttpStatus.NOT_ACCEPTABLE
+    ) {
+      clearSession()
+      throw new Error('Session expired. Please log in again.')
+    }
+    const errorMessage = await parseErrorResponse(response)
+    throw new Error(`${method} ${endpoint}: ${errorMessage}`)
+  }
+}
+
+/**
+ * Parse a JSON response, detecting stale sessions that return HTML login pages.
+ */
+function parseJsonResponse<T>(response: Response, method: string, endpoint: string): Promise<T> {
+  const contentType = response.headers.get('Content-Type') || ''
+
+  // Try to parse JSON first, regardless of Content-Type header.
+  // The API sometimes returns JSON with incorrect Content-Type: text/html header.
+  return response.json().catch(() => {
+    // JSON parsing failed - now check if this looks like a stale session
+    // Detect stale session: when the API returns HTML instead of JSON with status 200,
+    // it means the session expired and the server is returning a login page.
+    if (contentType.includes('text/html')) {
+      // Check if pathname ends with "/login" to avoid false positives on paths
+      // like "/api/v2/login-history" or "/user/login-preferences"
+      const pathname = new URL(response.url).pathname.toLowerCase()
+      const isLoginPage = pathname === '/login' || pathname.endsWith('/login')
+      if (isLoginPage) {
+        clearSession()
+        throw new Error('Session expired. Please log in again.')
+      }
+    }
+
+    throw new Error(
+      `${method} ${endpoint}: Invalid JSON response (Content-Type: ${contentType || 'unknown'}, status: ${response.status})`
+    )
+  })
+}
+
+/**
+ * Generic fetch wrapper for API requests with form-encoded bodies.
  *
  * Handles URL construction, header management, session tokens, CSRF,
  * error responses, and stale session detection.
@@ -61,45 +115,63 @@ export async function apiRequest<T>(
     body: method !== 'GET' && body ? buildFormData(body).toString() : undefined,
   })
 
-  // Capture session token from response headers (iOS Safari PWA)
-  captureSessionToken(response)
+  await handleResponse(response, method, endpoint)
+  return parseJsonResponse<T>(response, method, endpoint)
+}
 
-  if (!response.ok) {
-    if (
-      response.status === HttpStatus.UNAUTHORIZED ||
-      response.status === HttpStatus.FORBIDDEN ||
-      response.status === HttpStatus.NOT_ACCEPTABLE
-    ) {
-      clearSession()
-      throw new Error('Session expired. Please log in again.')
-    }
-    const errorMessage = await parseErrorResponse(response)
-    throw new Error(`${method} ${endpoint}: ${errorMessage}`)
-  }
+/**
+ * Send a multipart/form-data request (e.g. file uploads).
+ *
+ * Unlike apiRequest, this accepts a pre-built FormData body and does not
+ * set Content-Type (the browser sets it with the correct boundary).
+ *
+ * @param endpoint - API path relative to the base URL
+ * @param formData - FormData body
+ * @returns Parsed JSON response
+ */
+export async function apiRequestFormData<T>(endpoint: string, formData: FormData): Promise<T> {
+  const url = `${API_BASE_URL}${endpoint}`
 
-  const contentType = response.headers.get('Content-Type') || ''
+  const response = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: getSessionHeaders(),
+    body: formData,
+  })
 
-  // Try to parse JSON first, regardless of Content-Type header.
-  // The API sometimes returns JSON with incorrect Content-Type: text/html header.
-  try {
-    return await response.json()
-  } catch {
-    // JSON parsing failed - now check if this looks like a stale session
-    // Detect stale session: when the API returns HTML instead of JSON with status 200,
-    // it means the session expired and the server is returning a login page.
-    if (contentType.includes('text/html')) {
-      // Check if pathname ends with "/login" to avoid false positives on paths
-      // like "/api/v2/login-history" or "/user/login-preferences"
-      const pathname = new URL(response.url).pathname.toLowerCase()
-      const isLoginPage = pathname === '/login' || pathname.endsWith('/login')
-      if (isLoginPage) {
-        clearSession()
-        throw new Error('Session expired. Please log in again.')
-      }
-    }
+  await handleResponse(response, 'POST', endpoint)
+  return parseJsonResponse<T>(response, 'POST', endpoint)
+}
 
-    throw new Error(
-      `${method} ${endpoint}: Invalid JSON response (Content-Type: ${contentType || 'unknown'}, status: ${response.status})`
-    )
-  }
+/**
+ * Send a request that returns no meaningful body (void response).
+ *
+ * Handles session tokens, error responses, and custom content types.
+ * Does not attempt to parse the response body.
+ *
+ * @param endpoint - API path relative to the base URL
+ * @param method - HTTP method
+ * @param body - URL-encoded body string
+ * @param contentType - Content-Type header value
+ */
+export async function apiRequestVoid(
+  endpoint: string,
+  method: 'POST' | 'PUT' | 'DELETE',
+  body: string,
+  contentType: string = 'application/x-www-form-urlencoded'
+): Promise<void> {
+  const url = `${API_BASE_URL}${endpoint}`
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': contentType,
+      ...getSessionHeaders(),
+    },
+    credentials: 'include',
+    body,
+  })
+
+  await handleResponse(response, method, endpoint)
 }

--- a/web-app/src/api/transport.ts
+++ b/web-app/src/api/transport.ts
@@ -29,6 +29,9 @@ async function handleResponse(response: Response, method: string, endpoint: stri
   captureSessionToken(response)
 
   if (!response.ok) {
+    // 401/403 are standard auth failures. 406 (NOT_ACCEPTABLE) is also treated as
+    // session expiry because the VolleyManager API returns 406 when the session cookie
+    // is stale/invalid. Applied uniformly across all transport functions for consistency.
     if (
       response.status === HttpStatus.UNAUTHORIZED ||
       response.status === HttpStatus.FORBIDDEN ||


### PR DESCRIPTION
## Summary

- Extract `handleResponse`/`parseJsonResponse` helpers in `transport.ts` to eliminate duplicated session/error handling in `uploadResource` and `switchRoleAndAttribute`
- Add `apiRequestFormData` (file uploads) and `apiRequestVoid` (void responses) transport functions
- Unify `SearchConfiguration` type: shared type now includes both simplified fields (mobile/hooks) and Neos Flow property filters (web-app API calls)
- Remove redundant `ApiClient` re-export from `real-api.ts`; web-app `client.ts` now re-exports `SearchConfiguration` from shared package

## Test plan

- [ ] All tests pass (`pnpm test` in web-app and packages/shared)
- [ ] Production build succeeds (`pnpm run build` in web-app)
- [ ] Lint and knip pass with zero warnings
- [ ] Verify search functionality works end-to-end (assignments, compensations, exchanges)

https://claude.ai/code/session_01KEEKb8ChWzBH1Nz4AZ6sjY