### PR TITLE
feat(docs): add /github-api skill for GitHub REST API interactions

### DIFF
--- a/.claude/commands/github-api.md
+++ b/.claude/commands/github-api.md
@@ -1,0 +1,124 @@
+# GitHub API Skill
+
+Interact with the GitHub REST API using curl. Use this skill for any GitHub operations (issues, PRs, comments, checks, labels, etc.).
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Interpret the user input as a GitHub API operation request. Examples:
+- `list open PRs` → list open pull requests
+- `get issue #42` → fetch issue details
+- `create issue "title" "body"` → create a new issue
+- `list checks on HEAD` → get CI check status for current commit
+- `add label bug to issue #5` → add a label
+- `get review comments on PR #12` → fetch PR review comments
+
+## Setup
+
+### Step 1: Detect Repository
+
+```bash
+bash -c 'REMOTE=$(git remote get-url origin 2>/dev/null); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then echo "owner=${BASH_REMATCH[1]}"; echo "repo=${BASH_REMATCH[2]}"; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then echo "owner=${BASH_REMATCH[1]}"; echo "repo=${BASH_REMATCH[2]}"; else echo "ERROR: Could not detect GitHub repo from remote: $REMOTE"; exit 1; fi'
+```
+
+Store the `owner` and `repo` values for subsequent API calls.
+
+### Step 2: Check Token
+
+```bash
+bash -c 'if [ -n "$GITHUB_TOKEN" ]; then echo "TOKEN=available"; else echo "TOKEN=missing (read-only public access only)"; fi'
+```
+
+## API Call Pattern
+
+**CRITICAL**: All curl commands MUST be wrapped in `bash -c` to access `$GITHUB_TOKEN`. Direct curl will fail with 401.
+
+### Authenticated request template
+
+```bash
+bash -c 'curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" | jq .'
+```
+
+### POST/PATCH/PUT template
+
+**IMPORTANT**: Always use heredoc for multiline body content. Never use inline `\n` escapes in jq args.
+
+```bash
+bash -c 'BODY=$(cat <<'\''EOF'\''
+BODY_CONTENT_HERE
+EOF
+)
+jq -n --arg title "TITLE" --arg body "$BODY" "{title: \$title, body: \$body}" | curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" -d @- | jq .'
+```
+
+## Common Operations Reference
+
+Use these as templates. Replace `OWNER`, `REPO`, and parameters as needed.
+
+### Pull Requests
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| List open PRs | GET | `/repos/OWNER/REPO/pulls?state=open` |
+| Get PR | GET | `/repos/OWNER/REPO/pulls/NUMBER` |
+| Create PR | POST | `/repos/OWNER/REPO/pulls` (body: title, body, head, base) |
+| Update PR | PATCH | `/repos/OWNER/REPO/pulls/NUMBER` |
+| List PR files | GET | `/repos/OWNER/REPO/pulls/NUMBER/files` |
+| List PR reviews | GET | `/repos/OWNER/REPO/pulls/NUMBER/reviews` |
+| List PR comments | GET | `/repos/OWNER/REPO/pulls/NUMBER/comments` |
+| Check if PR exists for branch | GET | `/repos/OWNER/REPO/pulls?head=OWNER:BRANCH&state=open` |
+
+### Issues
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| List issues | GET | `/repos/OWNER/REPO/issues?state=open` |
+| Get issue | GET | `/repos/OWNER/REPO/issues/NUMBER` |
+| Create issue | POST | `/repos/OWNER/REPO/issues` (body: title, body, labels, assignees) |
+| Update issue | PATCH | `/repos/OWNER/REPO/issues/NUMBER` |
+| Add comment | POST | `/repos/OWNER/REPO/issues/NUMBER/comments` (body: body) |
+| List comments | GET | `/repos/OWNER/REPO/issues/NUMBER/comments` |
+| Add labels | POST | `/repos/OWNER/REPO/issues/NUMBER/labels` (body: labels array) |
+
+### CI / Checks
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| Check runs for commit | GET | `/repos/OWNER/REPO/commits/SHA/check-runs` |
+| Check runs for PR | GET | `/repos/OWNER/REPO/commits/SHA/check-runs` (get SHA from PR head) |
+| Combined status | GET | `/repos/OWNER/REPO/commits/SHA/status` |
+
+### Repository
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| Get repo | GET | `/repos/OWNER/REPO` |
+| List branches | GET | `/repos/OWNER/REPO/branches` |
+| List releases | GET | `/repos/OWNER/REPO/releases` |
+| List workflows | GET | `/repos/OWNER/REPO/actions/workflows` |
+| List workflow runs | GET | `/repos/OWNER/REPO/actions/runs` |
+
+## Execution
+
+Based on the user input:
+
+1. Run **Step 1** and **Step 2** to detect repo and token
+2. Determine the appropriate API endpoint and method from the reference above
+3. Construct and execute the curl command using the authenticated template
+4. Parse the response with `jq` to show relevant fields
+5. If the response is paginated (has `Link` header), inform the user
+
+## Tips
+
+- URL-encode branch names: `printf '%s' "$BRANCH" | jq -sRr @uri`
+- Filter by user: `jq '[.[] | select(.user.login == "USERNAME")]'`
+- Get current branch: `git rev-parse --abbrev-ref HEAD`
+- Get current SHA: `git rev-parse HEAD`
+- Pagination: add `?per_page=100&page=N` for large result sets
+
+## Output
+
+Show the API response formatted with jq. For list operations, show a concise summary table. For mutations, confirm the action and show the resulting URL.

