### PR TITLE
refactor(web): adopt React 19 useActionState in ExchangeConfirmationModal

### DIFF
--- a/.changeset/adopt-useactionstate.md
+++ b/.changeset/adopt-useactionstate.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Adopt React 19 useActionState in ExchangeConfirmationModal

--- a/web-app/src/features/exchanges/components/ExchangeConfirmationModal.tsx
+++ b/web-app/src/features/exchanges/components/ExchangeConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, memo } from 'react'
+import { memo, useActionState } from 'react'
 
 import type { GameExchange } from '@/api/client'
 import { Button } from '@/shared/components/Button'
@@ -27,39 +27,19 @@ function ExchangeConfirmationModalComponent({
 }: ExchangeConfirmationModalProps) {
   const { t } = useTranslation()
 
-  const isSubmittingRef = useRef(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const ignoreRef = useRef(false)
-
-  useEffect(() => {
-    ignoreRef.current = false
-    return () => {
-      ignoreRef.current = true
-    }
-  }, [])
-
-  const handleConfirm = useCallback(async () => {
-    if (isSubmittingRef.current) return
-    isSubmittingRef.current = true
-    setIsSubmitting(true)
-
-    try {
-      await onConfirm()
-    } catch (error) {
-      logger.error('[ExchangeConfirmationModal] Failed to confirm action:', error)
-      if (!ignoreRef.current) {
-        isSubmittingRef.current = false
-        setIsSubmitting(false)
+  const [, submitAction, isPending] = useActionState(
+    async (_previousState: string | null) => {
+      try {
+        await onConfirm()
+        onClose()
+        return null
+      } catch (err) {
+        logger.error('[ExchangeConfirmationModal] Failed to confirm action:', err)
+        return 'error'
       }
-      return
-    }
-
-    if (!ignoreRef.current) {
-      isSubmittingRef.current = false
-      setIsSubmitting(false)
-      onClose()
-    }
-  }, [onConfirm, onClose])
+    },
+    null
+  )
 
   const game = exchange.refereeGame?.game
   const homeTeam = game?.encounter?.teamHome?.name || t('common.tbd')
@@ -136,25 +116,28 @@ function ExchangeConfirmationModalComponent({
         <div className="border-t border-border-default dark:border-border-default-dark pt-4">
           <p className="text-sm text-text-muted dark:text-text-muted-dark mb-4">{t(confirmKey)}</p>
 
-          <ModalFooter>
-            <Button
-              variant="secondary"
-              className="flex-1"
-              onClick={onClose}
-              disabled={isSubmitting}
-            >
-              {t('common.cancel')}
-            </Button>
-            <Button
-              variant={confirmVariant}
-              className="flex-1"
-              onClick={handleConfirm}
-              disabled={isSubmitting}
-              aria-busy={isSubmitting}
-            >
-              {isSubmitting ? t('common.loading') : t(buttonKey)}
-            </Button>
-          </ModalFooter>
+          <form action={submitAction}>
+            <ModalFooter>
+              <Button
+                variant="secondary"
+                className="flex-1"
+                type="button"
+                onClick={onClose}
+                disabled={isPending}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                variant={confirmVariant}
+                className="flex-1"
+                type="submit"
+                disabled={isPending}
+                aria-busy={isPending}
+              >
+                {isPending ? t('common.loading') : t(buttonKey)}
+              </Button>
+            </ModalFooter>
+          </form>
         </div>
       </ModalErrorBoundary>
     </Modal>


### PR DESCRIPTION
## Summary

- Adopt React 19 `useActionState` in `ExchangeConfirmationModal` as the first usage of this pattern in the codebase
- Replace manual `isSubmittingRef`, `isSubmitting` state, and `ignoreRef` + cleanup effect with a single `useActionState` call
- Convert confirm button from `onClick` handler to `<form action={submitAction}>` with `type="submit"`
- Net reduction of 12 lines while preserving identical behavior (loading state, double-submit prevention, error keeps modal open)

## Test plan

- [ ] Open exchange confirmation modal, click confirm → loading state shown, action completes, modal closes
- [ ] Double-click confirm → only one submission occurs
- [ ] If action fails → modal stays open, can retry
- [ ] Click cancel during idle → modal closes
- [ ] Cancel button disabled during pending state

https://claude.ai/code/session_01W4euEF8iZreqXFWYfzWHqJ