### PR TITLE
fix(ci): auto-fix audit vulnerabilities during dependency updates

### DIFF
--- a/.github/workflows/update-deps-mobile.yml
+++ b/.github/workflows/update-deps-mobile.yml
@@ -122,6 +122,22 @@ jobs:
       - name: Reinstall dependencies
         if: steps.check-updates.outputs.has_updates == 'true'
         run: pnpm install --no-frozen-lockfile
+      - name: Auto-fix audit vulnerabilities
+        if: steps.check-updates.outputs.has_updates == 'true'
+        run: |
+          echo "Checking for fixable audit vulnerabilities..."
+          if ! pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+            echo "Audit issues found, attempting auto-fix..."
+            pnpm audit --fix || true
+            pnpm install --no-frozen-lockfile
+            if pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+              echo "::notice::Audit vulnerabilities were automatically fixed"
+            else
+              echo "::warning::Some audit vulnerabilities could not be auto-fixed"
+            fi
+          else
+            echo "No audit issues found"
+          fi
       - name: Run Expo Doctor
         if: steps.check-updates.outputs.has_updates == 'true'
         working-directory: packages/mobile

--- a/.github/workflows/update-deps-mobile.yml
+++ b/.github/workflows/update-deps-mobile.yml
@@ -126,7 +126,7 @@ jobs:
         if: steps.check-updates.outputs.has_updates == 'true'
         run: |
           echo "Checking for fixable audit vulnerabilities..."
-          if ! pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+          if ! pnpm audit --audit-level high --prod; then
             echo "Audit issues found, attempting auto-fix..."
             pnpm audit --fix || true
             pnpm install --no-frozen-lockfile
@@ -166,6 +166,7 @@ jobs:
           name: updated-packages-mobile
           path: |
             pnpm-lock.yaml
+            package.json
             packages/mobile/package.json
           retention-days: 1
   validate:

--- a/.github/workflows/update-deps-shared.yml
+++ b/.github/workflows/update-deps-shared.yml
@@ -105,6 +105,22 @@ jobs:
 
           # Install updated dependencies (--no-frozen-lockfile needed since ncu modified package.json)
           pnpm install --no-frozen-lockfile
+      - name: Auto-fix audit vulnerabilities
+        if: steps.check-updates.outputs.has_updates == 'true'
+        run: |
+          echo "Checking for fixable audit vulnerabilities..."
+          if ! pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+            echo "Audit issues found, attempting auto-fix..."
+            pnpm audit --fix || true
+            pnpm install --no-frozen-lockfile
+            if pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+              echo "::notice::Audit vulnerabilities were automatically fixed"
+            else
+              echo "::warning::Some audit vulnerabilities could not be auto-fixed"
+            fi
+          else
+            echo "No audit issues found"
+          fi
       - name: Upload updated files
         if: steps.check-updates.outputs.has_updates == 'true'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/update-deps-shared.yml
+++ b/.github/workflows/update-deps-shared.yml
@@ -109,7 +109,7 @@ jobs:
         if: steps.check-updates.outputs.has_updates == 'true'
         run: |
           echo "Checking for fixable audit vulnerabilities..."
-          if ! pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+          if ! pnpm audit --audit-level high --prod; then
             echo "Audit issues found, attempting auto-fix..."
             pnpm audit --fix || true
             pnpm install --no-frozen-lockfile
@@ -128,6 +128,7 @@ jobs:
           name: updated-packages-shared
           path: |
             pnpm-lock.yaml
+            package.json
             packages/shared/package.json
           retention-days: 1
   validate:

--- a/.github/workflows/update-deps-web.yml
+++ b/.github/workflows/update-deps-web.yml
@@ -111,7 +111,7 @@ jobs:
         if: steps.check-updates.outputs.has_updates == 'true'
         run: |
           echo "Checking for fixable audit vulnerabilities..."
