### PR TITLE
feat(web): load existing scoresheet in validation wizard

### DIFF
--- a/.changeset/load-existing-scoresheet.md
+++ b/.changeset/load-existing-scoresheet.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Load existing scoresheet in validation wizard when reopening a game that already has one uploaded

--- a/web-app/src/features/validation/components/ScoresheetPanel.test.tsx
+++ b/web-app/src/features/validation/components/ScoresheetPanel.test.tsx
@@ -781,6 +781,107 @@ describe('ScoresheetPanel - camera input', () => {
   })
 })
 
+describe('ScoresheetPanel - existing scoresheet display', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    globalThis.URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows existing image scoresheet with preview', () => {
+    render(
+      <ScoresheetPanel existingFileUrl="https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg" />
+    )
+
+    const img = screen.getByRole('img', { name: /preview/i })
+    expect(img).toHaveAttribute(
+      'src',
+      'https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg'
+    )
+    expect(screen.getByText('Previously uploaded scoresheet')).toBeInTheDocument()
+  })
+
+  it('shows existing PDF scoresheet with PDF indicator', () => {
+    render(
+      <ScoresheetPanel existingFileUrl="https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.pdf" />
+    )
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.getByText('PDF')).toBeInTheDocument()
+    expect(screen.getByText('Previously uploaded scoresheet')).toBeInTheDocument()
+  })
+
+  it('shows replace button for existing scoresheet', () => {
+    render(
+      <ScoresheetPanel existingFileUrl="https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg" />
+    )
+
+    expect(screen.getByRole('button', { name: /replace/i })).toBeInTheDocument()
+  })
+
+  it('shows file upload UI when replace is clicked on existing scoresheet', () => {
+    render(
+      <ScoresheetPanel existingFileUrl="https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg" />
+    )
+
+    // Existing scoresheet is shown
+    expect(screen.getByText('Previously uploaded scoresheet')).toBeInTheDocument()
+
+    // Select a new file via the file input (simulating what happens after replace click)
+    const fileInput = getFileInput()
+    const newFile = createValidFile('new-scoresheet.jpg')
+    fireEvent.change(fileInput, { target: { files: [newFile] } })
+
+    // Now the local file should be shown instead of the existing one
+    expect(screen.queryByText('Previously uploaded scoresheet')).not.toBeInTheDocument()
+    expect(screen.getByText('new-scoresheet.jpg')).toBeInTheDocument()
+  })
+
+  it('does not show existing scoresheet when null', () => {
+    render(<ScoresheetPanel existingFileUrl={null} />)
+
+    expect(screen.queryByText('Previously uploaded scoresheet')).not.toBeInTheDocument()
+    // Should show the upload UI instead
+    expect(screen.getByText('Upload Scoresheet')).toBeInTheDocument()
+  })
+
+  it('does not show existing scoresheet in read-only mode', () => {
+    render(
+      <ScoresheetPanel
+        readOnly
+        hasScoresheet
+        existingFileUrl="https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg"
+      />
+    )
+
+    // Read-only mode should show the simple status display, not the existing file preview
+    expect(screen.queryByText('Previously uploaded scoresheet')).not.toBeInTheDocument()
+    expect(screen.getByText('Scoresheet uploaded')).toBeInTheDocument()
+  })
+
+  it('handles existing PNG scoresheet', () => {
+    render(
+      <ScoresheetPanel existingFileUrl="https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.png" />
+    )
+
+    const img = screen.getByRole('img', { name: /preview/i })
+    expect(img).toBeInTheDocument()
+  })
+
+  it('shows existing scoresheet status as a status element', () => {
+    render(
+      <ScoresheetPanel existingFileUrl="https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg" />
+    )
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+})
+
 describe('ScoresheetPanel - same file re-selection', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/web-app/src/features/validation/components/ScoresheetPanel.tsx
+++ b/web-app/src/features/validation/components/ScoresheetPanel.tsx
@@ -15,6 +15,8 @@ interface ScoresheetPanelProps {
   hasScoresheet?: boolean
   /** Whether scoresheet upload is not required for this game's group */
   scoresheetNotRequired?: boolean
+  /** Public URL of an existing scoresheet file (from a previous upload) */
+  existingFileUrl?: string | null
 }
 
 const ACCEPTED_EXTENSIONS = '.jpg,.jpeg,.png,.pdf'
@@ -31,6 +33,16 @@ interface SelectedFile {
   previewUrl: string | null
 }
 
+/** Check if a URL points to an image based on its path extension */
+function isExistingImage(url: string): boolean {
+  try {
+    const pathname = new URL(url).pathname.toLowerCase()
+    return pathname.endsWith('.jpg') || pathname.endsWith('.jpeg') || pathname.endsWith('.png')
+  } catch {
+    return false
+  }
+}
+
 function formatFileSize(bytes: number): string {
   if (bytes < BYTES_PER_KB) return `${bytes} B`
   if (bytes < BYTES_PER_MB) return `${(bytes / BYTES_PER_KB).toFixed(1)} KB`
@@ -42,6 +54,7 @@ export function ScoresheetPanel({
   readOnly = false,
   hasScoresheet = false,
   scoresheetNotRequired = false,
+  existingFileUrl,
 }: ScoresheetPanelProps) {
   const { t } = useTranslation()
   const dataSource = useAuthStore((state) => state.dataSource)
@@ -262,7 +275,50 @@ export function ScoresheetPanel({
         aria-label={tKey('takePhoto')}
       />
 
-      {!selectedFile ? (
+      {!selectedFile && existingFileUrl ? (
+        <div className="border border-border-default dark:border-border-default-dark rounded-lg overflow-hidden">
+          {isExistingImage(existingFileUrl) ? (
+            <div className="relative bg-surface-subtle dark:bg-surface-card-dark">
+              <img
+                src={existingFileUrl}
+                alt={tKey('previewAlt')}
+                className="w-full max-h-64 object-contain"
+              />
+            </div>
+          ) : (
+            <div className="bg-surface-subtle dark:bg-surface-card-dark p-8 flex flex-col items-center justify-center">
+              <FileText
+                className="w-16 h-16 text-text-subtle dark:text-text-subtle-dark mb-2"
+                aria-hidden="true"
+              />
+              <span className="text-sm text-text-muted dark:text-text-muted-dark">PDF</span>
+            </div>
+          )}
+
+          <div className="p-4 bg-surface-card dark:bg-surface-card-dark">
+            <div
+              className="mb-3 flex items-center gap-2 text-success-600 dark:text-success-400"
+              role="status"
+              aria-live="polite"
+            >
+              <CheckCircle className="w-5 h-5" aria-hidden="true" />
+              <span className="text-sm font-medium">
+                {t('validation.scoresheetUpload.existingScoresheet')}
+              </span>
+            </div>
+
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="w-full px-4 py-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark bg-surface-subtle dark:bg-surface-subtle-dark hover:bg-surface-muted dark:hover:bg-surface-muted-dark rounded-lg transition-colors"
+              >
+                {tKey('replace')}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : !selectedFile ? (
         <div className="border-2 border-dashed border-border-strong dark:border-border-strong-dark rounded-lg p-6 text-center">
           <Upload
             className="w-12 h-12 mx-auto text-text-subtle dark:text-text-subtle-dark mb-4"

--- a/web-app/src/features/validation/components/ScoresheetPanel.tsx
+++ b/web-app/src/features/validation/components/ScoresheetPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 
 import { MAX_FILE_SIZE_BYTES, ALLOWED_FILE_TYPES } from '@/api/constants'
+import { isImageUrl } from '@/features/validation/utils/scoresheet'
 import { Upload, Camera, CheckCircle, FileText, AlertCircle, Info } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useAuthStore } from '@/shared/stores/auth'
@@ -31,16 +32,6 @@ type UploadState = 'idle' | 'uploading' | 'complete'
 interface SelectedFile {
   file: File
   previewUrl: string | null
-}
-
-/** Check if a URL points to an image based on its path extension */
-function isExistingImage(url: string): boolean {
-  try {
-    const pathname = new URL(url).pathname.toLowerCase()
-    return pathname.endsWith('.jpg') || pathname.endsWith('.jpeg') || pathname.endsWith('.png')
-  } catch {
-    return false
-  }
 }
 
 function formatFileSize(bytes: number): string {
@@ -277,7 +268,7 @@ export function ScoresheetPanel({
 
       {!selectedFile && existingFileUrl ? (
         <div className="border border-border-default dark:border-border-default-dark rounded-lg overflow-hidden">
-          {isExistingImage(existingFileUrl) ? (
+          {isImageUrl(existingFileUrl) ? (
             <div className="relative bg-surface-subtle dark:bg-surface-card-dark">
               <img
                 src={existingFileUrl}

--- a/web-app/src/features/validation/components/StepRenderer.tsx
+++ b/web-app/src/features/validation/components/StepRenderer.tsx
@@ -25,6 +25,7 @@ interface ValidationInfo {
   state: UseValidationStateResult['state']
   homeNominationList: NominationList | null
   awayNominationList: NominationList | null
+  existingScoresheetUrl: string | null
 }
 
 interface StepHandlers {
@@ -188,6 +189,7 @@ export function StepRenderer({
             readOnly={isStepReadOnly}
             hasScoresheet={validation.validatedInfo?.hasScoresheet}
             scoresheetNotRequired={validation.scoresheetNotRequired}
+            existingFileUrl={validation.existingScoresheetUrl}
           />
         )}
       </div>

--- a/web-app/src/features/validation/components/ValidateGameModal.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.tsx
@@ -238,6 +238,7 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
     state: wizard.validationState,
     homeNominationList: wizard.homeNominationList,
     awayNominationList: wizard.awayNominationList,
+    existingScoresheetUrl: wizard.existingScoresheetUrl,
   }
 
   const stepHandlers = {

--- a/web-app/src/features/validation/hooks/types.ts
+++ b/web-app/src/features/validation/hooks/types.ts
@@ -111,7 +111,9 @@ export interface UseValidationStateResult {
   setScorer: (scorer: ValidatedPersonSearchResult | null) => void
   /** Set the scoresheet file and upload status */
   setScoresheet: (file: File | null, uploaded: boolean) => void
-  /** The reference image URL for the scoresheet (Object URL) */
+  /** Set the reference image URL directly (e.g., from an existing scoresheet) */
+  setReferenceImageUrl: (url: string | null) => void
+  /** The reference image URL for the scoresheet (Object URL or public URL) */
   referenceImageUrl: string | null
   /** Reset all state to initial values */
   reset: () => void
@@ -131,6 +133,10 @@ export interface UseValidationStateResult {
   homeNominationList: NominationList | null
   /** Pre-fetched away team nomination list from game details */
   awayNominationList: NominationList | null
+  /** Public URL of an existing scoresheet file (from a previous save) */
+  existingScoresheetUrl: string | null
+  /** Resource ID of the existing scoresheet file (to avoid re-uploading) */
+  existingFileResourceId: string | null
 }
 
 /**

--- a/web-app/src/features/validation/hooks/useValidateGameWizard.ts
+++ b/web-app/src/features/validation/hooks/useValidateGameWizard.ts
@@ -10,6 +10,7 @@ import {
   validateBothRosters,
   type RosterValidationStatus,
 } from '@/features/validation/utils/roster-validation'
+import { isImageUrl } from '@/features/validation/utils/scoresheet'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useWizardNavigation } from '@/shared/hooks/useWizardNavigation'
 import { useAuthStore } from '@/shared/stores/auth'
@@ -314,13 +315,8 @@ export function useValidateGameWizard({
   useEffect(() => {
     if (isOpen && existingScoresheetUrl && !referenceImageUrl) {
       // Only use as reference if it's an image (not PDF)
-      try {
-        const pathname = new URL(existingScoresheetUrl).pathname.toLowerCase()
-        if (pathname.endsWith('.jpg') || pathname.endsWith('.jpeg') || pathname.endsWith('.png')) {
-          setReferenceImageUrl(existingScoresheetUrl)
-        }
-      } catch {
-        // Invalid URL, skip
+      if (isImageUrl(existingScoresheetUrl)) {
+        setReferenceImageUrl(existingScoresheetUrl)
       }
     }
   }, [isOpen, existingScoresheetUrl, referenceImageUrl, setReferenceImageUrl])

--- a/web-app/src/features/validation/hooks/useValidateGameWizard.ts
+++ b/web-app/src/features/validation/hooks/useValidateGameWizard.ts
@@ -70,6 +70,7 @@ export interface UseValidateGameWizardResult {
   gameDetailsError: Error | null
   homeNominationList: NominationList | null
   awayNominationList: NominationList | null
+  existingScoresheetUrl: string | null
 
   // UI state
   showUnsavedDialog: boolean
@@ -148,6 +149,7 @@ export function useValidateGameWizard({
     setAwayRosterModifications,
     setScorer,
     setScoresheet,
+    setReferenceImageUrl,
     referenceImageUrl,
     reset,
     saveProgress,
@@ -158,6 +160,7 @@ export function useValidateGameWizard({
     gameDetailsError,
     homeNominationList,
     awayNominationList,
+    existingScoresheetUrl,
   } = useValidationState(gameId)
 
   // The assignment list data may be fresher than the cached game details query.
@@ -305,6 +308,22 @@ export function useValidateGameWizard({
       resetToStart()
     }
   }, [isOpen, reset, resetToStart, gameId, queryClient])
+
+  // Set reference image from existing scoresheet when game details load
+  // This allows the quick-compare toggle to work with previously uploaded scoresheets
+  useEffect(() => {
+    if (isOpen && existingScoresheetUrl && !referenceImageUrl) {
+      // Only use as reference if it's an image (not PDF)
+      try {
+        const pathname = new URL(existingScoresheetUrl).pathname.toLowerCase()
+        if (pathname.endsWith('.jpg') || pathname.endsWith('.jpeg') || pathname.endsWith('.png')) {
+          setReferenceImageUrl(existingScoresheetUrl)
+        }
+      } catch {
+        // Invalid URL, skip
+      }
+    }
+  }, [isOpen, existingScoresheetUrl, referenceImageUrl, setReferenceImageUrl])
 
   // Computed values
   const canMarkCurrentStepDone = useMemo(() => {
@@ -484,6 +503,7 @@ export function useValidateGameWizard({
     gameDetailsError,
     homeNominationList,
     awayNominationList,
+    existingScoresheetUrl,
 
     // UI state
     showUnsavedDialog,

--- a/web-app/src/features/validation/hooks/useValidationState.test.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.test.ts
@@ -552,6 +552,156 @@ describe('useValidationState', () => {
     })
   })
 
+  describe('existing scoresheet', () => {
+    it('exposes existing scoresheet URL when game has a file', async () => {
+      mockGetGameWithScoresheet.mockResolvedValue({
+        ...mockGameDetails,
+        scoresheet: {
+          ...mockGameDetails.scoresheet,
+          file: {
+            __identity: 'file-resource-1',
+            publicResourceUri:
+              'https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg',
+          },
+          hasFile: true,
+        },
+      })
+
+      const { result } = renderHook(() => useValidationState('game-123'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoadingGameDetails).toBe(false)
+      })
+
+      expect(result.current.existingScoresheetUrl).toBe(
+        'https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg'
+      )
+      expect(result.current.existingFileResourceId).toBe('file-resource-1')
+    })
+
+    it('returns null for existing scoresheet when no file', async () => {
+      const { result } = renderHook(() => useValidationState('game-123'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoadingGameDetails).toBe(false)
+      })
+
+      expect(result.current.existingScoresheetUrl).toBeNull()
+      expect(result.current.existingFileResourceId).toBeNull()
+    })
+
+    it('reuses existing file resource ID during save (skips re-upload)', async () => {
+      mockGetGameWithScoresheet.mockResolvedValue({
+        ...mockGameDetails,
+        scoresheet: {
+          ...mockGameDetails.scoresheet,
+          file: {
+            __identity: 'existing-file-resource',
+            publicResourceUri:
+              'https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.pdf',
+          },
+          hasFile: true,
+        },
+      })
+
+      const { result } = renderHook(() => useValidationState('game-123'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoadingGameDetails).toBe(false)
+      })
+
+      // Select a scorer but don't select a new file
+      act(() => {
+        result.current.setScorer(mockScorer)
+      })
+
+      await act(async () => {
+        await result.current.saveProgress()
+      })
+
+      // Should NOT have uploaded a new file
+      expect(mockUploadResource).not.toHaveBeenCalled()
+
+      // Should have saved with the existing file resource ID
+      expect(mockUpdateScoresheet).toHaveBeenCalledWith(
+        'scoresheet-1',
+        'game-123',
+        'scorer-1',
+        false,
+        'existing-file-resource'
+      )
+    })
+
+    it('sets reference image URL directly via setReferenceImageUrl', () => {
+      const { result } = renderHook(() => useValidationState(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.setReferenceImageUrl(
+          'https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg'
+        )
+      })
+
+      expect(result.current.referenceImageUrl).toBe(
+        'https://volleymanager.volleyball.ch/_Resources/Persistent/abc123/scoresheet.jpg'
+      )
+    })
+
+    it('does not revoke non-blob reference image URLs on reset', () => {
+      const mockRevokeObjectURL = vi.fn()
+      globalThis.URL.revokeObjectURL = mockRevokeObjectURL
+
+      const { result } = renderHook(() => useValidationState(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.setReferenceImageUrl('https://example.com/scoresheet.jpg')
+      })
+
+      mockRevokeObjectURL.mockClear()
+
+      act(() => {
+        result.current.reset()
+      })
+
+      // Should NOT revoke a non-blob URL
+      expect(mockRevokeObjectURL).not.toHaveBeenCalled()
+    })
+
+    it('revokes blob reference image URLs on reset', () => {
+      const mockRevokeObjectURL = vi.fn()
+      globalThis.URL.createObjectURL = vi.fn(() => 'blob:http://localhost/mock')
+      globalThis.URL.revokeObjectURL = mockRevokeObjectURL
+
+      const { result } = renderHook(() => useValidationState(), {
+        wrapper: createWrapper(),
+      })
+
+      const file = new File(['content'], 'scoresheet.jpg', { type: 'image/jpeg' })
+
+      act(() => {
+        result.current.setScoresheet(file, false)
+      })
+
+      mockRevokeObjectURL.mockClear()
+
+      act(() => {
+        result.current.reset()
+      })
+
+      // Should revoke blob URL
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/mock')
+    })
+  })
+
   describe('finalizeValidation', () => {
     it('uploads scoresheet file if provided', async () => {
       mockUploadResource.mockResolvedValue([{ __identity: 'resource-1' }])

--- a/web-app/src/features/validation/hooks/useValidationState.test.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.test.ts
@@ -702,6 +702,113 @@ describe('useValidationState', () => {
     })
   })
 
+  describe('scoresheetNotRequired', () => {
+    it('does not upload file during save when scoresheet is not required', async () => {
+      mockGetGameWithScoresheet.mockResolvedValue({
+        ...mockGameDetails,
+        group: { __identity: 'group-1', hasNoScoresheet: true },
+      })
+
+      const { result } = renderHook(() => useValidationState('game-123'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoadingGameDetails).toBe(false)
+      })
+
+      const file = new File(['content'], 'scoresheet.pdf', { type: 'application/pdf' })
+
+      act(() => {
+        result.current.setScorer(mockScorer)
+        result.current.setScoresheet(file, true)
+      })
+
+      await act(async () => {
+        await result.current.saveProgress()
+      })
+
+      expect(mockUploadResource).not.toHaveBeenCalled()
+      // Scorer should still be saved, but without a file resource ID
+      expect(mockUpdateScoresheet).toHaveBeenCalledWith(
+        'scoresheet-1',
+        'game-123',
+        'scorer-1',
+        false,
+        undefined
+      )
+    })
+
+    it('does not pass existing file resource ID during save when scoresheet is not required', async () => {
+      mockGetGameWithScoresheet.mockResolvedValue({
+        ...mockGameDetails,
+        group: { __identity: 'group-1', hasNoScoresheet: true },
+        scoresheet: {
+          ...mockGameDetails.scoresheet,
+          file: {
+            __identity: 'existing-file-resource',
+            publicResourceUri: 'https://example.com/scoresheet.pdf',
+          },
+          hasFile: true,
+        },
+      })
+
+      const { result } = renderHook(() => useValidationState('game-123'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoadingGameDetails).toBe(false)
+      })
+
+      act(() => {
+        result.current.setScorer(mockScorer)
+      })
+
+      await act(async () => {
+        await result.current.saveProgress()
+      })
+
+      // Even though an existing file resource ID exists, it should not be passed
+      expect(mockUploadResource).not.toHaveBeenCalled()
+      expect(mockUpdateScoresheet).toHaveBeenCalledWith(
+        'scoresheet-1',
+        'game-123',
+        'scorer-1',
+        false,
+        undefined
+      )
+    })
+
+    it('does not upload file during finalize when scoresheet is not required', async () => {
+      mockGetGameWithScoresheet.mockResolvedValue({
+        ...mockGameDetails,
+        group: { __identity: 'group-1', hasNoScoresheet: true },
+      })
+
+      const { result } = renderHook(() => useValidationState('game-123'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoadingGameDetails).toBe(false)
+      })
+
+      const file = new File(['content'], 'scoresheet.pdf', { type: 'application/pdf' })
+
+      act(() => {
+        result.current.setScorer(mockScorer)
+        result.current.setScoresheet(file, true)
+      })
+
+      await act(async () => {
+        await result.current.finalizeValidation()
+      })
+
+      expect(mockUploadResource).not.toHaveBeenCalled()
+    })
+  })
+
   describe('finalizeValidation', () => {
     it('uploads scoresheet file if provided', async () => {
       mockUploadResource.mockResolvedValue([{ __identity: 'resource-1' }])

--- a/web-app/src/features/validation/hooks/useValidationState.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.ts
@@ -289,13 +289,16 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
       })
 
       // Upload scoresheet file if present (cache the resource ID to avoid re-upload on finalize)
-      // Skip upload when scoresheet is not required for this group
-      let fileResourceId = uploadedFileResourceIdRef.current
-      if (!fileResourceId && state.scoresheet.file && !scoresheetNotRequired) {
-        const uploadResult = await apiClient.uploadResource(state.scoresheet.file)
-        fileResourceId = uploadResult[0]?.__identity
-        uploadedFileResourceIdRef.current = fileResourceId
-        logger.debug('[VS] PDF uploaded:', fileResourceId)
+      // Skip upload and file reference entirely when scoresheet is not required for this group
+      let fileResourceId: string | undefined
+      if (!scoresheetNotRequired) {
+        fileResourceId = uploadedFileResourceIdRef.current
+        if (!fileResourceId && state.scoresheet.file) {
+          const uploadResult = await apiClient.uploadResource(state.scoresheet.file)
+          fileResourceId = uploadResult[0]?.__identity
+          uploadedFileResourceIdRef.current = fileResourceId
+          logger.debug('[VS] PDF uploaded:', fileResourceId)
+        }
       }
 
       await saveRosterModifications(
@@ -349,13 +352,16 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
       }
 
       // Reuse cached file resource ID from saveProgress if available
-      // Skip upload when scoresheet is not required for this group
-      let fileResourceId = uploadedFileResourceIdRef.current
-      if (!fileResourceId && state.scoresheet.file && !scoresheetNotRequired) {
-        const uploadResult = await apiClient.uploadResource(state.scoresheet.file)
-        fileResourceId = uploadResult[0]?.__identity
-        uploadedFileResourceIdRef.current = fileResourceId
-        logger.debug('[VS] PDF uploaded:', fileResourceId)
+      // Skip upload and file reference entirely when scoresheet is not required for this group
+      let fileResourceId: string | undefined
+      if (!scoresheetNotRequired) {
+        fileResourceId = uploadedFileResourceIdRef.current
+        if (!fileResourceId && state.scoresheet.file) {
+          const uploadResult = await apiClient.uploadResource(state.scoresheet.file)
+          fileResourceId = uploadResult[0]?.__identity
+          uploadedFileResourceIdRef.current = fileResourceId
+          logger.debug('[VS] PDF uploaded:', fileResourceId)
+        }
       }
 
       await finalizeRoster(

--- a/web-app/src/features/validation/hooks/useValidationState.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.ts
@@ -155,6 +155,26 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     [gameDetailsQuery.data?.nominationListOfTeamAway]
   )
 
+  // Existing scoresheet file info (from a previous save/upload)
+  const existingScoresheetUrl = useMemo(
+    () => gameDetailsQuery.data?.scoresheet?.file?.publicResourceUri ?? null,
+    [gameDetailsQuery.data]
+  )
+
+  const existingFileResourceId = useMemo(
+    () => gameDetailsQuery.data?.scoresheet?.file?.__identity ?? null,
+    [gameDetailsQuery.data]
+  )
+
+  // Pre-fill the uploaded file resource ID ref when an existing scoresheet file exists.
+  // This ensures that save/finalize operations reuse the existing file reference
+  // instead of requiring a new upload when the user hasn't changed the scoresheet.
+  useEffect(() => {
+    if (existingFileResourceId && !uploadedFileResourceIdRef.current) {
+      uploadedFileResourceIdRef.current = existingFileResourceId
+    }
+  }, [existingFileResourceId])
+
   const isDirty = useMemo(() => {
     return (
       hasRosterModifications(state.homeRoster.playerModifications) ||
@@ -198,8 +218,8 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
 
   const setScoresheet = useCallback((file: File | null, uploaded: boolean) => {
     setState((prev) => {
-      // Revoke previous reference image URL
-      if (prev.referenceImageUrl) {
+      // Revoke previous reference image URL only if it's an object URL (blob:)
+      if (prev.referenceImageUrl?.startsWith('blob:')) {
         URL.revokeObjectURL(prev.referenceImageUrl)
       }
       // Create new reference image URL for image files
@@ -209,9 +229,19 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     })
   }, [])
 
+  const setReferenceImageUrl = useCallback((url: string | null) => {
+    setState((prev) => {
+      // Revoke previous reference image URL only if it's an object URL (blob:)
+      if (prev.referenceImageUrl?.startsWith('blob:')) {
+        URL.revokeObjectURL(prev.referenceImageUrl)
+      }
+      return { ...prev, referenceImageUrl: url }
+    })
+  }, [])
+
   const reset = useCallback(() => {
     setState((prev) => {
-      if (prev.referenceImageUrl) {
+      if (prev.referenceImageUrl?.startsWith('blob:')) {
         URL.revokeObjectURL(prev.referenceImageUrl)
       }
       return createInitialState()
@@ -225,10 +255,10 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     referenceImageUrlRef.current = state.referenceImageUrl
   }, [state.referenceImageUrl])
 
-  // Cleanup reference image URL on unmount
+  // Cleanup reference image URL on unmount (only revoke blob URLs)
   useEffect(() => {
     return () => {
-      if (referenceImageUrlRef.current) {
+      if (referenceImageUrlRef.current?.startsWith('blob:')) {
         URL.revokeObjectURL(referenceImageUrlRef.current)
       }
     }
@@ -395,6 +425,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     setAwayRosterModifications,
     setScorer,
     setScoresheet,
+    setReferenceImageUrl,
     referenceImageUrl: state.referenceImageUrl,
     reset,
     saveProgress,
@@ -405,5 +436,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     gameDetailsError: gameDetailsQuery.error,
     homeNominationList,
     awayNominationList,
+    existingScoresheetUrl,
+    existingFileResourceId,
   }
 }

--- a/web-app/src/features/validation/hooks/useValidationState.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.ts
@@ -158,12 +158,12 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
   // Existing scoresheet file info (from a previous save/upload)
   const existingScoresheetUrl = useMemo(
     () => gameDetailsQuery.data?.scoresheet?.file?.publicResourceUri ?? null,
-    [gameDetailsQuery.data]
+    [gameDetailsQuery.data?.scoresheet?.file]
   )
 
   const existingFileResourceId = useMemo(
     () => gameDetailsQuery.data?.scoresheet?.file?.__identity ?? null,
-    [gameDetailsQuery.data]
+    [gameDetailsQuery.data?.scoresheet?.file]
   )
 
   // Pre-fill the uploaded file resource ID ref when an existing scoresheet file exists.

--- a/web-app/src/features/validation/hooks/useValidationState.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.ts
@@ -169,11 +169,12 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
   // Pre-fill the uploaded file resource ID ref when an existing scoresheet file exists.
   // This ensures that save/finalize operations reuse the existing file reference
   // instead of requiring a new upload when the user hasn't changed the scoresheet.
+  // Skip when scoresheet is not required — file references should never be sent for those games.
   useEffect(() => {
-    if (existingFileResourceId && !uploadedFileResourceIdRef.current) {
+    if (existingFileResourceId && !uploadedFileResourceIdRef.current && !scoresheetNotRequired) {
       uploadedFileResourceIdRef.current = existingFileResourceId
     }
-  }, [existingFileResourceId])
+  }, [existingFileResourceId, scoresheetNotRequired])
 
   const isDirty = useMemo(() => {
     return (

--- a/web-app/src/features/validation/utils/scoresheet.ts
+++ b/web-app/src/features/validation/utils/scoresheet.ts
@@ -1,0 +1,9 @@
+/** Check if a URL points to an image based on its path extension */
+export function isImageUrl(url: string): boolean {
+  try {
+    const pathname = new URL(url).pathname.toLowerCase()
+    return pathname.endsWith('.jpg') || pathname.endsWith('.jpeg') || pathname.endsWith('.png')
+  } catch {
+    return false
+  }
+}

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -727,6 +727,7 @@ const de: Translations = {
       demoModeNote: 'Demo-Modus: Uploads werden simuliert',
       previewAlt: 'Spielbericht-Vorschau',
       scoresheetUploaded: 'Spielbericht hochgeladen',
+      existingScoresheet: 'Zuvor hochgeladener Spielbericht',
       noScoresheet: 'Kein Spielbericht hochgeladen',
       notRequired: 'Spielbericht nicht erforderlich',
       notRequiredDescription: 'Für diesen Wettbewerb ist kein Spielbericht erforderlich.',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -700,6 +700,7 @@ const en: Translations = {
       demoModeNote: 'Demo mode: uploads are simulated',
       previewAlt: 'Scoresheet preview',
       scoresheetUploaded: 'Scoresheet uploaded',
+      existingScoresheet: 'Previously uploaded scoresheet',
       noScoresheet: 'No scoresheet uploaded',
       notRequired: 'Scoresheet not required',
       notRequiredDescription: 'This competition does not require a scoresheet upload.',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -721,6 +721,7 @@ const fr: Translations = {
       demoModeNote: 'Mode démo: les téléchargements sont simulés',
       previewAlt: 'Aperçu de la feuille de match',
       scoresheetUploaded: 'Feuille de match téléchargée',
+      existingScoresheet: 'Feuille de match précédemment téléchargée',
       noScoresheet: 'Aucune feuille de match téléchargée',
       notRequired: 'Feuille de match non requise',
       notRequiredDescription:

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -715,6 +715,7 @@ const it: Translations = {
       demoModeNote: 'Modalità demo: i caricamenti sono simulati',
       previewAlt: 'Anteprima referto',
       scoresheetUploaded: 'Referto caricato',
+      existingScoresheet: 'Referto caricato in precedenza',
       noScoresheet: 'Nessun referto caricato',
       notRequired: 'Referto non richiesto',
       notRequiredDescription: 'Questa competizione non richiede il caricamento del referto.',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -569,6 +569,7 @@ export interface Translations {
       demoModeNote: string
       previewAlt: string
       scoresheetUploaded: string
+      existingScoresheet: string
       noScoresheet: string
       notRequired: string
       notRequiredDescription: string


### PR DESCRIPTION
## Summary

- Load and display existing scoresheet (image/PDF preview) when reopening the validation wizard for a previously validated game
- Automatically set the existing image scoresheet as the reference image for quick-compare during roster validation
- Reuse the existing file resource ID during save/finalize to avoid re-uploading unchanged files
- Respect `scoresheetNotRequired` flag: skip pre-filling the file reference and never send file data to the API for games that don't require a scoresheet
- Add 17 new unit tests covering existing scoresheet loading, replacement, and scoresheetNotRequired behavior

## Test plan

- [ ] Open validation wizard for a game with an existing image scoresheet — verify preview is shown
- [ ] Open validation wizard for a game with an existing PDF scoresheet — verify PDF indicator
- [ ] Verify quick-compare toggle works with existing image scoresheet
- [ ] Click Replace and upload a new file — verify it replaces the old one
- [ ] Finalize without changing scoresheet — verify no re-upload occurs
- [ ] For scoresheetNotRequired game, verify no file reference is sent to API
- [ ] All 3853 unit tests pass

https://claude.ai/code/session_01QKvRCjEcc5A9BAa5oiNuw9