### PR TITLE
feat(ci): add architecture reviewer for PR code reviews

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,6 +1,6 @@
 # Create PR and Address Reviews
 
-Open a PR for the current branch and address Claude Code Review comments.
+Open a PR for the current branch and address Claude Code Review comments (both code quality and architecture reviews).
 
 ## Prerequisites
 
@@ -58,9 +58,9 @@ EOF
 REMOTE=$(git remote get-url origin); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; fi; jq -n --arg title "PR_TITLE_HERE" --arg body "$BODY" "{title: \$title, body: \$body}" | curl -s -X PATCH -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/pulls/PR_NUMBER_HERE" -d @- | jq "{number, html_url}"'
 ```
 
-### Step 4: Wait for Claude Code Review
+### Step 4: Wait for Claude Code Reviews
 
-Inform the user, then wait 1 minute 30 seconds for the review workflow:
+Inform the user that two reviewers will run (Code Quality + Architecture), then wait 1 minute 30 seconds:
 
 ```bash
 sleep 90
@@ -68,23 +68,27 @@ sleep 90
 
 ### Step 5: Fetch Review Comments (with retry)
 
-Fetch the latest review comment from Claude:
+Fetch ALL review comments from Claude (both code quality and architecture reviews):
 
 ```bash
-bash -c 'REMOTE=$(git remote get-url origin); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; fi; curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/issues/PR_NUMBER_HERE/comments" | jq "[.[] | select(.user.login == \"claude[bot]\") | {id, created_at, body}] | sort_by(.created_at) | last"'
+bash -c 'REMOTE=$(git remote get-url origin); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; fi; curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/issues/PR_NUMBER_HERE/comments" | jq "[.[] | select(.user.login == \"claude[bot]\") | {id, created_at, body}] | sort_by(.created_at)"'
 ```
 
-If no review comment is found (null result) or the comment is older than this PR update, wait 1 more minute and retry:
+Identify the two most recent comments:
+- **Code Quality Review**: contains `## Claude Code Review` header
+- **Architecture Review**: contains `## Architecture Review` header
+
+If fewer than 2 review comments are found or either review is missing, wait 1 more minute and retry:
 
 ```bash
 sleep 60
 ```
 
 ```bash
-bash -c 'REMOTE=$(git remote get-url origin); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; fi; curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/issues/PR_NUMBER_HERE/comments" | jq "[.[] | select(.user.login == \"claude[bot]\") | {id, created_at, body}] | sort_by(.created_at) | last"'
+bash -c 'REMOTE=$(git remote get-url origin); if [[ "$REMOTE" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; elif [[ "$REMOTE" =~ /git/([^/]+)/([^/]+)$ ]]; then OWNER=${BASH_REMATCH[1]}; REPO=${BASH_REMATCH[2]}; fi; curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/issues/PR_NUMBER_HERE/comments" | jq "[.[] | select(.user.login == \"claude[bot]\") | {id, created_at, body}] | sort_by(.created_at)"'
 ```
 
-If still no review after retry, inform the user and stop.
+If still missing reviews after retry, proceed with whatever reviews are available. Inform the user about any missing reviews.
 
 ### Step 6: Check CI Status
 
@@ -100,17 +104,23 @@ Record any failed checks (`conclusion: "failure"`) to address in Step 9.
 
 ### Step 7: Parse and Address Review Issues
 
+Address issues from BOTH reviews:
+
+**Code Quality Review** (`## Claude Code Review`):
 From the review comment body, find the `### Issues Found` section.
+
+**Architecture Review** (`## Architecture Review`):
+From the review comment body, find the `### Issues Found` section. Issues are tagged with categories: `[boundary]` `[separation]` `[structure]` `[adapter]` `[organization]`.
 
 Format: `1. **\`file.ts:123\` - Description\*\*`
 
-For each issue:
+For each issue across both reviews:
 
 1. Read the file at the specified line
 2. Understand and implement the fix
 3. Move to next issue
 
-If "No issues found" or "LGTM", skip to Step 9 (or Step 10 if no CI failures).
+If both reviews say "No issues found" or "LGTM", skip to Step 9 (or Step 10 if no CI failures).
 
 ### Step 8: Commit Review Fixes (don't push yet)
 

