### PR TITLE
fix(web): prevent signature overlay from being swiped away

### DIFF
--- a/.changeset/fix-signature-overlay-swipe.md
+++ b/.changeset/fix-signature-overlay-swipe.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Prevent signature overlay from being swiped away on touch devices

--- a/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
@@ -118,22 +118,33 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
     onComplete(dataUrl)
   }, [onComplete])
 
-  // Lock body scroll while overlay is open
+  // Lock body scroll and prevent swipe-to-navigate while overlay is open
   useEffect(() => {
     const prev = document.body.style.overflow
+    const prevOverscroll = document.body.style.overscrollBehavior
     document.body.style.overflow = 'hidden'
+    document.body.style.overscrollBehavior = 'none'
     return () => {
       document.body.style.overflow = prev
+      document.body.style.overscrollBehavior = prevOverscroll
     }
+  }, [])
+
+  // Prevent swipe-to-navigate gestures on the overlay container
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    // Allow touch events on the canvas (signature_pad handles them)
+    if (e.target instanceof HTMLCanvasElement) return
+    e.preventDefault()
   }, [])
 
   return (
     <div
-      className="fixed inset-0 bg-white flex flex-col"
+      className="fixed inset-0 bg-white flex flex-col touch-none overscroll-none"
       style={{ zIndex: SIGNATURE_OVERLAY_Z_INDEX }}
       role="dialog"
       aria-modal="true"
       aria-label={t('pdf.wizard.signature.title')}
+      onTouchMove={handleTouchMove}
     >
       {/* Header toolbar */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-gray-50">


### PR DESCRIPTION
## Summary
- Add `touch-action: none` and `overscroll-behavior: none` CSS classes to the signature overlay container to prevent browser swipe gestures
- Set `overscroll-behavior: none` on `document.body` while the overlay is open to block pull-to-refresh
- Add `onTouchMove` handler that prevents default on non-canvas elements, stopping swipe-to-navigate while preserving signature drawing

## Test plan
- [ ] Open signature overlay on a touch device or touch-enabled browser
- [ ] Swipe left/right on the toolbar area — should not trigger back/forward navigation
- [ ] Pull down — should not trigger pull-to-refresh
- [ ] Draw a signature on the canvas — should still work normally
- [ ] Verify Cancel/Clear/Done buttons respond to taps
- [ ] Verify overlay dismisses correctly via Cancel button and Escape key