### PR TITLE
fix(ci): make pre-commit validation package-aware and subfolder-safe

### DIFF
--- a/.claude/hooks/pre-git-commit.sh
+++ b/.claude/hooks/pre-git-commit.sh
@@ -243,9 +243,12 @@ mkdir -p "$VALIDATION_STEPS_DIR"
 echo "$(date +%s)" >"$VALIDATION_START_FILE"
 
 # Start validation in background
+# cd to project root first to ensure git/pnpm commands resolve correctly
+# even when Claude is cd'ed into a subfolder
 (
   # Disable errexit inside subshell to ensure exit code is captured even on failure
   set +e
+  cd "$PROJECT_DIR" || exit 1
   CLAUDE_CODE_REMOTE=true VALIDATION_STEPS_DIR="$VALIDATION_STEPS_DIR" \
     "$VALIDATION_SCRIPT" >"$VALIDATION_OUTPUT_FILE" 2>&1
   echo "$?" >"$VALIDATION_RESULT_FILE"

--- a/.claude/hooks/pre-git-commit.sh
+++ b/.claude/hooks/pre-git-commit.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 # =============================================================================
 
 # File patterns that require validation (regex for grep -E)
-SOURCE_PATTERNS='\.(ts|tsx|js|jsx)$'
+SOURCE_PATTERNS='\.(ts|tsx|js|jsx|astro)$'
 
 # File patterns that can be skipped (validation not needed)
 SKIP_PATTERNS='\.(md|txt|json|yaml|yml|sh|css|svg|png|jpg|jpeg|gif|ico)$'

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -9,12 +9,24 @@ The pre-commit hook (`scripts/pre-commit-validate.sh`) runs automatically in Cla
 ### What the Hook Does
 
 1. **Detect staged changes** - Skip validation for docs-only changes (`.md` files only)
-2. **Generate API types** - If `volleymanager-openapi.yaml` is staged
-3. **Format (auto-fix)** - Run `pnpm run format` to auto-fix formatting issues
-4. **Run in PARALLEL**: lint, knip, test
-5. **Run build** - Production build (only if parallel steps pass)
+2. **Detect affected packages** - Determines which packages have changes (web-app, shared, mobile, worker, help-site)
+3. **Generate API types** - If `volleymanager-openapi.yaml` is staged
+4. **Run checks in PARALLEL** - Per-package validation (format, lint, knip, typecheck, test)
+5. **Run build sequentially** - Build affected packages (shared → web-app → help-site)
+
+Shared package changes also trigger web-app and mobile validation (downstream consumers).
 
 The commit is **blocked** if any step fails. Fix issues and commit again.
+
+### Checks Per Package
+
+| Package   | format | lint | knip | typecheck | test | build |
+| --------- | ------ | ---- | ---- | --------- | ---- | ----- |
+| web-app   | ✓      | ✓    | ✓    | (in build)| ✓    | ✓     |
+| shared    | ✓      | ✓    | –    | ✓         | ✓    | ✓     |
+| mobile    | ✓      | ✓    | –    | ✓         | ✓    | –     |
+| worker    | ✓      | ✓    | –    | –         | ✓    | –     |
+| help-site | ✓      | –    | –    | –         | –    | ✓     |
 
 ### Manual Validation Commands
 

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -106,9 +106,12 @@ if [ "$HAS_SHARED" = true ]; then
   HAS_MOBILE=true
 fi
 
-# Root config changes affect everything
+# Root config changes affect all packages
 if echo "$STAGED_FILES" | grep -qE '^(package\.json|tsconfig\.json|eslint\.config)'; then
   HAS_WEB_APP=true
+  HAS_SHARED=true
+  HAS_MOBILE=true
+  HAS_WORKER=true
 fi
 
 # Log affected packages
@@ -145,15 +148,14 @@ run_validation() {
   local name=$1
   local dir=$2
   shift 2
-  local cmd="$*"
   local output_file="$TEMP_DIR/${name}.out"
   local result_file="$TEMP_DIR/${name}.result"
 
   # Ensure each background job runs from the correct directory
   cd "$dir"
 
-  # Default to failure, only set success if command passes
-  if eval "$cmd" >"$output_file" 2>&1; then
+  # Execute command directly via "$@" (avoids eval and command injection risks)
+  if "$@" >"$output_file" 2>&1; then
     echo "0" >"$result_file"
   else
     echo "1" >"$result_file"
@@ -213,42 +215,42 @@ launch_job() {
 # --- Web App checks ---
 if [ "$HAS_WEB_APP" = true ]; then
   WEB_DIR="$ROOT_DIR/web-app"
-  launch_job "web:format"  "$WEB_DIR" "pnpm run format:check"
-  launch_job "web:lint"    "$WEB_DIR" "pnpm run lint"
-  launch_job "web:knip"    "$WEB_DIR" "pnpm run knip"
-  launch_job "web:test"    "$WEB_DIR" "pnpm test"
+  launch_job "web:format"  "$WEB_DIR" pnpm run format:check
+  launch_job "web:lint"    "$WEB_DIR" pnpm run lint
+  launch_job "web:knip"    "$WEB_DIR" pnpm run knip
+  launch_job "web:test"    "$WEB_DIR" pnpm test
 fi
 
 # --- Shared package checks ---
 if [ "$HAS_SHARED" = true ]; then
   SHARED_DIR="$ROOT_DIR/packages/shared"
-  launch_job "shared:format"    "$SHARED_DIR" "pnpm run format:check"
-  launch_job "shared:lint"      "$SHARED_DIR" "pnpm run lint"
-  launch_job "shared:typecheck" "$SHARED_DIR" "pnpm run typecheck"
-  launch_job "shared:test"      "$SHARED_DIR" "pnpm test"
+  launch_job "shared:format"    "$SHARED_DIR" pnpm run format:check
+  launch_job "shared:lint"      "$SHARED_DIR" pnpm run lint
+  launch_job "shared:typecheck" "$SHARED_DIR" pnpm run typecheck
+  launch_job "shared:test"      "$SHARED_DIR" pnpm test
 fi
 
 # --- Mobile package checks ---
 if [ "$HAS_MOBILE" = true ]; then
   MOBILE_DIR="$ROOT_DIR/packages/mobile"
-  launch_job "mobile:format"    "$MOBILE_DIR" "pnpm run format:check"
-  launch_job "mobile:lint"      "$MOBILE_DIR" "pnpm run lint"
-  launch_job "mobile:typecheck" "$MOBILE_DIR" "pnpm run typecheck"
-  launch_job "mobile:test"      "$MOBILE_DIR" "pnpm test"
+  launch_job "mobile:format"    "$MOBILE_DIR" pnpm run format:check
+  launch_job "mobile:lint"      "$MOBILE_DIR" pnpm run lint
+  launch_job "mobile:typecheck" "$MOBILE_DIR" pnpm run typecheck
+  launch_job "mobile:test"      "$MOBILE_DIR" pnpm test
 fi
 
 # --- Worker checks ---
 if [ "$HAS_WORKER" = true ]; then
   WORKER_DIR="$ROOT_DIR/worker"
-  launch_job "worker:format" "$WORKER_DIR" "pnpm run format:check"
-  launch_job "worker:lint"   "$WORKER_DIR" "pnpm run lint"
-  launch_job "worker:test"   "$WORKER_DIR" "pnpm test"
+  launch_job "worker:format" "$WORKER_DIR" pnpm run format:check
+  launch_job "worker:lint"   "$WORKER_DIR" pnpm run lint
+  launch_job "worker:test"   "$WORKER_DIR" pnpm test
 fi
 
 # --- Help site checks ---
 if [ "$HAS_HELP_SITE" = true ]; then
   HELP_DIR="$ROOT_DIR/help-site"
-  launch_job "help:format" "$HELP_DIR" "pnpm run format:check"
+  launch_job "help:format" "$HELP_DIR" pnpm run format:check
 fi
 
 NUM_JOBS=${#JOB_NAMES[@]}

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Pre-commit validation hook for VolleyKit
-# Runs format, lint, knip, and test in PARALLEL, then build sequentially
+# Detects which packages have staged changes and runs their validation
+# checks in PARALLEL, then build sequentially.
 #
 # IMPORTANT: This hook only runs in Claude Code web environment
 # to avoid slowing down human developers. Human devs rely on CI.
@@ -27,17 +28,8 @@ if [ -z "$ROOT_DIR" ]; then
   exit 1
 fi
 
-WEB_APP_DIR="$ROOT_DIR/web-app"
-
-# Verify web-app directory exists
-if [ ! -d "$WEB_APP_DIR" ]; then
-  echo -e "${RED}Error: web-app directory not found at $WEB_APP_DIR${NC}"
-  exit 1
-fi
-
 echo "Pre-commit validation starting..."
 echo "  Root: $ROOT_DIR"
-echo "  Web App: $WEB_APP_DIR"
 
 # Get list of staged files (for pre-commit hook)
 STAGED_FILES=$(git diff --name-only --cached 2>/dev/null || echo "")
@@ -55,11 +47,30 @@ else
   HAS_NON_MD=false
 fi
 
-# Check if source files are staged
-if echo "$STAGED_FILES" | grep -qE '\.(ts|tsx|js|jsx)$'; then
+# Skip validation for docs-only changes
+if [ "$HAS_NON_MD" = false ]; then
+  echo -e "${GREEN}Only documentation changes detected, skipping validation${NC}"
+  exit 0
+fi
+
+# Check if source files are staged (any package)
+if echo "$STAGED_FILES" | grep -qE '\.(ts|tsx|js|jsx|astro)$'; then
   HAS_SOURCE=true
 else
   HAS_SOURCE=false
+fi
+
+# Check for config files that always trigger validation
+if echo "$STAGED_FILES" | grep -qE '(package\.json|tsconfig\.json|vite\.config|eslint\.config)'; then
+  HAS_CONFIG=true
+else
+  HAS_CONFIG=false
+fi
+
+# Skip validation if no source or config files changed
+if [ "$HAS_SOURCE" = false ] && [ "$HAS_CONFIG" = false ]; then
+  echo -e "${YELLOW}No source or config files changed, skipping validation${NC}"
+  exit 0
 fi
 
 # Check if OpenAPI spec is staged
@@ -69,24 +80,50 @@ else
   HAS_OPENAPI=false
 fi
 
-# Skip validation for docs-only changes
-if [ "$HAS_NON_MD" = false ]; then
-  echo -e "${GREEN}Only documentation changes detected, skipping validation${NC}"
-  exit 0
+# =============================================================================
+# DETECT AFFECTED PACKAGES
+# =============================================================================
+
+has_changes_in() {
+  echo "$STAGED_FILES" | grep -q "^$1"
+}
+
+HAS_WEB_APP=false
+HAS_SHARED=false
+HAS_MOBILE=false
+HAS_WORKER=false
+HAS_HELP_SITE=false
+
+has_changes_in "web-app/" && HAS_WEB_APP=true
+has_changes_in "packages/shared/" && HAS_SHARED=true
+has_changes_in "packages/mobile/" && HAS_MOBILE=true
+has_changes_in "worker/" && HAS_WORKER=true
+has_changes_in "help-site/" && HAS_HELP_SITE=true
+
+# Shared changes also affect web-app and mobile (downstream consumers)
+if [ "$HAS_SHARED" = true ]; then
+  HAS_WEB_APP=true
+  HAS_MOBILE=true
 fi
 
-# Skip validation if no source files changed (but warn)
-if [ "$HAS_SOURCE" = false ]; then
-  echo -e "${YELLOW}No source files changed, skipping validation${NC}"
-  exit 0
+# Root config changes affect everything
+if echo "$STAGED_FILES" | grep -qE '^(package\.json|tsconfig\.json|eslint\.config)'; then
+  HAS_WEB_APP=true
 fi
 
-# Change to web-app directory using absolute path
-cd "$WEB_APP_DIR"
+# Log affected packages
+AFFECTED=""
+[ "$HAS_WEB_APP" = true ] && AFFECTED="$AFFECTED web-app"
+[ "$HAS_SHARED" = true ] && AFFECTED="$AFFECTED shared"
+[ "$HAS_MOBILE" = true ] && AFFECTED="$AFFECTED mobile"
+[ "$HAS_WORKER" = true ] && AFFECTED="$AFFECTED worker"
+[ "$HAS_HELP_SITE" = true ] && AFFECTED="$AFFECTED help-site"
+echo "  Affected packages:$AFFECTED"
 
-# Generate API types if OpenAPI spec changed
+# Generate API types if OpenAPI spec changed (run from root)
 if [ "$HAS_OPENAPI" = true ]; then
   echo "OpenAPI spec changed, generating types..."
+  cd "$ROOT_DIR"
   pnpm run generate:api
 fi
 
@@ -98,26 +135,32 @@ trap "rm -rf \"$TEMP_DIR\"" EXIT
 # Set VALIDATION_STEPS_DIR to save per-step outputs (format.log, lint.log, etc.)
 STEPS_DIR="${VALIDATION_STEPS_DIR:-}"
 
-# Function to run a validation step and capture result
+# =============================================================================
+# VALIDATION FUNCTIONS
+# =============================================================================
+
+# Run a validation step in a specific directory and capture result
+# Args: name, directory, command...
 run_validation() {
   local name=$1
-  local cmd=$2
+  local dir=$2
+  shift 2
+  local cmd="$*"
   local output_file="$TEMP_DIR/${name}.out"
   local result_file="$TEMP_DIR/${name}.result"
 
-  # Ensure each background job runs from web-app directory
-  # (prevents failures when parent shell cwd changes or is a subfolder)
-  cd "$WEB_APP_DIR"
+  # Ensure each background job runs from the correct directory
+  cd "$dir"
 
   # Default to failure, only set success if command passes
-  if $cmd >"$output_file" 2>&1; then
+  if eval "$cmd" >"$output_file" 2>&1; then
     echo "0" >"$result_file"
   else
     echo "1" >"$result_file"
   fi
 }
 
-# Function to print result immediately when a job completes
+# Print result immediately when a job completes
 print_result_immediate() {
   local name=$1
   local result=$2
@@ -128,104 +171,10 @@ print_result_immediate() {
   else
     echo -e "${RED}✗ ${name} failed${NC}"
     echo ""
-    # Show output for failed checks immediately
     cat "$output_file"
     echo ""
   fi
 }
-
-echo ""
-echo -e "${BLUE}Running format, lint, knip, and test in parallel...${NC}"
-echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-
-# Run format, lint, knip, and test in parallel
-run_validation "format" "pnpm run format:check" &
-FORMAT_PID=$!
-
-run_validation "lint" "pnpm run lint" &
-LINT_PID=$!
-
-run_validation "knip" "pnpm run knip" &
-KNIP_PID=$!
-
-run_validation "test" "pnpm test" &
-TEST_PID=$!
-
-# Track job completion
-FORMAT_DONE=0
-LINT_DONE=0
-KNIP_DONE=0
-TEST_DONE=0
-FORMAT_RESULT=""
-LINT_RESULT=""
-KNIP_RESULT=""
-TEST_RESULT=""
-
-echo "  Running: Format, Lint, Knip, Test"
-echo ""
-
-# Monitor jobs and print results immediately as they complete
-while [ $FORMAT_DONE -eq 0 ] || [ $LINT_DONE -eq 0 ] || [ $KNIP_DONE -eq 0 ] || [ $TEST_DONE -eq 0 ]; do
-  # Check format
-  if [ $FORMAT_DONE -eq 0 ] && ! kill -0 $FORMAT_PID 2>/dev/null; then
-    wait $FORMAT_PID 2>/dev/null || true
-    FORMAT_DONE=1
-    FORMAT_RESULT=$(cat "$TEMP_DIR/format.result" 2>/dev/null || echo "1")
-    print_result_immediate "Format" "$FORMAT_RESULT"
-  fi
-
-  # Check lint
-  if [ $LINT_DONE -eq 0 ] && ! kill -0 $LINT_PID 2>/dev/null; then
-    wait $LINT_PID 2>/dev/null || true
-    LINT_DONE=1
-    LINT_RESULT=$(cat "$TEMP_DIR/lint.result" 2>/dev/null || echo "1")
-    print_result_immediate "Lint" "$LINT_RESULT"
-  fi
-
-  # Check knip
-  if [ $KNIP_DONE -eq 0 ] && ! kill -0 $KNIP_PID 2>/dev/null; then
-    wait $KNIP_PID 2>/dev/null || true
-    KNIP_DONE=1
-    KNIP_RESULT=$(cat "$TEMP_DIR/knip.result" 2>/dev/null || echo "1")
-    print_result_immediate "Knip" "$KNIP_RESULT"
-  fi
-
-  # Check test
-  if [ $TEST_DONE -eq 0 ] && ! kill -0 $TEST_PID 2>/dev/null; then
-    wait $TEST_PID 2>/dev/null || true
-    TEST_DONE=1
-    TEST_RESULT=$(cat "$TEMP_DIR/test.result" 2>/dev/null || echo "1")
-    print_result_immediate "Test" "$TEST_RESULT"
-  fi
-
-  # Small delay to avoid busy loop (only if jobs still running)
-  if [ $FORMAT_DONE -eq 0 ] || [ $LINT_DONE -eq 0 ] || [ $KNIP_DONE -eq 0 ] || [ $TEST_DONE -eq 0 ]; then
-    sleep 0.2
-  fi
-done
-
-# Run build (only if previous steps passed)
-BUILD_RESULT=0
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-if [ "$FORMAT_RESULT" -eq 0 ] && [ "$LINT_RESULT" -eq 0 ] && [ "$KNIP_RESULT" -eq 0 ] && [ "$TEST_RESULT" -eq 0 ]; then
-  echo "Running build..."
-  if pnpm run build; then
-    echo -e "${GREEN}Build passed${NC}"
-  else
-    echo -e "${RED}Build failed${NC}"
-    BUILD_RESULT=1
-  fi
-else
-  echo -e "${YELLOW}Build skipped (previous checks failed)${NC}"
-  BUILD_RESULT=2
-fi
-
-# Summary
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Validation Summary"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 print_status() {
   local name=$1
@@ -239,22 +188,182 @@ print_status() {
   fi
 }
 
-print_status "Format" "$FORMAT_RESULT"
-print_status "Lint" "$LINT_RESULT"
-print_status "Knip" "$KNIP_RESULT"
-print_status "Test" "$TEST_RESULT"
+# =============================================================================
+# LAUNCH PARALLEL VALIDATION JOBS
+# =============================================================================
+
+echo ""
+echo -e "${BLUE}Running validation checks in parallel...${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+# Arrays to track jobs
+declare -a JOB_NAMES=()
+declare -a JOB_PIDS=()
+
+# Helper to launch a validation job
+launch_job() {
+  local name=$1
+  local dir=$2
+  shift 2
+  run_validation "$name" "$dir" "$@" &
+  JOB_NAMES+=("$name")
+  JOB_PIDS+=($!)
+}
+
+# --- Web App checks ---
+if [ "$HAS_WEB_APP" = true ]; then
+  WEB_DIR="$ROOT_DIR/web-app"
+  launch_job "web:format"  "$WEB_DIR" "pnpm run format:check"
+  launch_job "web:lint"    "$WEB_DIR" "pnpm run lint"
+  launch_job "web:knip"    "$WEB_DIR" "pnpm run knip"
+  launch_job "web:test"    "$WEB_DIR" "pnpm test"
+fi
+
+# --- Shared package checks ---
+if [ "$HAS_SHARED" = true ]; then
+  SHARED_DIR="$ROOT_DIR/packages/shared"
+  launch_job "shared:format"    "$SHARED_DIR" "pnpm run format:check"
+  launch_job "shared:lint"      "$SHARED_DIR" "pnpm run lint"
+  launch_job "shared:typecheck" "$SHARED_DIR" "pnpm run typecheck"
+  launch_job "shared:test"      "$SHARED_DIR" "pnpm test"
+fi
+
+# --- Mobile package checks ---
+if [ "$HAS_MOBILE" = true ]; then
+  MOBILE_DIR="$ROOT_DIR/packages/mobile"
+  launch_job "mobile:format"    "$MOBILE_DIR" "pnpm run format:check"
+  launch_job "mobile:lint"      "$MOBILE_DIR" "pnpm run lint"
+  launch_job "mobile:typecheck" "$MOBILE_DIR" "pnpm run typecheck"
+  launch_job "mobile:test"      "$MOBILE_DIR" "pnpm test"
+fi
+
+# --- Worker checks ---
+if [ "$HAS_WORKER" = true ]; then
+  WORKER_DIR="$ROOT_DIR/worker"
+  launch_job "worker:format" "$WORKER_DIR" "pnpm run format:check"
+  launch_job "worker:lint"   "$WORKER_DIR" "pnpm run lint"
+  launch_job "worker:test"   "$WORKER_DIR" "pnpm test"
+fi
+
+# --- Help site checks ---
+if [ "$HAS_HELP_SITE" = true ]; then
+  HELP_DIR="$ROOT_DIR/help-site"
+  launch_job "help:format" "$HELP_DIR" "pnpm run format:check"
+fi
+
+NUM_JOBS=${#JOB_NAMES[@]}
+echo "  Running $NUM_JOBS checks across:$AFFECTED"
+echo ""
+
+# =============================================================================
+# MONITOR JOBS AND COLLECT RESULTS
+# =============================================================================
+
+declare -a JOB_DONE=()
+declare -a JOB_RESULTS=()
+for ((i=0; i<NUM_JOBS; i++)); do
+  JOB_DONE+=("0")
+  JOB_RESULTS+=("")
+done
+
+COMPLETED=0
+while [ "$COMPLETED" -lt "$NUM_JOBS" ]; do
+  for ((i=0; i<NUM_JOBS; i++)); do
+    if [ "${JOB_DONE[$i]}" -eq 0 ] && ! kill -0 "${JOB_PIDS[$i]}" 2>/dev/null; then
+      wait "${JOB_PIDS[$i]}" 2>/dev/null || true
+      JOB_DONE[$i]=1
+      JOB_RESULTS[$i]=$(cat "$TEMP_DIR/${JOB_NAMES[$i]}.result" 2>/dev/null || echo "1")
+      print_result_immediate "${JOB_NAMES[$i]}" "${JOB_RESULTS[$i]}"
+      COMPLETED=$((COMPLETED + 1))
+    fi
+  done
+
+  if [ "$COMPLETED" -lt "$NUM_JOBS" ]; then
+    sleep 0.2
+  fi
+done
+
+# =============================================================================
+# CHECK FOR FAILURES
+# =============================================================================
+
+HAS_FAILURES=false
+for ((i=0; i<NUM_JOBS; i++)); do
+  if [ "${JOB_RESULTS[$i]}" -ne 0 ]; then
+    HAS_FAILURES=true
+    break
+  fi
+done
+
+# =============================================================================
+# BUILD (only if all checks passed)
+# =============================================================================
+
+BUILD_RESULT=0
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$HAS_FAILURES" = false ]; then
+  # Build shared first (dependency for web-app and mobile)
+  if [ "$HAS_SHARED" = true ]; then
+    echo "Building shared..."
+    if (cd "$ROOT_DIR/packages/shared" && pnpm run build) ; then
+      echo -e "${GREEN}shared build passed${NC}"
+    else
+      echo -e "${RED}shared build failed${NC}"
+      BUILD_RESULT=1
+    fi
+  fi
+
+  # Build web-app (only if shared build passed)
+  if [ "$HAS_WEB_APP" = true ] && [ "$BUILD_RESULT" -eq 0 ]; then
+    echo "Building web-app..."
+    if (cd "$ROOT_DIR/web-app" && pnpm run build) ; then
+      echo -e "${GREEN}web-app build passed${NC}"
+    else
+      echo -e "${RED}web-app build failed${NC}"
+      BUILD_RESULT=1
+    fi
+  fi
+
+  # Build help-site
+  if [ "$HAS_HELP_SITE" = true ] && [ "$BUILD_RESULT" -eq 0 ]; then
+    echo "Building help-site..."
+    if (cd "$ROOT_DIR/help-site" && pnpm run build) ; then
+      echo -e "${GREEN}help-site build passed${NC}"
+    else
+      echo -e "${RED}help-site build failed${NC}"
+      BUILD_RESULT=1
+    fi
+  fi
+else
+  echo -e "${YELLOW}Build skipped (previous checks failed)${NC}"
+  BUILD_RESULT=2
+fi
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Validation Summary"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+for ((i=0; i<NUM_JOBS; i++)); do
+  print_status "${JOB_NAMES[$i]}" "${JOB_RESULTS[$i]}"
+done
 print_status "Build" "$BUILD_RESULT"
 
 # Exit with error if any check failed
-if [ "$FORMAT_RESULT" -ne 0 ] || [ "$LINT_RESULT" -ne 0 ] || [ "$KNIP_RESULT" -ne 0 ] || [ "$TEST_RESULT" -ne 0 ] || [ "$BUILD_RESULT" -eq 1 ]; then
+if [ "$HAS_FAILURES" = true ] || [ "$BUILD_RESULT" -eq 1 ]; then
   # Save per-step outputs if STEPS_DIR is set (for Claude hooks)
   if [ -n "$STEPS_DIR" ]; then
     mkdir -p "$STEPS_DIR"
-    [ -f "$TEMP_DIR/format.out" ] && cp "$TEMP_DIR/format.out" "$STEPS_DIR/format.log"
-    [ -f "$TEMP_DIR/lint.out" ] && cp "$TEMP_DIR/lint.out" "$STEPS_DIR/lint.log"
-    [ -f "$TEMP_DIR/knip.out" ] && cp "$TEMP_DIR/knip.out" "$STEPS_DIR/knip.log"
-    [ -f "$TEMP_DIR/test.out" ] && cp "$TEMP_DIR/test.out" "$STEPS_DIR/test.log"
-    # Build output goes to stdout, capture separately if needed
+    for ((i=0; i<NUM_JOBS; i++)); do
+      local_name="${JOB_NAMES[$i]}"
+      [ -f "$TEMP_DIR/${local_name}.out" ] && cp "$TEMP_DIR/${local_name}.out" "$STEPS_DIR/${local_name}.log"
+    done
     echo "Step outputs saved to $STEPS_DIR"
   fi
 

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -105,6 +105,10 @@ run_validation() {
   local output_file="$TEMP_DIR/${name}.out"
   local result_file="$TEMP_DIR/${name}.result"
 
+  # Ensure each background job runs from web-app directory
+  # (prevents failures when parent shell cwd changes or is a subfolder)
+  cd "$WEB_APP_DIR"
+
   # Default to failure, only set success if command passes
   if $cmd >"$output_file" 2>&1; then
     echo "0" >"$result_file"


### PR DESCRIPTION
## Summary
- Refactored pre-commit validation to detect affected packages from staged files and run per-package checks (format, lint, knip, typecheck, test)
- Shared package changes now cascade to downstream consumers (web-app, mobile)
- Background validation subshell now cd's to project root before launching, fixing subfolder cwd issues
- Added `.astro` to source patterns so help-site changes trigger validation
- Builds run sequentially respecting dependency order (shared → web-app → help-site)
- Updated VALIDATION.md with per-package check matrix

## Test plan
- [ ] Commit a change in `web-app/` only — verify only web-app checks run
- [ ] Commit a change in `packages/shared/` — verify shared, web-app, and mobile checks run
- [ ] Commit a change in `worker/` — verify only worker checks run
- [ ] Commit from a subfolder (e.g. `cd web-app/src`) — verify validation still works
- [ ] Commit docs-only changes — verify validation is skipped

https://claude.ai/code/session_01B1oMPdTGX6kTaxzEboTd9b