### PR TITLE
feat(web): move scoresheet to first wizard step with reference photo viewing

### DIFF
--- a/.changeset/move-quick-view-button.md
+++ b/.changeset/move-quick-view-button.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Moved quick-compare scoresheet button to bottom bar and fixed split-view height on scorer step

--- a/web-app/src/features/validation/components/StepRenderer.tsx
+++ b/web-app/src/features/validation/components/StepRenderer.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import type { Assignment, NominationList } from '@/api/client'
 import type { ValidationStepId } from '@/features/validation/hooks/useValidateGameWizard'
 import type { UseValidationStateResult } from '@/features/validation/hooks/useValidationState'
-import { Lock, Eye } from '@/shared/components/icons'
+import { Lock } from '@/shared/components/icons'
 import { ModalErrorBoundary } from '@/shared/components/ModalErrorBoundary'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import type { ValidationReferenceMode } from '@/shared/stores/settings'
@@ -144,18 +144,6 @@ export function StepRenderer({
                 : t('validation.wizard.scoresheetFinalized')}
             </p>
           </div>
-        )}
-
-        {/* Quick-compare toggle button */}
-        {isQuickCompare && (
-          <button
-            type="button"
-            onClick={handleToggleReference}
-            className="mb-3 w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark rounded-lg border border-border-default dark:border-border-default-dark transition-colors"
-          >
-            <Eye className="w-4 h-4" aria-hidden="true" />
-            {t('validation.referenceImage.showScoresheet')}
-          </button>
         )}
 
         {currentStepId === 'home-roster' && (

--- a/web-app/src/features/validation/components/StepRenderer.tsx
+++ b/web-app/src/features/validation/components/StepRenderer.tsx
@@ -147,56 +147,56 @@ export function StepRenderer({
         )}
 
         {currentStepId === 'home-roster' && (
-        <HomeRosterPanel
-          assignment={assignment}
-          onModificationsChange={handlers.setHomeRosterModifications}
-          onAddPlayerSheetOpenChange={handlers.onAddPlayerSheetOpenChange}
-          readOnly={isStepReadOnly}
-          initialModifications={validation.state.homeRoster.playerModifications}
-          initialCoachModifications={validation.state.homeRoster.coachModifications}
-          prefetchedNominationList={validation.homeNominationList}
-        />
-      )}
+          <HomeRosterPanel
+            assignment={assignment}
+            onModificationsChange={handlers.setHomeRosterModifications}
+            onAddPlayerSheetOpenChange={handlers.onAddPlayerSheetOpenChange}
+            readOnly={isStepReadOnly}
+            initialModifications={validation.state.homeRoster.playerModifications}
+            initialCoachModifications={validation.state.homeRoster.coachModifications}
+            prefetchedNominationList={validation.homeNominationList}
+          />
+        )}
 
-      {currentStepId === 'away-roster' && (
-        <AwayRosterPanel
-          assignment={assignment}
-          onModificationsChange={handlers.setAwayRosterModifications}
-          onAddPlayerSheetOpenChange={handlers.onAddPlayerSheetOpenChange}
-          readOnly={isStepReadOnly}
-          initialModifications={validation.state.awayRoster.playerModifications}
-          initialCoachModifications={validation.state.awayRoster.coachModifications}
-          prefetchedNominationList={validation.awayNominationList}
-        />
-      )}
+        {currentStepId === 'away-roster' && (
+          <AwayRosterPanel
+            assignment={assignment}
+            onModificationsChange={handlers.setAwayRosterModifications}
+            onAddPlayerSheetOpenChange={handlers.onAddPlayerSheetOpenChange}
+            readOnly={isStepReadOnly}
+            initialModifications={validation.state.awayRoster.playerModifications}
+            initialCoachModifications={validation.state.awayRoster.coachModifications}
+            prefetchedNominationList={validation.awayNominationList}
+          />
+        )}
 
-      {currentStepId === 'scorer' && (
-        <ScorerPanel
-          key={validation.pendingScorer?.__identity ?? 'no-pending-scorer'}
-          onScorerChange={handlers.setScorer}
-          readOnly={isStepReadOnly}
-          readOnlyScorerName={validation.validatedInfo?.scorerName}
-          readOnlyScorerBirthday={validation.validatedInfo?.scorerBirthday}
-          initialScorer={
-            validation.pendingScorer
-              ? {
-                  __identity: validation.pendingScorer.__identity,
-                  displayName: validation.pendingScorer.displayName,
-                  birthday: validation.pendingScorer.birthday ?? '',
-                }
-              : null
-          }
-        />
-      )}
+        {currentStepId === 'scorer' && (
+          <ScorerPanel
+            key={validation.pendingScorer?.__identity ?? 'no-pending-scorer'}
+            onScorerChange={handlers.setScorer}
+            readOnly={isStepReadOnly}
+            readOnlyScorerName={validation.validatedInfo?.scorerName}
+            readOnlyScorerBirthday={validation.validatedInfo?.scorerBirthday}
+            initialScorer={
+              validation.pendingScorer
+                ? {
+                    __identity: validation.pendingScorer.__identity,
+                    displayName: validation.pendingScorer.displayName,
+                    birthday: validation.pendingScorer.birthday ?? '',
+                  }
+                : null
+            }
+          />
+        )}
 
