### PR TITLE
fix(web): preserve scroll position, disable swipe nav, and fix image viewer gestures

### DIFF
--- a/.changeset/fix-validation-scroll-gestures.md
+++ b/.changeset/fix-validation-scroll-gestures.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fix validation wizard scroll and gesture issues: preserve roster scroll position when toggling scoresheet reference image, disable swipe navigation on wizard steps (buttons/indicators only), lock down picture overlay to prevent pull-to-refresh and horizontal scroll, and fix jumpy pan/zoom behavior in the reference image viewer

--- a/web-app/src/features/validation/components/ReferenceImageViewer.tsx
+++ b/web-app/src/features/validation/components/ReferenceImageViewer.tsx
@@ -39,12 +39,15 @@ export function ReferenceImageViewer({
   const containerRef = useRef<HTMLDivElement>(null)
   const [zoom, setZoom] = useState(MIN_ZOOM)
   const [pan, setPan] = useState({ x: 0, y: 0 })
-  const [isPanning, setIsPanning] = useState(false)
+  /** Whether any gesture (pan or pinch) is actively in progress — disables CSS transitions */
+  const [isInteracting, setIsInteracting] = useState(false)
   const lastTapRef = useRef(0)
   const isPanningRef = useRef(false)
+  const panPointerIdRef = useRef<number | null>(null)
   const lastPanPointRef = useRef({ x: 0, y: 0 })
   const initialPinchDistanceRef = useRef<number | null>(null)
   const initialPinchZoomRef = useRef(MIN_ZOOM)
+  const initialPinchPanRef = useRef({ x: 0, y: 0 })
   const [prevImageUrl, setPrevImageUrl] = useState(imageUrl)
 
   // Reset zoom/pan when image changes (computed during render, per React docs)
@@ -85,6 +88,9 @@ export function ReferenceImageViewer({
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
+      // Only track a single pointer for panning (ignore additional fingers)
+      if (panPointerIdRef.current !== null) return
+
       // Double-tap detection
       const now = Date.now()
       if (now - lastTapRef.current < DOUBLE_TAP_THRESHOLD_MS) {
@@ -101,8 +107,11 @@ export function ReferenceImageViewer({
       lastTapRef.current = now
 
       if (zoom > MIN_ZOOM) {
+        // Capture this pointer so moves/ups are tracked even outside the element
+        ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+        panPointerIdRef.current = e.pointerId
         isPanningRef.current = true
-        setIsPanning(true)
+        setIsInteracting(true)
         lastPanPointRef.current = { x: e.clientX, y: e.clientY }
       }
     },
@@ -111,7 +120,8 @@ export function ReferenceImageViewer({
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
-      if (!isPanningRef.current) return
+      // Only respond to the pointer we're tracking
+      if (!isPanningRef.current || e.pointerId !== panPointerIdRef.current) return
       const dx = e.clientX - lastPanPointRef.current.x
       const dy = e.clientY - lastPanPointRef.current.y
       lastPanPointRef.current = { x: e.clientX, y: e.clientY }
@@ -120,49 +130,73 @@ export function ReferenceImageViewer({
     [zoom, clampPan]
   )
 
-  const handlePointerUp = useCallback(() => {
+  const handlePointerUp = useCallback((e: React.PointerEvent) => {
+    if (e.pointerId !== panPointerIdRef.current) return
     isPanningRef.current = false
-    setIsPanning(false)
+    panPointerIdRef.current = null
+    setIsInteracting(false)
   }, [])
 
   const handleTouchStart = useCallback(
     (e: React.TouchEvent) => {
       if (e.touches.length === 2) {
+        // Cancel any in-progress single-finger pan so it doesn't interfere
+        isPanningRef.current = false
+        panPointerIdRef.current = null
+
         const t0 = e.touches[0]!
         const t1 = e.touches[1]!
         const dx = t0.clientX - t1.clientX
         const dy = t0.clientY - t1.clientY
         initialPinchDistanceRef.current = Math.hypot(dx, dy)
         initialPinchZoomRef.current = zoom
+        initialPinchPanRef.current = { x: pan.x, y: pan.y }
+        setIsInteracting(true)
       }
     },
-    [zoom]
+    [zoom, pan]
   )
 
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (e.touches.length === 2 && initialPinchDistanceRef.current !== null) {
-      e.preventDefault()
-      const t0 = e.touches[0]!
-      const t1 = e.touches[1]!
-      const dx = t0.clientX - t1.clientX
-      const dy = t0.clientY - t1.clientY
-      const distance = Math.hypot(dx, dy)
-      const scale = distance / initialPinchDistanceRef.current
-      const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, initialPinchZoomRef.current * scale))
-      setZoom(newZoom)
-      if (newZoom <= MIN_ZOOM) setPan({ x: 0, y: 0 })
-    }
-  }, [])
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (e.touches.length === 2 && initialPinchDistanceRef.current !== null) {
+        e.preventDefault()
+        const t0 = e.touches[0]!
+        const t1 = e.touches[1]!
+        const dx = t0.clientX - t1.clientX
+        const dy = t0.clientY - t1.clientY
+        const distance = Math.hypot(dx, dy)
+        const scale = distance / initialPinchDistanceRef.current
+        const newZoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, initialPinchZoomRef.current * scale))
+        setZoom(newZoom)
+        if (newZoom <= MIN_ZOOM) {
+          setPan({ x: 0, y: 0 })
+        } else {
+          // Scale pan proportionally so the image stays centered during pinch
+          const panScale = newZoom / initialPinchZoomRef.current
+          setPan(
+            clampPan(
+              initialPinchPanRef.current.x * panScale,
+              initialPinchPanRef.current.y * panScale,
+              newZoom
+            )
+          )
+        }
+      }
+    },
+    [clampPan]
+  )
 
   const handleTouchEnd = useCallback(() => {
     initialPinchDistanceRef.current = null
+    setIsInteracting(false)
   }, [])
 
   return (
     <div
       ref={containerRef}
       className={`relative overflow-hidden bg-surface-subtle dark:bg-surface-card-dark select-none ${className}`}
-      style={{ touchAction: 'none' }}
+      style={{ touchAction: 'none', overscrollBehavior: 'none' }}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
@@ -178,7 +212,7 @@ export function ReferenceImageViewer({
         style={{
           transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
           transformOrigin: 'center center',
-          transition: isPanning ? 'none' : 'transform 0.15s ease-out',
+          transition: isInteracting ? 'none' : 'transform 0.15s ease-out',
         }}
         draggable={false}
       />

--- a/web-app/src/features/validation/components/ReferenceImageViewer.tsx
+++ b/web-app/src/features/validation/components/ReferenceImageViewer.tsx
@@ -48,6 +48,10 @@ export function ReferenceImageViewer({
   const initialPinchDistanceRef = useRef<number | null>(null)
   const initialPinchZoomRef = useRef(MIN_ZOOM)
   const initialPinchPanRef = useRef({ x: 0, y: 0 })
+  const panRef = useRef(pan)
+  useEffect(() => {
+    panRef.current = pan
+  }, [pan])
   const [prevImageUrl, setPrevImageUrl] = useState(imageUrl)
 
   // Reset zoom/pan when image changes (computed during render, per React docs)
@@ -150,11 +154,11 @@ export function ReferenceImageViewer({
         const dy = t0.clientY - t1.clientY
         initialPinchDistanceRef.current = Math.hypot(dx, dy)
         initialPinchZoomRef.current = zoom
-        initialPinchPanRef.current = { x: pan.x, y: pan.y }
+        initialPinchPanRef.current = { x: panRef.current.x, y: panRef.current.y }
         setIsInteracting(true)
       }
     },
-    [zoom, pan]
+    [zoom]
   )
 
   const handleTouchMove = useCallback(
@@ -189,7 +193,10 @@ export function ReferenceImageViewer({
 
   const handleTouchEnd = useCallback(() => {
     initialPinchDistanceRef.current = null
-    setIsInteracting(false)
+    // Only clear isInteracting if no single-finger pan is still active
+    if (!isPanningRef.current) {
+      setIsInteracting(false)
+    }
   }, [])
 
   return (

--- a/web-app/src/features/validation/components/ValidateGameModal.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback, useMemo } from 'react'
+import { memo, useState, useCallback, useMemo, useRef } from 'react'
 
 import { getTeamNames } from '@volleykit/shared/utils'
 
@@ -195,6 +195,8 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
 
   const [showingReference, setShowingReference] = useState(false)
   const [prevStepId, setPrevStepId] = useState(wizard.currentStepId)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const savedScrollTopRef = useRef(0)
 
   // Reset reference view when navigating between steps
   if (prevStepId !== wizard.currentStepId) {
@@ -206,7 +208,20 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
   const canShowReference = !!wizard.referenceImageUrl && isNonScoresheetStep
 
   const handleToggleReference = useCallback(() => {
-    setShowingReference((prev) => !prev)
+    setShowingReference((prev) => {
+      if (!prev) {
+        // About to show reference — save current scroll position
+        savedScrollTopRef.current = scrollContainerRef.current?.scrollTop ?? 0
+      } else {
+        // About to hide reference — restore scroll position after render
+        requestAnimationFrame(() => {
+          if (scrollContainerRef.current) {
+            scrollContainerRef.current.scrollTop = savedScrollTopRef.current
+          }
+        })
+      }
+      return !prev
+    })
   }, [])
 
   const loadingState = {
@@ -289,9 +304,13 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
           totalSteps={wizard.totalSteps}
           onSwipeNext={wizard.goNext}
           onSwipePrevious={wizard.goBack}
-          swipeEnabled={wizard.isSwipeEnabled && !showingReference}
+          swipeEnabled={false}
         >
-          <div className="max-h-80 overflow-y-auto">
+          <div
+            ref={scrollContainerRef}
+            className={`max-h-80 ${showingReference ? 'overflow-hidden' : 'overflow-y-auto'}`}
+            style={{ overscrollBehavior: 'none' }}
+          >
             <StepRenderer
               currentStepId={wizard.currentStepId}
               assignment={assignment}


### PR DESCRIPTION
## Summary

- **Scroll position preservation**: Save/restore roster scroll position when toggling the scoresheet reference image overlay on and off
- **Disable wizard swipe navigation**: Only Previous/Next buttons and step indicator dots can navigate between wizard steps — no swipe gestures
- **Lock down picture overlay**: Prevent pull-to-refresh and horizontal scroll when reference image is displayed (`overflow-hidden`, `overscroll-behavior: none`)
- **Fix image viewer zoom/pan**: Track pointer IDs to prevent multi-touch confusion, use pointer capture for reliable drag tracking, unified `isInteracting` state disables CSS transitions during both pan and pinch gestures

## Test plan

- [ ] Open validation wizard, scroll down in a roster step, toggle scoresheet reference on then off — scroll position should be restored
- [ ] With reference image showing, try pull-to-refresh and horizontal scroll — nothing should move
- [ ] Try swiping left/right on wizard steps — should not navigate (only buttons / step dots work)
- [ ] Zoom and pan the reference image on desktop — should be smooth, no jumps
- [ ] Pinch-to-zoom on touch device — should be smooth with no jitter

https://claude.ai/code/session_01G65QvXF2fVggrYKS5gvjn5