-          if ! pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+          if ! pnpm audit --audit-level high --prod; then
             echo "Audit issues found, attempting auto-fix..."
             pnpm audit --fix || true
             pnpm install --no-frozen-lockfile
@@ -130,6 +130,7 @@ jobs:
           name: updated-packages
           path: |
             pnpm-lock.yaml
+            package.json
             web-app/package.json
           retention-days: 1
   validate:

--- a/.github/workflows/update-deps-web.yml
+++ b/.github/workflows/update-deps-web.yml
@@ -107,6 +107,22 @@ jobs:
 
           # Install updated dependencies (--no-frozen-lockfile needed since ncu modified package.json)
           pnpm install --no-frozen-lockfile
+      - name: Auto-fix audit vulnerabilities
+        if: steps.check-updates.outputs.has_updates == 'true'
+        run: |
+          echo "Checking for fixable audit vulnerabilities..."
+          if ! pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+            echo "Audit issues found, attempting auto-fix..."
+            pnpm audit --fix || true
+            pnpm install --no-frozen-lockfile
+            if pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+              echo "::notice::Audit vulnerabilities were automatically fixed"
+            else
+              echo "::warning::Some audit vulnerabilities could not be auto-fixed"
+            fi
+          else
+            echo "No audit issues found"
+          fi
       - name: Upload updated files
         if: steps.check-updates.outputs.has_updates == 'true'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/update-deps-worker.yml
+++ b/.github/workflows/update-deps-worker.yml
@@ -111,7 +111,7 @@ jobs:
         if: steps.check-updates.outputs.has_updates == 'true'
         run: |
           echo "Checking for fixable audit vulnerabilities..."
-          if ! pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+          if ! pnpm audit --audit-level high --prod; then
             echo "Audit issues found, attempting auto-fix..."
             pnpm audit --fix || true
             pnpm install --no-frozen-lockfile
@@ -130,6 +130,7 @@ jobs:
           name: updated-packages-worker
           path: |
             pnpm-lock.yaml
+            package.json
             worker/package.json
           retention-days: 1
   validate:

--- a/.github/workflows/update-deps-worker.yml
+++ b/.github/workflows/update-deps-worker.yml
@@ -107,6 +107,22 @@ jobs:
 
           # Install updated dependencies (--no-frozen-lockfile needed since ncu modified package.json)
           pnpm install --no-frozen-lockfile
+      - name: Auto-fix audit vulnerabilities
+        if: steps.check-updates.outputs.has_updates == 'true'
+        run: |
+          echo "Checking for fixable audit vulnerabilities..."
+          if ! pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+            echo "Audit issues found, attempting auto-fix..."
+            pnpm audit --fix || true
+            pnpm install --no-frozen-lockfile
+            if pnpm audit --audit-level high --prod > /dev/null 2>&1; then
+              echo "::notice::Audit vulnerabilities were automatically fixed"
+            else
+              echo "::warning::Some audit vulnerabilities could not be auto-fixed"
+            fi
+          else
+            echo "No audit issues found"
+          fi
       - name: Upload updated files
         if: steps.check-updates.outputs.has_updates == 'true'
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Added an "Auto-fix audit vulnerabilities" step to all 4 dependency update workflows (web, shared, mobile, worker)
- When `pnpm audit` detects high-severity production vulnerabilities after dependency updates, the workflow now attempts `pnpm audit --fix` (non-breaking fixes only) before the validation job runs
- Fixes are included in the uploaded artifact so the PR contains both the dependency updates and any audit fixes
- Reports success/warning via GitHub Actions annotations

## Test plan

- [ ] Trigger a manual dry-run of each update workflow to verify the new step executes correctly
- [ ] Verify that when no audit issues exist, the step passes cleanly with "No audit issues found"
- [ ] Verify that when fixable audit issues exist, they are resolved and the workflow continues
- [ ] Verify that unfixable audit issues produce a warning annotation but don't block the update job (the validate job's audit step handles final pass/fail)