### PR TITLE
fix(web): portal SignatureCanvas to body to prevent PWA pull-to-refresh

### DIFF
--- a/.changeset/fix-pwa-signature-pull-to-refresh.md
+++ b/.changeset/fix-pwa-signature-pull-to-refresh.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': patch
+---
+
+Fix pull-to-refresh gesture triggering during signature drawing in PWA landscape mode

--- a/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 import SignaturePad from 'signature_pad'
 
@@ -137,7 +138,9 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
     e.preventDefault()
   }, [])
 
-  return (
+  // Portal to document.body so the overlay is outside the PullToRefresh DOM tree,
+  // preventing pull-to-refresh gestures from interfering with signature drawing
+  return createPortal(
     <div
       className="fixed inset-0 bg-white flex flex-col touch-none overscroll-none"
       style={{ zIndex: SIGNATURE_OVERLAY_Z_INDEX }}
@@ -196,6 +199,7 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
           </div>
         )}
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
 
+import { createPortal } from 'react-dom'
 import SignaturePad from 'signature_pad'
 
 import { Button } from '@/shared/components/Button'


### PR DESCRIPTION
## Summary

- Portal the `SignatureCanvas` overlay to `document.body` via `createPortal` so it renders outside the `PullToRefresh` DOM tree
- Prevents the swipe-down pull-to-refresh gesture from interfering with signature drawing in PWA standalone landscape mode

## Test plan

- [ ] Install PWA and open a sports hall report signature in landscape mode
- [ ] Verify swipe-down gestures on the canvas draw signatures without triggering pull-to-refresh
- [ ] Verify pull-to-refresh still works on the assignments page when the signature overlay is closed
- [ ] Verify signature completion and cancellation still work correctly

https://claude.ai/code/session_01NZcW8svZev3tmQ5F3Z9pnz