### PR TITLE
feat(web,shared): improve scorer search with gender display, association ID search, and higher result limit

### DIFF
--- a/packages/shared/src/api/queryKeys.test.ts
+++ b/packages/shared/src/api/queryKeys.test.ts
@@ -319,7 +319,7 @@ describe('PersonSearchFilter', () => {
       searchTerm: 'test',
       firstName: 'John',
       lastName: 'Doe',
-      associationId: 1,
+      associationId: '1',
     }
 
     expect(filter).toBeDefined()

--- a/packages/shared/src/api/queryKeys.ts
+++ b/packages/shared/src/api/queryKeys.ts
@@ -84,7 +84,7 @@ export interface PersonSearchFilter {
   searchTerm?: string
   firstName?: string
   lastName?: string
-  associationId?: number
+  associationId?: string
 }
 
 export const queryKeys = {

--- a/web-app/src/api/client.test.ts
+++ b/web-app/src/api/client.test.ts
@@ -450,7 +450,7 @@ describe('API Client', () => {
 
       await api.searchPersons({ lastName: 'müller' })
 
-      expect(capturedUrl).toContain('searchConfiguration%5Blimit%5D=50')
+      expect(capturedUrl).toContain('searchConfiguration%5Blimit%5D=100')
     })
 
     it('respects custom limit when provided', async () => {

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -44,6 +44,7 @@ export interface PersonSearchFilter {
   firstName?: string
   lastName?: string
   yearOfBirth?: string
+  associationId?: string
 }
 
 // Re-export search types from shared package (single source of truth)

--- a/web-app/src/api/constants.ts
+++ b/web-app/src/api/constants.ts
@@ -31,4 +31,4 @@ export const ALLOWED_FILE_TYPES: readonly string[] = ['application/pdf', 'image/
  * Default limit for search results pagination.
  * Used for person search and similar paginated endpoints.
  */
-export const DEFAULT_SEARCH_RESULTS_LIMIT = 50
+export const DEFAULT_SEARCH_RESULTS_LIMIT = 100

--- a/web-app/src/api/mock-api.ts
+++ b/web-app/src/api/mock-api.ts
@@ -471,7 +471,7 @@ export const mockApi = {
     await delay(MOCK_NETWORK_DELAY_MS)
 
     const store = useDemoStore.getState()
-    const { firstName, lastName, yearOfBirth } = filters
+    const { firstName, lastName, yearOfBirth, associationId } = filters
 
     // When only lastName is provided (single search term), search both
     // firstName and lastName fields to mimic Elasticsearch fuzzy matching.
@@ -479,6 +479,11 @@ export const mockApi = {
     const isSingleTermSearch = lastName && !firstName
 
     const filtered = store.scorers.filter((scorer: PersonSearchResult) => {
+      // Association ID search: match by member number
+      if (associationId) {
+        return scorer.associationId?.toString().includes(associationId)
+      }
+
       // Use accent-insensitive matching (e.g., "muller" matches "Müller")
       const scorerFirstName = normalizeForSearch(scorer.firstName ?? '')
       const scorerLastName = normalizeForSearch(scorer.lastName ?? '')

--- a/web-app/src/api/real-api.ts
+++ b/web-app/src/api/real-api.ts
@@ -269,7 +269,28 @@ export const api = {
     filters: PersonSearchFilter,
     options?: { offset?: number; limit?: number }
   ): Promise<PersonSearchResponse> {
-    const { firstName, lastName, yearOfBirth } = filters
+    const { firstName, lastName, yearOfBirth, associationId } = filters
+
+    // Association ID search: direct lookup by member number
+    if (associationId) {
+      const data = await apiRequest<unknown>(
+        '/sportmanager.core/api%5celasticsearchperson/search',
+        'GET',
+        {
+          searchConfiguration: {
+            propertyFilters: [{ propertyName: 'associationId', text: associationId }],
+            offset: options?.offset ?? 0,
+            limit: options?.limit ?? DEFAULT_SEARCH_RESULTS_LIMIT,
+          },
+          propertyRenderConfiguration: PERSON_SEARCH_PROPERTIES,
+        }
+      )
+      return validateResponse(
+        data,
+        personSearchResponseSchema,
+        'searchPersons'
+      ) as PersonSearchResponse
+    }
 
     // When both firstName and lastName are provided, search both orderings
     // in parallel so "Bühler Renee" finds the same results as "Renee Bühler".

--- a/web-app/src/features/validation/components/ScorerResultsList.test.tsx
+++ b/web-app/src/features/validation/components/ScorerResultsList.test.tsx
@@ -91,4 +91,29 @@ describe('ScorerResultsList', () => {
     const options = screen.getAllByRole('option')
     expect(options).toHaveLength(2)
   })
+
+  it('displays gender icons for scorers', () => {
+    render(<ScorerResultsList {...defaultProps} />)
+
+    expect(screen.getByLabelText('M')).toBeInTheDocument()
+    expect(screen.getByLabelText('F')).toBeInTheDocument()
+  })
+
+  it('does not display gender icons when not provided', () => {
+    const scorersWithoutGender: ValidatedPersonSearchResult[] = [
+      {
+        __identity: 'a3333333-3333-4333-a333-333333333333',
+        firstName: 'Test',
+        lastName: 'Person',
+        displayName: 'Test Person',
+        associationId: 99999,
+        birthday: '1995-01-01T00:00:00+00:00',
+      },
+    ]
+    render(<ScorerResultsList {...defaultProps} results={scorersWithoutGender} />)
+
+    expect(screen.getByText('Test Person')).toBeInTheDocument()
+    expect(screen.queryByLabelText('M')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('F')).not.toBeInTheDocument()
+  })
 })

--- a/web-app/src/features/validation/components/ScorerResultsList.tsx
+++ b/web-app/src/features/validation/components/ScorerResultsList.tsx
@@ -1,5 +1,5 @@
 import type { ValidatedPersonSearchResult } from '@/api/validation'
-import { ChevronRight } from '@/shared/components/icons'
+import { ChevronRight, MaleIcon, FemaleIcon } from '@/shared/components/icons'
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { formatDOB } from '@/shared/utils/date-helpers'
@@ -100,6 +100,12 @@ export function ScorerResultsList({
                     <span>
                       {t('common.dob')}: {formatDOB(scorer.birthday)}
                     </span>
+                  )}
+                  {scorer.gender === 'm' && (
+                    <MaleIcon className="w-4 h-4" aria-label={t('common.genderMale')} />
+                  )}
+                  {scorer.gender === 'f' && (
+                    <FemaleIcon className="w-4 h-4" aria-label={t('common.genderFemale')} />
                   )}
                 </div>
               </div>

--- a/web-app/src/features/validation/components/ScorerSearchPanel.test.tsx
+++ b/web-app/src/features/validation/components/ScorerSearchPanel.test.tsx
@@ -91,14 +91,14 @@ describe('ScorerSearchPanel', () => {
     render(<ScorerSearchPanel {...defaultProps} />, {
       wrapper: createWrapper(),
     })
-    expect(screen.getByPlaceholderText('Search scorer by name...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search scorer by name or ID...')).toBeInTheDocument()
   })
 
   it('displays search hint text', () => {
     render(<ScorerSearchPanel {...defaultProps} />, {
       wrapper: createWrapper(),
     })
-    expect(screen.getByText(/Enter name.*or add birth year/i)).toBeInTheDocument()
+    expect(screen.getByText(/Enter name.*birth year/i)).toBeInTheDocument()
   })
 
   it("shows 'no scorer selected' message when empty and not searching", () => {
@@ -113,7 +113,7 @@ describe('ScorerSearchPanel', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -129,7 +129,7 @@ describe('ScorerSearchPanel', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -145,7 +145,7 @@ describe('ScorerSearchPanel', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -166,7 +166,7 @@ describe('ScorerSearchPanel', () => {
 
     expect(screen.getByText('Hans Müller')).toBeInTheDocument()
     expect(screen.getByText('ID: 12345')).toBeInTheDocument()
-    expect(screen.queryByPlaceholderText('Search scorer by name...')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Search scorer by name or ID...')).not.toBeInTheDocument()
   })
 
   it('calls onScorerSelect with null when clear button is clicked', () => {
@@ -192,7 +192,9 @@ describe('ScorerSearchPanel', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...') as HTMLInputElement
+    const searchInput = screen.getByPlaceholderText(
+      'Search scorer by name or ID...'
+    ) as HTMLInputElement
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -279,7 +281,7 @@ describe('ScorerSearchPanel - Cannot Find Scorer', () => {
       { wrapper: createWrapper() }
     )
 
-    expect(screen.queryByPlaceholderText('Search scorer by name...')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Search scorer by name or ID...')).not.toBeInTheDocument()
   })
 
   it('shows hint text when scorerNotFound is checked', () => {
@@ -320,7 +322,7 @@ describe('ScorerSearchPanel - Loading State', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -354,7 +356,7 @@ describe('ScorerSearchPanel - Error State', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -390,7 +392,7 @@ describe('ScorerSearchPanel - Empty Results', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'XYZ' } })
 
     act(() => {
@@ -423,7 +425,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -441,7 +443,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -462,7 +464,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -481,7 +483,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -499,7 +501,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -520,7 +522,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -540,7 +542,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -558,7 +560,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -591,7 +593,7 @@ describe('ScorerSearchPanel - Keyboard Navigation', () => {
 
     rerender(<ScorerSearchPanel selectedScorer={null} onScorerSelect={onScorerSelect} />)
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -638,7 +640,7 @@ describe('ScorerSearchPanel - Screen Reader Announcements', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -662,7 +664,7 @@ describe('ScorerSearchPanel - Screen Reader Announcements', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Hans' } })
 
     act(() => {
@@ -686,7 +688,7 @@ describe('ScorerSearchPanel - Screen Reader Announcements', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -710,7 +712,7 @@ describe('ScorerSearchPanel - Screen Reader Announcements', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -734,7 +736,7 @@ describe('ScorerSearchPanel - Screen Reader Announcements', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'XYZ' } })
 
     act(() => {
@@ -778,7 +780,7 @@ describe('ScorerSearchPanel - ARIA Attributes', () => {
     })
 
     const searchInput = screen.getByRole('combobox')
-    const hintText = screen.getByText(/Enter name.*or add birth year/i)
+    const hintText = screen.getByText(/Enter name.*birth year/i)
 
     expect(hintText).toHaveAttribute('id')
     expect(searchInput).toHaveAttribute('aria-describedby', hintText.getAttribute('id'))
@@ -789,7 +791,7 @@ describe('ScorerSearchPanel - ARIA Attributes', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -805,7 +807,7 @@ describe('ScorerSearchPanel - ARIA Attributes', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {
@@ -858,7 +860,7 @@ describe('ScorerSearchPanel - ARIA Attributes', () => {
       wrapper: createWrapper(),
     })
 
-    const searchInput = screen.getByPlaceholderText('Search scorer by name...')
+    const searchInput = screen.getByPlaceholderText('Search scorer by name or ID...')
     fireEvent.change(searchInput, { target: { value: 'Müller' } })
 
     act(() => {

--- a/web-app/src/features/validation/components/ValidateGameModal.test.tsx
+++ b/web-app/src/features/validation/components/ValidateGameModal.test.tsx
@@ -338,7 +338,7 @@ describe('ValidateGameModal', () => {
       await waitFor(() => expect(screen.getByText('Step 4 of 4')).toBeInTheDocument())
 
       // ScorerPanel shows search input and no-selection message
-      expect(screen.getByPlaceholderText('Search scorer by name...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Search scorer by name or ID...')).toBeInTheDocument()
       expect(screen.getByText(/No scorer selected/)).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Finalize/i, hidden: true })).toBeInTheDocument()
     })

--- a/web-app/src/features/validation/components/panels.test.tsx
+++ b/web-app/src/features/validation/components/panels.test.tsx
@@ -162,7 +162,7 @@ vi.mock('@/shared/stores/auth', () => ({
 describe('ScorerPanel', () => {
   it('renders without crashing', () => {
     render(<ScorerPanel />, { wrapper: createWrapper() })
-    expect(screen.getByPlaceholderText('Search scorer by name...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search scorer by name or ID...')).toBeInTheDocument()
     expect(screen.getByText(/No scorer selected/)).toBeInTheDocument()
   })
 })

--- a/web-app/src/features/validation/hooks/useScorerSearch.test.tsx
+++ b/web-app/src/features/validation/hooks/useScorerSearch.test.tsx
@@ -181,6 +181,19 @@ describe('parseSearchInput', () => {
       lastName: 'von Berg',
     })
   })
+
+  it('parses non-4-digit numeric input as associationId', () => {
+    expect(parseSearchInput('12345')).toEqual({ associationId: '12345' })
+    expect(parseSearchInput('123456')).toEqual({ associationId: '123456' })
+    expect(parseSearchInput('12')).toEqual({ associationId: '12' })
+    expect(parseSearchInput('1')).toEqual({ associationId: '1' })
+    expect(parseSearchInput('99999')).toEqual({ associationId: '99999' })
+  })
+
+  it('preserves 4-digit numeric input as yearOfBirth (not associationId)', () => {
+    expect(parseSearchInput('1985')).toEqual({ yearOfBirth: '1985' })
+    expect(parseSearchInput('2000')).toEqual({ yearOfBirth: '2000' })
+  })
 })
 
 describe('useScorerSearch', () => {

--- a/web-app/src/features/validation/hooks/useScorerSearch.ts
+++ b/web-app/src/features/validation/hooks/useScorerSearch.ts
@@ -61,6 +61,12 @@ export function parseSearchInput(input: string): PersonSearchFilter {
     return {}
   }
 
+  // Purely numeric input (not exactly 4 digits, which is year-of-birth) → association ID search
+  const YEAR_LENGTH = 4
+  if (/^\d+$/.test(trimmed) && trimmed.length !== YEAR_LENGTH) {
+    return { associationId: trimmed }
+  }
+
   const tokens = trimmed.split(/\s+/)
   const result: PersonSearchFilter = {}
 
@@ -118,7 +124,9 @@ export function useScorerSearch(
   const dataSource = useAuthStore((state) => state.dataSource)
   const apiClient = getApiClient(dataSource)
 
-  const hasFilters = Boolean(filters.firstName || filters.lastName || filters.yearOfBirth)
+  const hasFilters = Boolean(
+    filters.firstName || filters.lastName || filters.yearOfBirth || filters.associationId
+  )
 
   const query = useQuery({
     queryKey: queryKeys.scorerSearch.search(filters),

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -153,6 +153,8 @@ const de: Translations = {
     stepIndicatorInvalid: '(unvollständig)',
     stepIndicatorFinalized: '(abgeschlossen)',
     dob: 'Geb.',
+    genderMale: 'M',
+    genderFemale: 'W',
   },
   auth: {
     login: 'Anmelden',
@@ -700,9 +702,9 @@ const de: Translations = {
       loadCoachesError: 'Trainer konnten nicht geladen werden',
     },
     scorerSearch: {
-      searchPlaceholder: 'Schreiber nach Name suchen...',
+      searchPlaceholder: 'Schreiber nach Name oder ID suchen...',
       searchHint:
-        "Namen eingeben (z.B. 'Müller' oder 'Hans Müller') oder Geburtsjahr hinzufügen (z.B. 'Müller 1985')",
+        "Namen eingeben (z.B. 'Müller' oder 'Hans Müller'), Geburtsjahr (z.B. 'Müller 1985') oder SV-ID (z.B. '12345')",
       searchError: 'Schreibersuche fehlgeschlagen',
       noScorerSelected:
         'Kein Schreiber ausgewählt. Verwenden Sie die Suche oben, um einen Schreiber zu finden und auszuwählen.',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -152,6 +152,8 @@ const en: Translations = {
     stepIndicatorInvalid: '(incomplete)',
     stepIndicatorFinalized: '(finalized)',
     dob: 'DOB',
+    genderMale: 'M',
+    genderFemale: 'F',
   },
   auth: {
     login: 'Login',
@@ -674,9 +676,9 @@ const en: Translations = {
       loadCoachesError: 'Failed to load coaches',
     },
     scorerSearch: {
-      searchPlaceholder: 'Search scorer by name...',
+      searchPlaceholder: 'Search scorer by name or ID...',
       searchHint:
-        "Enter name (e.g., 'Müller' or 'Hans Müller') or add birth year (e.g., 'Müller 1985')",
+        "Enter name (e.g., 'Müller' or 'Hans Müller'), birth year (e.g., 'Müller 1985'), or SV-ID (e.g., '12345')",
       searchError: 'Failed to search scorers',
       noScorerSelected: 'No scorer selected. Use the search above to find and select a scorer.',
       noScorersFound: 'No scorers found',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -154,6 +154,8 @@ const fr: Translations = {
     stepIndicatorInvalid: '(incomplet)',
     stepIndicatorFinalized: '(finalisé)',
     dob: 'DDN',
+    genderMale: 'H',
+    genderFemale: 'F',
   },
   auth: {
     login: 'Connexion',
@@ -694,9 +696,9 @@ const fr: Translations = {
       loadCoachesError: 'Échec du chargement des entraîneurs',
     },
     scorerSearch: {
-      searchPlaceholder: 'Rechercher un marqueur par nom...',
+      searchPlaceholder: 'Rechercher un marqueur par nom ou ID...',
       searchHint:
-        "Entrez le nom (ex. 'Müller' ou 'Hans Müller') ou ajoutez l'année de naissance (ex. 'Müller 1985')",
+        "Entrez le nom (ex. 'Müller' ou 'Hans Müller'), l'année de naissance (ex. 'Müller 1985') ou l'ID SV (ex. '12345')",
       searchError: 'Échec de la recherche de marqueurs',
       noScorerSelected:
         'Aucun marqueur sélectionné. Utilisez la recherche ci-dessus pour trouver et sélectionner un marqueur.',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -153,6 +153,8 @@ const it: Translations = {
     stepIndicatorInvalid: '(incompleto)',
     stepIndicatorFinalized: '(finalizzato)',
     dob: 'DDN',
+    genderMale: 'M',
+    genderFemale: 'F',
   },
   auth: {
     login: 'Accesso',
@@ -688,9 +690,9 @@ const it: Translations = {
       loadCoachesError: 'Caricamento allenatori fallito',
     },
     scorerSearch: {
-      searchPlaceholder: 'Cerca segnapunti per nome...',
+      searchPlaceholder: 'Cerca segnapunti per nome o ID...',
       searchHint:
-        "Inserisci il nome (es. 'Müller' o 'Hans Müller') o aggiungi l'anno di nascita (es. 'Müller 1985')",
+        "Inserisci il nome (es. 'Müller' o 'Hans Müller'), l'anno di nascita (es. 'Müller 1985') o l'ID SV (es. '12345')",
       searchError: 'Ricerca segnapunti fallita',
       noScorerSelected:
         'Nessun segnapunti selezionato. Usa la ricerca sopra per trovare e selezionare un segnapunti.',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -52,6 +52,8 @@ export interface Translations {
     stepIndicatorInvalid: string
     stepIndicatorFinalized: string
     dob: string
+    genderMale: string
+    genderFemale: string
   }
   auth: {
     login: string


### PR DESCRIPTION
## Summary

- Show gender icons (male/female) in scorer search results for easier disambiguation of common names
- Add support for searching by association ID number (numeric input is treated as ID lookup)
- Increase default search results limit from 50 to 100
- Update search hints in all 4 languages (de/en/fr/it) to mention ID search capability

## Test plan

- [ ] Verify gender icons display correctly in scorer search results (male and female)
- [ ] Search by numeric association ID (e.g. "12345") returns matching person
- [ ] Four-digit input (e.g. "1985") still treated as year-of-birth search
- [ ] Name search continues to work as before (single term, two terms, with year)
- [ ] Search hints show updated text mentioning ID search in all 4 languages
- [ ] Results list displays up to 100 results (increased from 50)
- [ ] All 3873 unit tests pass, lint clean, build succeeds