### PR TITLE
refactor(web): redesign settings page with collapsible groups and standardized layout

### DIFF
--- a/web-app/src/features/settings/Settings.integration.test.tsx
+++ b/web-app/src/features/settings/Settings.integration.test.tsx
@@ -85,6 +85,7 @@ describe('Settings Integration', () => {
         sbbDestinationType: 'address',
       },
       levelFilterEnabled: false,
+      settingsGroupExpanded: {},
     })
   })
 
@@ -113,9 +114,8 @@ describe('Settings Integration', () => {
     it('shows demo section when in demo mode', async () => {
       renderSettingsPage()
 
-      // Demo section should be visible - look for the heading specifically
       await waitFor(() => {
-        expect(screen.getByRole('heading', { name: /Demo Data/i })).toBeInTheDocument()
+        expect(screen.getByText('Demo Data')).toBeInTheDocument()
       })
     })
 
@@ -228,7 +228,7 @@ describe('Settings Integration', () => {
 
       await waitFor(
         () => {
-          expect(screen.getByRole('heading', { name: /Home Location/i })).toBeInTheDocument()
+          expect(screen.getByText('Home Location')).toBeInTheDocument()
         },
         { timeout: 3000 }
       )

--- a/web-app/src/features/settings/SettingsPage.test.tsx
+++ b/web-app/src/features/settings/SettingsPage.test.tsx
@@ -70,6 +70,8 @@ function mockSettingsStore(overrides = {}) {
   const state = {
     isSafeModeEnabled: true,
     setSafeMode: mockSetSafeMode,
+    settingsGroupExpanded: {},
+    setSettingsGroupExpanded: vi.fn(),
     ...overrides,
   }
   vi.mocked(settingsStore.useSettingsStore).mockReturnValue(
@@ -132,18 +134,18 @@ describe('SettingsPage', () => {
     it('hides safe mode section in demo mode', () => {
       mockAuthStore({ dataSource: 'demo' })
       render(<SettingsPage />, { wrapper: createWrapper() })
-      expect(screen.queryByText('settings.safeMode')).not.toBeInTheDocument()
+      expect(screen.queryByText('settings.safeModeDescription')).not.toBeInTheDocument()
     })
 
     it('hides safe mode section in calendar mode', () => {
       mockAuthStore({ dataSource: 'calendar' })
       render(<SettingsPage />, { wrapper: createWrapper() })
-      expect(screen.queryByText('settings.safeMode')).not.toBeInTheDocument()
+      expect(screen.queryByText('settings.safeModeDescription')).not.toBeInTheDocument()
     })
 
     it('shows safe mode section when not in demo or calendar mode', () => {
       render(<SettingsPage />, { wrapper: createWrapper() })
-      expect(screen.getByText('settings.safeMode')).toBeInTheDocument()
+      expect(screen.getByText('settings.safeModeDescription')).toBeInTheDocument()
     })
   })
 

--- a/web-app/src/features/settings/SettingsPage.tsx
+++ b/web-app/src/features/settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useShallow } from 'zustand/react/shallow'
 
 import { Button } from '@/shared/components/Button'
+import { SlidersHorizontal, MapPin, Info, Lock } from '@/shared/components/icons'
 import { features } from '@/shared/config/features'
 import { useTour } from '@/shared/hooks/useTour'
 import { useTranslation } from '@/shared/hooks/useTranslation'
@@ -18,6 +19,7 @@ import {
   DemoSection,
   AppInfoSection,
 } from './components'
+import { SettingsGroup } from './components/SettingsGroup'
 import { TravelSettingsSection } from './components/TravelSettingsSection'
 
 export function SettingsPage() {
@@ -49,6 +51,8 @@ export function SettingsPage() {
   // Initialize tour for this page (triggers auto-start on first visit)
   useTour('settings')
 
+  const showSafeMode = !isDemoMode && !isCalendarMode
+
   return (
     <div className="space-y-6 max-w-2xl">
       <h1 className="text-2xl font-bold text-text-primary dark:text-text-primary-dark">
@@ -57,25 +61,112 @@ export function SettingsPage() {
 
       {user && <ProfileSection user={user} />}
 
-      <PreferencesSection preventZoom={preventZoom} onSetPreventZoom={setPreventZoom} />
+      <SettingsGroup
+        groupKey="preferences"
+        icon={
+          <SlidersHorizontal
+            className="w-5 h-5 text-text-muted dark:text-text-muted-dark"
+            aria-hidden="true"
+          />
+        }
+        title={t('settings.preferences.title')}
+        badge={
+          showSafeMode && !isSafeModeEnabled ? (
+            <svg
+              className="w-5 h-5 text-warning-600 dark:text-warning-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          ) : undefined
+        }
+      >
+        <PreferencesSection preventZoom={preventZoom} onSetPreventZoom={setPreventZoom} />
 
-      {!isDemoMode && !isCalendarMode && (
-        <SafeModeSection isSafeModeEnabled={isSafeModeEnabled} onSetSafeMode={setSafeMode} />
+        {showSafeMode && (
+          <>
+            <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
+            <SafeModeSection isSafeModeEnabled={isSafeModeEnabled} onSetSafeMode={setSafeMode} />
+          </>
+        )}
+      </SettingsGroup>
+
+      {(features.homeLocation || features.transport) && (
+        <SettingsGroup
+          groupKey="locationTravel"
+          icon={
+            <MapPin
+              className="w-5 h-5 text-text-muted dark:text-text-muted-dark"
+              aria-hidden="true"
+            />
+          }
+          title={t('settings.locationTravel.title')}
+        >
+          {features.homeLocation && <HomeLocationSection />}
+
+          {features.homeLocation && features.transport && (
+            <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
+          )}
+
+          {features.transport && <TravelSettingsSection />}
+        </SettingsGroup>
       )}
 
-      {features.homeLocation && <HomeLocationSection />}
+      <SettingsGroup
+        groupKey="appUpdates"
+        icon={
+          <Info className="w-5 h-5 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+        }
+        title={t('settings.about')}
+      >
+        <AppInfoSection showUpdates={__PWA_ENABLED__} />
+      </SettingsGroup>
 
-      {features.transport && <TravelSettingsSection />}
-
-      <AppInfoSection showUpdates={__PWA_ENABLED__} />
-
-      <DataRetentionSection />
-
-      {isDemoMode && (
-        <DemoSection activeAssociationCode={activeAssociationCode} onRefreshData={refreshData} />
+      {features.helpTours && (
+        <SettingsGroup
+          groupKey="helpTours"
+          icon={
+            <Info
+              className="w-5 h-5 text-text-muted dark:text-text-muted-dark"
+              aria-hidden="true"
+            />
+          }
+          title={t('settings.helpTours.title')}
+          defaultExpanded={false}
+          data-tour="tour-reset"
+        >
+          <HelpToursSection isDemoMode={isDemoMode} />
+        </SettingsGroup>
       )}
 
-      {features.helpTours && <HelpToursSection isDemoMode={isDemoMode} />}
+      <SettingsGroup
+        groupKey="dataPrivacy"
+        icon={
+          <Lock className="w-5 h-5 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+        }
+        title={t('settings.dataRetention.title')}
+        defaultExpanded={false}
+      >
+        <DataRetentionSection />
+
+        {isDemoMode && (
+          <>
+            <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
+            <DemoSection
+              activeAssociationCode={activeAssociationCode}
+              onRefreshData={refreshData}
+            />
+          </>
+        )}
+      </SettingsGroup>
 
       {/* Logout */}
       <div className="pt-4 border-t border-border-default dark:border-border-default-dark">

--- a/web-app/src/features/settings/SettingsPage.tsx
+++ b/web-app/src/features/settings/SettingsPage.tsx
@@ -59,23 +59,23 @@ export function SettingsPage() {
 
       <PreferencesSection preventZoom={preventZoom} onSetPreventZoom={setPreventZoom} />
 
+      {!isDemoMode && !isCalendarMode && (
+        <SafeModeSection isSafeModeEnabled={isSafeModeEnabled} onSetSafeMode={setSafeMode} />
+      )}
+
       {features.homeLocation && <HomeLocationSection />}
 
       {features.transport && <TravelSettingsSection />}
 
-      <DataRetentionSection />
+      <AppInfoSection showUpdates={__PWA_ENABLED__} />
 
-      {features.helpTours && <HelpToursSection isDemoMode={isDemoMode} />}
+      <DataRetentionSection />
 
       {isDemoMode && (
         <DemoSection activeAssociationCode={activeAssociationCode} onRefreshData={refreshData} />
       )}
 
-      {!isDemoMode && !isCalendarMode && (
-        <SafeModeSection isSafeModeEnabled={isSafeModeEnabled} onSetSafeMode={setSafeMode} />
-      )}
-
-      <AppInfoSection showUpdates={__PWA_ENABLED__} />
+      {features.helpTours && <HelpToursSection isDemoMode={isDemoMode} />}
 
       {/* Logout */}
       <div className="pt-4 border-t border-border-default dark:border-border-default-dark">

--- a/web-app/src/features/settings/SettingsPage.tsx
+++ b/web-app/src/features/settings/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useShallow } from 'zustand/react/shallow'
 
 import { Button } from '@/shared/components/Button'
-import { SlidersHorizontal, MapPin, Info, Lock } from '@/shared/components/icons'
+import { SlidersHorizontal, MapPin, Info, Lock, AlertTriangle } from '@/shared/components/icons'
 import { features } from '@/shared/config/features'
 import { useTour } from '@/shared/hooks/useTour'
 import { useTranslation } from '@/shared/hooks/useTranslation'
@@ -72,20 +72,13 @@ export function SettingsPage() {
         title={t('settings.preferences.title')}
         badge={
           showSafeMode && !isSafeModeEnabled ? (
-            <svg
-              className="w-5 h-5 text-warning-600 dark:text-warning-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            <>
+              <AlertTriangle
+                className="w-5 h-5 text-warning-600 dark:text-warning-400"
+                aria-hidden="true"
               />
-            </svg>
+              <span className="sr-only">{t('settings.safeModeWarning')}</span>
+            </>
           ) : undefined
         }
       >

--- a/web-app/src/features/settings/components/AppInfoSection.tsx
+++ b/web-app/src/features/settings/components/AppInfoSection.tsx
@@ -2,12 +2,13 @@ import { useCallback, memo } from 'react'
 
 import { usePWA } from '@/contexts/PWAContext'
 import { Button } from '@/shared/components/Button'
-import { Card, CardContent, CardHeader } from '@/shared/components/Card'
 import { ToggleSwitch } from '@/shared/components/ToggleSwitch'
 import { features } from '@/shared/config/features'
 import { usePwaStandalone } from '@/shared/hooks/usePwaStandalone'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useSettingsStore } from '@/shared/stores/settings'
+
+import { SettingsItem } from './SettingsItem'
 
 // Build OCR POC URL relative to the app's base path (features.ocrPoc)
 const OCR_POC_URL = features.ocrPoc ? `${import.meta.env.BASE_URL}ocr-poc/` : ''
@@ -51,167 +52,147 @@ function AppInfoSectionComponent({ showUpdates }: AppInfoSectionProps) {
   )
 
   return (
-    <Card>
-      <CardHeader>
-        <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
-          {t('settings.about')}
-        </h2>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {/* Version info */}
-        <div className="space-y-2 text-sm">
-          <div className="flex justify-between">
-            <span className="text-text-muted dark:text-text-muted-dark">
-              {t('settings.version')}
+    <>
+      {/* Version info */}
+      <div className="space-y-2 text-sm">
+        <div className="flex justify-between">
+          <span className="text-text-muted dark:text-text-muted-dark">{t('settings.version')}</span>
+          <span className="text-text-primary dark:text-text-primary-dark">
+            {__APP_VERSION__}{' '}
+            <span className="text-text-muted dark:text-text-muted-dark font-mono text-xs">
+              ({__GIT_HASH__})
             </span>
-            <span className="text-text-primary dark:text-text-primary-dark">
-              {__APP_VERSION__}{' '}
-              <span className="text-text-muted dark:text-text-muted-dark font-mono text-xs">
-                ({__GIT_HASH__})
-              </span>
-            </span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-text-muted dark:text-text-muted-dark">
-              {t('settings.platform')}
-            </span>
-            <span className="text-text-primary dark:text-text-primary-dark">{platform}</span>
-          </div>
+          </span>
         </div>
+        <div className="flex justify-between">
+          <span className="text-text-muted dark:text-text-muted-dark">
+            {t('settings.platform')}
+          </span>
+          <span className="text-text-primary dark:text-text-primary-dark">{platform}</span>
+        </div>
+      </div>
 
-        {/* Updates section - only shown when PWA is enabled */}
-        {showUpdates && (
-          <>
-            <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
-            <div className="space-y-4">
-              <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                {t('settings.updates')}
-              </div>
-              <div className="flex items-center justify-between">
-                <div className="flex-1">
-                  <div
-                    className="text-sm font-medium text-text-primary dark:text-text-primary-dark"
-                    aria-live="polite"
-                  >
-                    {needRefresh ? t('settings.updateAvailable') : t('settings.upToDate')}
-                  </div>
-                  {lastChecked && (
-                    <div className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
-                      {t('settings.lastChecked')}: {formatLastChecked(lastChecked)}
-                    </div>
-                  )}
-                  {checkError && (
-                    <div className="text-xs text-danger-600 dark:text-danger-400 mt-1" role="alert">
-                      {t('settings.updateCheckFailed')}
-                    </div>
-                  )}
+      {/* Updates section - only shown when PWA is enabled */}
+      {showUpdates && (
+        <>
+          <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
+          <div className="space-y-4">
+            <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+              {t('settings.updates')}
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <div
+                  className="text-sm font-medium text-text-primary dark:text-text-primary-dark"
+                  aria-live="polite"
+                >
+                  {needRefresh ? t('settings.updateAvailable') : t('settings.upToDate')}
                 </div>
-                {needRefresh ? (
-                  <Button
-                    variant="primary"
-                    onClick={updateApp}
-                    aria-label={t('settings.updateNow')}
-                  >
-                    {t('settings.updateNow')}
-                  </Button>
-                ) : (
-                  <Button
-                    variant="secondary"
-                    onClick={checkForUpdate}
-                    loading={isChecking}
-                    aria-label={t('settings.checkForUpdates')}
-                  >
-                    {isChecking ? t('settings.checking') : t('settings.checkForUpdates')}
-                  </Button>
+                {lastChecked && (
+                  <div className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+                    {t('settings.lastChecked')}: {formatLastChecked(lastChecked)}
+                  </div>
+                )}
+                {checkError && (
+                  <div className="text-xs text-danger-600 dark:text-danger-400 mt-1" role="alert">
+                    {t('settings.updateCheckFailed')}
+                  </div>
                 )}
               </div>
+              {needRefresh ? (
+                <Button variant="primary" onClick={updateApp} aria-label={t('settings.updateNow')}>
+                  {t('settings.updateNow')}
+                </Button>
+              ) : (
+                <Button
+                  variant="secondary"
+                  onClick={checkForUpdate}
+                  loading={isChecking}
+                  aria-label={t('settings.checkForUpdates')}
+                >
+                  {isChecking ? t('settings.checking') : t('settings.checkForUpdates')}
+                </Button>
+              )}
             </div>
-          </>
-        )}
+          </div>
+        </>
+      )}
 
-        {/* Experimental features (features.ocr / features.ocrPoc) */}
-        {(features.ocr || features.ocrPoc) && (
-          <>
-            <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
-            <div className="space-y-4">
-              <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                {t('settings.experimental.title')}
-              </div>
-              <p className="text-sm text-text-muted dark:text-text-muted-dark">
-                {t('settings.experimental.description')}
-              </p>
+      {/* Experimental features (features.ocr / features.ocrPoc) */}
+      {(features.ocr || features.ocrPoc) && (
+        <>
+          <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
+          <div className="space-y-4">
+            <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+              {t('settings.experimental.title')}
+            </div>
+            <p className="text-sm text-text-muted dark:text-text-muted-dark">
+              {t('settings.experimental.description')}
+            </p>
 
-              {/* OCR POC standalone app link (features.ocrPoc) */}
-              {features.ocrPoc && (
-                <div className="flex items-center justify-between">
-                  <div className="space-y-1">
-                    <p className="font-medium text-text-primary dark:text-text-primary-dark text-sm">
-                      {t('settings.experimental.ocrPoc')}
-                    </p>
-                    <p className="text-xs text-text-muted dark:text-text-muted-dark">
-                      {t('settings.experimental.ocrPocDescription')}
-                    </p>
-                  </div>
-                  <Button
-                    variant="secondary"
-                    onClick={() => window.open(OCR_POC_URL, '_blank', 'noopener,noreferrer')}
-                    aria-label={t('settings.experimental.openOcrPoc')}
-                  >
-                    {t('settings.experimental.openOcrPoc')}
-                  </Button>
+            {/* OCR POC standalone app link (features.ocrPoc) */}
+            {features.ocrPoc && (
+              <div className="flex items-center justify-between">
+                <div className="space-y-1">
+                  <p className="font-medium text-text-primary dark:text-text-primary-dark text-sm">
+                    {t('settings.experimental.ocrPoc')}
+                  </p>
+                  <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                    {t('settings.experimental.ocrPocDescription')}
+                  </p>
                 </div>
-              )}
+                <Button
+                  variant="secondary"
+                  onClick={() => window.open(OCR_POC_URL, '_blank', 'noopener,noreferrer')}
+                  aria-label={t('settings.experimental.openOcrPoc')}
+                >
+                  {t('settings.experimental.openOcrPoc')}
+                </Button>
+              </div>
+            )}
 
-              {/* OCR Validation Toggle (features.ocr) */}
-              {features.ocr && (
-                <>
-                  <div className="flex items-center justify-between py-2">
-                    <div className="flex-1">
-                      <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                        {t('settings.experimental.ocrValidation')}
-                      </div>
-                      <div className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
-                        {t('settings.experimental.ocrValidationDescription')}
-                      </div>
-                    </div>
-                    <ToggleSwitch
-                      checked={isOCREnabled}
-                      onChange={handleToggleOCR}
-                      label={t('settings.experimental.ocrValidation')}
-                    />
-                  </div>
-                  <div className="text-xs text-text-muted dark:text-text-muted-dark">
-                    {isOCREnabled
-                      ? t('settings.experimental.ocrValidationEnabled')
-                      : t('settings.experimental.ocrValidationDisabled')}
-                  </div>
-                </>
-              )}
-            </div>
-          </>
-        )}
+            {/* OCR Validation Toggle (features.ocr) */}
+            {features.ocr && (
+              <SettingsItem
+                label={t('settings.experimental.ocrValidation')}
+                description={t('settings.experimental.ocrValidationDescription')}
+                status={
+                  isOCREnabled
+                    ? t('settings.experimental.ocrValidationEnabled')
+                    : t('settings.experimental.ocrValidationDisabled')
+                }
+              >
+                <ToggleSwitch
+                  checked={isOCREnabled}
+                  onChange={handleToggleOCR}
+                  label={t('settings.experimental.ocrValidation')}
+                />
+              </SettingsItem>
+            )}
+          </div>
+        </>
+      )}
 
-        {/* Official website and disclaimer */}
-        <div className="border-t border-border-subtle dark:border-border-subtle-dark pt-3">
-          <a
-            href="https://volleymanager.volleyball.ch"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary-600 dark:text-primary-400 hover:underline text-sm"
-          >
-            {t('settings.openWebsite')} →
-          </a>
-        </div>
-        <div className="border-t border-border-subtle dark:border-border-subtle-dark pt-3 space-y-2">
-          <p className="text-sm text-text-muted dark:text-text-muted-dark">
-            {t('settings.dataSource')}
-          </p>
-          <p className="text-xs text-text-subtle dark:text-text-subtle-dark">
-            {t('settings.disclaimer')}
-          </p>
-        </div>
-      </CardContent>
-    </Card>
+      {/* Official website and disclaimer */}
+      <div className="border-t border-border-subtle dark:border-border-subtle-dark pt-3">
+        <a
+          href="https://volleymanager.volleyball.ch"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary-600 dark:text-primary-400 hover:underline text-sm"
+        >
+          {t('settings.openWebsite')} →
+        </a>
+      </div>
+      <div className="border-t border-border-subtle dark:border-border-subtle-dark pt-3 space-y-2">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t('settings.dataSource')}
+        </p>
+        <p className="text-xs text-text-subtle dark:text-text-subtle-dark">
+          {t('settings.disclaimer')}
+        </p>
+      </div>
+    </>
   )
 }
 

--- a/web-app/src/features/settings/components/DataRetentionSection.tsx
+++ b/web-app/src/features/settings/components/DataRetentionSection.tsx
@@ -5,7 +5,6 @@ import { useShallow } from 'zustand/react/shallow'
 
 import { queryKeys } from '@/api/queryKeys'
 import { Button } from '@/shared/components/Button'
-import { Card, CardContent, CardHeader } from '@/shared/components/Card'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useSettingsStore } from '@/shared/stores/settings'
 
@@ -42,175 +41,152 @@ function DataRetentionSectionComponent() {
   }, [])
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-2">
-          <svg
-            className="w-5 h-5 text-text-muted dark:text-text-muted-dark"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-            />
-          </svg>
-          <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
-            {t('settings.dataRetention.title')}
-          </h2>
+    <div className="space-y-4">
+      {/* Privacy statements */}
+      <div className="space-y-2 text-sm text-text-muted dark:text-text-muted-dark">
+        <p>{t('settings.privacyNoCollection')}</p>
+        <p>{t('settings.privacyDirectComm')}</p>
+        <p>{t('settings.privacyNoAnalytics')}</p>
+      </div>
+
+      {/* Separator */}
+      <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
+
+      <p className="text-sm text-text-muted dark:text-text-muted-dark">
+        {t('settings.dataRetention.description')}
+      </p>
+
+      {/* Data stored locally */}
+      <div className="space-y-2">
+        <ul className="space-y-2 text-sm text-text-primary dark:text-text-primary-dark">
+          <li className="flex items-start gap-2">
+            <svg
+              className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+            <span>{t('settings.dataRetention.homeLocation')}</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <svg
+              className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+            <span>{t('settings.dataRetention.filterPreferences')}</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <svg
+              className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+            <span>{t('settings.dataRetention.travelTimeCache')}</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <svg
+              className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+            <span>{t('settings.dataRetention.languagePreference')}</span>
+          </li>
+        </ul>
+      </div>
+
+      {/* External services note */}
+      {transportEnabled && (
+        <div className="p-3 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg">
+          <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-1">
+            {t('settings.dataRetention.externalServices')}
+          </h3>
+          <p className="text-xs text-text-muted dark:text-text-muted-dark">
+            {t('settings.dataRetention.transportApiNote')}
+          </p>
         </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Privacy statements */}
-        <div className="space-y-2 text-sm text-text-muted dark:text-text-muted-dark">
-          <p>{t('settings.privacyNoCollection')}</p>
-          <p>{t('settings.privacyDirectComm')}</p>
-          <p>{t('settings.privacyNoAnalytics')}</p>
-        </div>
+      )}
 
-        {/* Separator */}
-        <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
-
-        <p className="text-sm text-text-muted dark:text-text-muted-dark">
-          {t('settings.dataRetention.description')}
-        </p>
-
-        {/* Data stored locally */}
-        <div className="space-y-2">
-          <ul className="space-y-2 text-sm text-text-primary dark:text-text-primary-dark">
-            <li className="flex items-start gap-2">
-              <svg
-                className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-              <span>{t('settings.dataRetention.homeLocation')}</span>
-            </li>
-            <li className="flex items-start gap-2">
-              <svg
-                className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-              <span>{t('settings.dataRetention.filterPreferences')}</span>
-            </li>
-            <li className="flex items-start gap-2">
-              <svg
-                className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-              <span>{t('settings.dataRetention.travelTimeCache')}</span>
-            </li>
-            <li className="flex items-start gap-2">
-              <svg
-                className="w-4 h-4 mt-0.5 flex-shrink-0 text-primary-600 dark:text-primary-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-              <span>{t('settings.dataRetention.languagePreference')}</span>
-            </li>
-          </ul>
-        </div>
-
-        {/* External services note */}
-        {transportEnabled && (
-          <div className="p-3 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg">
-            <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-1">
-              {t('settings.dataRetention.externalServices')}
-            </h3>
-            <p className="text-xs text-text-muted dark:text-text-muted-dark">
-              {t('settings.dataRetention.transportApiNote')}
-            </p>
-          </div>
-        )}
-
-        {/* Clear data button */}
-        {(homeLocation || transportEnabled) && (
-          <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
-            {!showConfirm ? (
-              <Button
-                variant="secondary"
-                onClick={handleShowConfirm}
-                fullWidth
-                iconLeft={
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                    />
-                  </svg>
-                }
-              >
-                {t('settings.dataRetention.clearData')}
-              </Button>
-            ) : (
-              <div className="space-y-3">
-                <p className="text-sm text-text-primary dark:text-text-primary-dark">
-                  {t('settings.dataRetention.clearDataConfirm')}
-                </p>
-                <div className="flex gap-2">
-                  <Button variant="secondary" onClick={handleCancelConfirm} className="flex-1">
-                    {t('common.cancel')}
-                  </Button>
-                  <Button variant="primary" onClick={handleClearData} className="flex-1">
-                    {t('common.confirm')}
-                  </Button>
-                </div>
+      {/* Clear data button */}
+      {(homeLocation || transportEnabled) && (
+        <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+          {!showConfirm ? (
+            <Button
+              variant="secondary"
+              onClick={handleShowConfirm}
+              fullWidth
+              iconLeft={
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              }
+            >
+              {t('settings.dataRetention.clearData')}
+            </Button>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-sm text-text-primary dark:text-text-primary-dark">
+                {t('settings.dataRetention.clearDataConfirm')}
+              </p>
+              <div className="flex gap-2">
+                <Button variant="secondary" onClick={handleCancelConfirm} className="flex-1">
+                  {t('common.cancel')}
+                </Button>
+                <Button variant="primary" onClick={handleClearData} className="flex-1">
+                  {t('common.confirm')}
+                </Button>
               </div>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/web-app/src/features/settings/components/DemoSection.tsx
+++ b/web-app/src/features/settings/components/DemoSection.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, useRef, useEffect, memo } from 'react'
 
 import { Button } from '@/shared/components/Button'
-import { Card, CardContent, CardHeader } from '@/shared/components/Card'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 
 const DEMO_RESET_MESSAGE_DURATION_MS = 3000
@@ -39,45 +38,41 @@ function DemoSectionComponent({ activeAssociationCode, onRefreshData }: DemoSect
   }, [onRefreshData])
 
   return (
-    <Card>
-      <CardHeader>
-        <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
-          {t('settings.demoData')}
-        </h2>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <p className="text-sm text-text-muted dark:text-text-muted-dark">
-          {t('settings.demoDataDescription')}
-        </p>
+    <div className="space-y-4">
+      <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+        {t('settings.demoData')}
+      </div>
+      <p className="text-sm text-text-muted dark:text-text-muted-dark">
+        {t('settings.demoDataDescription')}
+      </p>
 
-        <div className="flex items-center justify-between py-2">
-          <div className="flex-1">
-            {demoDataReset && (
-              <div
-                className="text-sm font-medium text-success-600 dark:text-success-400"
-                role="status"
-                aria-live="polite"
-              >
-                {t('settings.demoDataReset')}
-              </div>
-            )}
-            {activeAssociationCode && !demoDataReset && (
-              <div className="text-sm text-text-muted dark:text-text-muted-dark">
-                {activeAssociationCode}
-              </div>
-            )}
-          </div>
-
-          <Button
-            variant="secondary"
-            onClick={handleResetDemoData}
-            aria-label={t('settings.resetDemoData')}
-          >
-            {t('settings.resetDemoData')}
-          </Button>
+      <div className="flex items-center justify-between py-2">
+        <div className="flex-1">
+          {demoDataReset && (
+            <div
+              className="text-sm font-medium text-success-600 dark:text-success-400"
+              role="status"
+              aria-live="polite"
+            >
+              {t('settings.demoDataReset')}
+            </div>
+          )}
+          {activeAssociationCode && !demoDataReset && (
+            <div className="text-sm text-text-muted dark:text-text-muted-dark">
+              {activeAssociationCode}
+            </div>
+          )}
         </div>
-      </CardContent>
-    </Card>
+
+        <Button
+          variant="secondary"
+          onClick={handleResetDemoData}
+          aria-label={t('settings.resetDemoData')}
+        >
+          {t('settings.resetDemoData')}
+        </Button>
+      </div>
+    </div>
   )
 }
 

--- a/web-app/src/features/settings/components/HelpToursSection.tsx
+++ b/web-app/src/features/settings/components/HelpToursSection.tsx
@@ -1,10 +1,8 @@
 import { memo } from 'react'
 
-import { BookOpen } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 
 import { Button } from '@/shared/components/Button'
-import { Card, CardContent, CardHeader } from '@/shared/components/Card'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useTourStore, type TourId } from '@/shared/stores/tour'
 import { getHelpSiteUrl } from '@/shared/utils/constants'
@@ -25,91 +23,81 @@ function HelpToursSectionComponent({ isDemoMode }: HelpToursSectionProps) {
   )
 
   return (
-    <Card data-tour="tour-reset">
-      <CardHeader>
-        <div className="flex items-center gap-2">
-          <BookOpen className="w-5 h-5 text-primary-600 dark:text-primary-400" aria-hidden="true" />
-          <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
-            {t('settings.helpTours.title')}
-          </h2>
+    <>
+      {/* Help documentation link */}
+      <div className="space-y-2">
+        <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+          {t('settings.help.title')}
         </div>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {/* Help documentation link */}
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t('settings.help.description')}
+        </p>
+        <a
+          href={getHelpSiteUrl()}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:underline text-sm"
+        >
+          {t('settings.help.openDocs')} &rarr;
+        </a>
+      </div>
+
+      {/* Separator */}
+      <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
+
+      {/* Tours */}
+      <div className="space-y-4">
+        <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+          {t('tour.settings.tourSection.title')}
+        </div>
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t('tour.settings.tourSection.description')}
+        </p>
+
+        {/* Safe mode note - only show outside demo mode */}
+        {!isDemoMode && (
+          <p className="text-sm text-warning-600 dark:text-warning-400">
+            {t('tour.settings.tourSection.safeModeNote')}
+          </p>
+        )}
+
+        {/* Tour status list */}
         <div className="space-y-2">
-          <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-            {t('settings.help.title')}
-          </div>
-          <p className="text-sm text-text-muted dark:text-text-muted-dark">
-            {t('settings.help.description')}
-          </p>
-          <a
-            href={getHelpSiteUrl()}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:underline text-sm"
-          >
-            {t('settings.help.openDocs')} &rarr;
-          </a>
-        </div>
-
-        {/* Separator */}
-        <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
-
-        {/* Tours */}
-        <div className="space-y-4">
-          <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-            {t('tour.settings.tourSection.title')}
-          </div>
-          <p className="text-sm text-text-muted dark:text-text-muted-dark">
-            {t('tour.settings.tourSection.description')}
-          </p>
-
-          {/* Safe mode note - only show outside demo mode */}
-          {!isDemoMode && (
-            <p className="text-sm text-warning-600 dark:text-warning-400">
-              {t('tour.settings.tourSection.safeModeNote')}
-            </p>
-          )}
-
-          {/* Tour status list */}
-          <div className="space-y-2">
-            {TOUR_IDS.map((tourId) => {
-              const status = getTourStatus(tourId)
-              return (
-                <div key={tourId} className="flex items-center justify-between py-1">
-                  <span className="text-sm text-text-primary dark:text-text-primary-dark capitalize">
-                    {t(`nav.${tourId}` as Parameters<typeof t>[0])}
-                  </span>
-                  <span
-                    className={`text-xs px-2 py-0.5 rounded-full ${
-                      status === 'completed'
-                        ? 'bg-success-100 text-success-700 dark:bg-success-900/50 dark:text-success-300'
-                        : status === 'dismissed'
-                          ? 'bg-warning-100 text-warning-700 dark:bg-warning-900/50 dark:text-warning-300'
-                          : 'bg-surface-subtle text-text-muted dark:bg-surface-subtle-dark dark:text-text-muted-dark'
-                    }`}
-                  >
-                    {status === 'completed'
-                      ? t('tour.settings.tourSection.statusCompleted')
+          {TOUR_IDS.map((tourId) => {
+            const status = getTourStatus(tourId)
+            return (
+              <div key={tourId} className="flex items-center justify-between py-1">
+                <span className="text-sm text-text-primary dark:text-text-primary-dark capitalize">
+                  {t(`nav.${tourId}` as Parameters<typeof t>[0])}
+                </span>
+                <span
+                  className={`text-xs px-2 py-0.5 rounded-full ${
+                    status === 'completed'
+                      ? 'bg-success-100 text-success-700 dark:bg-success-900/50 dark:text-success-300'
                       : status === 'dismissed'
-                        ? t('tour.settings.tourSection.statusSkipped')
-                        : t('tour.settings.tourSection.statusNotStarted')}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
-
-          {/* Reset button */}
-          <div className="pt-2">
-            <Button variant="secondary" onClick={resetAllTours}>
-              {t('tour.settings.tourSection.restart')}
-            </Button>
-          </div>
+                        ? 'bg-warning-100 text-warning-700 dark:bg-warning-900/50 dark:text-warning-300'
+                        : 'bg-surface-subtle text-text-muted dark:bg-surface-subtle-dark dark:text-text-muted-dark'
+                  }`}
+                >
+                  {status === 'completed'
+                    ? t('tour.settings.tourSection.statusCompleted')
+                    : status === 'dismissed'
+                      ? t('tour.settings.tourSection.statusSkipped')
+                      : t('tour.settings.tourSection.statusNotStarted')}
+                </span>
+              </div>
+            )
+          })}
         </div>
-      </CardContent>
-    </Card>
+
+        {/* Reset button */}
+        <div className="pt-2">
+          <Button variant="secondary" onClick={resetAllTours}>
+            {t('tour.settings.tourSection.restart')}
+          </Button>
+        </div>
+      </div>
+    </>
   )
 }
 

--- a/web-app/src/features/settings/components/HomeLocationSection.tsx
+++ b/web-app/src/features/settings/components/HomeLocationSection.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react'
 
 import { Button } from '@/shared/components/Button'
-import { Card, CardContent, CardHeader } from '@/shared/components/Card'
 import { MapPin, X, Clock } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 
@@ -15,122 +14,115 @@ function HomeLocationSectionComponent() {
   const homeLocation = useHomeLocationSettings({ t })
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-2">
-          <MapPin className="w-5 h-5 text-text-muted dark:text-text-muted-dark" />
-          <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
-            {t('settings.homeLocation.title')}
-          </h2>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4" data-tour="home-location">
-        <p className="text-sm text-text-muted dark:text-text-muted-dark">
-          {t('settings.homeLocation.description')}
-        </p>
+    <div className="space-y-4" data-tour="home-location">
+      <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+        {t('settings.homeLocation.title')}
+      </div>
+      <p className="text-sm text-text-muted dark:text-text-muted-dark">
+        {t('settings.homeLocation.description')}
+      </p>
 
-        {/* Current location display */}
-        {homeLocation.homeLocation && (
-          <div className="flex items-center justify-between p-3 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg">
-            <div className="flex items-center gap-2 min-w-0">
-              <MapPin className="w-5 h-5 flex-shrink-0 text-primary-600 dark:text-primary-400" />
-              <span className="text-sm text-text-primary dark:text-text-primary-dark truncate">
-                {homeLocation.homeLocation.label}
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={homeLocation.handleClearLocation}
-              className="ml-2 p-1 text-text-muted hover:text-text-primary dark:text-text-muted-dark dark:hover:text-text-primary-dark rounded transition-colors"
-              aria-label={t('settings.homeLocation.clear')}
-            >
-              <X className="w-5 h-5" />
-            </button>
+      {/* Current location display */}
+      {homeLocation.homeLocation && (
+        <div className="flex items-center justify-between p-3 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg">
+          <div className="flex items-center gap-2 min-w-0">
+            <MapPin className="w-5 h-5 flex-shrink-0 text-primary-600 dark:text-primary-400" />
+            <span className="text-sm text-text-primary dark:text-text-primary-dark truncate">
+              {homeLocation.homeLocation.label}
+            </span>
           </div>
-        )}
-
-        {/* Use current location button */}
-        {homeLocation.geoSupported && (
-          <Button
-            variant="secondary"
-            onClick={homeLocation.requestLocation}
-            loading={homeLocation.geoLoading}
-            fullWidth
-            iconLeft={!homeLocation.geoLoading && <Clock className="w-4 h-4" />}
+          <button
+            type="button"
+            onClick={homeLocation.handleClearLocation}
+            className="ml-2 p-1 text-text-muted hover:text-text-primary dark:text-text-muted-dark dark:hover:text-text-primary-dark rounded transition-colors"
+            aria-label={t('settings.homeLocation.clear')}
           >
-            {homeLocation.geoLoading
-              ? t('settings.homeLocation.locating')
-              : t('settings.homeLocation.useCurrentLocation')}
-          </Button>
-        )}
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      )}
 
-        {/* Geolocation error */}
-        {homeLocation.geoError && (
+      {/* Use current location button */}
+      {homeLocation.geoSupported && (
+        <Button
+          variant="secondary"
+          onClick={homeLocation.requestLocation}
+          loading={homeLocation.geoLoading}
+          fullWidth
+          iconLeft={!homeLocation.geoLoading && <Clock className="w-4 h-4" />}
+        >
+          {homeLocation.geoLoading
+            ? t('settings.homeLocation.locating')
+            : t('settings.homeLocation.useCurrentLocation')}
+        </Button>
+      )}
+
+      {/* Geolocation error */}
+      {homeLocation.geoError && (
+        <p className="text-sm text-error-600 dark:text-error-400">
+          {getGeolocationErrorMessage(homeLocation.geoError, t)}
+        </p>
+      )}
+
+      {/* Address search */}
+      <div className="space-y-2">
+        <label
+          htmlFor="address-search"
+          className="block text-sm font-medium text-text-primary dark:text-text-primary-dark"
+        >
+          {t('settings.homeLocation.searchLabel')}
+        </label>
+        <div className="relative">
+          <input
+            id="address-search"
+            type="text"
+            value={homeLocation.addressQuery}
+            onChange={homeLocation.handleAddressChange}
+            placeholder={t('settings.homeLocation.searchPlaceholder')}
+            className="w-full px-4 py-2 text-sm border border-border-default dark:border-border-default-dark rounded-lg bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark placeholder:text-text-muted dark:placeholder:text-text-muted-dark focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+          />
+          {homeLocation.geocodeLoading && (
+            <div className="absolute right-3 top-1/2 -translate-y-1/2">
+              <span className="w-4 h-4 block border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+        </div>
+
+        {/* Geocoding error */}
+        {homeLocation.geocodeError && (
           <p className="text-sm text-error-600 dark:text-error-400">
-            {getGeolocationErrorMessage(homeLocation.geoError, t)}
+            {t('settings.homeLocation.searchError')}
           </p>
         )}
 
-        {/* Address search */}
-        <div className="space-y-2">
-          <label
-            htmlFor="address-search"
-            className="block text-sm font-medium text-text-primary dark:text-text-primary-dark"
-          >
-            {t('settings.homeLocation.searchLabel')}
-          </label>
-          <div className="relative">
-            <input
-              id="address-search"
-              type="text"
-              value={homeLocation.addressQuery}
-              onChange={homeLocation.handleAddressChange}
-              placeholder={t('settings.homeLocation.searchPlaceholder')}
-              className="w-full px-4 py-2 text-sm border border-border-default dark:border-border-default-dark rounded-lg bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark placeholder:text-text-muted dark:placeholder:text-text-muted-dark focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-            />
-            {homeLocation.geocodeLoading && (
-              <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                <span className="w-4 h-4 block border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
-              </div>
-            )}
-          </div>
+        {/* Geocoding results */}
+        {homeLocation.geocodeResults.length > 0 && (
+          <ul className="border border-border-default dark:border-border-default-dark rounded-lg overflow-hidden divide-y divide-border-subtle dark:divide-border-subtle-dark">
+            {homeLocation.geocodeResults.map((result) => (
+              <li key={result.id}>
+                <button
+                  type="button"
+                  onClick={() => homeLocation.handleSelectGeocodedLocation(result)}
+                  className="w-full px-4 py-3 text-left text-sm text-text-primary dark:text-text-primary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark transition-colors"
+                >
+                  {result.displayName}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
 
-          {/* Geocoding error */}
-          {homeLocation.geocodeError && (
-            <p className="text-sm text-error-600 dark:text-error-400">
-              {t('settings.homeLocation.searchError')}
+        {/* No results message */}
+        {homeLocation.debouncedQuery.length >= homeLocation.minSearchLength &&
+          !homeLocation.geocodeLoading &&
+          homeLocation.geocodeResults.length === 0 &&
+          !homeLocation.geocodeError && (
+            <p className="text-sm text-text-muted dark:text-text-muted-dark">
+              {t('settings.homeLocation.noResults')}
             </p>
           )}
-
-          {/* Geocoding results */}
-          {homeLocation.geocodeResults.length > 0 && (
-            <ul className="border border-border-default dark:border-border-default-dark rounded-lg overflow-hidden divide-y divide-border-subtle dark:divide-border-subtle-dark">
-              {homeLocation.geocodeResults.map((result) => (
-                <li key={result.id}>
-                  <button
-                    type="button"
-                    onClick={() => homeLocation.handleSelectGeocodedLocation(result)}
-                    className="w-full px-4 py-3 text-left text-sm text-text-primary dark:text-text-primary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark transition-colors"
-                  >
-                    {result.displayName}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-
-          {/* No results message */}
-          {homeLocation.debouncedQuery.length >= homeLocation.minSearchLength &&
-            !homeLocation.geocodeLoading &&
-            homeLocation.geocodeResults.length === 0 &&
-            !homeLocation.geocodeError && (
-              <p className="text-sm text-text-muted dark:text-text-muted-dark">
-                {t('settings.homeLocation.noResults')}
-              </p>
-            )}
-        </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   )
 }
 

--- a/web-app/src/features/settings/components/PreferencesSection.tsx
+++ b/web-app/src/features/settings/components/PreferencesSection.tsx
@@ -1,9 +1,10 @@
 import { useCallback, memo } from 'react'
 
-import { Card, CardContent, CardHeader } from '@/shared/components/Card'
 import { LanguageSwitcher } from '@/shared/components/LanguageSwitcher'
 import { ToggleSwitch } from '@/shared/components/ToggleSwitch'
 import { useTranslation } from '@/shared/hooks/useTranslation'
+
+import { SettingsItem } from './SettingsItem'
 
 interface PreferencesSectionProps {
   preventZoom: boolean
@@ -18,58 +19,44 @@ function PreferencesSectionComponent({ preventZoom, onSetPreventZoom }: Preferen
   }, [preventZoom, onSetPreventZoom])
 
   return (
-    <Card>
-      <CardHeader>
-        <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
-          {t('settings.preferences.title')}
-        </h2>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {/* Language selection */}
-        <div data-tour="language-switcher">
-          <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-2">
-            {t('settings.language')}
-          </div>
-          <LanguageSwitcher variant="grid" />
+    <>
+      {/* Language selection */}
+      <div data-tour="language-switcher">
+        <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-2">
+          {t('settings.language')}
         </div>
+        <LanguageSwitcher variant="grid" />
+      </div>
 
-        {/* Separator */}
-        <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
+      {/* Separator */}
+      <div className="border-t border-border-subtle dark:border-border-subtle-dark" />
 
-        {/* Accessibility: Prevent Zoom Toggle */}
-        <div className="space-y-2">
-          <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-            {t('settings.accessibility.title')}
-          </div>
-          <p className="text-sm text-text-muted dark:text-text-muted-dark">
-            {t('settings.accessibility.description')}
-          </p>
+      {/* Accessibility: Prevent Zoom Toggle */}
+      <div className="space-y-2">
+        <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+          {t('settings.accessibility.title')}
+        </div>
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t('settings.accessibility.description')}
+        </p>
 
-          <div className="flex items-center justify-between py-2">
-            <div className="flex-1">
-              <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                {t('settings.accessibility.preventZoom')}
-              </div>
-              <div className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
-                {t('settings.accessibility.preventZoomDescription')}
-              </div>
-            </div>
-
-            <ToggleSwitch
-              checked={preventZoom}
-              onChange={handleTogglePreventZoom}
-              label={t('settings.accessibility.preventZoom')}
-            />
-          </div>
-
-          <div className="text-xs text-text-muted dark:text-text-muted-dark">
-            {preventZoom
+        <SettingsItem
+          label={t('settings.accessibility.preventZoom')}
+          description={t('settings.accessibility.preventZoomDescription')}
+          status={
+            preventZoom
               ? t('settings.accessibility.preventZoomEnabled')
-              : t('settings.accessibility.preventZoomDisabled')}
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+              : t('settings.accessibility.preventZoomDisabled')
+          }
+        >
+          <ToggleSwitch
+            checked={preventZoom}
+            onChange={handleTogglePreventZoom}
+            label={t('settings.accessibility.preventZoom')}
+          />
+        </SettingsItem>
+      </div>
+    </>
   )
 }
 

--- a/web-app/src/features/settings/components/SafeModeSection.tsx
+++ b/web-app/src/features/settings/components/SafeModeSection.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback, lazy, Suspense, memo } from 'react'
 
-import { Card, CardContent, CardHeader } from '@/shared/components/Card'
 import { ToggleSwitch } from '@/shared/components/ToggleSwitch'
 import { useTranslation } from '@/shared/hooks/useTranslation'
+
+import { SettingsItem } from './SettingsItem'
 
 const SafeModeWarningModal = lazy(() =>
   import('@/shared/components/SafeModeWarningModal').then((m) => ({
@@ -37,78 +38,24 @@ function SafeModeSectionComponent({ isSafeModeEnabled, onSetSafeMode }: SafeMode
 
   return (
     <>
-      <Card>
-        <CardHeader>
-          <div className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-text-muted dark:text-text-muted-dark"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-              />
-            </svg>
-            <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
-              {t('settings.safeModeSection.title')}
-            </h2>
-            {!isSafeModeEnabled && (
-              <svg
-                className="w-5 h-5 text-warning-600 dark:text-warning-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                />
-              </svg>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {/* Safe Mode */}
-          <div className="space-y-4">
-            <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-              {t('settings.safeMode')}
-            </div>
-            <p className="text-sm text-text-muted dark:text-text-muted-dark">
-              {t('settings.safeModeDescription')}
-            </p>
+      <div className="space-y-4">
+        <p className="text-sm text-text-muted dark:text-text-muted-dark">
+          {t('settings.safeModeDescription')}
+        </p>
 
-            <div className="flex items-center justify-between py-2">
-              <div className="flex-1">
-                <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                  {isSafeModeEnabled
-                    ? t('settings.safeModeEnabled')
-                    : t('settings.safeModeDisabled')}
-                </div>
-                {!isSafeModeEnabled && (
-                  <div className="text-xs text-warning-600 dark:text-warning-400 mt-1">
-                    {t('settings.safeModeDangerous')}
-                  </div>
-                )}
-              </div>
-
-              <ToggleSwitch
-                checked={isSafeModeEnabled}
-                onChange={handleToggleSafeMode}
-                label={t('settings.safeMode')}
-                variant="success"
-              />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+        <SettingsItem
+          label={isSafeModeEnabled ? t('settings.safeModeEnabled') : t('settings.safeModeDisabled')}
+          status={!isSafeModeEnabled ? t('settings.safeModeDangerous') : undefined}
+          statusVariant="warning"
+        >
+          <ToggleSwitch
+            checked={isSafeModeEnabled}
+            onChange={handleToggleSafeMode}
+            label={t('settings.safeMode')}
+            variant="success"
+          />
+        </SettingsItem>
+      </div>
 
       {/* Safe Mode Warning Modal */}
       {showSafeModeWarning && (

--- a/web-app/src/features/settings/components/SettingsGroup.tsx
+++ b/web-app/src/features/settings/components/SettingsGroup.tsx
@@ -1,0 +1,75 @@
+import { type ReactNode, useCallback, useId } from 'react'
+
+import { useShallow } from 'zustand/react/shallow'
+
+import { Card } from '@/shared/components/Card'
+import { ExpandArrow } from '@/shared/components/ExpandArrow'
+import { useSettingsStore } from '@/shared/stores/settings'
+
+interface SettingsGroupProps {
+  /** Unique key for persisting expansion state */
+  groupKey: string
+  icon?: ReactNode
+  title: string
+  /** Default expansion state when no persisted state exists */
+  defaultExpanded?: boolean
+  children: ReactNode
+  'data-tour'?: string
+  /** Optional badge/icon next to the title (e.g., warning icon) */
+  badge?: ReactNode
+}
+
+export function SettingsGroup({
+  groupKey,
+  icon,
+  title,
+  defaultExpanded = true,
+  children,
+  'data-tour': dataTour,
+  badge,
+}: SettingsGroupProps) {
+  const detailsId = useId()
+
+  const { expandedMap, setExpanded } = useSettingsStore(
+    useShallow((state) => ({
+      expandedMap: state.settingsGroupExpanded,
+      setExpanded: state.setSettingsGroupExpanded,
+    }))
+  )
+
+  const isExpanded = expandedMap?.[groupKey] ?? defaultExpanded
+
+  const handleToggle = useCallback(() => {
+    setExpanded?.(groupKey, !isExpanded)
+  }, [groupKey, isExpanded, setExpanded])
+
+  return (
+    <Card data-tour={dataTour}>
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-expanded={isExpanded}
+        aria-controls={detailsId}
+        className="w-full text-left px-4 py-3 flex items-center gap-2 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-inset rounded-xl"
+      >
+        {icon}
+        <h2 className="font-semibold text-text-primary dark:text-text-primary-dark flex-1">
+          {title}
+        </h2>
+        {badge}
+        <ExpandArrow isExpanded={isExpanded} className="shrink-0" />
+      </button>
+
+      <div
+        id={detailsId}
+        className={`grid transition-[grid-template-rows] duration-200 ease-in-out ${
+          isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="p-4 space-y-6">{children}</div>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/web-app/src/features/settings/components/SettingsGroup.tsx
+++ b/web-app/src/features/settings/components/SettingsGroup.tsx
@@ -62,7 +62,7 @@ export function SettingsGroup({
 
       <div
         id={detailsId}
-        className={`grid transition-[grid-template-rows] duration-200 ease-in-out ${
+        className={`grid motion-safe:transition-[grid-template-rows] motion-safe:duration-200 motion-safe:ease-in-out ${
           isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
         }`}
       >

--- a/web-app/src/features/settings/components/SettingsItem.tsx
+++ b/web-app/src/features/settings/components/SettingsItem.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+
+interface SettingsItemProps {
+  label: string
+  description?: string
+  status?: string
+  statusVariant?: 'default' | 'warning' | 'success'
+  children: ReactNode
+  'data-tour'?: string
+}
+
+const statusColors = {
+  default: 'text-text-muted dark:text-text-muted-dark',
+  warning: 'text-warning-600 dark:text-warning-400',
+  success: 'text-success-600 dark:text-success-400',
+} as const
+
+export function SettingsItem({
+  label,
+  description,
+  status,
+  statusVariant = 'default',
+  children,
+  'data-tour': dataTour,
+}: SettingsItemProps) {
+  return (
+    <div data-tour={dataTour}>
+      <div className="flex items-center justify-between py-2">
+        <div className="flex-1 pr-3">
+          <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+            {label}
+          </div>
+          {description && (
+            <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5">
+              {description}
+            </div>
+          )}
+        </div>
+        {children}
+      </div>
+      {status && <div className={`text-xs mt-1 ${statusColors[statusVariant]}`}>{status}</div>}
+    </div>
+  )
+}

--- a/web-app/src/features/settings/components/TravelSettingsSection.tsx
+++ b/web-app/src/features/settings/components/TravelSettingsSection.tsx
@@ -1,20 +1,11 @@
 import { memo } from 'react'
 
-import { Card, CardContent, CardHeader } from '@/shared/components/Card'
-import { TrainFront, MapPin, Clock, Info, Navigation } from '@/shared/components/icons'
+import { Badge } from '@/shared/components/Badge'
+import { MapPin, Clock, Info, TrainFront, Navigation } from '@/shared/components/icons'
 import { ToggleSwitch } from '@/shared/components/ToggleSwitch'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 
 import { useTransportSettings } from '../hooks/useTransportSettings'
-
-/** Badge showing the current association code */
-function AssociationBadge({ code }: { code: string }) {
-  return (
-    <span className="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300">
-      {code}
-    </span>
-  )
-}
 
 function TravelSettingsSectionComponent() {
   const { t, tInterpolate } = useTranslation()
@@ -26,268 +17,263 @@ function TravelSettingsSectionComponent() {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-2">
-          <TrainFront className="w-5 h-5 text-text-muted dark:text-text-muted-dark" />
-          <h2 className="font-semibold text-text-primary dark:text-text-primary-dark">
-            {t('settings.transport.title')}
-          </h2>
-          <AssociationBadge code={transport.associationCode} />
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <div className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+          {t('settings.transport.title')}
         </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Association context message */}
-        <div className="flex items-start gap-2 p-3 bg-primary-50 dark:bg-primary-900/20 rounded-lg">
-          <Info className="w-4 h-4 flex-shrink-0 mt-0.5 text-primary-600 dark:text-primary-400" />
-          <p className="text-xs text-primary-700 dark:text-primary-300">
-            {t('settings.transport.perAssociationNote')}
-          </p>
-        </div>
-
-        <p className="text-sm text-text-muted dark:text-text-muted-dark">
-          {t('settings.transport.description')}
+        <Badge variant="neutral">{transport.associationCode}</Badge>
+      </div>
+      {/* Association context message */}
+      <div className="flex items-start gap-2 p-3 bg-primary-50 dark:bg-primary-900/20 rounded-lg">
+        <Info className="w-4 h-4 flex-shrink-0 mt-0.5 text-primary-600 dark:text-primary-400" />
+        <p className="text-xs text-primary-700 dark:text-primary-300">
+          {t('settings.transport.perAssociationNote')}
         </p>
+      </div>
 
-        {/* Status messages */}
-        {!transport.hasHomeLocation && (
-          <div className="flex items-center gap-2 p-3 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg">
-            <Info className="w-5 h-5 flex-shrink-0 text-text-muted dark:text-text-muted-dark" />
-            <span className="text-sm text-text-muted dark:text-text-muted-dark">
-              {t('settings.transport.requiresHomeLocation')}
-            </span>
-          </div>
-        )}
+      <p className="text-sm text-text-muted dark:text-text-muted-dark">
+        {t('settings.transport.description')}
+      </p>
 
-        {transport.hasHomeLocation && !transport.isTransportAvailable && (
-          <div className="flex items-center gap-2 p-3 bg-warning-50 dark:bg-warning-900/20 rounded-lg">
-            <Info className="w-5 h-5 flex-shrink-0 text-warning-600 dark:text-warning-400" />
-            <span className="text-sm text-warning-700 dark:text-warning-300">
-              {t('settings.transport.apiNotConfigured')}
-            </span>
-          </div>
-        )}
-
-        {/* Enable transport toggle */}
-        <div className="py-2">
-          <div className="flex items-center justify-between">
-            <div className="flex-1">
-              <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                {t('settings.transport.enableCalculations')}
-              </span>
-            </div>
-            <ToggleSwitch
-              checked={transport.isTransportEnabled}
-              onChange={transport.handleToggleTransport}
-              disabled={!transport.canEnableTransport}
-              label={t('settings.transport.enableCalculations')}
-            />
-          </div>
-          {!transport.canEnableTransport && (
-            <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
-              {!transport.hasHomeLocation
-                ? t('settings.transport.requiresHomeLocation')
-                : !transport.isTransportAvailable
-                  ? t('settings.transport.apiNotConfigured')
-                  : t('settings.transport.disabledHint')}
-            </p>
-          )}
+      {/* Status messages */}
+      {!transport.hasHomeLocation && (
+        <div className="flex items-center gap-2 p-3 bg-surface-subtle dark:bg-surface-subtle-dark rounded-lg">
+          <Info className="w-5 h-5 flex-shrink-0 text-text-muted dark:text-text-muted-dark" />
+          <span className="text-sm text-text-muted dark:text-text-muted-dark">
+            {t('settings.transport.requiresHomeLocation')}
+          </span>
         </div>
+      )}
 
-        {/* Settings that require home location */}
-        {transport.hasHomeLocation && (
-          <>
-            {/* Max Distance setting */}
-            <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
-              <div className="flex items-center justify-between py-2">
-                <div className="flex-1 pr-3">
-                  <div className="flex items-center gap-2">
-                    <MapPin className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
-                    <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                      {t('settings.transport.maxDistance')}
-                    </span>
-                  </div>
-                  <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5 ml-6">
-                    {t('settings.transport.maxDistanceDescription')}
-                  </div>
-                </div>
+      {transport.hasHomeLocation && !transport.isTransportAvailable && (
+        <div className="flex items-center gap-2 p-3 bg-warning-50 dark:bg-warning-900/20 rounded-lg">
+          <Info className="w-5 h-5 flex-shrink-0 text-warning-600 dark:text-warning-400" />
+          <span className="text-sm text-warning-700 dark:text-warning-300">
+            {t('settings.transport.apiNotConfigured')}
+          </span>
+        </div>
+      )}
+
+      {/* Enable transport toggle */}
+      <div className="py-2">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+              {t('settings.transport.enableCalculations')}
+            </span>
+          </div>
+          <ToggleSwitch
+            checked={transport.isTransportEnabled}
+            onChange={transport.handleToggleTransport}
+            disabled={!transport.canEnableTransport}
+            label={t('settings.transport.enableCalculations')}
+          />
+        </div>
+        {!transport.canEnableTransport && (
+          <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+            {!transport.hasHomeLocation
+              ? t('settings.transport.requiresHomeLocation')
+              : !transport.isTransportAvailable
+                ? t('settings.transport.apiNotConfigured')
+                : t('settings.transport.disabledHint')}
+          </p>
+        )}
+      </div>
+
+      {/* Settings that require home location */}
+      {transport.hasHomeLocation && (
+        <>
+          {/* Max Distance setting */}
+          <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+            <div className="flex items-center justify-between py-2">
+              <div className="flex-1 pr-3">
                 <div className="flex items-center gap-2">
-                  <input
-                    type="number"
-                    min={transport.minMaxDistance}
-                    max={transport.maxMaxDistance}
-                    value={transport.localMaxDistance}
-                    onChange={transport.handleMaxDistanceChange}
-                    className="w-16 px-2 py-1 text-sm text-right border border-border-default dark:border-border-default-dark rounded-md bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
-                    aria-label={t('settings.transport.maxDistance')}
-                  />
-                  <span className="text-sm text-text-muted dark:text-text-muted-dark">
-                    {t('common.distanceUnit')}
+                  <MapPin className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                  <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                    {t('settings.transport.maxDistance')}
                   </span>
                 </div>
+                <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5 ml-6">
+                  {t('settings.transport.maxDistanceDescription')}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min={transport.minMaxDistance}
+                  max={transport.maxMaxDistance}
+                  value={transport.localMaxDistance}
+                  onChange={transport.handleMaxDistanceChange}
+                  className="w-16 px-2 py-1 text-sm text-right border border-border-default dark:border-border-default-dark rounded-md bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  aria-label={t('settings.transport.maxDistance')}
+                />
+                <span className="text-sm text-text-muted dark:text-text-muted-dark">
+                  {t('common.distanceUnit')}
+                </span>
               </div>
             </div>
+          </div>
 
-            {/* Settings that require transport enabled */}
-            {transport.isTransportEnabled && (
-              <>
-                {/* Max Travel Time setting */}
-                <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
-                  <div className="flex items-center justify-between py-2">
-                    <div className="flex-1 pr-3">
-                      <div className="flex items-center gap-2">
-                        <TrainFront className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
-                        <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                          {t('settings.transport.maxTravelTime')}
-                        </span>
-                      </div>
-                      <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5 ml-6">
-                        {t('settings.transport.maxTravelTimeDescription')}
-                      </div>
-                    </div>
+          {/* Settings that require transport enabled */}
+          {transport.isTransportEnabled && (
+            <>
+              {/* Max Travel Time setting */}
+              <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+                <div className="flex items-center justify-between py-2">
+                  <div className="flex-1 pr-3">
                     <div className="flex items-center gap-2">
-                      <input
-                        type="number"
-                        min={transport.minMaxTravelTime}
-                        max={transport.maxMaxTravelTime}
-                        step={15}
-                        value={transport.localMaxTravelTime}
-                        onChange={transport.handleMaxTravelTimeChange}
-                        className="w-16 px-2 py-1 text-sm text-right border border-border-default dark:border-border-default-dark rounded-md bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
-                        aria-label={t('settings.transport.maxTravelTime')}
-                      />
-                      <span className="text-sm text-text-muted dark:text-text-muted-dark">
-                        {t('common.minutesUnit')}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Arrival time setting */}
-                <div
-                  className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark"
-                  data-tour="arrival-time"
-                >
-                  <div className="flex items-center justify-between py-2">
-                    <div className="flex-1 pr-3">
-                      <div className="flex items-center gap-2">
-                        <Clock className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
-                        <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                          {t('settings.transport.arrivalTime')}
-                        </span>
-                      </div>
-                      <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5 ml-6">
-                        {t('settings.transport.arrivalTimeDescription')}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="number"
-                        min={transport.minArrivalBuffer}
-                        max={transport.maxArrivalBuffer}
-                        value={transport.localArrivalBuffer}
-                        onChange={transport.handleArrivalBufferChange}
-                        className="w-16 px-2 py-1 text-sm text-right border border-border-default dark:border-border-default-dark rounded-md bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
-                        aria-label={t('settings.transport.arrivalTime')}
-                      />
-                      <span className="text-sm text-text-muted dark:text-text-muted-dark">
-                        {t('common.minutesUnit')}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* SBB destination type setting */}
-                <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
-                  <div className="py-2">
-                    <div className="flex items-center gap-2 mb-2">
-                      <Navigation className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                      <TrainFront className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
                       <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                        {t('settings.transport.sbbDestination')}
+                        {t('settings.transport.maxTravelTime')}
                       </span>
                     </div>
-                    <div className="text-xs text-text-muted dark:text-text-muted-dark mb-3 ml-6">
-                      {t('settings.transport.sbbDestinationDescription')}
-                    </div>
-                    <div className="flex flex-col gap-2 ml-6">
-                      <label className="flex items-center gap-2 cursor-pointer">
-                        <input
-                          type="radio"
-                          name="sbbDestinationType"
-                          value="address"
-                          checked={transport.sbbDestinationType === 'address'}
-                          onChange={() => transport.handleSbbDestinationTypeChange('address')}
-                          className="w-4 h-4 text-primary-600 border-border-default dark:border-border-default-dark focus:ring-primary-500"
-                        />
-                        <span className="text-sm text-text-primary dark:text-text-primary-dark">
-                          {t('settings.transport.sbbDestinationAddress')}
-                        </span>
-                      </label>
-                      <label className="flex items-center gap-2 cursor-pointer">
-                        <input
-                          type="radio"
-                          name="sbbDestinationType"
-                          value="station"
-                          checked={transport.sbbDestinationType === 'station'}
-                          onChange={() => transport.handleSbbDestinationTypeChange('station')}
-                          className="w-4 h-4 text-primary-600 border-border-default dark:border-border-default-dark focus:ring-primary-500"
-                        />
-                        <span className="text-sm text-text-primary dark:text-text-primary-dark">
-                          {t('settings.transport.sbbDestinationStation')}
-                        </span>
-                      </label>
+                    <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5 ml-6">
+                      {t('settings.transport.maxTravelTimeDescription')}
                     </div>
                   </div>
-                </div>
-
-                {/* Cache management */}
-                <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
-                  <p className="text-xs text-text-muted dark:text-text-muted-dark mb-2">
-                    {t('settings.transport.cacheInfo')}
-                  </p>
-
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm text-text-secondary dark:text-text-secondary-dark">
-                      {tInterpolate('settings.transport.cacheEntries', {
-                        count: transport.cacheEntryCount,
-                      })}
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={transport.minMaxTravelTime}
+                      max={transport.maxMaxTravelTime}
+                      step={15}
+                      value={transport.localMaxTravelTime}
+                      onChange={transport.handleMaxTravelTimeChange}
+                      className="w-16 px-2 py-1 text-sm text-right border border-border-default dark:border-border-default-dark rounded-md bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
+                      aria-label={t('settings.transport.maxTravelTime')}
+                    />
+                    <span className="text-sm text-text-muted dark:text-text-muted-dark">
+                      {t('common.minutesUnit')}
                     </span>
+                  </div>
+                </div>
+              </div>
 
-                    {!transport.showClearConfirm ? (
+              {/* Arrival time setting */}
+              <div
+                className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark"
+                data-tour="arrival-time"
+              >
+                <div className="flex items-center justify-between py-2">
+                  <div className="flex-1 pr-3">
+                    <div className="flex items-center gap-2">
+                      <Clock className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                      <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                        {t('settings.transport.arrivalTime')}
+                      </span>
+                    </div>
+                    <div className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5 ml-6">
+                      {t('settings.transport.arrivalTimeDescription')}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={transport.minArrivalBuffer}
+                      max={transport.maxArrivalBuffer}
+                      value={transport.localArrivalBuffer}
+                      onChange={transport.handleArrivalBufferChange}
+                      className="w-16 px-2 py-1 text-sm text-right border border-border-default dark:border-border-default-dark rounded-md bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-500"
+                      aria-label={t('settings.transport.arrivalTime')}
+                    />
+                    <span className="text-sm text-text-muted dark:text-text-muted-dark">
+                      {t('common.minutesUnit')}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* SBB destination type setting */}
+              <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+                <div className="py-2">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Navigation className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                    <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                      {t('settings.transport.sbbDestination')}
+                    </span>
+                  </div>
+                  <div className="text-xs text-text-muted dark:text-text-muted-dark mb-3 ml-6">
+                    {t('settings.transport.sbbDestinationDescription')}
+                  </div>
+                  <div className="flex flex-col gap-2 ml-6">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="sbbDestinationType"
+                        value="address"
+                        checked={transport.sbbDestinationType === 'address'}
+                        onChange={() => transport.handleSbbDestinationTypeChange('address')}
+                        className="w-4 h-4 text-primary-600 border-border-default dark:border-border-default-dark focus:ring-primary-500"
+                      />
+                      <span className="text-sm text-text-primary dark:text-text-primary-dark">
+                        {t('settings.transport.sbbDestinationAddress')}
+                      </span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="radio"
+                        name="sbbDestinationType"
+                        value="station"
+                        checked={transport.sbbDestinationType === 'station'}
+                        onChange={() => transport.handleSbbDestinationTypeChange('station')}
+                        className="w-4 h-4 text-primary-600 border-border-default dark:border-border-default-dark focus:ring-primary-500"
+                      />
+                      <span className="text-sm text-text-primary dark:text-text-primary-dark">
+                        {t('settings.transport.sbbDestinationStation')}
+                      </span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              {/* Cache management */}
+              <div className="pt-2 border-t border-border-subtle dark:border-border-subtle-dark">
+                <p className="text-xs text-text-muted dark:text-text-muted-dark mb-2">
+                  {t('settings.transport.cacheInfo')}
+                </p>
+
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                    {tInterpolate('settings.transport.cacheEntries', {
+                      count: transport.cacheEntryCount,
+                    })}
+                  </span>
+
+                  {!transport.showClearConfirm ? (
+                    <button
+                      type="button"
+                      onClick={() => transport.setShowClearConfirm(true)}
+                      disabled={transport.cacheEntryCount === 0}
+                      className="text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {t('settings.transport.refreshCache')}
+                    </button>
+                  ) : (
+                    <div className="flex items-center gap-2">
                       <button
                         type="button"
-                        onClick={() => transport.setShowClearConfirm(true)}
-                        disabled={transport.cacheEntryCount === 0}
-                        className="text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                        onClick={() => transport.setShowClearConfirm(false)}
+                        className="text-sm text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
                       >
-                        {t('settings.transport.refreshCache')}
+                        {t('common.cancel')}
                       </button>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <button
-                          type="button"
-                          onClick={() => transport.setShowClearConfirm(false)}
-                          className="text-sm text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark"
-                        >
-                          {t('common.cancel')}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={transport.handleClearCache}
-                          className="text-sm text-error-600 dark:text-error-400 hover:text-error-700 dark:hover:text-error-300"
-                        >
-                          {t('common.confirm')}
-                        </button>
-                      </div>
-                    )}
-                  </div>
+                      <button
+                        type="button"
+                        onClick={transport.handleClearCache}
+                        className="text-sm text-error-600 dark:text-error-400 hover:text-error-700 dark:hover:text-error-300"
+                      >
+                        {t('common.confirm')}
+                      </button>
+                    </div>
+                  )}
                 </div>
-              </>
-            )}
-          </>
-        )}
-      </CardContent>
-    </Card>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
   )
 }
 

--- a/web-app/src/i18n/locales/de.ts
+++ b/web-app/src/i18n/locales/de.ts
@@ -533,6 +533,7 @@ const de: Translations = {
       'Der Sicherheitsmodus beschränkt gefährliche Operationen wie das Hinzufügen/Übernehmen von Spielen zur/von Tauschbörse. Die Validierung speichert Ihre Änderungen, schliesst das Spiel aber nicht ab — Sie schliessen die Validierung im VolleyManager ab.',
     safeModeEnabled: 'Sicherheitsmodus ist aktiviert',
     safeModeDisabled: 'Sicherheitsmodus ist deaktiviert',
+    safeModeWarning: 'Sicherheitsmodus ist deaktiviert — Aktion erforderlich',
     safeModeWarningTitle: 'Sicherheitsmodus deaktivieren?',
     safeModeWarningMessage:
       'Das Deaktivieren des Sicherheitsmodus ermöglicht Operationen, die Ihre Einsätze und Spiele ändern können.',

--- a/web-app/src/i18n/locales/en.ts
+++ b/web-app/src/i18n/locales/en.ts
@@ -515,6 +515,7 @@ const en: Translations = {
       'Safe mode restricts dangerous operations like adding/taking games from exchange. Validation saves your changes but does not finalize the game — you complete the validation on VolleyManager.',
     safeModeEnabled: 'Safe mode is enabled',
     safeModeDisabled: 'Safe mode is disabled',
+    safeModeWarning: 'Safe mode is disabled — action required',
     safeModeWarningTitle: 'Disable Safe Mode?',
     safeModeWarningMessage:
       'Disabling safe mode will enable operations that may modify your assignments and games.',

--- a/web-app/src/i18n/locales/fr.ts
+++ b/web-app/src/i18n/locales/fr.ts
@@ -530,6 +530,7 @@ const fr: Translations = {
       "Le mode sécurisé restreint les opérations dangereuses comme l'ajout/la prise de matchs depuis la bourse aux échanges. La validation enregistre vos modifications mais ne finalise pas le match — vous complétez la validation sur VolleyManager.",
     safeModeEnabled: 'Le mode sécurisé est activé',
     safeModeDisabled: 'Le mode sécurisé est désactivé',
+    safeModeWarning: 'Mode sécurisé désactivé — action requise',
     safeModeWarningTitle: 'Désactiver le mode sécurisé?',
     safeModeWarningMessage:
       'La désactivation du mode sécurisé activera des opérations pouvant modifier vos désignations et matchs.',

--- a/web-app/src/i18n/locales/it.ts
+++ b/web-app/src/i18n/locales/it.ts
@@ -526,6 +526,7 @@ const it: Translations = {
       "La modalità sicura limita operazioni pericolose come l'aggiunta/assunzione di partite dalla borsa scambi. La convalida salva le modifiche ma non finalizza la partita — completi la convalida su VolleyManager.",
     safeModeEnabled: 'La modalità sicura è attivata',
     safeModeDisabled: 'La modalità sicura è disattivata',
+    safeModeWarning: 'Modalità sicura disattivata — azione richiesta',
     safeModeWarningTitle: 'Disattivare la modalità sicura?',
     safeModeWarningMessage:
       'La disattivazione della modalità sicura abiliterà operazioni che potrebbero modificare le tue designazioni e partite.',

--- a/web-app/src/i18n/types.ts
+++ b/web-app/src/i18n/types.ts
@@ -393,6 +393,7 @@ export interface Translations {
     safeModeDescription: string
     safeModeEnabled: string
     safeModeDisabled: string
+    safeModeWarning: string
     safeModeWarningTitle: string
     safeModeWarningMessage: string
     safeModeWarningPoint1: string

--- a/web-app/src/shared/stores/settings.ts
+++ b/web-app/src/shared/stores/settings.ts
@@ -205,6 +205,10 @@ interface SettingsState {
   preventZoom: boolean
   setPreventZoom: (enabled: boolean) => void
 
+  // Settings page group expansion state
+  settingsGroupExpanded: Record<string, boolean>
+  setSettingsGroupExpanded: (key: string, expanded: boolean) => void
+
   // === Mode-specific settings ===
 
   /** Current data source mode - synced from auth store */
@@ -483,6 +487,7 @@ export const useSettingsStore = create<SettingsState>()(
         isOCREnabled: false,
         validationReferenceMode: 'quick-compare' as ValidationReferenceMode,
         preventZoom: false,
+        settingsGroupExpanded: {},
 
         // Mode tracking
         currentMode: 'api' as DataSource,
@@ -527,6 +532,15 @@ export const useSettingsStore = create<SettingsState>()(
 
         setPreventZoom: (enabled: boolean) => {
           set({ preventZoom: enabled })
+        },
+
+        setSettingsGroupExpanded: (key: string, expanded: boolean) => {
+          set((state) => ({
+            settingsGroupExpanded: {
+              ...state.settingsGroupExpanded,
+              [key]: expanded,
+            },
+          }))
         },
 
         setHomeLocation: (location: UserLocation | null) => {
@@ -788,6 +802,7 @@ export const useSettingsStore = create<SettingsState>()(
           isOCREnabled: state.isOCREnabled,
           validationReferenceMode: state.validationReferenceMode,
           preventZoom: state.preventZoom,
+          settingsGroupExpanded: state.settingsGroupExpanded,
           // Mode-specific settings stored per mode
           settingsByMode: state.settingsByMode,
           // Don't persist currentMode - it's synced from auth store on load
@@ -844,6 +859,7 @@ export const useSettingsStore = create<SettingsState>()(
                 isOCREnabled?: boolean
                 validationReferenceMode?: ValidationReferenceMode
                 preventZoom?: boolean
+                settingsGroupExpanded?: Record<string, boolean>
                 settingsByMode?: Record<DataSource, Partial<ModeSettings>>
               }
             | undefined
@@ -913,6 +929,8 @@ export const useSettingsStore = create<SettingsState>()(
             validationReferenceMode:
               persistedState?.validationReferenceMode ?? current.validationReferenceMode,
             preventZoom: persistedState?.preventZoom ?? current.preventZoom,
+            settingsGroupExpanded:
+              persistedState?.settingsGroupExpanded ?? current.settingsGroupExpanded,
             // Preserve mode-specific settings
             settingsByMode: mergedSettingsByMode,
           }

--- a/web-app/src/shared/stores/settings.ts
+++ b/web-app/src/shared/stores/settings.ts
@@ -349,6 +349,9 @@ const HIDE_OWN_EXCHANGES_VERSION = 8
 /** Version that added validation reference mode */
 const VALIDATION_REFERENCE_MODE_VERSION = 9
 
+/** Version that added settings group expansion state */
+const SETTINGS_GROUP_EXPANDED_VERSION = 10
+
 /** V1 state shape (flat settings) */
 interface V1State {
   isSafeModeEnabled?: boolean
@@ -795,7 +798,7 @@ export const useSettingsStore = create<SettingsState>()(
       }),
       {
         name: 'volleykit-settings',
-        version: 9,
+        version: 10,
         partialize: (state) => ({
           // Global settings
           isSafeModeEnabled: state.isSafeModeEnabled,
@@ -845,6 +848,13 @@ export const useSettingsStore = create<SettingsState>()(
           if (version < VALIDATION_REFERENCE_MODE_VERSION) {
             if (!(state as Record<string, unknown>).validationReferenceMode) {
               ;(state as Record<string, unknown>).validationReferenceMode = 'quick-compare'
+            }
+          }
+
+          // v9 → v10: Add settings group expansion state
+          if (version < SETTINGS_GROUP_EXPANDED_VERSION) {
+            if (!(state as Record<string, unknown>).settingsGroupExpanded) {
+              ;(state as Record<string, unknown>).settingsGroupExpanded = {}
             }
           }
 


### PR DESCRIPTION
## Summary

- Reorganize settings page section order, moving less-used sections (Help & Tours, Data & Privacy) to the bottom
- Add new `SettingsGroup` collapsible container component with smooth CSS Grid animation and persisted expansion state
- Add new `SettingsItem` standardized row component for consistent settings layout
- Group related settings into 5 logical collapsible sections: Preferences (with Safe Mode), Location & Travel, App & Updates, Help & Tours, Data & Privacy
- Persist group expansion state to localStorage via Zustand settings store
- Remove individual Card wrappers from section components (now wrapped by SettingsGroup)
- Safe Mode keeps prominent display with warning badge in Preferences group header when disabled

## Test plan

- [x] All 3869 unit/integration tests pass
- [x] Build succeeds
- [x] Lint passes with 0 warnings
- [x] Knip (dead code detection) passes
- [ ] Settings groups collapse/expand smoothly with CSS Grid animation
- [ ] Expansion state persists across page reloads
- [ ] Safe mode warning badge appears in Preferences header when disabled
- [ ] Feature-gated sections (Home Location, Travel, Help Tours) render correctly
- [ ] Demo mode and calendar mode conditional sections work as expected
- [ ] Tour data attributes preserved for guided tours

https://claude.ai/code/session_01MfEF28ZCoZvnDNDvkRqa8c