--- a/.claude/commands/github-api.md
+++ b/.claude/commands/github-api.md
@@ -26,17 +26,19 @@ bash -c 'REMOTE=$(git remote get-url origin 2>/dev/null); if [[ "$REMOTE" =~ git
 
 Store the `owner` and `repo` values for subsequent API calls.
 
-### Step 2: Detect API Method
+### Step 2: Detect Available Tools
 
 ```bash
-command -v gh >/dev/null 2>&1 && echo "METHOD=gh" || echo "METHOD=curl"
+bash -c 'if command -v gh &>/dev/null; then echo "TOOL=gh"; elif [ -n "$GITHUB_TOKEN" ]; then echo "TOOL=curl"; else echo "TOOL=none (read-only public access only)"; fi'
 ```
 
-Use `gh api` when available (GitHub Actions, local dev with gh installed). Fall back to `curl` with `$GITHUB_TOKEN` (Claude Code web).
+- **`gh` available** (e.g., GitHub Actions): Use `gh api` — handles auth and JSON automatically
+- **`gh` unavailable, `$GITHUB_TOKEN` set** (e.g., Claude Code web): Use `curl` wrapped in `bash -c`
+- **Neither**: Read-only public API access only
 
 ## API Call Patterns
 
-### Using `gh api` (preferred when available)
+### When `gh` is available (preferred)
 
 #### GET request
 
@@ -47,27 +49,16 @@ gh api repos/OWNER/REPO/ENDPOINT
 #### POST/PATCH/PUT request
 
 ```bash
+gh api repos/OWNER/REPO/ENDPOINT -X POST -f title="TITLE" -f body="BODY"
+```
+
+For multiline body content:
+
+```bash
 gh api repos/OWNER/REPO/ENDPOINT -X POST --input <(jq -n --arg title "TITLE" --arg body "BODY" '{title: $title, body: $body}')
 ```
 
-For multiline body content, use a heredoc variable:
-
-```bash
-BODY=$(cat <<'EOF'
-Line 1
-Line 2
-EOF
-)
-gh api repos/OWNER/REPO/ENDPOINT -X POST --input <(jq -n --arg title "TITLE" --arg body "$BODY" '{title: $title, body: $body}')
-```
-
-#### Pagination
-
-```bash
-gh api --paginate repos/OWNER/REPO/issues
-```
-
-### Using `curl` (fallback when `gh` is unavailable)
+### When using curl (fallback)
 
 **CRITICAL**: All curl commands MUST be wrapped in `bash -c` to access `$GITHUB_TOKEN`. Direct curl will fail with 401.
 
@@ -82,21 +73,6 @@ bash -c 'curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: applicatio
 ```bash
 bash -c 'jq -n --arg title "TITLE" --arg body "BODY" "{title: \$title, body: \$body}" | curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" -d @- | jq .'
 ```
