### PR TITLE
feat(web): add "cannot find scorer" checkbox to validation wizard

### DIFF
--- a/.changeset/add-cannot-find-scorer.md
+++ b/.changeset/add-cannot-find-scorer.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Add "Cannot find scorer" checkbox to validation wizard for scorers not found in the system

--- a/web-app/src/features/validation/components/ScorerPanel.tsx
+++ b/web-app/src/features/validation/components/ScorerPanel.tsx
@@ -7,6 +7,10 @@ import { ScorerSearchPanel } from './ScorerSearchPanel'
 interface ScorerPanelProps {
   onScorerChange?: (scorer: ValidatedPersonSearchResult | null) => void
   initialScorer?: ValidatedPersonSearchResult | null
+  /** Whether the scorer has been marked as not found */
+  scorerNotFound?: boolean
+  /** Called when the "cannot find scorer" checkbox changes */
+  onScorerNotFoundChange?: (notFound: boolean) => void
   /** When true, shows scorer in view-only mode without edit controls */
   readOnly?: boolean
   /** Scorer name to display in read-only mode when no scorer data is available */
@@ -23,6 +27,8 @@ interface ScorerPanelProps {
 export function ScorerPanel({
   onScorerChange,
   initialScorer = null,
+  scorerNotFound = false,
+  onScorerNotFoundChange,
   readOnly = false,
   readOnlyScorerName,
   readOnlyScorerBirthday,
@@ -48,6 +54,8 @@ export function ScorerPanel({
     <ScorerSearchPanel
       selectedScorer={selectedScorer}
       onScorerSelect={handleScorerSelect}
+      scorerNotFound={scorerNotFound}
+      onScorerNotFoundChange={onScorerNotFoundChange}
       readOnly={readOnly}
       readOnlyScorerName={readOnlyScorerName}
       readOnlyScorerBirthday={readOnlyScorerBirthday}

--- a/web-app/src/features/validation/components/ScorerSearchPanel.test.tsx
+++ b/web-app/src/features/validation/components/ScorerSearchPanel.test.tsx
@@ -207,6 +207,96 @@ describe('ScorerSearchPanel', () => {
   })
 })
 
+describe('ScorerSearchPanel - Cannot Find Scorer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows checkbox when onScorerNotFoundChange is provided', () => {
+    render(
+      <ScorerSearchPanel
+        selectedScorer={null}
+        onScorerSelect={vi.fn()}
+        onScorerNotFoundChange={vi.fn()}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByText('Cannot find scorer')).toBeInTheDocument()
+  })
+
+  it('does not show checkbox when onScorerNotFoundChange is not provided', () => {
+    render(<ScorerSearchPanel selectedScorer={null} onScorerSelect={vi.fn()} />, {
+      wrapper: createWrapper(),
+    })
+
+    expect(screen.queryByText('Cannot find scorer')).not.toBeInTheDocument()
+  })
+
+  it('does not show checkbox when a scorer is selected', () => {
+    render(
+      <ScorerSearchPanel
+        selectedScorer={mockScorers[0]}
+        onScorerSelect={vi.fn()}
+        onScorerNotFoundChange={vi.fn()}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.queryByText('Cannot find scorer')).not.toBeInTheDocument()
+  })
+
+  it('calls onScorerNotFoundChange when checkbox is clicked', () => {
+    const onScorerNotFoundChange = vi.fn()
+    render(
+      <ScorerSearchPanel
+        selectedScorer={null}
+        onScorerSelect={vi.fn()}
+        onScorerNotFoundChange={onScorerNotFoundChange}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    const checkbox = screen.getByRole('checkbox')
+    fireEvent.click(checkbox)
+
+    expect(onScorerNotFoundChange).toHaveBeenCalledWith(true)
+  })
+
+  it('hides search input when scorerNotFound is true', () => {
+    render(
+      <ScorerSearchPanel
+        selectedScorer={null}
+        onScorerSelect={vi.fn()}
+        scorerNotFound={true}
+        onScorerNotFoundChange={vi.fn()}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.queryByPlaceholderText('Search scorer by name...')).not.toBeInTheDocument()
+  })
+
+  it('shows hint text when scorerNotFound is checked', () => {
+    render(
+      <ScorerSearchPanel
+        selectedScorer={null}
+        onScorerSelect={vi.fn()}
+        scorerNotFound={true}
+        onScorerNotFoundChange={vi.fn()}
+      />,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByText(/validation will be saved but not finalized/i)).toBeInTheDocument()
+  })
+})
+
 describe('ScorerSearchPanel - Loading State', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/web-app/src/features/validation/components/ScorerSearchPanel.tsx
+++ b/web-app/src/features/validation/components/ScorerSearchPanel.tsx
@@ -33,6 +33,10 @@ const SCORER_SEARCH_HINT_ID = 'scorer-search-hint'
 interface ScorerSearchPanelProps {
   selectedScorer?: ValidatedPersonSearchResult | null
   onScorerSelect: (scorer: ValidatedPersonSearchResult | null) => void
+  /** Whether the scorer has been marked as not found */
+  scorerNotFound?: boolean
+  /** Called when the "cannot find scorer" checkbox changes */
+  onScorerNotFoundChange?: (notFound: boolean) => void
   /** When true, shows scorer in view-only mode without edit controls */
   readOnly?: boolean
   /** Scorer name to display in read-only mode when no scorer data is available */
@@ -48,6 +52,8 @@ interface ScorerSearchPanelProps {
 export function ScorerSearchPanel({
   selectedScorer,
   onScorerSelect,
+  scorerNotFound = false,
+  onScorerNotFoundChange,
   readOnly = false,
   readOnlyScorerName,
   readOnlyScorerBirthday,
@@ -165,7 +171,7 @@ export function ScorerSearchPanel({
     <div className="py-4">
       {selectedScorer && <SelectedScorerCard scorer={selectedScorer} onClear={handleClear} />}
 
-      {!selectedScorer && (
+      {!selectedScorer && !scorerNotFound && (
         <>
           <div className="mb-4">
             <input
@@ -236,10 +242,37 @@ export function ScorerSearchPanel({
         </>
       )}
 
-      {!selectedScorer && !showResults && (
+      {!selectedScorer && !showResults && !scorerNotFound && (
         <p className="text-sm text-text-muted dark:text-text-muted-dark">
           {t('validation.scorerSearch.noScorerSelected')}
         </p>
+      )}
+
+      {/* "Cannot find scorer" checkbox */}
+      {!selectedScorer && onScorerNotFoundChange && (
+        <label className="mt-4 flex items-start gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={scorerNotFound}
+            onChange={(e) => onScorerNotFoundChange(e.target.checked)}
+            className="
+              mt-0.5 h-4 w-4 rounded
+              border-border-strong dark:border-border-strong-dark
+              text-primary-600 focus:ring-primary-500/20
+              cursor-pointer
+            "
+          />
+          <div>
+            <span className="text-sm text-text-primary dark:text-text-primary-dark">
+              {t('validation.scorerSearch.cannotFindScorer')}
+            </span>
+            {scorerNotFound && (
+              <p className="mt-1 text-xs text-warning-600 dark:text-warning-400">
+                {t('validation.scorerSearch.cannotFindScorerHint')}
+              </p>
+            )}
+          </div>
+        </label>
       )}
     </div>
   )

--- a/web-app/src/features/validation/components/StepRenderer.tsx
+++ b/web-app/src/features/validation/components/StepRenderer.tsx
@@ -32,6 +32,7 @@ interface StepHandlers {
   setHomeRosterModifications: UseValidationStateResult['setHomeRosterModifications']
   setAwayRosterModifications: UseValidationStateResult['setAwayRosterModifications']
   setScorer: UseValidationStateResult['setScorer']
+  setScorerNotFound: UseValidationStateResult['setScorerNotFound']
   setScoresheet: UseValidationStateResult['setScoresheet']
   onAddPlayerSheetOpenChange: (open: boolean) => void
   onClose: () => void
@@ -168,6 +169,8 @@ export function StepRenderer({
           <ScorerPanel
             key={validation.pendingScorer?.__identity ?? 'no-pending-scorer'}
             onScorerChange={handlers.setScorer}
+            scorerNotFound={validation.state.scorer.notFound}
+            onScorerNotFoundChange={handlers.setScorerNotFound}
             readOnly={isStepReadOnly}
             readOnlyScorerName={validation.validatedInfo?.scorerName}
             readOnlyScorerBirthday={validation.validatedInfo?.scorerBirthday}

--- a/web-app/src/features/validation/components/ValidateGameModal.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.tsx
@@ -245,6 +245,7 @@ function ValidateGameModalComponent({ assignment, isOpen, onClose }: ValidateGam
     setHomeRosterModifications: wizard.setHomeRosterModifications,
     setAwayRosterModifications: wizard.setAwayRosterModifications,
     setScorer: wizard.setScorer,
+    setScorerNotFound: wizard.setScorerNotFound,
     setScoresheet: wizard.setScoresheet,
     onAddPlayerSheetOpenChange: wizard.handleAddPlayerSheetOpenChange,
     onClose,

--- a/web-app/src/features/validation/hooks/types.ts
+++ b/web-app/src/features/validation/hooks/types.ts
@@ -28,6 +28,8 @@ export interface RosterPanelState {
 export interface ScorerPanelState {
   /** The selected scorer, or null if none */
   selected: ValidatedPersonSearchResult | null
+  /** Whether the user indicated the scorer cannot be found in the system */
+  notFound: boolean
 }
 
 /**
@@ -109,6 +111,8 @@ export interface UseValidationStateResult {
   setAwayRosterModifications: (modifications: RosterPanelModifications) => void
   /** Set the selected scorer */
   setScorer: (scorer: ValidatedPersonSearchResult | null) => void
+  /** Set whether the scorer cannot be found */
+  setScorerNotFound: (notFound: boolean) => void
   /** Set the scoresheet file and upload status */
   setScoresheet: (file: File | null, uploaded: boolean) => void
   /** Set the reference image URL directly (e.g., from an existing scoresheet) */
@@ -154,7 +158,7 @@ export function createInitialState(): ValidationState {
       playerModifications: { added: [], removed: [] },
       coachModifications: { added: new Map(), removed: new Set() },
     },
-    scorer: { selected: null },
+    scorer: { selected: null, notFound: false },
     scoresheet: { file: null, uploaded: false },
     referenceImageUrl: null,
   }

--- a/web-app/src/features/validation/hooks/useValidateGameWizard.ts
+++ b/web-app/src/features/validation/hooks/useValidateGameWizard.ts
@@ -64,6 +64,7 @@ export interface UseValidateGameWizardResult {
   setHomeRosterModifications: ReturnType<typeof useValidationState>['setHomeRosterModifications']
   setAwayRosterModifications: ReturnType<typeof useValidationState>['setAwayRosterModifications']
   setScorer: ReturnType<typeof useValidationState>['setScorer']
+  setScorerNotFound: ReturnType<typeof useValidationState>['setScorerNotFound']
   setScoresheet: ReturnType<typeof useValidationState>['setScoresheet']
   isSaving: boolean
   isFinalizing: boolean
@@ -149,6 +150,7 @@ export function useValidateGameWizard({
     setHomeRosterModifications,
     setAwayRosterModifications,
     setScorer,
+    setScorerNotFound,
     setScoresheet,
     setReferenceImageUrl,
     referenceImageUrl,
@@ -352,13 +354,16 @@ export function useValidateGameWizard({
   }, [onClose, isValidated])
 
   // Shared finalization logic used by both handleFinish and handleRosterWarningProceed
+  // When scorer is marked as "not found", we force save-only mode (like safe validation)
+  // to prevent finalizing without a scorer on volleymanager.
+  const scorerNotFound = validationState.scorer.notFound
   const performFinalization = useCallback(async () => {
     isFinalizingRef.current = true
     setSaveError(null)
 
     try {
-      if (useSafeValidation) {
-        // Safe validation mode: save only, don't finalize
+      if (useSafeValidation || scorerNotFound) {
+        // Safe validation mode (or scorer not found): save only, don't finalize
         await saveProgress()
         setShowSafeValidationComplete(true)
       } else {
@@ -376,7 +381,7 @@ export function useValidateGameWizard({
     } finally {
       isFinalizingRef.current = false
     }
-  }, [useSafeValidation, saveProgress, finalizeValidation, t, onClose])
+  }, [useSafeValidation, scorerNotFound, saveProgress, finalizeValidation, t, onClose])
 
   const handleFinish = useCallback(async () => {
     if (isFinalizingRef.current) return
@@ -492,6 +497,7 @@ export function useValidateGameWizard({
     setHomeRosterModifications,
     setAwayRosterModifications,
     setScorer,
+    setScorerNotFound,
     setScoresheet,
     isSaving,
     isFinalizing,

--- a/web-app/src/features/validation/hooks/useValidationState.test.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.test.ts
@@ -240,6 +240,75 @@ describe('useValidationState', () => {
 
       expect(result.current.isDirty).toBe(true)
     })
+
+    it('marks scorer as not found and completes the step', () => {
+      const { result } = renderHook(() => useValidationState(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.setScorerNotFound(true)
+      })
+
+      expect(result.current.state.scorer.notFound).toBe(true)
+      expect(result.current.state.scorer.selected).toBeNull()
+      expect(result.current.completionStatus.scorer).toBe(true)
+    })
+
+    it('clears selected scorer when marking as not found', () => {
+      const { result } = renderHook(() => useValidationState(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.setScorer(mockScorer)
+      })
+
+      act(() => {
+        result.current.setScorerNotFound(true)
+      })
+
+      expect(result.current.state.scorer.selected).toBeNull()
+      expect(result.current.state.scorer.notFound).toBe(true)
+    })
+
+    it('clears notFound when selecting a scorer', () => {
+      const { result } = renderHook(() => useValidationState(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.setScorerNotFound(true)
+      })
+
+      act(() => {
+        result.current.setScorer(mockScorer)
+      })
+
+      expect(result.current.state.scorer.notFound).toBe(false)
+      expect(result.current.state.scorer.selected).toEqual(mockScorer)
+    })
+
+    it('does not save scorer to API when scorer is not found', async () => {
+      const { result } = renderHook(() => useValidationState('game-123'), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoadingGameDetails).toBe(false)
+      })
+
+      act(() => {
+        result.current.setScorerNotFound(true)
+      })
+
+      await act(async () => {
+        await result.current.saveProgress()
+      })
+
+      // updateScoresheet should not be called since no scorer is selected
+      expect(mockUpdateScoresheet).not.toHaveBeenCalled()
+    })
   })
 
   describe('scoresheet handling', () => {

--- a/web-app/src/features/validation/hooks/useValidationState.ts
+++ b/web-app/src/features/validation/hooks/useValidationState.ts
@@ -82,10 +82,15 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     () => ({
       homeRoster: state.homeRoster.reviewed,
       awayRoster: state.awayRoster.reviewed,
-      scorer: state.scorer.selected !== null,
+      scorer: state.scorer.selected !== null || state.scorer.notFound,
       scoresheet: true,
     }),
-    [state.homeRoster.reviewed, state.awayRoster.reviewed, state.scorer.selected]
+    [
+      state.homeRoster.reviewed,
+      state.awayRoster.reviewed,
+      state.scorer.selected,
+      state.scorer.notFound,
+    ]
   )
 
   const isAllRequiredComplete = useMemo(
@@ -214,7 +219,14 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
   }, [])
 
   const setScorer = useCallback((scorer: ValidatedPersonSearchResult | null) => {
-    setState((prev) => ({ ...prev, scorer: { selected: scorer } }))
+    setState((prev) => ({ ...prev, scorer: { ...prev.scorer, selected: scorer, notFound: false } }))
+  }, [])
+
+  const setScorerNotFound = useCallback((notFound: boolean) => {
+    setState((prev) => ({
+      ...prev,
+      scorer: { selected: notFound ? null : prev.scorer.selected, notFound },
+    }))
   }, [])
 
   const setScoresheet = useCallback((file: File | null, uploaded: boolean) => {
@@ -431,6 +443,7 @@ export function useValidationState(gameId?: string): UseValidationStateResult {
     setHomeRosterModifications,
     setAwayRosterModifications,
     setScorer,
+    setScorerNotFound,
     setScoresheet,
     setReferenceImageUrl,
     referenceImageUrl: state.referenceImageUrl,

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -710,6 +710,9 @@ const de: Translations = {
       searchResults: 'Suchergebnisse',
       resultsCount: '{count} Ergebnisse gefunden',
       resultsCountOne: '1 Ergebnis gefunden',
+      cannotFindScorer: 'Schreiber nicht gefunden',
+      cannotFindScorerHint:
+        'Die Validierung wird gespeichert, aber nicht abgeschlossen. Vervollständigen Sie die Schreiberauswahl auf VolleyManager.',
     },
     scoresheetUpload: {
       title: 'Spielbericht hochladen',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -683,6 +683,9 @@ const en: Translations = {
       searchResults: 'Search results',
       resultsCount: '{count} results found',
       resultsCountOne: '1 result found',
+      cannotFindScorer: 'Cannot find scorer',
+      cannotFindScorerHint:
+        'The validation will be saved but not finalized. Complete the scorer selection on VolleyManager.',
     },
     scoresheetUpload: {
       title: 'Upload Scoresheet',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -704,6 +704,9 @@ const fr: Translations = {
       searchResults: 'Résultats de recherche',
       resultsCount: '{count} résultats trouvés',
       resultsCountOne: '1 résultat trouvé',
+      cannotFindScorer: 'Marqueur introuvable',
+      cannotFindScorerHint:
+        'La validation sera enregistrée mais pas finalisée. Complétez la sélection du marqueur sur VolleyManager.',
     },
     scoresheetUpload: {
       title: 'Télécharger la feuille de match',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -698,6 +698,9 @@ const it: Translations = {
       searchResults: 'Risultati della ricerca',
       resultsCount: '{count} risultati trovati',
       resultsCountOne: '1 risultato trovato',
+      cannotFindScorer: 'Segnapunti non trovato',
+      cannotFindScorerHint:
+        'La validazione verrà salvata ma non finalizzata. Completa la selezione del segnapunti su VolleyManager.',
     },
     scoresheetUpload: {
       title: 'Carica referto',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -552,6 +552,8 @@ export interface Translations {
       searchResults: string
       resultsCount: string
       resultsCountOne: string
+      cannotFindScorer: string
+      cannotFindScorerHint: string
     }
     scoresheetUpload: {
       title: string


### PR DESCRIPTION
## Summary

- Add a "Cannot find scorer" checkbox to the scorer step in the validation wizard
- When checked, the scorer step is marked complete but finalization is blocked (forces save-only mode like safe validation)
- No scorer is submitted to volleymanager when saving with this flag, allowing the user to complete scorer selection directly on VolleyManager
- Translations added in all 4 languages (de/en/fr/it)

## Test plan

- [x] New unit tests for `useValidationState`: scorer notFound state, completion status, save skips scorer
- [x] New unit tests for `ScorerSearchPanel`: checkbox visibility, click handler, search hidden when checked, hint text
- [x] All 182 test files pass (3863 tests)
- [x] Build passes
- [x] Lint + format + knip pass

https://claude.ai/code/session_011coXDjy7kb83TzuPVtX8mC