### PR TITLE
fix(web): save scoresheet before finalize to prevent silent upload skip

### DIFF
--- a/.changeset/fix-scoresheet-upload.md
+++ b/.changeset/fix-scoresheet-upload.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fix scoresheet and scorer upload silently skipped when finalizing without safe mode

--- a/web-app/src/features/validation/hooks/useValidationState.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.ts
@@ -325,6 +325,9 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
 
       // Re-fetch game details to pick up the scoresheet identity created by the save
       const freshGameDetails = await apiClient.getGameWithScoresheet(gameId)
+      if (!freshGameDetails.scoresheet?.__identity) {
+        throw new Error('Scoresheet was not created after save — cannot finalize')
+      }
 
       await finalizeScoresheetWithFile(
         apiClient,

--- a/web-app/src/features/validation/hooks/useValidationState.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.ts
@@ -310,10 +310,26 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
         state.awayRoster.playerModifications,
         state.awayRoster.coachModifications
       )
-      await finalizeScoresheetWithFile(
+
+      // Save scorer/scoresheet first to ensure the scoresheet record exists on the
+      // server. Without safe-mode, saveProgress() is never called so the scoresheet
+      // may not have been created yet, causing finalizeScoresheetWithFile to silently
+      // skip due to a missing scoresheet identity.
+      await saveScorerSelection(
         apiClient,
         gameId,
         gameDetails.scoresheet,
+        state.scorer.selected?.__identity,
+        fileResourceId
+      )
+
+      // Re-fetch game details to pick up the scoresheet identity created by the save
+      const freshGameDetails = await apiClient.getGameWithScoresheet(gameId)
+
+      await finalizeScoresheetWithFile(
+        apiClient,
+        gameId,
+        freshGameDetails.scoresheet,
         state.scorer.selected?.__identity,
         fileResourceId
       )


### PR DESCRIPTION
## Summary

- Fix scoresheet and scorer upload silently skipped when finalizing a game without safe mode
- In non-safe mode, `saveProgress()` is never called, so no scoresheet record exists on the server. `finalizeScoresheetWithFile()` silently returns due to missing scoresheet identity
- Fix: call `saveScorerSelection()` before `finalizeScoresheetWithFile()` in the finalize path, then re-fetch game details to get the fresh scoresheet identity

## Test plan

- [ ] Finalize a game in safe mode — verify scoresheet and scorer still upload correctly
- [ ] Finalize a game without safe mode — verify scoresheet and scorer now upload correctly
- [ ] Finalize a game without a scoresheet file — verify no errors

https://claude.ai/code/session_01NtdbZhjEPzZUuo2RKm4dZH