-
-For multiline body content, use a heredoc variable inside `bash -c`:
-
-```bash
-bash -c 'BODY=$(cat <<'\''EOF'\''
-Line 1
-Line 2
-EOF
-)
-jq -n --arg title "TITLE" --arg body "$BODY" "{title: \$title, body: \$body}" | curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" -d @- | jq .'
-```
-
-#### Pagination
-
-Add `?per_page=100&page=N` for large result sets.
 
 ## Common Operations Reference
 
@@ -149,11 +125,11 @@ Use these as templates. Replace `OWNER`, `REPO`, and parameters as needed.
 
 Based on the user input:
 
-1. Run **Step 1** and **Step 2** to detect repo and API method
+1. Run **Step 1** and **Step 2** to detect repo and available tools
 2. Determine the appropriate API endpoint and method from the reference above
-3. Construct and execute the command using the detected method (`gh api` or `curl`)
+3. Construct and execute the command using `gh api` (preferred) or `curl` (fallback)
 4. Parse the response with `jq` to show relevant fields
-5. For paginated results: use `gh api --paginate` or `?per_page=100&page=N` (curl)
+5. If the response is paginated, use `gh api --paginate` or add `?per_page=100&page=N` for curl
 
 ## Tips
 

--- a/.claude/commands/github-api.md
+++ b/.claude/commands/github-api.md
@@ -1,6 +1,6 @@
 # GitHub API Skill
 
-Interact with the GitHub REST API using curl. Use this skill for any GitHub operations (issues, PRs, comments, checks, labels, etc.).
+Interact with the GitHub REST API. Use this skill for any GitHub operations (issues, PRs, comments, checks, labels, etc.).
 
 ## User Input
 
@@ -26,33 +26,77 @@ bash -c 'REMOTE=$(git remote get-url origin 2>/dev/null); if [[ "$REMOTE" =~ git
 
 Store the `owner` and `repo` values for subsequent API calls.
 
-### Step 2: Check Token
+### Step 2: Detect API Method
 
 ```bash
-bash -c 'if [ -n "$GITHUB_TOKEN" ]; then echo "TOKEN=available"; else echo "TOKEN=missing (read-only public access only)"; fi'
+command -v gh >/dev/null 2>&1 && echo "METHOD=gh" || echo "METHOD=curl"
 ```
 
-## API Call Pattern
+Use `gh api` when available (GitHub Actions, local dev with gh installed). Fall back to `curl` with `$GITHUB_TOKEN` (Claude Code web).
+
+## API Call Patterns
+
+### Using `gh api` (preferred when available)
+
+#### GET request
+
+```bash
+gh api repos/OWNER/REPO/ENDPOINT
+```
+
+#### POST/PATCH/PUT request
+
+```bash
+gh api repos/OWNER/REPO/ENDPOINT -X POST --input <(jq -n --arg title "TITLE" --arg body "BODY" '{title: $title, body: $body}')
+```
+
+For multiline body content, use a heredoc variable:
+
+```bash
+BODY=$(cat <<'EOF'
+Line 1
+Line 2
+EOF
+)
+gh api repos/OWNER/REPO/ENDPOINT -X POST --input <(jq -n --arg title "TITLE" --arg body "$BODY" '{title: $title, body: $body}')
+```
+
+#### Pagination
+
+```bash
+gh api --paginate repos/OWNER/REPO/issues
+```
+
+### Using `curl` (fallback when `gh` is unavailable)
 
 **CRITICAL**: All curl commands MUST be wrapped in `bash -c` to access `$GITHUB_TOKEN`. Direct curl will fail with 401.
 
-### Authenticated request template
+#### GET request
 
 ```bash
 bash -c 'curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" | jq .'
 ```
 
-### POST/PATCH/PUT template
+#### POST/PATCH/PUT request
 
-**IMPORTANT**: Always use heredoc for multiline body content. Never use inline `\n` escapes in jq args.
+```bash
+bash -c 'jq -n --arg title "TITLE" --arg body "BODY" "{title: \$title, body: \$body}" | curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" -d @- | jq .'
+```
+
+For multiline body content, use a heredoc variable inside `bash -c`:
 
 ```bash
 bash -c 'BODY=$(cat <<'\''EOF'\''
-BODY_CONTENT_HERE
+Line 1
+Line 2
 EOF
 )
 jq -n --arg title "TITLE" --arg body "$BODY" "{title: \$title, body: \$body}" | curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" -d @- | jq .'
 ```
