### PR TITLE
feat(web): add per-team jersey advertising toggles to sports hall report wizard

### DIFF
--- a/.changeset/add-jersey-commercial-toggle.md
+++ b/.changeset/add-jersey-commercial-toggle.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Added per-team jersey advertising toggles to the sports hall report wizard

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -59,7 +59,7 @@ export function SportsHallReportWizardModal({
   onClose,
   defaultLanguage,
 }: SportsHallReportWizardModalProps) {
-  const { t } = useTranslation()
+  const { t, tInterpolate } = useTranslation()
   const [language, setLanguage] = useState<Language>(defaultLanguage)
   const [confirmed, setConfirmed] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
@@ -235,12 +235,9 @@ export function SportsHallReportWizardModal({
                 </div>
                 {confirmed && (
                   <div className="mt-3 space-y-2.5">
-                    <ul className="space-y-1.5">
-                      <ConfirmItem label={t('pdf.wizard.allCheckpointsOk')} />
-                    </ul>
                     <div className="space-y-1.5">
                       <JerseyAdToggle
-                        team={homeTeam || '–'}
+                        label={tInterpolate('pdf.wizard.advertisingTeam', { team: homeTeam || '–' })}
                         checked={jerseyAdvertising.homeTeam}
                         onChange={() =>
                           setJerseyAdvertising((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
@@ -248,7 +245,7 @@ export function SportsHallReportWizardModal({
                         disabled={isGenerating}
                       />
                       <JerseyAdToggle
-                        team={awayTeam || '–'}
+                        label={tInterpolate('pdf.wizard.advertisingTeam', { team: awayTeam || '–' })}
                         checked={jerseyAdvertising.awayTeam}
                         onChange={() =>
                           setJerseyAdvertising((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
@@ -307,22 +304,13 @@ export function SportsHallReportWizardModal({
   )
 }
 
-function ConfirmItem({ label }: { label: string }) {
-  return (
-    <li className="flex items-center gap-2 text-sm text-success-700 dark:text-success-400">
-      <CheckCircle className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-      <span>{label}</span>
-    </li>
-  )
-}
-
 function JerseyAdToggle({
-  team,
+  label,
   checked,
   onChange,
   disabled,
 }: {
-  team: string
+  label: string
   checked: boolean
   onChange: () => void
   disabled: boolean
@@ -333,7 +321,7 @@ function JerseyAdToggle({
       type="button"
       onClick={onChange}
       disabled={disabled}
-      title={team}
+      title={label}
       className={`flex items-center gap-2 min-w-0 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
         checked
           ? 'text-success-700 dark:text-success-400'
@@ -341,7 +329,7 @@ function JerseyAdToggle({
       }`}
     >
       <Icon className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-      <span className="truncate">{team}</span>
+      <span className="truncate">{label}</span>
     </button>
   )
 }

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react'
 
 import type { Assignment } from '@/api/client'
 import { Button } from '@/shared/components/Button'
-import { FileText, CheckCircle } from '@/shared/components/icons'
+import { FileText, CheckCircle, XCircle } from '@/shared/components/icons'
 import { Modal } from '@/shared/components/Modal'
 import { ModalFooter } from '@/shared/components/ModalFooter'
 import { ModalHeader } from '@/shared/components/ModalHeader'
@@ -239,26 +239,39 @@ export function SportsHallReportWizardModal({
                       <ConfirmItem label={t('pdf.wizard.allCheckpointsOk')} />
                     </ul>
                     <div className="space-y-2">
-                      <JerseyAdToggle
-                        label={tInterpolate('pdf.wizard.advertisingTeam', {
-                          team: homeTeam || '–',
-                        })}
-                        checked={jerseyAdvertising.homeTeam}
-                        onChange={() =>
-                          setJerseyAdvertising((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
-                        }
-                        disabled={isGenerating}
-                      />
-                      <JerseyAdToggle
-                        label={tInterpolate('pdf.wizard.advertisingTeam', {
-                          team: awayTeam || '–',
-                        })}
-                        checked={jerseyAdvertising.awayTeam}
-                        onChange={() =>
-                          setJerseyAdvertising((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
-                        }
-                        disabled={isGenerating}
-                      />
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-sm text-text-secondary dark:text-text-secondary-dark">
+                          {t('pdf.wizard.advertisingLabel')}
+                        </span>
+                        <ToggleSwitch
+                          checked={jerseyAdvertising.homeTeam && jerseyAdvertising.awayTeam}
+                          onChange={() => {
+                            const allOk = jerseyAdvertising.homeTeam && jerseyAdvertising.awayTeam
+                            setJerseyAdvertising({ homeTeam: !allOk, awayTeam: !allOk })
+                          }}
+                          label={t('pdf.wizard.advertisingLabel')}
+                          variant="success"
+                          disabled={isGenerating}
+                        />
+                      </div>
+                      <div className="flex gap-2">
+                        <JerseyAdButton
+                          team={homeTeam || '–'}
+                          checked={jerseyAdvertising.homeTeam}
+                          onChange={() =>
+                            setJerseyAdvertising((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
+                          }
+                          disabled={isGenerating}
+                        />
+                        <JerseyAdButton
+                          team={awayTeam || '–'}
+                          checked={jerseyAdvertising.awayTeam}
+                          onChange={() =>
+                            setJerseyAdvertising((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
+                          }
+                          disabled={isGenerating}
+                        />
+                      </div>
                     </div>
                   </div>
                 )}
@@ -320,40 +333,32 @@ function ConfirmItem({ label }: { label: string }) {
   )
 }
 
-function JerseyAdToggle({
-  label,
+function JerseyAdButton({
+  team,
   checked,
   onChange,
   disabled,
 }: {
-  label: string
+  team: string
   checked: boolean
   onChange: () => void
   disabled: boolean
 }) {
+  const Icon = checked ? CheckCircle : XCircle
   return (
-    <div className="flex items-center justify-between gap-2">
-      <div className="flex items-center gap-2 min-w-0">
-        <CheckCircle
-          className={`w-4 h-4 flex-shrink-0 ${checked ? 'text-success-700 dark:text-success-400' : 'text-warning-500 dark:text-warning-400'}`}
-          aria-hidden="true"
-        />
-        <span
-          className={`text-sm truncate ${checked ? 'text-success-700 dark:text-success-400' : 'text-warning-600 dark:text-warning-400'}`}
-          title={label}
-        >
-          {label}
-        </span>
-      </div>
-      <div className="flex-shrink-0">
-        <ToggleSwitch
-          checked={checked}
-          onChange={onChange}
-          label={label}
-          variant="success"
-          disabled={disabled}
-        />
-      </div>
-    </div>
+    <button
+      type="button"
+      onClick={onChange}
+      disabled={disabled}
+      title={team}
+      className={`flex-1 min-w-0 flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+        checked
+          ? 'border-success-500 bg-success-50 text-success-700 dark:bg-success-900/20 dark:text-success-400 dark:border-success-600'
+          : 'border-red-300 bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400 dark:border-red-600'
+      }`}
+    >
+      <Icon className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+      <span className="truncate">{team}</span>
+    </button>
   )
 }

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -59,7 +59,7 @@ export function SportsHallReportWizardModal({
   onClose,
   defaultLanguage,
 }: SportsHallReportWizardModalProps) {
-  const { t, tInterpolate } = useTranslation()
+  const { t } = useTranslation()
   const [language, setLanguage] = useState<Language>(defaultLanguage)
   const [confirmed, setConfirmed] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
@@ -254,24 +254,22 @@ export function SportsHallReportWizardModal({
                           disabled={isGenerating}
                         />
                       </div>
-                      <div className="flex gap-2">
-                        <JerseyAdButton
-                          team={homeTeam || '–'}
-                          checked={jerseyAdvertising.homeTeam}
-                          onChange={() =>
-                            setJerseyAdvertising((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
-                          }
-                          disabled={isGenerating}
-                        />
-                        <JerseyAdButton
-                          team={awayTeam || '–'}
-                          checked={jerseyAdvertising.awayTeam}
-                          onChange={() =>
-                            setJerseyAdvertising((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
-                          }
-                          disabled={isGenerating}
-                        />
-                      </div>
+                      <JerseyAdToggle
+                        team={homeTeam || '–'}
+                        checked={jerseyAdvertising.homeTeam}
+                        onChange={() =>
+                          setJerseyAdvertising((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
+                        }
+                        disabled={isGenerating}
+                      />
+                      <JerseyAdToggle
+                        team={awayTeam || '–'}
+                        checked={jerseyAdvertising.awayTeam}
+                        onChange={() =>
+                          setJerseyAdvertising((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
+                        }
+                        disabled={isGenerating}
+                      />
                     </div>
                   </div>
                 )}
@@ -333,7 +331,7 @@ function ConfirmItem({ label }: { label: string }) {
   )
 }
 
-function JerseyAdButton({
+function JerseyAdToggle({
   team,
   checked,
   onChange,
@@ -351,10 +349,10 @@ function JerseyAdButton({
       onClick={onChange}
       disabled={disabled}
       title={team}
-      className={`flex-1 min-w-0 flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+      className={`flex items-center gap-2 min-w-0 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
         checked
-          ? 'border-success-500 bg-success-50 text-success-700 dark:bg-success-900/20 dark:text-success-400 dark:border-success-600'
-          : 'border-red-300 bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400 dark:border-red-600'
+          ? 'text-success-700 dark:text-success-400'
+          : 'text-red-600 dark:text-red-400'
       }`}
     >
       <Icon className="w-4 h-4 flex-shrink-0" aria-hidden="true" />

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -322,10 +322,10 @@ function JerseyAdToggle({
       onClick={onChange}
       disabled={disabled}
       title={label}
-      className={`flex items-center gap-2 min-w-0 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+      className={`flex w-full items-center gap-2 min-w-0 rounded-lg border py-2 px-3 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
         checked
-          ? 'text-success-700 dark:text-success-400'
-          : 'text-red-600 dark:text-red-400'
+          ? 'border-success-200 bg-success-50 text-success-700 hover:bg-success-100 dark:border-success-800 dark:bg-success-900/20 dark:text-success-400 dark:hover:bg-success-900/30'
+          : 'border-red-200 bg-red-50 text-red-600 hover:bg-red-100 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30'
       }`}
     >
       <Icon className="w-4 h-4 flex-shrink-0" aria-hidden="true" />

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -10,7 +10,12 @@ import { ToggleSwitch } from '@/shared/components/ToggleSwitch'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { toast } from '@/shared/stores/toast'
 import { createLogger } from '@/shared/utils/logger'
-import type { Language, LeagueCategory, SportsHallReportData } from '@/shared/utils/pdf-form-filler'
+import type {
+  JerseyAdvertisingOptions,
+  Language,
+  LeagueCategory,
+  SportsHallReportData,
+} from '@/shared/utils/pdf-form-filler'
 
 import { SignatureCanvas } from './SignatureCanvas'
 
@@ -59,6 +64,10 @@ export function SportsHallReportWizardModal({
   const [confirmed, setConfirmed] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
   const [showSignature, setShowSignature] = useState(false)
+  const [jerseyAdvertising, setJerseyAdvertising] = useState<JerseyAdvertisingOptions>({
+    homeTeam: true,
+    awayTeam: true,
+  })
 
   // Reset state when modal opens
   useEffect(() => {
@@ -67,6 +76,7 @@ export function SportsHallReportWizardModal({
       setConfirmed(false)
       setIsGenerating(false)
       setShowSignature(false)
+      setJerseyAdvertising({ homeTeam: true, awayTeam: true })
     }
   }, [isOpen, defaultLanguage])
 
@@ -94,7 +104,8 @@ export function SportsHallReportWizardModal({
           info.reportData,
           info.leagueCategory,
           language,
-          signatureDataUrl
+          signatureDataUrl,
+          jerseyAdvertising
         )
 
         const { downloadPdf } = await import('@/shared/utils/pdf-form-filler')
@@ -110,7 +121,7 @@ export function SportsHallReportWizardModal({
         setIsGenerating(false)
       }
     },
-    [assignment, language, onClose, t]
+    [assignment, language, jerseyAdvertising, onClose, t]
   )
 
   const handleSignatureCancel = useCallback(() => {
@@ -223,10 +234,31 @@ export function SportsHallReportWizardModal({
                   />
                 </div>
                 {confirmed && (
-                  <ul className="mt-3 space-y-1.5">
-                    <ConfirmItem label={t('pdf.wizard.allCheckpointsOk')} />
-                    <ConfirmItem label={t('pdf.wizard.advertisingDeclared')} />
-                  </ul>
+                  <div className="mt-3 space-y-2.5">
+                    <ul className="space-y-1.5">
+                      <ConfirmItem label={t('pdf.wizard.allCheckpointsOk')} />
+                    </ul>
+                    <div className="space-y-2">
+                      <JerseyAdToggle
+                        label={t('pdf.wizard.advertisingHomeTeam')}
+                        teamName={homeTeam}
+                        checked={jerseyAdvertising.homeTeam}
+                        onChange={() =>
+                          setJerseyAdvertising((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
+                        }
+                        disabled={isGenerating}
+                      />
+                      <JerseyAdToggle
+                        label={t('pdf.wizard.advertisingAwayTeam')}
+                        teamName={awayTeam}
+                        checked={jerseyAdvertising.awayTeam}
+                        onChange={() =>
+                          setJerseyAdvertising((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
+                        }
+                        disabled={isGenerating}
+                      />
+                    </div>
+                  </div>
                 )}
               </div>
             </div>
@@ -283,5 +315,43 @@ function ConfirmItem({ label }: { label: string }) {
       <CheckCircle className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
       <span>{label}</span>
     </li>
+  )
+}
+
+function JerseyAdToggle({
+  label,
+  teamName,
+  checked,
+  onChange,
+  disabled,
+}: {
+  label: string
+  teamName: string
+  checked: boolean
+  onChange: () => void
+  disabled: boolean
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-2 min-w-0">
+        <CheckCircle
+          className={`w-4 h-4 flex-shrink-0 ${checked ? 'text-success-700 dark:text-success-400' : 'text-warning-500 dark:text-warning-400'}`}
+          aria-hidden="true"
+        />
+        <span
+          className={`text-sm truncate ${checked ? 'text-success-700 dark:text-success-400' : 'text-warning-600 dark:text-warning-400'}`}
+          title={teamName ? `${label} (${teamName})` : label}
+        >
+          {label}
+        </span>
+      </div>
+      <ToggleSwitch
+        checked={checked}
+        onChange={onChange}
+        label={label}
+        variant="success"
+        disabled={disabled}
+      />
+    </div>
   )
 }

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -238,22 +238,7 @@ export function SportsHallReportWizardModal({
                     <ul className="space-y-1.5">
                       <ConfirmItem label={t('pdf.wizard.allCheckpointsOk')} />
                     </ul>
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="text-sm text-text-secondary dark:text-text-secondary-dark">
-                          {t('pdf.wizard.advertisingLabel')}
-                        </span>
-                        <ToggleSwitch
-                          checked={jerseyAdvertising.homeTeam && jerseyAdvertising.awayTeam}
-                          onChange={() => {
-                            const allOk = jerseyAdvertising.homeTeam && jerseyAdvertising.awayTeam
-                            setJerseyAdvertising({ homeTeam: !allOk, awayTeam: !allOk })
-                          }}
-                          label={t('pdf.wizard.advertisingLabel')}
-                          variant="success"
-                          disabled={isGenerating}
-                        />
-                      </div>
+                    <div className="space-y-1.5">
                       <JerseyAdToggle
                         team={homeTeam || '–'}
                         checked={jerseyAdvertising.homeTeam}

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -59,7 +59,7 @@ export function SportsHallReportWizardModal({
   onClose,
   defaultLanguage,
 }: SportsHallReportWizardModalProps) {
-  const { t } = useTranslation()
+  const { t, tInterpolate } = useTranslation()
   const [language, setLanguage] = useState<Language>(defaultLanguage)
   const [confirmed, setConfirmed] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
@@ -240,8 +240,9 @@ export function SportsHallReportWizardModal({
                     </ul>
                     <div className="space-y-2">
                       <JerseyAdToggle
-                        label={t('pdf.wizard.advertisingHomeTeam')}
-                        teamName={homeTeam}
+                        label={tInterpolate('pdf.wizard.advertisingTeam', {
+                          team: homeTeam || '–',
+                        })}
                         checked={jerseyAdvertising.homeTeam}
                         onChange={() =>
                           setJerseyAdvertising((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
@@ -249,8 +250,9 @@ export function SportsHallReportWizardModal({
                         disabled={isGenerating}
                       />
                       <JerseyAdToggle
-                        label={t('pdf.wizard.advertisingAwayTeam')}
-                        teamName={awayTeam}
+                        label={tInterpolate('pdf.wizard.advertisingTeam', {
+                          team: awayTeam || '–',
+                        })}
                         checked={jerseyAdvertising.awayTeam}
                         onChange={() =>
                           setJerseyAdvertising((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
@@ -320,13 +322,11 @@ function ConfirmItem({ label }: { label: string }) {
 
 function JerseyAdToggle({
   label,
-  teamName,
   checked,
   onChange,
   disabled,
 }: {
   label: string
-  teamName: string
   checked: boolean
   onChange: () => void
   disabled: boolean
@@ -340,18 +340,20 @@ function JerseyAdToggle({
         />
         <span
           className={`text-sm truncate ${checked ? 'text-success-700 dark:text-success-400' : 'text-warning-600 dark:text-warning-400'}`}
-          title={teamName ? `${label} (${teamName})` : label}
+          title={label}
         >
           {label}
         </span>
       </div>
-      <ToggleSwitch
-        checked={checked}
-        onChange={onChange}
-        label={label}
-        variant="success"
-        disabled={disabled}
-      />
+      <div className="flex-shrink-0">
+        <ToggleSwitch
+          checked={checked}
+          onChange={onChange}
+          label={label}
+          variant="success"
+          disabled={disabled}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -100,13 +100,13 @@ export function SportsHallReportWizardModal({
 
         const { generateWizardReportBytes } = await import('@/shared/utils/pdf-form-filler')
 
-        const { pdfBytes, filename } = await generateWizardReportBytes(
-          info.reportData,
-          info.leagueCategory,
+        const { pdfBytes, filename } = await generateWizardReportBytes({
+          data: info.reportData,
+          leagueCategory: info.leagueCategory,
           language,
           signatureDataUrl,
-          jerseyAdvertising
-        )
+          jerseyAdvertising,
+        })
 
         const { downloadPdf } = await import('@/shared/utils/pdf-form-filler')
         downloadPdf(pdfBytes, filename)

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -638,7 +638,6 @@ const de: Translations = {
     wizard: {
       title: 'Hallenrapport',
       confirmLabel: 'Ich bestätige, dass alles in Ordnung ist',
-      allCheckpointsOk: 'Alle Punkte in Ordnung',
       advertisingTeam: 'Werbung — {team}',
 
       generate: 'Rapport erstellen',

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -639,6 +639,7 @@ const de: Translations = {
       title: 'Hallenrapport',
       confirmLabel: 'Ich bestätige, dass alles in Ordnung ist',
       allCheckpointsOk: 'Alle Punkte in Ordnung',
+      advertisingLabel: 'Trikotwerbung OK',
       advertisingTeam: 'Werbung — {team}',
 
       generate: 'Rapport erstellen',

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -639,7 +639,7 @@ const de: Translations = {
       title: 'Hallenrapport',
       confirmLabel: 'Ich bestätige, dass alles in Ordnung ist',
       allCheckpointsOk: 'Alle Punkte in Ordnung',
-      advertisingTeam: 'Werbung auf Trikot — {team}',
+      advertisingTeam: 'Werbung — {team}',
 
       generate: 'Rapport erstellen',
       downloadPreFilled: 'Vorausgefüllten Rapport herunterladen',

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -639,7 +639,6 @@ const de: Translations = {
       title: 'Hallenrapport',
       confirmLabel: 'Ich bestätige, dass alles in Ordnung ist',
       allCheckpointsOk: 'Alle Punkte in Ordnung',
-      advertisingLabel: 'Trikotwerbung OK',
       advertisingTeam: 'Werbung — {team}',
 
       generate: 'Rapport erstellen',

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -639,7 +639,6 @@ const de: Translations = {
       title: 'Hallenrapport',
       confirmLabel: 'Ich bestätige, dass alles in Ordnung ist',
       allCheckpointsOk: 'Alle Punkte in Ordnung',
-      advertisingDeclared: 'Werbung auf Spielerkleidung für beide Teams deklariert',
       advertisingHomeTeam: 'Werbung auf Spielerkleidung Heimteam',
       advertisingAwayTeam: 'Werbung auf Spielerkleidung Gastteam',
 

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -639,8 +639,7 @@ const de: Translations = {
       title: 'Hallenrapport',
       confirmLabel: 'Ich bestätige, dass alles in Ordnung ist',
       allCheckpointsOk: 'Alle Punkte in Ordnung',
-      advertisingHomeTeam: 'Werbung auf Spielerkleidung Heimteam',
-      advertisingAwayTeam: 'Werbung auf Spielerkleidung Gastteam',
+      advertisingTeam: 'Werbung auf Trikot — {team}',
 
       generate: 'Rapport erstellen',
       downloadPreFilled: 'Vorausgefüllten Rapport herunterladen',

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -640,6 +640,8 @@ const de: Translations = {
       confirmLabel: 'Ich bestätige, dass alles in Ordnung ist',
       allCheckpointsOk: 'Alle Punkte in Ordnung',
       advertisingDeclared: 'Werbung auf Spielerkleidung für beide Teams deklariert',
+      advertisingHomeTeam: 'Werbung auf Spielerkleidung Heimteam',
+      advertisingAwayTeam: 'Werbung auf Spielerkleidung Gastteam',
 
       generate: 'Rapport erstellen',
       downloadPreFilled: 'Vorausgefüllten Rapport herunterladen',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -615,7 +615,6 @@ const en: Translations = {
     wizard: {
       title: 'Sports Hall Report',
       confirmLabel: 'I confirm everything is in order',
-      allCheckpointsOk: 'All points in order',
       advertisingTeam: 'Advertising — {team}',
 
       generate: 'Generate Report',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -616,8 +616,7 @@ const en: Translations = {
       title: 'Sports Hall Report',
       confirmLabel: 'I confirm everything is in order',
       allCheckpointsOk: 'All points in order',
-      advertisingHomeTeam: 'Advertising on uniform — Home team',
-      advertisingAwayTeam: 'Advertising on uniform — Away team',
+      advertisingTeam: 'Uniform advertising — {team}',
 
       generate: 'Generate Report',
       downloadPreFilled: 'Download pre-filled report instead',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -616,6 +616,7 @@ const en: Translations = {
       title: 'Sports Hall Report',
       confirmLabel: 'I confirm everything is in order',
       allCheckpointsOk: 'All points in order',
+      advertisingLabel: 'Jersey advertising OK',
       advertisingTeam: 'Advertising — {team}',
 
       generate: 'Generate Report',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -616,7 +616,6 @@ const en: Translations = {
       title: 'Sports Hall Report',
       confirmLabel: 'I confirm everything is in order',
       allCheckpointsOk: 'All points in order',
-      advertisingDeclared: 'Advertising on uniform declared for both teams',
       advertisingHomeTeam: 'Advertising on uniform — Home team',
       advertisingAwayTeam: 'Advertising on uniform — Away team',
 

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -617,6 +617,8 @@ const en: Translations = {
       confirmLabel: 'I confirm everything is in order',
       allCheckpointsOk: 'All points in order',
       advertisingDeclared: 'Advertising on uniform declared for both teams',
+      advertisingHomeTeam: 'Advertising on uniform — Home team',
+      advertisingAwayTeam: 'Advertising on uniform — Away team',
 
       generate: 'Generate Report',
       downloadPreFilled: 'Download pre-filled report instead',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -616,7 +616,6 @@ const en: Translations = {
       title: 'Sports Hall Report',
       confirmLabel: 'I confirm everything is in order',
       allCheckpointsOk: 'All points in order',
-      advertisingLabel: 'Jersey advertising OK',
       advertisingTeam: 'Advertising — {team}',
 
       generate: 'Generate Report',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -616,7 +616,7 @@ const en: Translations = {
       title: 'Sports Hall Report',
       confirmLabel: 'I confirm everything is in order',
       allCheckpointsOk: 'All points in order',
-      advertisingTeam: 'Uniform advertising — {team}',
+      advertisingTeam: 'Advertising — {team}',
 
       generate: 'Generate Report',
       downloadPreFilled: 'Download pre-filled report instead',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -634,7 +634,7 @@ const fr: Translations = {
       title: 'Rapport de salle',
       confirmLabel: 'Je confirme que tout est en ordre',
       allCheckpointsOk: 'Tous les points en ordre',
-      advertisingTeam: 'Publicité sur la tenue — {team}',
+      advertisingTeam: 'Publicité — {team}',
 
       generate: 'Générer le rapport',
       downloadPreFilled: 'Télécharger le rapport pré-rempli',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -634,7 +634,6 @@ const fr: Translations = {
       title: 'Rapport de salle',
       confirmLabel: 'Je confirme que tout est en ordre',
       allCheckpointsOk: 'Tous les points en ordre',
-      advertisingDeclared: 'Publicité sur la tenue déclarée pour les deux équipes',
       advertisingHomeTeam: 'Publicité sur la tenue — Équipe domicile',
       advertisingAwayTeam: 'Publicité sur la tenue — Équipe visiteur',
 

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -633,7 +633,6 @@ const fr: Translations = {
     wizard: {
       title: 'Rapport de salle',
       confirmLabel: 'Je confirme que tout est en ordre',
-      allCheckpointsOk: 'Tous les points en ordre',
       advertisingTeam: 'Publicité — {team}',
 
       generate: 'Générer le rapport',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -634,8 +634,7 @@ const fr: Translations = {
       title: 'Rapport de salle',
       confirmLabel: 'Je confirme que tout est en ordre',
       allCheckpointsOk: 'Tous les points en ordre',
-      advertisingHomeTeam: 'Publicité sur la tenue — Équipe domicile',
-      advertisingAwayTeam: 'Publicité sur la tenue — Équipe visiteur',
+      advertisingTeam: 'Publicité sur la tenue — {team}',
 
       generate: 'Générer le rapport',
       downloadPreFilled: 'Télécharger le rapport pré-rempli',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -635,6 +635,8 @@ const fr: Translations = {
       confirmLabel: 'Je confirme que tout est en ordre',
       allCheckpointsOk: 'Tous les points en ordre',
       advertisingDeclared: 'Publicité sur la tenue déclarée pour les deux équipes',
+      advertisingHomeTeam: 'Publicité sur la tenue — Équipe domicile',
+      advertisingAwayTeam: 'Publicité sur la tenue — Équipe visiteur',
 
       generate: 'Générer le rapport',
       downloadPreFilled: 'Télécharger le rapport pré-rempli',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -634,6 +634,7 @@ const fr: Translations = {
       title: 'Rapport de salle',
       confirmLabel: 'Je confirme que tout est en ordre',
       allCheckpointsOk: 'Tous les points en ordre',
+      advertisingLabel: 'Publicité OK',
       advertisingTeam: 'Publicité — {team}',
 
       generate: 'Générer le rapport',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -634,7 +634,6 @@ const fr: Translations = {
       title: 'Rapport de salle',
       confirmLabel: 'Je confirme que tout est en ordre',
       allCheckpointsOk: 'Tous les points en ordre',
-      advertisingLabel: 'Publicité OK',
       advertisingTeam: 'Publicité — {team}',
 
       generate: 'Générer le rapport',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -629,7 +629,6 @@ const it: Translations = {
       title: 'Rapporto sala sportiva',
       confirmLabel: 'Confermo che tutto è in ordine',
       allCheckpointsOk: 'Tutti i punti in ordine',
-      advertisingDeclared: 'Pubblicità sulla tenuta dichiarata per entrambe le squadre',
       advertisingHomeTeam: 'Pubblicità sulla tenuta — Squadra di casa',
       advertisingAwayTeam: 'Pubblicità sulla tenuta — Squadra ospite',
 

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -629,7 +629,6 @@ const it: Translations = {
       title: 'Rapporto sala sportiva',
       confirmLabel: 'Confermo che tutto è in ordine',
       allCheckpointsOk: 'Tutti i punti in ordine',
-      advertisingLabel: 'Pubblicità OK',
       advertisingTeam: 'Pubblicità — {team}',
 
       generate: 'Genera rapporto',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -629,7 +629,7 @@ const it: Translations = {
       title: 'Rapporto sala sportiva',
       confirmLabel: 'Confermo che tutto è in ordine',
       allCheckpointsOk: 'Tutti i punti in ordine',
-      advertisingTeam: 'Pubblicità sulla tenuta — {team}',
+      advertisingTeam: 'Pubblicità — {team}',
 
       generate: 'Genera rapporto',
       downloadPreFilled: 'Scarica il rapporto precompilato',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -630,6 +630,8 @@ const it: Translations = {
       confirmLabel: 'Confermo che tutto è in ordine',
       allCheckpointsOk: 'Tutti i punti in ordine',
       advertisingDeclared: 'Pubblicità sulla tenuta dichiarata per entrambe le squadre',
+      advertisingHomeTeam: 'Pubblicità sulla tenuta — Squadra di casa',
+      advertisingAwayTeam: 'Pubblicità sulla tenuta — Squadra ospite',
 
       generate: 'Genera rapporto',
       downloadPreFilled: 'Scarica il rapporto precompilato',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -629,6 +629,7 @@ const it: Translations = {
       title: 'Rapporto sala sportiva',
       confirmLabel: 'Confermo che tutto è in ordine',
       allCheckpointsOk: 'Tutti i punti in ordine',
+      advertisingLabel: 'Pubblicità OK',
       advertisingTeam: 'Pubblicità — {team}',
 
       generate: 'Genera rapporto',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -629,8 +629,7 @@ const it: Translations = {
       title: 'Rapporto sala sportiva',
       confirmLabel: 'Confermo che tutto è in ordine',
       allCheckpointsOk: 'Tutti i punti in ordine',
-      advertisingHomeTeam: 'Pubblicità sulla tenuta — Squadra di casa',
-      advertisingAwayTeam: 'Pubblicità sulla tenuta — Squadra ospite',
+      advertisingTeam: 'Pubblicità sulla tenuta — {team}',
 
       generate: 'Genera rapporto',
       downloadPreFilled: 'Scarica il rapporto precompilato',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -628,7 +628,6 @@ const it: Translations = {
     wizard: {
       title: 'Rapporto sala sportiva',
       confirmLabel: 'Confermo che tutto è in ordine',
-      allCheckpointsOk: 'Tutti i punti in ordine',
       advertisingTeam: 'Pubblicità — {team}',
 
       generate: 'Genera rapporto',

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -489,7 +489,6 @@ export interface Translations {
       title: string
       confirmLabel: string
       allCheckpointsOk: string
-      advertisingDeclared: string
       advertisingHomeTeam: string
       advertisingAwayTeam: string
 

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -489,6 +489,7 @@ export interface Translations {
       title: string
       confirmLabel: string
       allCheckpointsOk: string
+      advertisingLabel: string
       advertisingTeam: string
 
       generate: string

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -490,6 +490,8 @@ export interface Translations {
       confirmLabel: string
       allCheckpointsOk: string
       advertisingDeclared: string
+      advertisingHomeTeam: string
+      advertisingAwayTeam: string
 
       generate: string
       downloadPreFilled: string

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -488,7 +488,6 @@ export interface Translations {
     wizard: {
       title: string
       confirmLabel: string
-      allCheckpointsOk: string
       advertisingTeam: string
 
       generate: string

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -489,8 +489,7 @@ export interface Translations {
       title: string
       confirmLabel: string
       allCheckpointsOk: string
-      advertisingHomeTeam: string
-      advertisingAwayTeam: string
+      advertisingTeam: string
 
       generate: string
       downloadPreFilled: string

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -489,7 +489,6 @@ export interface Translations {
       title: string
       confirmLabel: string
       allCheckpointsOk: string
-      advertisingLabel: string
       advertisingTeam: string
 
       generate: string

--- a/packages/web/src/shared/utils/pdf-form-filler.ts
+++ b/packages/web/src/shared/utils/pdf-form-filler.ts
@@ -309,6 +309,14 @@ const NLB_WIZARD_FIELDS: WizardFieldMapping = {
 /** OK option value used by all radio groups in the PDF templates */
 const RADIO_OK_OPTION = 'Auswahl3'
 
+/** Not-OK option value used by advertising radio groups in the PDF templates */
+const RADIO_NOT_OK_OPTION = 'Auswahl4'
+
+export interface JerseyAdvertisingOptions {
+  homeTeam: boolean
+  awayTeam: boolean
+}
+
 function getWizardFieldMapping(leagueCategory: LeagueCategory): WizardFieldMapping {
   return leagueCategory === 'NLA' ? NLA_WIZARD_FIELDS : NLB_WIZARD_FIELDS
 }
@@ -460,7 +468,8 @@ export async function fillSportsHallReportWizard(
   data: SportsHallReportData,
   leagueCategory: LeagueCategory,
   language: Language,
-  signatureDataUrl?: string
+  signatureDataUrl?: string,
+  jerseyAdvertising: JerseyAdvertisingOptions = { homeTeam: true, awayTeam: true }
 ): Promise<Uint8Array> {
   const { pdfDoc, form } = await loadPdfForm(leagueCategory, language)
   const mapping = getFieldMapping(leagueCategory)
@@ -475,12 +484,15 @@ export async function fillSportsHallReportWizard(
     logger.warn(`Could not check "${wizardMapping.allPointsInOrderCheckbox}":`, error)
   }
 
-  // Set advertising "Werbung auf Spielerkleidung" to Ja for both teams
-  for (const adField of wizardMapping.advertisingRadioGroups) {
+  // Set advertising "Werbung auf Spielerkleidung" per team
+  const adFlags = [jerseyAdvertising.homeTeam, jerseyAdvertising.awayTeam]
+  for (let i = 0; i < wizardMapping.advertisingRadioGroups.length; i++) {
+    const adField = wizardMapping.advertisingRadioGroups[i]!
+    const hasAdvertising = adFlags[i] ?? true
     try {
-      form.getRadioGroup(adField).select(RADIO_OK_OPTION)
+      form.getRadioGroup(adField).select(hasAdvertising ? RADIO_OK_OPTION : RADIO_NOT_OK_OPTION)
     } catch (error) {
-      logger.warn(`Could not set advertising "${adField}" to Ja:`, error)
+      logger.warn(`Could not set advertising "${adField}":`, error)
     }
   }
 
@@ -505,13 +517,15 @@ export async function generateWizardReportBytes(
   data: SportsHallReportData,
   leagueCategory: LeagueCategory,
   language: Language,
-  signatureDataUrl: string
+  signatureDataUrl: string,
+  jerseyAdvertising?: JerseyAdvertisingOptions
 ): Promise<{ pdfBytes: Uint8Array; filename: string }> {
   const pdfBytes = await fillSportsHallReportWizard(
     data,
     leagueCategory,
     language,
-    signatureDataUrl
+    signatureDataUrl,
+    jerseyAdvertising
   )
   const filename = buildReportFilename(
     leagueCategory,

--- a/packages/web/src/shared/utils/pdf-form-filler.ts
+++ b/packages/web/src/shared/utils/pdf-form-filler.ts
@@ -292,18 +292,22 @@ export async function generateAndDownloadSportsHallReport(
 interface WizardFieldMapping {
   /** Checkbox field name for "Tous les points sont en ordre" / "Alle Punkte in Ordnung" */
   allPointsInOrderCheckbox: string
-  /** Radio group field names for "Werbung auf Spielerkleidung" (Ja/Nein) — left unchecked for manual verification */
-  advertisingRadioGroups: readonly string[]
+  /** Radio group field name for home team "Werbung auf Spielerkleidung" (Ja/Nein) */
+  advertisingHomeTeam: string
+  /** Radio group field name for away team "Werbung auf Spielerkleidung" (Ja/Nein) */
+  advertisingAwayTeam: string
 }
 
 const NLA_WIZARD_FIELDS: WizardFieldMapping = {
   allPointsInOrderCheckbox: 'Kontrollkästchen8',
-  advertisingRadioGroups: ['Gruppe430', 'Gruppe434'],
+  advertisingHomeTeam: 'Gruppe430',
+  advertisingAwayTeam: 'Gruppe434',
 }
 
 const NLB_WIZARD_FIELDS: WizardFieldMapping = {
   allPointsInOrderCheckbox: 'Kontrollkästchen17',
-  advertisingRadioGroups: ['31', '34'],
+  advertisingHomeTeam: '31',
+  advertisingAwayTeam: '34',
 }
 
 /** OK option value used by all radio groups in the PDF templates */
@@ -464,13 +468,24 @@ async function embedSignature(
  * When a signatureDataUrl is provided, the first referee's signature is
  * embedded at the designated position on the PDF.
  */
+export interface WizardReportOptions {
+  data: SportsHallReportData
+  leagueCategory: LeagueCategory
+  language: Language
+  signatureDataUrl?: string
+  jerseyAdvertising?: JerseyAdvertisingOptions
+}
+
 export async function fillSportsHallReportWizard(
-  data: SportsHallReportData,
-  leagueCategory: LeagueCategory,
-  language: Language,
-  signatureDataUrl?: string,
-  jerseyAdvertising: JerseyAdvertisingOptions = { homeTeam: true, awayTeam: true }
+  options: WizardReportOptions
 ): Promise<Uint8Array> {
+  const {
+    data,
+    leagueCategory,
+    language,
+    signatureDataUrl,
+    jerseyAdvertising = { homeTeam: true, awayTeam: true },
+  } = options
   const { pdfDoc, form } = await loadPdfForm(leagueCategory, language)
   const mapping = getFieldMapping(leagueCategory)
   const wizardMapping = getWizardFieldMapping(leagueCategory)
@@ -485,14 +500,15 @@ export async function fillSportsHallReportWizard(
   }
 
   // Set advertising "Werbung auf Spielerkleidung" per team
-  const adFlags = [jerseyAdvertising.homeTeam, jerseyAdvertising.awayTeam]
-  for (let i = 0; i < wizardMapping.advertisingRadioGroups.length; i++) {
-    const adField = wizardMapping.advertisingRadioGroups[i]!
-    const hasAdvertising = adFlags[i] ?? true
+  const adEntries: Array<{ field: string; hasAd: boolean }> = [
+    { field: wizardMapping.advertisingHomeTeam, hasAd: jerseyAdvertising.homeTeam },
+    { field: wizardMapping.advertisingAwayTeam, hasAd: jerseyAdvertising.awayTeam },
+  ]
+  for (const { field, hasAd } of adEntries) {
     try {
-      form.getRadioGroup(adField).select(hasAdvertising ? RADIO_OK_OPTION : RADIO_NOT_OK_OPTION)
+      form.getRadioGroup(field).select(hasAd ? RADIO_OK_OPTION : RADIO_NOT_OK_OPTION)
     } catch (error) {
-      logger.warn(`Could not set advertising "${adField}":`, error)
+      logger.warn(`Could not set advertising "${field}":`, error)
     }
   }
 
@@ -514,24 +530,14 @@ export async function fillSportsHallReportWizard(
  * for use with the Web Share API or print dialog.
  */
 export async function generateWizardReportBytes(
-  data: SportsHallReportData,
-  leagueCategory: LeagueCategory,
-  language: Language,
-  signatureDataUrl: string,
-  jerseyAdvertising?: JerseyAdvertisingOptions
+  options: WizardReportOptions & { signatureDataUrl: string }
 ): Promise<{ pdfBytes: Uint8Array; filename: string }> {
-  const pdfBytes = await fillSportsHallReportWizard(
-    data,
-    leagueCategory,
-    language,
-    signatureDataUrl,
-    jerseyAdvertising
-  )
+  const pdfBytes = await fillSportsHallReportWizard(options)
   const filename = buildReportFilename(
-    leagueCategory,
-    language,
-    data.startingDateTime,
-    data.gameNumber
+    options.leagueCategory,
+    options.language,
+    options.data.startingDateTime,
+    options.data.gameNumber
   )
   return { pdfBytes, filename }
 }


### PR DESCRIPTION
## Summary

- Added individual toggle switches for home and away team jersey advertising (Werbung auf Spielerkleidung) in the sports hall report wizard
- Both toggles default to ON; when toggled OFF, the PDF advertising radio is set to "not OK" instead of "Ja"
- Added i18n translations for per-team advertising labels in all 4 languages (de/en/fr/it)
- New `JerseyAdvertisingOptions` interface passed through from wizard modal to PDF form filler

## Test plan

- [ ] Open sports hall report wizard for an NLA/NLB game
- [ ] Verify both advertising toggles appear and default to ON (green) when confirmation is toggled
- [ ] Toggle one or both OFF and generate the PDF — verify the corresponding radio is set to "Nein"
- [ ] Verify toggles reset when re-opening the modal
- [ ] Verify existing tests pass (`pnpm test`)

https://claude.ai/code/session_01AmJhSMTaXp6qtGoKDKMXR6