### PR TITLE
fix(ci): sync pnpm-lock.yaml astro specifier with package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
       astro:
-        specifier: 6.0.0-beta.20
+        specifier: ^6.0.0-beta.20
         version: 6.0.0-beta.20(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(terser@5.46.0)(typescript@5.9.3)(yaml@2.8.2)
       tailwindcss:
         specifier: ^4.2.1


### PR DESCRIPTION
## Summary

- Fixed `pnpm-lock.yaml` specifier mismatch that broke all CI workflows on `main`
- The astro dependency specifier in the lockfile was `6.0.0-beta.20` (exact) while `help-site/package.json` had `^6.0.0-beta.20` (caret range)
- This caused `pnpm install --frozen-lockfile` to fail with `ERR_PNPM_OUTDATED_LOCKFILE` in every CI job

## Test plan

- [x] Verified `pnpm install --frozen-lockfile` passes locally after the fix
- [ ] CI workflows pass on this branch