+
+#### Pagination
+
+Add `?per_page=100&page=N` for large result sets.
 
 ## Common Operations Reference
 
@@ -105,11 +149,11 @@ Use these as templates. Replace `OWNER`, `REPO`, and parameters as needed.
 
 Based on the user input:
 
-1. Run **Step 1** and **Step 2** to detect repo and token
+1. Run **Step 1** and **Step 2** to detect repo and API method
 2. Determine the appropriate API endpoint and method from the reference above
-3. Construct and execute the curl command using the authenticated template
+3. Construct and execute the command using the detected method (`gh api` or `curl`)
 4. Parse the response with `jq` to show relevant fields
-5. If the response is paginated (has `Link` header), inform the user
+5. For paginated results: use `gh api --paginate` or `?per_page=100&page=N` (curl)
 
 ## Tips
 
@@ -117,7 +161,6 @@ Based on the user input:
 - Filter by user: `jq '[.[] | select(.user.login == "USERNAME")]'`
 - Get current branch: `git rev-parse --abbrev-ref HEAD`
 - Get current SHA: `git rev-parse HEAD`
-- Pagination: add `?per_page=100&page=N` for large result sets
 
 ## Output
 

--- a/.claude/commands/github-api.md
+++ b/.claude/commands/github-api.md
@@ -36,6 +36,8 @@ bash -c 'if command -v gh &>/dev/null; then echo "TOOL=gh"; elif [ -n "$GITHUB_T
 - **`gh` unavailable, `$GITHUB_TOKEN` set** (e.g., Claude Code web): Use `curl` wrapped in `bash -c`
 - **Neither**: Read-only public API access only
 
+**IMPORTANT**: When using curl, you MUST wrap all curl commands in `bash -c '...'` to access `$GITHUB_TOKEN`. Direct curl commands will fail with 401 because the token is only available inside a `bash -c` subshell.
+
 ## API Call Patterns
 
 ### When `gh` is available (preferred)
