### PR TITLE
fix(web): hide address input fields when home location is already set

### DIFF
--- a/.changeset/hide-address-fields-when-set.md
+++ b/.changeset/hide-address-fields-when-set.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Hide "use current location" button and address search field when a home address is already set

--- a/web-app/src/features/settings/components/HomeLocationSection.tsx
+++ b/web-app/src/features/settings/components/HomeLocationSection.tsx
@@ -42,86 +42,91 @@ function HomeLocationSectionComponent() {
         </div>
       )}
 
-      {/* Use current location button */}
-      {homeLocation.geoSupported && (
-        <Button
-          variant="secondary"
-          onClick={homeLocation.requestLocation}
-          loading={homeLocation.geoLoading}
-          fullWidth
-          iconLeft={!homeLocation.geoLoading && <Clock className="w-4 h-4" />}
-        >
-          {homeLocation.geoLoading
-            ? t('settings.homeLocation.locating')
-            : t('settings.homeLocation.useCurrentLocation')}
-        </Button>
-      )}
-
-      {/* Geolocation error */}
-      {homeLocation.geoError && (
-        <p className="text-sm text-error-600 dark:text-error-400">
-          {getGeolocationErrorMessage(homeLocation.geoError, t)}
-        </p>
-      )}
-
-      {/* Address search */}
-      <div className="space-y-2">
-        <label
-          htmlFor="address-search"
-          className="block text-sm font-medium text-text-primary dark:text-text-primary-dark"
-        >
-          {t('settings.homeLocation.searchLabel')}
-        </label>
-        <div className="relative">
-          <input
-            id="address-search"
-            type="text"
-            value={homeLocation.addressQuery}
-            onChange={homeLocation.handleAddressChange}
-            placeholder={t('settings.homeLocation.searchPlaceholder')}
-            className="w-full px-4 py-2 text-sm border border-border-default dark:border-border-default-dark rounded-lg bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark placeholder:text-text-muted dark:placeholder:text-text-muted-dark focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-          />
-          {homeLocation.geocodeLoading && (
-            <div className="absolute right-3 top-1/2 -translate-y-1/2">
-              <span className="w-4 h-4 block border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
-            </div>
+      {/* Hide location input controls when a home address is already set */}
+      {!homeLocation.homeLocation && (
+        <>
+          {/* Use current location button */}
+          {homeLocation.geoSupported && (
+            <Button
+              variant="secondary"
+              onClick={homeLocation.requestLocation}
+              loading={homeLocation.geoLoading}
+              fullWidth
+              iconLeft={!homeLocation.geoLoading && <Clock className="w-4 h-4" />}
+            >
+              {homeLocation.geoLoading
+                ? t('settings.homeLocation.locating')
+                : t('settings.homeLocation.useCurrentLocation')}
+            </Button>
           )}
-        </div>
 
-        {/* Geocoding error */}
-        {homeLocation.geocodeError && (
-          <p className="text-sm text-error-600 dark:text-error-400">
-            {t('settings.homeLocation.searchError')}
-          </p>
-        )}
-
-        {/* Geocoding results */}
-        {homeLocation.geocodeResults.length > 0 && (
-          <ul className="border border-border-default dark:border-border-default-dark rounded-lg overflow-hidden divide-y divide-border-subtle dark:divide-border-subtle-dark">
-            {homeLocation.geocodeResults.map((result) => (
-              <li key={result.id}>
-                <button
-                  type="button"
-                  onClick={() => homeLocation.handleSelectGeocodedLocation(result)}
-                  className="w-full px-4 py-3 text-left text-sm text-text-primary dark:text-text-primary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark transition-colors"
-                >
-                  {result.displayName}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-
-        {/* No results message */}
-        {homeLocation.debouncedQuery.length >= homeLocation.minSearchLength &&
-          !homeLocation.geocodeLoading &&
-          homeLocation.geocodeResults.length === 0 &&
-          !homeLocation.geocodeError && (
-            <p className="text-sm text-text-muted dark:text-text-muted-dark">
-              {t('settings.homeLocation.noResults')}
+          {/* Geolocation error */}
+          {homeLocation.geoError && (
+            <p className="text-sm text-error-600 dark:text-error-400">
+              {getGeolocationErrorMessage(homeLocation.geoError, t)}
             </p>
           )}
-      </div>
+
+          {/* Address search */}
+          <div className="space-y-2">
+            <label
+              htmlFor="address-search"
+              className="block text-sm font-medium text-text-primary dark:text-text-primary-dark"
+            >
+              {t('settings.homeLocation.searchLabel')}
+            </label>
+            <div className="relative">
+              <input
+                id="address-search"
+                type="text"
+                value={homeLocation.addressQuery}
+                onChange={homeLocation.handleAddressChange}
+                placeholder={t('settings.homeLocation.searchPlaceholder')}
+                className="w-full px-4 py-2 text-sm border border-border-default dark:border-border-default-dark rounded-lg bg-surface-card dark:bg-surface-card-dark text-text-primary dark:text-text-primary-dark placeholder:text-text-muted dark:placeholder:text-text-muted-dark focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              />
+              {homeLocation.geocodeLoading && (
+                <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                  <span className="w-4 h-4 block border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
+            </div>
+
+            {/* Geocoding error */}
+            {homeLocation.geocodeError && (
+              <p className="text-sm text-error-600 dark:text-error-400">
+                {t('settings.homeLocation.searchError')}
+              </p>
+            )}
+
+            {/* Geocoding results */}
+            {homeLocation.geocodeResults.length > 0 && (
+              <ul className="border border-border-default dark:border-border-default-dark rounded-lg overflow-hidden divide-y divide-border-subtle dark:divide-border-subtle-dark">
+                {homeLocation.geocodeResults.map((result) => (
+                  <li key={result.id}>
+                    <button
+                      type="button"
+                      onClick={() => homeLocation.handleSelectGeocodedLocation(result)}
+                      className="w-full px-4 py-3 text-left text-sm text-text-primary dark:text-text-primary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark transition-colors"
+                    >
+                      {result.displayName}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {/* No results message */}
+            {homeLocation.debouncedQuery.length >= homeLocation.minSearchLength &&
+              !homeLocation.geocodeLoading &&
+              homeLocation.geocodeResults.length === 0 &&
+              !homeLocation.geocodeError && (
+                <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                  {t('settings.homeLocation.noResults')}
+                </p>
+              )}
+          </div>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Hide the "use current location" button and address search input field in settings when a home address is already set
- Users can clear the existing address via the X button to reveal the inputs again
- Reduces visual clutter on the settings page

## Test plan

- [ ] Open settings with no home location set — verify "use current location" button and address search are visible
- [ ] Set a home address — verify button and search field are hidden, only the saved address with clear button is shown
- [ ] Click the X to clear the address — verify inputs reappear

https://claude.ai/code/session_01TBiWARwT6eftGLSbYK7HSA