--- a/.claude/hooks/session-start-review-architecture.sh
+++ b/.claude/hooks/session-start-review-architecture.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Session start hook for Architecture Claude Code Review (architecture review workflow only)
+# This hook ensures architecture review guidelines are loaded before reviewing PRs
+
+# Only run when CLAUDE_CODE_REVIEW_TYPE=architecture (set by claude-code-review-architecture.yml)
+if [ "${CLAUDE_CODE_REVIEW_TYPE:-}" != "architecture" ]; then
+  exit 0
+fi
+
+# Synchronous execution - block until complete
+cat <<'EOF'
+=== Architecture Code Review Session ===
+
+MANDATORY: You MUST read these files FIRST before reviewing any code:
+
+1. docs/REVIEW_CHECKLIST_ARCHITECTURE.md - Architecture review criteria (READ THIS FIRST)
+2. docs/CODE_PATTERNS.md - Code patterns and module structure
+
+These files define what architectural violations to flag. Do not proceed with
+the review until you have read and understood the checklist.
+
+IMPORTANT: You are the ARCHITECTURE reviewer. Focus ONLY on:
+- Monorepo boundary violations
+- Feature module structure
+- Separation of concerns (hooks, components, services, utils)
+- Platform adapter pattern compliance
+- State management boundaries
+- Circular dependencies and layer violations
+
+Do NOT review: naming conventions, accessibility, i18n, security — those are
+handled by the primary Code Review workflow.
+
+After reading, check for previous review comments on this PR to ensure
+consistency (don't repeat issues, acknowledge fixes).
+===============================
+EOF

--- a/.claude/settings-review-architecture.json
+++ b/.claude/settings-review-architecture.json
@@ -1,0 +1,30 @@
+{
+  "env": {
+    "CLAUDE_CODE_REVIEW": "true",
+    "CLAUDE_CODE_REVIEW_TYPE": "architecture"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh search:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-review-architecture.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings-review-architecture.json
+++ b/.claude/settings-review-architecture.json
@@ -1,6 +1,5 @@
 {
   "env": {
-    "CLAUDE_CODE_REVIEW": "true",
     "CLAUDE_CODE_REVIEW_TYPE": "architecture"
   },
   "permissions": {

--- a/.github/workflows/claude-code-review-architecture-retry.yml
+++ b/.github/workflows/claude-code-review-architecture-retry.yml
@@ -1,0 +1,130 @@
+name: Auto-Retry Architecture Review
+on:
+  workflow_run:
+    workflows: ['Architecture Review']
+    types: [completed]
+jobs:
+  retry-on-failure:
+    # Only run if the workflow failed and was triggered by a PR (not workflow_dispatch)
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get PR information
+        id: pr-info
+        run: |
+          # Search for the PR associated with this head SHA
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          PR_DATA=$(gh pr list --state open --json number,headRefOid -q ".[] | select(.headRefOid == \"$HEAD_SHA\")")
+
+          if [ -z "$PR_DATA" ]; then
+            echo "Could not find PR for SHA $HEAD_SHA"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "Found PR #$PR_NUMBER"
+
+          # Get base ref for checking changed files
+          BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
+          echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Check if retry should be skipped
+        id: check-guidelines
+        if: steps.pr-info.outputs.skip != 'true'
+        run: |
+          PR_NUMBER="${{ steps.pr-info.outputs.pr_number }}"
+
+          # Get changed files in the PR
+          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only)
+
+          # Skip retry if guidelines files were modified (expected failures during review)
+          if echo "$CHANGED_FILES" | grep -qE "^(CLAUDE\.md|docs/REVIEW_CHECKLIST_ARCHITECTURE\.md|docs/CODE_PATTERNS\.md)$"; then
+            echo "Guidelines files were modified - skipping retry"
+            echo "skip_retry=true" >> $GITHUB_OUTPUT
+            echo "skip_reason=guidelines_modified" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Skip retry if workflow files were modified (GitHub security restriction)
+          if echo "$CHANGED_FILES" | grep -qE "^\.github/workflows/.*\.ya?ml$"; then
+            echo "Workflow files were modified - skipping retry (GitHub security restriction)"
+            echo "skip_retry=true" >> $GITHUB_OUTPUT
+            echo "skip_reason=workflow_modified" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "No special files modified - retry is allowed"
+          echo "skip_retry=false" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Check retry count
+        id: check-retry
+        if: |
+          steps.pr-info.outputs.skip != 'true' &&
+          steps.check-guidelines.outputs.skip_retry != 'true'
+        run: |
+          MAX_RETRIES=3
+
+          # Get current attempt number from the failed run
+          CURRENT_ATTEMPT=$(gh run view ${{ github.event.workflow_run.id }} --json attempt -q '.attempt')
+
+          echo "Current attempt: $CURRENT_ATTEMPT of max $MAX_RETRIES"
+
+          if [ "$CURRENT_ATTEMPT" -ge "$MAX_RETRIES" ]; then
+            echo "Max retries ($MAX_RETRIES) reached - not retrying"
+            echo "should_retry=false" >> $GITHUB_OUTPUT
+          else
+            echo "Will trigger retry (attempt $((CURRENT_ATTEMPT + 1)) of $MAX_RETRIES)"
+            echo "should_retry=true" >> $GITHUB_OUTPUT
+            echo "retry_attempt=$((CURRENT_ATTEMPT + 1))" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Trigger retry
+        if: |
+          steps.pr-info.outputs.skip != 'true' &&
+          steps.check-guidelines.outputs.skip_retry != 'true' &&
+          steps.check-retry.outputs.should_retry == 'true'
+        run: |
+          RETRY_ATTEMPT="${{ steps.check-retry.outputs.retry_attempt }}"
+          RUN_ID="${{ github.event.workflow_run.id }}"
+
+          echo "Triggering retry attempt $RETRY_ATTEMPT for run $RUN_ID..."
+
+          # Wait before retrying to avoid rate limits
+          sleep 30
+
+          # Re-run the failed workflow run (maintains PR association and updates PR status)
+          gh run rerun "$RUN_ID" --failed
+
+          echo "Retry triggered successfully"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Log skip reason
+        if: |
+          steps.pr-info.outputs.skip == 'true' ||
+          steps.check-guidelines.outputs.skip_retry == 'true' ||
+          steps.check-retry.outputs.should_retry == 'false'
+        run: |
+          if [ "${{ steps.pr-info.outputs.skip }}" = "true" ]; then
+            echo "Skipped: Could not find associated PR"
+          elif [ "${{ steps.check-guidelines.outputs.skip_reason }}" = "guidelines_modified" ]; then
+            echo "Skipped: Guidelines files (CLAUDE.md, REVIEW_CHECKLIST_ARCHITECTURE.md, CODE_PATTERNS.md) were modified"
+          elif [ "${{ steps.check-guidelines.outputs.skip_reason }}" = "workflow_modified" ]; then
+            echo "Skipped: Workflow files (.github/workflows/*.yml) were modified - GitHub security restriction prevents retrying"
+          elif [ "${{ steps.check-retry.outputs.should_retry }}" = "false" ]; then
+            echo "Skipped: Maximum retry attempts reached"
+          fi

--- a/.github/workflows/claude-code-review-architecture.yml
+++ b/.github/workflows/claude-code-review-architecture.yml
@@ -1,0 +1,92 @@
+name: Architecture Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+jobs:
+  architecture-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Need full history to check changed files
+      - name: Check if guidelines or workflow files were modified
+        id: check-skip
+        run: |
+          # For workflow_dispatch, we need to fetch the PR info
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            # Fetch the PR branch
+            gh pr checkout "$PR_NUMBER" --detach 2>/dev/null || true
+            BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
+          else
+            BASE_REF="${{ github.base_ref }}"
+          fi
+
+          # Get the list of changed files in this PR
+          CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF"...HEAD 2>/dev/null || echo "")
+
+          # Check for guidelines files
+          if echo "$CHANGED_FILES" | grep -qE "^(CLAUDE\.md|docs/REVIEW_CHECKLIST_ARCHITECTURE\.md|docs/CODE_PATTERNS\.md)$"; then
+            echo "Guidelines files modified - retries disabled"
+            echo "guidelines_changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check for workflow files (GitHub security restriction prevents retrying)
+          if echo "$CHANGED_FILES" | grep -qE "^\.github/workflows/.*\.ya?ml$"; then
+            echo "Workflow files modified - retries disabled (GitHub security restriction)"
+            echo "guidelines_changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "No special files modified - retries enabled"
+          echo "guidelines_changed=false" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Run Architecture Review
+        id: architecture-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use architecture review-specific settings with hooks that auto-load guidelines
+          # Note: Changes won't take effect until merged (GitHub runs base branch workflow)
+          settings: ".claude/settings-review-architecture.json"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+            EVENT TYPE: ${{ github.event.action }}
+
+            Review this PR following the guidelines in docs/REVIEW_CHECKLIST_ARCHITECTURE.md.
+
+            You are the ARCHITECTURE reviewer. Focus ONLY on code architecture and separation of concerns.
+            Do NOT review naming conventions, accessibility, i18n, or security.
+
+            BEFORE reviewing, check for previous architecture review comments:
+            1. Run `gh pr view ${{ github.event.pull_request.number || inputs.pr_number }} --comments`
+            2. Look for comments with "## Architecture Review" header
+            3. For re-reviews (EVENT TYPE is "synchronize"): acknowledge fixes, flag new issues only
+
+            Post your review using `gh pr comment`. Output plain markdown (not wrapped in code blocks).
+          claude_args: '--model opus'
+          allowed_tools: |
+            Bash(gh issue view:*)
+            Bash(gh search:*)
+            Bash(gh issue list:*)
+            Bash(gh pr comment:*)
+            Bash(gh pr diff:*)
+            Bash(gh pr view:*)
+            Bash(gh pr list:*)
+    outputs:
+      guidelines_changed: ${{ steps.check-skip.outputs.guidelines_changed }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ VolleyKit is a multi-platform app suite for Swiss volleyball referee management 
 | Writing tests                 | [docs/TESTING_STRATEGY.md](docs/TESTING_STRATEGY.md)                          |
 | API integration               | [docs/api/](docs/api/) - OpenAPI spec, endpoint docs, captures                |
 | Reviewing PRs                 | [docs/REVIEW_CHECKLIST.md](docs/REVIEW_CHECKLIST.md)                          |
+| Reviewing PR architecture     | [docs/REVIEW_CHECKLIST_ARCHITECTURE.md](docs/REVIEW_CHECKLIST_ARCHITECTURE.md)|
 | Data storage questions        | [docs/DATA_RETENTION.md](docs/DATA_RETENTION.md)                              |
 
 ## Development Workflow

--- a/docs/REVIEW_CHECKLIST_ARCHITECTURE.md
+++ b/docs/REVIEW_CHECKLIST_ARCHITECTURE.md
@@ -1,0 +1,162 @@
+# Architecture Review Checklist
+
+Single source of truth for the Architecture Claude Code Review. This file is automatically loaded by the architecture review hook.
+
+## Focus Areas
+
+This reviewer focuses exclusively on **code architecture and separation of concerns**. It does NOT review naming conventions, accessibility, i18n, or security — those are handled by the primary Code Review.
+
+## Monorepo Boundary Violations (Must Flag)
+
+### Package Dependency Direction
+
+```
+web ──→ shared ←── mobile
+              ↑
+           worker (independent)
+```
+
+- `shared` MUST NOT import from `web`, `mobile`, or `worker`
+- `web` and `mobile` import from `shared` via subpath exports (`@volleykit/shared/hooks`, etc.)
+- `worker` is independent — no imports from other packages
+- Cross-package imports must use the package name, never relative paths (`../../../shared/`)
+
+### Subpath Export Boundaries
+
+Shared package exposes: `/api`, `/stores`, `/hooks`, `/utils`, `/i18n`, `/types`, `/adapters`, `/offline`
+
+- Flag imports that bypass subpath exports (e.g., `@volleykit/shared/src/internal/...`)
+- Flag deep imports into internal modules not exposed via barrel files
+
+## Feature Module Structure (Must Flag)
+
+### Expected Layout
+
+```
+packages/web/src/features/<feature>/
+├── index.ts              # Public API — explicit exports only
+├── components/           # UI components
+├── hooks/                # State + action hooks
+├── api/                  # Only if custom API logic needed
+└── utils/                # Pure utility functions
+```
+
+- Flag features missing `index.ts` barrel file
+- Flag `export *` in feature-level `index.ts` (must use explicit exports)
+- Flag components importing directly from another feature's internals instead of its `index.ts`
+
+### Cross-Feature Dependencies
+
+- Features should communicate through shared state (Zustand stores) or shared hooks, not by importing each other's internals
+- Flag direct imports between features (e.g., `import { X } from '../other-feature/components/Y'`)
+- Acceptable: importing from another feature's public API (`index.ts`)
+
+## Separation of Concerns (Must Flag)
+
+### Hook Responsibility Split
+
+- **State hooks**: `useState`, `useMemo`, `useCallback`, derived state — no API calls
+- **Action hooks**: API mutations, cache invalidation, side effects
+- **Components**: Rendering only — logic belongs in hooks
+
+Flag when:
+- A component contains business logic (>15 lines of non-rendering code)
+- A single hook mixes state management AND API calls AND exceeds ~300 LOC
+- API calls are made directly in components instead of through hooks or TanStack Query
+
+### Services vs Utils
+
+| Category   | Location      | Characteristics                                      |
+| ---------- | ------------- | ---------------------------------------------------- |
+| Services   | `services/`   | Stateful, side effects, platform APIs, singletons    |
+| Utils      | `utils/`      | Pure functions, no side effects, easily unit-testable |
+
+- Flag utility functions that have side effects or depend on platform APIs
+- Flag service code that could be a pure function (no state, no side effects)
+
+### State Management Boundaries
+
+| State Type   | Tool           | Location                |
+| ------------ | -------------- | ----------------------- |
+| Server state | TanStack Query | Via shared hooks        |
+| Client state | Zustand        | `shared/stores/`        |
+| Form state   | React state    | Component/hook-local    |
+| URL state    | React Router   | Route params/search     |
+
+- Flag server data stored in Zustand (should use TanStack Query)
+- Flag TanStack Query used for purely client-side state
+- Flag global Zustand state that is only used by one component (should be local state)
+
+## Platform Adapter Pattern (Must Flag)
+
+### Contract Compliance
+
+```typescript
+// shared defines the contract (interface)
+// web and mobile provide implementations
+// shared hooks accept adapters as parameters
+```
+
+- Flag platform-specific code (DOM APIs, React Native APIs) in `packages/shared/`
+- Flag shared hooks that import directly from `web` or `mobile` implementations
+- Flag missing adapter pattern when shared code needs platform-specific behavior
+
+## Code Organization (Should Flag)
+
+### File Size Thresholds
+
+| Threshold | Action                                         |
+| --------- | ---------------------------------------------- |
+| >300 LOC  | Consider splitting — flag if mixing concerns   |
+| >500 LOC  | Must split — flag with extraction suggestions  |
+
+### Circular Dependencies
+
+- Flag circular imports between modules
+- Flag features that form import cycles through shared modules
+
+### Layer Violations
+
+```
+Components → Hooks → API/Stores → Utils
+         (never the reverse)
+```
+
+- Flag hooks importing from components
+- Flag utils importing from hooks or components
+- Flag API layer importing from components
+
+## Review Output Format
+
+```markdown
+## Architecture Review
+
+**Review type:** [Initial review | Re-review after changes]
+
+### Summary
+
+[1-2 sentence overview of architectural health]
+
+### Issues Found
+
+[List issues with file:line references and category tags, or "No issues found"]
+
+Categories: `[boundary]` `[separation]` `[structure]` `[adapter]` `[organization]`
+
+### Fixed Since Last Review (re-reviews only)
+
+[List resolved issues, or omit section for initial reviews]
+
+### Recommendations
+
+[Optional suggestions for architectural improvements]
+```
+
+## Re-Review Guidelines
+
+When `EVENT TYPE` is `synchronize`:
+
+- DO NOT repeat issues still present — reference briefly
+- DO acknowledge fixed issues with "Fixed: [issue]"
+- DO flag NEW architectural issues in latest commits
+- Focus on changes since last review


### PR DESCRIPTION
## Summary

- Add a second Claude Code reviewer focused on **code architecture and separation of concerns**
- Runs alongside the existing code quality reviewer on every PR (both trigger on `opened`/`synchronize`)
- Reviews: monorepo boundary violations, feature module structure, hook responsibility splits, platform adapter compliance, state management boundaries, circular dependencies
- Includes auto-retry workflow (up to 3 attempts) matching existing retry pattern
- Updated `/pr-review` command to collect and address issues from both reviewers

## New files

| File | Purpose |
|------|---------|
| `docs/REVIEW_CHECKLIST_ARCHITECTURE.md` | Architecture review criteria |
| `.claude/settings-review-architecture.json` | Reviewer settings (`CLAUDE_CODE_REVIEW_TYPE=architecture`) |
| `.claude/hooks/session-start-review-architecture.sh` | Session hook to load architecture guidelines |
| `.github/workflows/claude-code-review-architecture.yml` | GitHub Actions workflow |
| `.github/workflows/claude-code-review-architecture-retry.yml` | Auto-retry on failure |

## Reviewer scope separation

| Concern | Code Quality (existing) | Architecture (new) |
|---------|------------------------|--------------------|
| Naming conventions | ✓ | |
| Accessibility | ✓ | |
| i18n | ✓ | |
| Security | ✓ | |
| Anti-patterns | ✓ | |
| Monorepo boundaries | | ✓ |
| Feature module structure | | ✓ |
| Separation of concerns | | ✓ |
| Platform adapter pattern | | ✓ |
| State management boundaries | | ✓ |

## Test plan

- [ ] Verify Architecture Review workflow triggers on PR open/synchronize
- [ ] Verify retry workflow triggers on Architecture Review failure
- [ ] Verify session hook only activates when `CLAUDE_CODE_REVIEW_TYPE=architecture`
- [ ] Verify `/pr-review` fetches comments from both reviewers
- [ ] Verify architecture review does not overlap with code quality review scope