@@ -60,7 +62,8 @@ gh api repos/OWNER/REPO/ENDPOINT -X POST --input <(jq -n --arg title "TITLE" --a
 
 ### When using curl (fallback)
 
-**CRITICAL**: All curl commands MUST be wrapped in `bash -c` to access `$GITHUB_TOKEN`. Direct curl will fail with 401.
+**CRITICAL**: All curl commands MUST be wrapped in `bash -c` to access `$GITHUB_TOKEN`.
+Direct curl commands will fail with 401 - always use the `bash -c` wrapper.
 
 #### GET request
 

--- a/.claude/commands/github-api.md
+++ b/.claude/commands/github-api.md
@@ -70,8 +70,14 @@ bash -c 'curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: applicatio
 
 #### POST/PATCH/PUT request
 
+**IMPORTANT**: Always use heredoc for multiline body content. Never use inline `\n` escapes in jq args.
+
 ```bash
-bash -c 'jq -n --arg title "TITLE" --arg body "BODY" "{title: \$title, body: \$body}" | curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" -d @- | jq .'
+bash -c 'BODY=$(cat <<'\''EOF'\''
+BODY_CONTENT_HERE
+EOF
+)
+jq -n --arg title "TITLE" --arg body "$BODY" "{title: \$title, body: \$body}" | curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" -d @- | jq .'
 ```
 
 ## Common Operations Reference

--- a/.claude/commands/github-api.md
+++ b/.claude/commands/github-api.md
@@ -1,3 +1,7 @@
+---
+description: Interact with the GitHub REST API for issues, PRs, comments, checks, labels, and other GitHub operations.
+---
+
 # GitHub API Skill
 
 Interact with the GitHub REST API. Use this skill for any GitHub operations (issues, PRs, comments, checks, labels, etc.).

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -77,11 +77,20 @@ echo "Development environment ready!"
 if [ -n "${GITHUB_TOKEN:-}" ]; then
   echo ""
   echo "=== GitHub API Access ==="
-  echo "GITHUB_TOKEN is available. Use /github-api skill for GitHub REST API operations."
+  echo "A GitHub token (GITHUB_TOKEN) is available in this environment."
   if command -v gh >/dev/null 2>&1; then
     echo "gh CLI is available. Prefer 'gh api' for GitHub API calls."
+    echo "Example: gh api repos/OWNER/REPO/issues"
   else
-    echo "gh CLI is NOT available. Use 'bash -c' with curl to access \$GITHUB_TOKEN."
+    echo "IMPORTANT: ALWAYS use the GitHub REST API via curl instead of the gh CLI."
+    echo "The gh CLI is NOT available. Use curl with the GITHUB_TOKEN for all GitHub operations."
+    echo ""
+    echo "CRITICAL: You MUST wrap curl commands in bash -c to access the token:"
+    echo "  bash -c 'curl -s -H \"Authorization: Bearer \$GITHUB_TOKEN\" \\"
+    echo '       -H "Accept: application/vnd.github+json" \'
+    echo "       https://api.github.com/repos/OWNER/REPO/issues'"
+    echo ""
+    echo "Direct curl commands will fail with 401 - always use bash -c wrapper."
   fi
   echo "========================="
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -78,6 +78,10 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
   echo ""
   echo "=== GitHub API Access ==="
   echo "GITHUB_TOKEN is available. Use /github-api skill for GitHub REST API operations."
-  echo "CRITICAL: Always wrap curl in bash -c to access the token. The gh CLI is NOT available."
+  if command -v gh >/dev/null 2>&1; then
+    echo "gh CLI is available. Prefer 'gh api' for GitHub API calls."
+  else
+    echo "gh CLI is NOT available. Use 'bash -c' with curl to access \$GITHUB_TOKEN."
+  fi
   echo "========================="
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -77,15 +77,7 @@ echo "Development environment ready!"
 if [ -n "${GITHUB_TOKEN:-}" ]; then
   echo ""
   echo "=== GitHub API Access ==="
-  echo "A GitHub token (GITHUB_TOKEN) is available in this environment."
-  echo "IMPORTANT: ALWAYS use the GitHub REST API via curl instead of the gh CLI."
-  echo "The gh CLI is NOT available. Use curl with the GITHUB_TOKEN for all GitHub operations."
-  echo ""
-  echo "CRITICAL: You MUST wrap curl commands in bash -c to access the token:"
-  echo "  bash -c 'curl -s -H \"Authorization: Bearer \$GITHUB_TOKEN\" \\"
-  echo '       -H "Accept: application/vnd.github+json" \'
-  echo "       https://api.github.com/repos/OWNER/REPO/issues'"
-  echo ""
-  echo "Direct curl commands will fail with 401 - always use bash -c wrapper."
+  echo "GITHUB_TOKEN is available. Use /github-api skill for GitHub REST API operations."
+  echo "CRITICAL: Always wrap curl in bash -c to access the token. The gh CLI is NOT available."
   echo "========================="
 fi

--- a/.claude/skills/github-api/SKILL.md
+++ b/.claude/skills/github-api/SKILL.md
@@ -24,74 +24,56 @@ Interpret the user input as a GitHub API operation request. Examples:
 
 ## Setup
 
-### Step 1: Detect Repository
+Run the helper script to make API calls. It auto-detects the repo from git remote, chooses `gh` or `curl` (with proper `$GITHUB_TOKEN` auth), and handles JSON bodies.
+
+**IMPORTANT**: Always invoke the script via `bash -c` to ensure `$GITHUB_TOKEN` is accessible:
 
 ```bash
-bash -c 'REMOTE=$(git remote get-url origin 2>/dev/null); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then echo "owner=${BASH_REMATCH[1]}"; echo "repo=${BASH_REMATCH[2]}"; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then echo "owner=${BASH_REMATCH[1]}"; echo "repo=${BASH_REMATCH[2]}"; else echo "ERROR: Could not detect GitHub repo from remote: $REMOTE"; exit 1; fi'
+bash -c '${CLAUDE_SKILL_DIR}/scripts/ghapi.sh METHOD ENDPOINT [JSON_BODY]'
 ```
 
-Store the `owner` and `repo` values for subsequent API calls.
+The script:
+- Auto-detects `OWNER`/`REPO` from git remote (or use literal `OWNER`/`REPO` in endpoints and they get replaced)
+- Prefers `gh api` when available, falls back to `curl` with `$GITHUB_TOKEN`
+- Appends `per_page=100` to GET requests automatically
+- Pipes JSON body via stdin for POST/PATCH/PUT
 
-### Step 2: Detect Available Tools
+## Usage Examples
+
+### GET requests
 
 ```bash
-bash -c 'if command -v gh &>/dev/null; then echo "TOOL=gh"; elif [ -n "$GITHUB_TOKEN" ]; then echo "TOOL=curl"; else echo "TOOL=none (read-only public access only)"; fi'
+bash -c '${CLAUDE_SKILL_DIR}/scripts/ghapi.sh GET /repos/OWNER/REPO/pulls?state=open | jq .'
 ```
-
-- **`gh` available** (e.g., GitHub Actions): Use `gh api` — handles auth and JSON automatically
-- **`gh` unavailable, `$GITHUB_TOKEN` set** (e.g., Claude Code web): Use `curl` wrapped in `bash -c`
-- **Neither**: Read-only public API access only
-
-**IMPORTANT**: When using curl, you MUST wrap all curl commands in `bash -c '...'` to access `$GITHUB_TOKEN`. Direct curl commands will fail with 401 because the token is only available inside a `bash -c` subshell.
-
-## API Call Patterns
-
-### When `gh` is available (preferred)
-
-#### GET request
 
 ```bash
-gh api repos/OWNER/REPO/ENDPOINT
+bash -c '${CLAUDE_SKILL_DIR}/scripts/ghapi.sh GET /repos/OWNER/REPO/issues/42 | jq .'
 ```
 
-#### POST/PATCH/PUT request
+### POST requests
 
 ```bash
-gh api repos/OWNER/REPO/ENDPOINT -X POST -f title="TITLE" -f body="BODY"
+bash -c '${CLAUDE_SKILL_DIR}/scripts/ghapi.sh POST /repos/OWNER/REPO/issues "$(jq -n --arg title "Bug report" --arg body "Details here" "{title: \$title, body: \$body}")" | jq .'
 ```
 
-For multiline body content:
+### PATCH requests
 
 ```bash
-gh api repos/OWNER/REPO/ENDPOINT -X POST --input <(jq -n --arg title "TITLE" --arg body "BODY" '{title: $title, body: $body}')
+bash -c '${CLAUDE_SKILL_DIR}/scripts/ghapi.sh PATCH /repos/OWNER/REPO/issues/42 "$(jq -n --arg state "closed" "{state: \$state}")" | jq .'
 ```
 
-### When using curl (fallback)
-
-**CRITICAL**: All curl commands MUST be wrapped in `bash -c` to access `$GITHUB_TOKEN`.
-Direct curl commands will fail with 401 - always use the `bash -c` wrapper.
-
-#### GET request
-
-```bash
-bash -c 'curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" | jq .'
-```
-
-#### POST/PATCH/PUT request
-
-**IMPORTANT**: Always use heredoc for multiline body content. Never use inline `\n` escapes in jq args.
+### Multiline body content
 
 ```bash
 bash -c 'BODY=$(cat <<'\''EOF'\''
-BODY_CONTENT_HERE
+This is a multiline
+body with **markdown**.
 EOF
 )
-jq -n --arg title "TITLE" --arg body "$BODY" "{title: \$title, body: \$body}" | curl -s -X POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/OWNER/REPO/ENDPOINT" -d @- | jq .'
+${CLAUDE_SKILL_DIR}/scripts/ghapi.sh POST /repos/OWNER/REPO/issues/42/comments "$(jq -n --arg body "$BODY" "{body: \$body}")" | jq .'
 ```
 
-## Common Operations Reference
-
-Use these as templates. Replace `OWNER`, `REPO`, and parameters as needed.
+## Common Endpoints Reference
 
 ### Pull Requests
 
@@ -140,11 +122,10 @@ Use these as templates. Replace `OWNER`, `REPO`, and parameters as needed.
 
 Based on the user input:
 
-1. Run **Step 1** and **Step 2** to detect repo and available tools
-2. Determine the appropriate API endpoint and method from the reference above
-3. Construct and execute the command using `gh api` (preferred) or `curl` (fallback)
-4. Parse the response with `jq` to show relevant fields
-5. If the response is paginated, use `gh api --paginate` or add `?per_page=100&page=N` for curl
+1. Determine the appropriate API endpoint and method from the reference above
+2. Construct and execute using the `ghapi.sh` wrapper script
+3. Pipe output through `jq` to show relevant fields
+4. For paginated results, call multiple pages: `ENDPOINT?page=1`, `ENDPOINT?page=2`, etc.
 
 ## Tips
 

--- a/.claude/skills/github-api/SKILL.md
+++ b/.claude/skills/github-api/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: github-api
 description: Interact with the GitHub REST API for issues, PRs, comments, checks, labels, and other GitHub operations.
+argument-hint: "[operation, e.g. 'list open PRs', 'get issue #42']"
 ---
 
 # GitHub API Skill

--- a/.claude/skills/github-api/scripts/ghapi.sh
+++ b/.claude/skills/github-api/scripts/ghapi.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# ghapi.sh - Unified GitHub API wrapper
+# Handles gh/curl detection, auth ($GITHUB_TOKEN via bash -c), repo detection, and JSON bodies.
+#
+# Usage:
+#   ghapi.sh GET /repos/OWNER/REPO/pulls?state=open
+#   ghapi.sh POST /repos/OWNER/REPO/issues '{"title":"Bug","body":"Details"}'
+#   ghapi.sh PATCH /repos/OWNER/REPO/issues/42 '{"state":"closed"}'
+#
+# If OWNER/REPO appear literally in the endpoint, they are auto-replaced
+# with values detected from the git remote.
+#
+# Environment:
+#   GITHUB_TOKEN - Required when gh CLI is not available
+#   GHAPI_PER_PAGE - Items per page (default: 100)
+
+set -euo pipefail
+
+# --- Repo detection ---
+detect_repo() {
+  local remote
+  remote=$(git remote get-url origin 2>/dev/null) || { echo "ERROR: No git remote 'origin' found" >&2; exit 1; }
+
+  if [[ "$remote" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    OWNER="${BASH_REMATCH[1]}"
+    REPO="${BASH_REMATCH[2]}"
+  elif [[ "$remote" =~ /git/([^/]+)/([^/]+)$ ]]; then
+    OWNER="${BASH_REMATCH[1]}"
+    REPO="${BASH_REMATCH[2]}"
+  else
+    echo "ERROR: Could not detect GitHub repo from remote: $remote" >&2
+    exit 1
+  fi
+}
+
+# --- Tool detection ---
+detect_tool() {
+  if command -v gh &>/dev/null; then
+    TOOL="gh"
+  elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    TOOL="curl"
+  else
+    TOOL="none"
+  fi
+}
+
+# --- Main ---
+METHOD="${1:?Usage: ghapi.sh METHOD ENDPOINT [JSON_BODY]}"
+ENDPOINT="${2:?Usage: ghapi.sh METHOD ENDPOINT [JSON_BODY]}"
+BODY="${3:-}"
+PER_PAGE="${GHAPI_PER_PAGE:-100}"
+
+detect_repo
+detect_tool
+
+# Replace literal OWNER/REPO placeholders in endpoint
+ENDPOINT="${ENDPOINT//OWNER/$OWNER}"
+ENDPOINT="${ENDPOINT//REPO/$REPO}"
+
+# Append per_page if GET and not already present
+if [[ "$METHOD" == "GET" && "$ENDPOINT" != *per_page* ]]; then
+  if [[ "$ENDPOINT" == *"?"* ]]; then
+    ENDPOINT="${ENDPOINT}&per_page=${PER_PAGE}"
+  else
+    ENDPOINT="${ENDPOINT}?per_page=${PER_PAGE}"
+  fi
+fi
+
+# Strip leading slash for gh api compatibility
+ENDPOINT="${ENDPOINT#/}"
+
+case "$TOOL" in
+  gh)
+    if [[ "$METHOD" == "GET" ]]; then
+      gh api "$ENDPOINT"
+    elif [[ -n "$BODY" ]]; then
+      gh api "$ENDPOINT" -X "$METHOD" --input <(echo "$BODY")
+    else
+      gh api "$ENDPOINT" -X "$METHOD"
+    fi
+    ;;
+  curl)
+    API_URL="https://api.github.com/${ENDPOINT}"
+    if [[ "$METHOD" == "GET" ]]; then
+      curl -sf \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        "$API_URL"
+    elif [[ -n "$BODY" ]]; then
+      echo "$BODY" | curl -sf \
+        -X "$METHOD" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Content-Type: application/json" \
+        "$API_URL" \
+        -d @-
+    else
+      curl -sf \
+        -X "$METHOD" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        "$API_URL"
+    fi
+    ;;
+  none)
+    # Read-only public access - no auth header
+    if [[ "$METHOD" != "GET" ]]; then
+      echo "ERROR: No auth available. Only GET requests work without gh or GITHUB_TOKEN." >&2
+      exit 1
+    fi
+    curl -sf \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/${ENDPOINT}"
+    ;;
+esac