-      {currentStepId === 'scoresheet' && (
-        <ScoresheetPanel
-          onScoresheetChange={handlers.setScoresheet}
-          readOnly={isStepReadOnly}
-          hasScoresheet={validation.validatedInfo?.hasScoresheet}
-          scoresheetNotRequired={validation.scoresheetNotRequired}
-        />
-      )}
+        {currentStepId === 'scoresheet' && (
+          <ScoresheetPanel
+            onScoresheetChange={handlers.setScoresheet}
+            readOnly={isStepReadOnly}
+            hasScoresheet={validation.validatedInfo?.hasScoresheet}
+            scoresheetNotRequired={validation.scoresheetNotRequired}
+          />
+        )}
       </div>
     </ModalErrorBoundary>
   )

--- a/web-app/src/features/validation/components/ValidateGameModal.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.tsx
@@ -5,6 +5,7 @@ import { getTeamNames } from '@volleykit/shared/utils'
 import type { Assignment, IndoorPlayerNomination, NominationList } from '@/api/client'
 import type { RosterPlayer } from '@/features/validation/hooks/useNominationList'
 import { useValidateGameWizard } from '@/features/validation/hooks/useValidateGameWizard'
+import { Eye, EyeOff } from '@/shared/components/icons'
 import { Modal } from '@/shared/components/Modal'
 import { ModalHeader } from '@/shared/components/ModalHeader'
 import { WizardStepContainer } from '@/shared/components/WizardStepContainer'
@@ -202,6 +203,15 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
     setShowingReference(false)
   }
 
+  const isNonScoresheetStep = wizard.currentStepId !== 'scoresheet'
+  const canShowReference = !!wizard.referenceImageUrl && isNonScoresheetStep
+  const isQuickCompare = canShowReference && validationReferenceMode === 'quick-compare'
+  const isSplitView = canShowReference && validationReferenceMode === 'split-view'
+
+  const handleToggleReference = useCallback(() => {
+    setShowingReference((prev) => !prev)
+  }, [])
+
   const loadingState = {
     isLoading: wizard.isLoadingGameDetails,
     error: wizard.gameDetailsError,
@@ -284,7 +294,7 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
           onSwipePrevious={wizard.goBack}
           swipeEnabled={wizard.isSwipeEnabled && !showingReference}
         >
-          <div className="max-h-80 overflow-y-auto">
+          <div className={isSplitView ? 'h-80' : 'max-h-80 overflow-y-auto'}>
             <StepRenderer
               currentStepId={wizard.currentStepId}
               assignment={assignment}
@@ -341,7 +351,7 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
           </div>
         )}
 
-        <div className="flex justify-between gap-3 pt-4 border-t border-border-default dark:border-border-default-dark mt-4">
+        <div className="flex items-center justify-between gap-3 pt-4 border-t border-border-default dark:border-border-default-dark mt-4">
           {wizard.isValidated ? (
             <ValidatedModeButtons
               navigation={navigation}
@@ -372,6 +382,26 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
               onValidateAndNext={wizard.handleValidateAndNext}
               onFinish={wizard.handleFinish}
             />
+          )}
+          {/* Quick-compare toggle — between Previous and Validate, always visible */}
+          {isQuickCompare && (
+            <div className="order-1">
+              <button
+                type="button"
+                onClick={handleToggleReference}
+                className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark rounded-lg border border-border-default dark:border-border-default-dark transition-colors"
+                aria-pressed={showingReference}
+              >
+                {showingReference ? (
+                  <EyeOff className="w-4 h-4" aria-hidden="true" />
+                ) : (
+                  <Eye className="w-4 h-4" aria-hidden="true" />
+                )}
+                {showingReference
+                  ? t('validation.referenceImage.hideScoresheet')
+                  : t('validation.referenceImage.showScoresheet')}
+              </button>
+            </div>
           )}
         </div>
       </Modal>

--- a/web-app/src/features/validation/components/WizardButtons.tsx
+++ b/web-app/src/features/validation/components/WizardButtons.tsx
@@ -33,14 +33,14 @@ function ReadOnlyModeButtons({
 
   return (
     <>
-      <div>
+      <div className="order-0">
         {!navigation.isFirstStep && (
           <Button variant="secondary" onClick={onBack}>
             {t('validation.wizard.previous')}
           </Button>
         )}
       </div>
-      <div>
+      <div className="order-2">
         {navigation.isLastStep ? (
           <Button variant={closeVariant} onClick={onClose} disabled={closeDisabled}>
             {closeLabel}
@@ -147,7 +147,7 @@ export function EditModeButtons({
 
   return (
     <>
-      <div>
+      <div className="order-0">
         {navigation.isFirstStep ? (
           <Button variant="secondary" onClick={onAttemptClose} disabled={state.isFinalizing}>
             {t('common.cancel')}
@@ -159,7 +159,7 @@ export function EditModeButtons({
         )}
       </div>
 
-      <div>
+      <div className="order-2">
         {navigation.isLastStep ? (
           <Button
             variant="success"


### PR DESCRIPTION
Move scoresheet capture from step 4 to step 1 so referees can photograph
the scoresheet first and reference it during roster/scorer validation.

Add two user-selectable viewing modes (configurable in Settings):
- Quick Compare: floating toggle button to flip between form and
  full-screen zoomable photo (pinch-to-zoom, double-tap, scroll wheel)
- Split View: top/bottom layout with draggable divider showing the
  reference photo alongside the form

When scoresheet step is skipped, remaining steps behave exactly as before.
OCR-captured images are automatically reused as the reference photo.

https://claude.ai/code/session_01Je7JYk3hwQGG2kQKbo4LHp