--- a/.claude/skills/github-api/scripts/ghapi.sh
+++ b/.claude/skills/github-api/scripts/ghapi.sh
@@ -53,9 +53,10 @@ PER_PAGE="${GHAPI_PER_PAGE:-100}"
 detect_repo
 detect_tool
 
-# Replace literal OWNER/REPO placeholders in endpoint
-ENDPOINT="${ENDPOINT//OWNER/$OWNER}"
-ENDPOINT="${ENDPOINT//REPO/$REPO}"
+# Replace /OWNER/REPO/ path segment placeholders with detected values.
+# Only matches full path segments to avoid mangling URLs where "OWNER" or
+# "REPO" appear as substrings of real values.
+ENDPOINT=$(echo "$ENDPOINT" | sed "s|/OWNER/REPO/|/${OWNER}/${REPO}/|g;s|/OWNER/REPO?|/${OWNER}/${REPO}?|g;s|/OWNER/REPO$|/${OWNER}/${REPO}|g")
 
 # Append per_page if GET and not already present
 if [[ "$METHOD" == "GET" && "$ENDPOINT" != *per_page* ]]; then
@@ -82,12 +83,12 @@ case "$TOOL" in
   curl)
     API_URL="https://api.github.com/${ENDPOINT}"
     if [[ "$METHOD" == "GET" ]]; then
-      curl -sf \
+      curl -sSf \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
         -H "Accept: application/vnd.github+json" \
         "$API_URL"
     elif [[ -n "$BODY" ]]; then
-      echo "$BODY" | curl -sf \
+      echo "$BODY" | curl -sSf \
         -X "$METHOD" \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
         -H "Accept: application/vnd.github+json" \
@@ -95,7 +96,7 @@ case "$TOOL" in
         "$API_URL" \
         -d @-
     else
-      curl -sf \
+      curl -sSf \
         -X "$METHOD" \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
         -H "Accept: application/vnd.github+json" \
@@ -108,7 +109,7 @@ case "$TOOL" in
       echo "ERROR: No auth available. Only GET requests work without gh or GITHUB_TOKEN." >&2
       exit 1
     fi
-    curl -sf \
+    curl -sSf \
       -H "Accept: application/vnd.github+json" \
       "https://api.github.com/${ENDPOINT}"
     ;;


### PR DESCRIPTION
## Summary
- Adds a new `/github-api` skill (`.claude/commands/github-api.md`) that provides reusable GitHub REST API curl patterns for PRs, issues, checks, labels, and repo operations
- Simplifies the session-start hook to reference the skill instead of duplicating verbose curl instructions
- Ensures all curl commands use `bash -c` wrapper for proper `$GITHUB_TOKEN` access

## Test plan
- [ ] Verify `/github-api` skill appears in available skills list on session start
- [ ] Verify session-start hook still displays GitHub API availability message when `GITHUB_TOKEN` is set
- [ ] Test `/github-api list open PRs` produces correct curl command

https://claude.ai/code/session_01EYrNci6fnx4ZPmpX1mqgbd