### PR TITLE
refactor(web): improve separation of concerns in sports hall report feature

### DIFF
--- a/packages/web/src/features/sports-hall-report/components/CommentStep.tsx
+++ b/packages/web/src/features/sports-hall-report/components/CommentStep.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
-import type { ChecklistSection } from '@/shared/utils/pdf-form-filler'
+import type { ChecklistSection } from '@/shared/utils/pdf-field-mappings'
 
 interface CommentStepProps {
   sections: readonly ChecklistSection[]

--- a/packages/web/src/features/sports-hall-report/components/HappyPathContent.tsx
+++ b/packages/web/src/features/sports-hall-report/components/HappyPathContent.tsx
@@ -9,17 +9,21 @@ import type { Language } from '@/shared/utils/pdf-report-data'
 import { JerseyAdvertisingSection } from './JerseyAdvertisingSection'
 import { LanguageSelector } from './LanguageSelector'
 
+export interface JerseyAdProps {
+  jerseyAdvertising: JerseyAdvertisingOptions
+  onToggleHome: () => void
+  onToggleAway: () => void
+  homeTeam: string
+  awayTeam: string
+}
+
 interface HappyPathContentProps {
   language: Language
   setLanguage: (lang: Language) => void
   confirmed: boolean
   setConfirmed: (fn: (prev: boolean) => boolean) => void
   isGenerating: boolean
-  jerseyAdvertising: JerseyAdvertisingOptions
-  onToggleHomeAd: () => void
-  onToggleAwayAd: () => void
-  homeTeam: string
-  awayTeam: string
+  jerseyAd: JerseyAdProps
   onGenerate: () => void
   onDownloadPreFilled: () => void
   onReportIssue?: () => void
@@ -32,11 +36,7 @@ export function HappyPathContent({
   confirmed,
   setConfirmed,
   isGenerating,
-  jerseyAdvertising,
-  onToggleHomeAd,
-  onToggleAwayAd,
-  homeTeam,
-  awayTeam,
+  jerseyAd,
   onGenerate,
   onDownloadPreFilled,
   onReportIssue,
@@ -74,11 +74,11 @@ export function HappyPathContent({
               {confirmed && (
                 <div className="mt-3">
                   <JerseyAdvertisingSection
-                    jerseyAdvertising={jerseyAdvertising}
-                    onToggleHome={onToggleHomeAd}
-                    onToggleAway={onToggleAwayAd}
-                    homeTeam={homeTeam}
-                    awayTeam={awayTeam}
+                    jerseyAdvertising={jerseyAd.jerseyAdvertising}
+                    onToggleHome={jerseyAd.onToggleHome}
+                    onToggleAway={jerseyAd.onToggleAway}
+                    homeTeam={jerseyAd.homeTeam}
+                    awayTeam={jerseyAd.awayTeam}
                     disabled={isGenerating}
                   />
                 </div>

--- a/packages/web/src/features/sports-hall-report/components/HappyPathContent.tsx
+++ b/packages/web/src/features/sports-hall-report/components/HappyPathContent.tsx
@@ -1,0 +1,143 @@
+import { Button } from '@/shared/components/Button'
+import { AlertTriangle } from '@/shared/components/icons'
+import { ModalFooter } from '@/shared/components/ModalFooter'
+import { ToggleSwitch } from '@/shared/components/ToggleSwitch'
+import { useTranslation } from '@/shared/hooks/useTranslation'
+import type { JerseyAdvertisingOptions } from '@/shared/utils/pdf-form-filler'
+import type { Language } from '@/shared/utils/pdf-report-data'
+
+import { JerseyAdvertisingSection } from './JerseyAdvertisingSection'
+import { LanguageSelector } from './LanguageSelector'
+
+interface HappyPathContentProps {
+  language: Language
+  setLanguage: (lang: Language) => void
+  confirmed: boolean
+  setConfirmed: (fn: (prev: boolean) => boolean) => void
+  isGenerating: boolean
+  jerseyAdvertising: JerseyAdvertisingOptions
+  onToggleHomeAd: () => void
+  onToggleAwayAd: () => void
+  homeTeam: string
+  awayTeam: string
+  onGenerate: () => void
+  onDownloadPreFilled: () => void
+  onReportIssue?: () => void
+  onClose: () => void
+}
+
+export function HappyPathContent({
+  language,
+  setLanguage,
+  confirmed,
+  setConfirmed,
+  isGenerating,
+  jerseyAdvertising,
+  onToggleHomeAd,
+  onToggleAwayAd,
+  homeTeam,
+  awayTeam,
+  onGenerate,
+  onDownloadPreFilled,
+  onReportIssue,
+  onClose,
+}: HappyPathContentProps) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <LanguageSelector language={language} setLanguage={setLanguage} disabled={isGenerating} />
+
+      {/* Confirmation */}
+      <div className="mb-5">
+        <div
+          className={`rounded-lg border p-4 transition-colors ${
+            confirmed
+              ? 'border-success-500 bg-success-50 dark:bg-success-900/20'
+              : 'border-border-default dark:border-border-default-dark'
+          }`}
+        >
+          <div className="flex items-start gap-3">
+            <div className="flex-1">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+                  {t('pdf.wizard.confirmLabel')}
+                </span>
+                <ToggleSwitch
+                  checked={confirmed}
+                  onChange={() => setConfirmed((prev) => !prev)}
+                  label={t('pdf.wizard.confirmLabel')}
+                  variant="success"
+                  disabled={isGenerating}
+                />
+              </div>
+              {confirmed && (
+                <div className="mt-3">
+                  <JerseyAdvertisingSection
+                    jerseyAdvertising={jerseyAdvertising}
+                    onToggleHome={onToggleHomeAd}
+                    onToggleAway={onToggleAwayAd}
+                    homeTeam={homeTeam}
+                    awayTeam={awayTeam}
+                    disabled={isGenerating}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Report issue link (only when non-conformant workflow is enabled) */}
+      {onReportIssue && (
+        <div className="mb-3">
+          <button
+            type="button"
+            onClick={onReportIssue}
+            disabled={isGenerating}
+            className="flex items-center gap-1.5 text-sm text-warning-600 dark:text-warning-400 hover:text-warning-700 dark:hover:text-warning-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+            {t('pdf.wizard.nonConformant.reportIssue')}
+          </button>
+        </div>
+      )}
+
+      {/* Download pre-filled fallback */}
+      <div className="mb-5">
+        <button
+          type="button"
+          onClick={onDownloadPreFilled}
+          disabled={isGenerating}
+          className="text-sm text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark underline underline-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {t('pdf.wizard.downloadPreFilled')}
+        </button>
+      </div>
+
+      <ModalFooter>
+        <Button variant="secondary" className="flex-1" onClick={onClose} disabled={isGenerating}>
+          {t('common.cancel')}
+        </Button>
+        <Button
+          variant="blue"
+          className="flex-1"
+          onClick={onGenerate}
+          disabled={!confirmed || isGenerating}
+        >
+          {isGenerating ? (
+            <>
+              <span
+                className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"
+                aria-hidden="true"
+              />
+              {t('pdf.generating')}
+            </>
+          ) : (
+            t('pdf.wizard.generate')
+          )}
+        </Button>
+      </ModalFooter>
+    </>
+  )
+}

--- a/packages/web/src/features/sports-hall-report/components/JerseyAdToggle.tsx
+++ b/packages/web/src/features/sports-hall-report/components/JerseyAdToggle.tsx
@@ -1,0 +1,28 @@
+import { CheckCircle, XCircle } from '@/shared/components/icons'
+
+interface JerseyAdToggleProps {
+  label: string
+  checked: boolean
+  onChange: () => void
+  disabled: boolean
+}
+
+export function JerseyAdToggle({ label, checked, onChange, disabled }: JerseyAdToggleProps) {
+  const Icon = checked ? CheckCircle : XCircle
+  return (
+    <button
+      type="button"
+      onClick={onChange}
+      disabled={disabled}
+      title={label}
+      className={`flex w-full items-center gap-2 min-w-0 rounded-lg border py-2 px-3 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
+        checked
+          ? 'border-success-200 bg-success-50 text-success-700 hover:bg-success-100 dark:border-success-800 dark:bg-success-900/20 dark:text-success-400 dark:hover:bg-success-900/30'
+          : 'border-red-200 bg-red-50 text-red-600 hover:bg-red-100 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30'
+      }`}
+    >
+      <Icon className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+      <span className="truncate">{label}</span>
+    </button>
+  )
+}

--- a/packages/web/src/features/sports-hall-report/components/JerseyAdvertisingSection.tsx
+++ b/packages/web/src/features/sports-hall-report/components/JerseyAdvertisingSection.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from '@/shared/hooks/useTranslation'
+import type { JerseyAdvertisingOptions } from '@/shared/utils/pdf-form-filler'
+
+import { JerseyAdToggle } from './JerseyAdToggle'
+
+interface JerseyAdvertisingSectionProps {
+  jerseyAdvertising: JerseyAdvertisingOptions
+  onToggleHome: () => void
+  onToggleAway: () => void
+  homeTeam: string
+  awayTeam: string
+  disabled: boolean
+}
+
+export function JerseyAdvertisingSection({
+  jerseyAdvertising,
+  onToggleHome,
+  onToggleAway,
+  homeTeam,
+  awayTeam,
+  disabled,
+}: JerseyAdvertisingSectionProps) {
+  const { tInterpolate } = useTranslation()
+
+  return (
+    <div className="space-y-1.5">
+      <JerseyAdToggle
+        label={tInterpolate('pdf.wizard.advertisingTeam', {
+          team: homeTeam || '–',
+        })}
+        checked={jerseyAdvertising.homeTeam}
+        onChange={onToggleHome}
+        disabled={disabled}
+      />
+      <JerseyAdToggle
+        label={tInterpolate('pdf.wizard.advertisingTeam', {
+          team: awayTeam || '–',
+        })}
+        checked={jerseyAdvertising.awayTeam}
+        onChange={onToggleAway}
+        disabled={disabled}
+      />
+    </div>
+  )
+}

--- a/packages/web/src/features/sports-hall-report/components/LanguageSelector.tsx
+++ b/packages/web/src/features/sports-hall-report/components/LanguageSelector.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from '@/shared/hooks/useTranslation'
+import type { Language } from '@/shared/utils/pdf-report-data'
+
+// Language names are intentionally hardcoded as self-names (endonyms) so that
+// each language is always displayed in its own script regardless of app locale.
+const LANGUAGES: ReadonlyArray<{ code: Language; name: string }> = [
+  { code: 'de', name: 'Deutsch' },
+  { code: 'fr', name: 'Français' },
+]
+
+interface LanguageSelectorProps {
+  language: Language
+  setLanguage: (lang: Language) => void
+  disabled: boolean
+}
+
+export function LanguageSelector({ language, setLanguage, disabled }: LanguageSelectorProps) {
+  const { t } = useTranslation()
+
+  return (
+    <fieldset className="mb-4">
+      <legend className="text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-2">
+        {t('pdf.selectLanguage')}
+      </legend>
+      <div className="flex gap-2">
+        {LANGUAGES.map(({ code, name }) => (
+          <label
+            key={code}
+            className={`flex-1 flex items-center justify-center gap-2 p-2.5 rounded-lg border cursor-pointer transition-colors text-sm ${
+              language === code
+                ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 text-text-primary dark:text-text-primary-dark'
+                : 'border-border-default dark:border-border-default-dark text-text-secondary dark:text-text-secondary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark'
+            }`}
+          >
+            <input
+              type="radio"
+              name="report-lang"
+              value={code}
+              checked={language === code}
+              onChange={() => setLanguage(code)}
+              className="sr-only"
+              disabled={disabled}
+            />
+            {name}
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  )
+}

--- a/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
+++ b/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
@@ -1,0 +1,208 @@
+import { useCallback } from 'react'
+
+import { createPortal } from 'react-dom'
+
+import { Button } from '@/shared/components/Button'
+import { ModalHeader } from '@/shared/components/ModalHeader'
+import { useBodyScrollLock } from '@/shared/hooks/useBodyScrollLock'
+import { useOverlayTouchGuard } from '@/shared/hooks/useOverlayTouchGuard'
+import { useTranslation } from '@/shared/hooks/useTranslation'
+import type { JerseyAdvertisingOptions } from '@/shared/utils/pdf-form-filler'
+
+import { CommentStep } from './CommentStep'
+import { JerseyAdvertisingSection } from './JerseyAdvertisingSection'
+import { LanguageSelector } from './LanguageSelector'
+import { PdfPreview } from './PdfPreview'
+import { SectionSelector } from './SectionSelector'
+import { SignatureCollectionStep } from './SignatureCollectionStep'
+import { SubItemSelector } from './SubItemSelector'
+import { WizardStepIndicator } from './WizardStepIndicator'
+
+import type { useNonConformantWizard } from '../hooks/useNonConformantWizard'
+
+const MODAL_TITLE_ID = 'sports-hall-report-wizard-title'
+
+interface NonConformantOverlayProps {
+  nc: ReturnType<typeof useNonConformantWizard>
+  language: import('@/shared/utils/pdf-report-data').Language
+  setLanguage: (lang: import('@/shared/utils/pdf-report-data').Language) => void
+  jerseyAdvertising: JerseyAdvertisingOptions
+  onToggleHomeAd: () => void
+  onToggleAwayAd: () => void
+  homeTeam: string
+  awayTeam: string
+  firstRefereeName?: string
+  secondRefereeName?: string
+  subtitle?: string
+  icon: React.ReactNode
+  onClose: () => void
+  onBack: () => void
+}
+
+export function NonConformantOverlay({
+  nc,
+  language,
+  setLanguage,
+  jerseyAdvertising,
+  onToggleHomeAd,
+  onToggleAwayAd,
+  homeTeam,
+  awayTeam,
+  firstRefereeName,
+  secondRefereeName,
+  subtitle,
+  icon,
+  onClose,
+  onBack,
+}: NonConformantOverlayProps) {
+  const { t } = useTranslation()
+  const touchGuard = useOverlayTouchGuard()
+  useBodyScrollLock(true)
+
+  const { setSectionComments } = nc
+
+  const handleSectionCommentChange = useCallback(
+    (sectionId: string, value: string) => {
+      setSectionComments((prev) => ({ ...prev, [sectionId]: value }))
+    },
+    [setSectionComments]
+  )
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-60 bg-surface-card dark:bg-surface-card-dark flex flex-col touch-none overscroll-none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={MODAL_TITLE_ID}
+      {...touchGuard}
+    >
+      {/* Header */}
+      <div className="flex-shrink-0 px-4 pt-4 pb-2 safe-area-inset-top">
+        <ModalHeader
+          title={t('pdf.wizard.nonConformant.title')}
+          titleId={MODAL_TITLE_ID}
+          titleSize="lg"
+          icon={icon}
+          subtitle={subtitle}
+          onClose={onClose}
+        />
+        <WizardStepIndicator steps={nc.ncSteps} currentStep={nc.ncStepIndex} />
+
+        {nc.ncStep === 'sections' && (
+          <LanguageSelector
+            language={language}
+            setLanguage={setLanguage}
+            disabled={nc.isGenerating}
+          />
+        )}
+      </div>
+
+      {/* Scrollable step content */}
+      <div className="flex-1 overflow-y-auto px-4 py-2 touch-auto" data-scrollable>
+        {nc.ncStep === 'sections' && (
+          <>
+            <SectionSelector
+              sections={nc.checklistSections}
+              flaggedSections={nc.flaggedSections}
+              onToggleSection={nc.handleToggleSection}
+            />
+
+            {/* Advertising question */}
+            <div className="mt-4">
+              <p className="text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-1.5">
+                {t('pdf.wizard.advertisingLabel')}
+              </p>
+              <JerseyAdvertisingSection
+                jerseyAdvertising={jerseyAdvertising}
+                onToggleHome={onToggleHomeAd}
+                onToggleAway={onToggleAwayAd}
+                homeTeam={homeTeam}
+                awayTeam={awayTeam}
+                disabled={nc.isGenerating}
+              />
+            </div>
+          </>
+        )}
+        {nc.ncStep === 'subItems' && (
+          <SubItemSelector
+            sections={nc.checklistSections}
+            flaggedSections={nc.flaggedSections}
+            nonConformantSubItems={nc.nonConformantSubItems}
+            onToggleSubItem={nc.handleToggleSubItem}
+          />
+        )}
+        {nc.ncStep === 'comment' && (
+          <CommentStep
+            sections={nc.checklistSections}
+            flaggedSections={nc.flaggedSections}
+            sectionComments={nc.sectionComments}
+            onSectionCommentChange={handleSectionCommentChange}
+          />
+        )}
+        {nc.ncStep === 'preview' && (
+          <PdfPreview pdfBytes={nc.previewPdfBytes} isLoading={nc.isGenerating} />
+        )}
+        {nc.ncStep === 'signatures' && (
+          <SignatureCollectionStep
+            firstRefereeName={firstRefereeName}
+            secondRefereeName={secondRefereeName}
+            signatures={nc.signatures}
+            onSignaturesChange={nc.setSignatures}
+            homeCoachName={nc.homeCoachName}
+            onHomeCoachNameChange={nc.setHomeCoachName}
+            awayCoachName={nc.awayCoachName}
+            onAwayCoachNameChange={nc.setAwayCoachName}
+            showAwayCoach={nc.showAwayCoach}
+            onToggleAwayCoach={() => nc.setShowAwayCoach(true)}
+          />
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex-shrink-0 px-4 pb-4 pt-2 border-t border-border-default dark:border-border-default-dark safe-area-inset-bottom">
+        <div className="flex gap-3">
+          <Button
+            variant="secondary"
+            className="flex-1"
+            onClick={onBack}
+            disabled={nc.isGenerating}
+          >
+            {t('pdf.wizard.nonConformant.back')}
+          </Button>
+          {nc.ncStep === 'signatures' ? (
+            <Button
+              variant="blue"
+              className="flex-1"
+              onClick={nc.handleNcDownload}
+              disabled={!nc.canProceed || nc.isGenerating}
+            >
+              {nc.isGenerating ? (
+                <>
+                  <span
+                    className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"
+                    aria-hidden="true"
+                  />
+                  {t('pdf.generating')}
+                </>
+              ) : (
+                t('pdf.wizard.nonConformant.downloadFinal')
+              )}
+            </Button>
+          ) : (
+            <Button
+              variant="blue"
+              className="flex-1"
+              onClick={nc.handleNcNext}
+              disabled={!nc.canProceed || nc.isGenerating}
+            >
+              {nc.ncStep === 'preview'
+                ? t('pdf.wizard.nonConformant.confirmAndSign')
+                : t('pdf.wizard.nonConformant.next')}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
+++ b/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
@@ -8,6 +8,7 @@ import { useBodyScrollLock } from '@/shared/hooks/useBodyScrollLock'
 import { useOverlayTouchGuard } from '@/shared/hooks/useOverlayTouchGuard'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import type { JerseyAdvertisingOptions } from '@/shared/utils/pdf-form-filler'
+import type { Language } from '@/shared/utils/pdf-report-data'
 
 import { CommentStep } from './CommentStep'
 import { JerseyAdvertisingSection } from './JerseyAdvertisingSection'
@@ -24,8 +25,8 @@ const MODAL_TITLE_ID = 'sports-hall-report-wizard-title'
 
 interface NonConformantOverlayProps {
   nc: ReturnType<typeof useNonConformantWizard>
-  language: import('@/shared/utils/pdf-report-data').Language
-  setLanguage: (lang: import('@/shared/utils/pdf-report-data').Language) => void
+  language: Language
+  setLanguage: (lang: Language) => void
   jerseyAdvertising: JerseyAdvertisingOptions
   onToggleHomeAd: () => void
   onToggleAwayAd: () => void

--- a/packages/web/src/features/sports-hall-report/components/SectionSelector.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SectionSelector.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { AlertTriangle, CheckCircle } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
-import type { ChecklistSection } from '@/shared/utils/pdf-form-filler'
+import type { ChecklistSection } from '@/shared/utils/pdf-field-mappings'
 
 interface SectionSelectorProps {
   sections: readonly ChecklistSection[]

--- a/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
@@ -5,6 +5,8 @@ import SignaturePad from 'signature_pad'
 
 import { Button } from '@/shared/components/Button'
 import { RotateCw, Trash2, Check, X } from '@/shared/components/icons'
+import { useBodyScrollLock } from '@/shared/hooks/useBodyScrollLock'
+import { useOverlayTouchGuard } from '@/shared/hooks/useOverlayTouchGuard'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 
 /** Z-index above the modal overlay (50) so the signature canvas is on top */
@@ -30,6 +32,9 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
   const [isPortrait, setIsPortrait] = useState(
     () => window.matchMedia('(orientation: portrait)').matches
   )
+
+  useBodyScrollLock(true)
+  const touchGuard = useOverlayTouchGuard()
 
   // Track orientation changes and enable/disable the pad accordingly
   useEffect(() => {
@@ -119,34 +124,6 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
     onComplete(dataUrl)
   }, [onComplete])
 
-  // Lock body scroll and prevent swipe-to-navigate while overlay is open
-  useEffect(() => {
-    const prev = document.body.style.overflow
-    const prevOverscroll = document.body.style.overscrollBehavior
-    document.body.style.overflow = 'hidden'
-    document.body.style.overscrollBehavior = 'none'
-    return () => {
-      document.body.style.overflow = prev
-      document.body.style.overscrollBehavior = prevOverscroll
-    }
-  }, [])
-
-  // Stop all touch events from propagating through the React tree.
-  // Without this, React's synthetic events bubble from this portal through the
-  // React component hierarchy up to PullToRefresh, which interprets drawing
-  // strokes as pull-to-refresh gestures and unmounts the signature overlay.
-  const stopPropagation = useCallback((e: React.TouchEvent) => {
-    e.stopPropagation()
-  }, [])
-
-  // Prevent swipe-to-navigate gestures on the overlay container
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    e.stopPropagation()
-    // Allow touch events on the canvas (signature_pad handles them)
-    if (e.target instanceof HTMLCanvasElement) return
-    e.preventDefault()
-  }, [])
-
   // Portal to document.body so the overlay is outside the PullToRefresh DOM tree,
   // preventing pull-to-refresh gestures from interfering with signature drawing
   return createPortal(
@@ -156,9 +133,7 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
       role="dialog"
       aria-modal="true"
       aria-label={t('pdf.wizard.signature.title')}
-      onTouchStart={stopPropagation}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={stopPropagation}
+      {...touchGuard}
     >
       {/* Header toolbar */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-gray-50">

--- a/packages/web/src/features/sports-hall-report/components/SignatureCollectionStep.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCollectionStep.tsx
@@ -21,6 +21,10 @@ interface SignatureCollectionStepProps {
   secondRefereeName?: string
   signatures: NonConformantSignatures
   onSignaturesChange: (signatures: NonConformantSignatures) => void
+  homeCoachName: string
+  onHomeCoachNameChange: (name: string) => void
+  awayCoachName: string
+  onAwayCoachNameChange: (name: string) => void
   showAwayCoach: boolean
   onToggleAwayCoach: () => void
 }
@@ -30,13 +34,15 @@ export function SignatureCollectionStep({
   secondRefereeName,
   signatures,
   onSignaturesChange,
+  homeCoachName,
+  onHomeCoachNameChange,
+  awayCoachName,
+  onAwayCoachNameChange,
   showAwayCoach,
   onToggleAwayCoach,
 }: SignatureCollectionStepProps) {
   const { t, tInterpolate } = useTranslation()
   const [activeSigner, setActiveSigner] = useState<SignerRole | null>(null)
-  const [homeCoachName, setHomeCoachName] = useState(signatures.homeTeamCoach?.name ?? '')
-  const [awayCoachName, setAwayCoachName] = useState(signatures.awayTeamCoach?.name ?? '')
 
   const signers: SignerInfo[] = [
     {
@@ -179,8 +185,8 @@ export function SignatureCollectionStep({
                       value={signer.role === 'homeTeamCoach' ? homeCoachName : awayCoachName}
                       onChange={(e) =>
                         signer.role === 'homeTeamCoach'
-                          ? setHomeCoachName(e.target.value)
-                          : setAwayCoachName(e.target.value)
+                          ? onHomeCoachNameChange(e.target.value)
+                          : onAwayCoachNameChange(e.target.value)
                       }
                       placeholder={t('pdf.wizard.nonConformant.coachNamePlaceholder')}
                       className="w-full rounded-md border border-border-default dark:border-border-default-dark bg-surface-primary dark:bg-surface-primary-dark text-text-primary dark:text-text-primary-dark text-sm px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder:text-text-muted dark:placeholder:text-text-muted-dark"

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -1,40 +1,24 @@
 import { useState, useCallback, useEffect } from 'react'
 
-import { createPortal } from 'react-dom'
-
 import type { Assignment } from '@/api/client'
-import { Button } from '@/shared/components/Button'
-import { AlertTriangle, FileText, CheckCircle, XCircle } from '@/shared/components/icons'
+import { AlertTriangle, FileText } from '@/shared/components/icons'
 import { Modal } from '@/shared/components/Modal'
-import { ModalFooter } from '@/shared/components/ModalFooter'
 import { ModalHeader } from '@/shared/components/ModalHeader'
-import { ToggleSwitch } from '@/shared/components/ToggleSwitch'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { useSettingsStore } from '@/shared/stores/settings'
-import { toast } from '@/shared/stores/toast'
 import { createLogger } from '@/shared/utils/logger'
-import type { JerseyAdvertisingOptions, Language } from '@/shared/utils/pdf-form-filler'
+import type { JerseyAdvertisingOptions } from '@/shared/utils/pdf-form-filler'
+import type { Language } from '@/shared/utils/pdf-report-data'
 
-import { CommentStep } from './CommentStep'
-import { PdfPreview } from './PdfPreview'
-import { SectionSelector } from './SectionSelector'
+import { HappyPathContent } from './HappyPathContent'
+import { NonConformantOverlay } from './NonConformantOverlay'
 import { SignatureCanvas } from './SignatureCanvas'
-import { SignatureCollectionStep } from './SignatureCollectionStep'
-import { SubItemSelector } from './SubItemSelector'
-import { WizardStepIndicator } from './WizardStepIndicator'
 import { useNonConformantWizard } from '../hooks/useNonConformantWizard'
-import { extractReportInfo } from '../utils/extractReportInfo'
+import { usePdfGeneration } from '../hooks/usePdfGeneration'
 
 const log = createLogger('SportsHallReportWizardModal')
 
 const MODAL_TITLE_ID = 'sports-hall-report-wizard-title'
-
-// Language names are intentionally hardcoded as self-names (endonyms) so that
-// each language is always displayed in its own script regardless of app locale.
-const LANGUAGES: ReadonlyArray<{ code: Language; name: string }> = [
-  { code: 'de', name: 'Deutsch' },
-  { code: 'fr', name: 'Français' },
-]
 
 type WizardMode = 'happy' | 'non-conformant'
 
@@ -51,26 +35,39 @@ export function SportsHallReportWizardModal({
   onClose,
   defaultLanguage,
 }: SportsHallReportWizardModalProps) {
-  const { t, tInterpolate } = useTranslation()
+  const { t } = useTranslation()
   const isNonConformantEnabled = useSettingsStore((s) => s.isNonConformantEnabled)
 
   // Shared state
   const [language, setLanguage] = useState<Language>(defaultLanguage)
   const [mode, setMode] = useState<WizardMode>('happy')
-
-  // Happy path state
-  const [confirmed, setConfirmed] = useState(false)
-  const [showSignature, setShowSignature] = useState(false)
-  const [isGeneratingHappy, setIsGeneratingHappy] = useState(false)
   const [jerseyAdvertising, setJerseyAdvertising] = useState<JerseyAdvertisingOptions>({
     homeTeam: true,
     awayTeam: true,
   })
 
-  // Non-conformant state (extracted hook)
-  const nc = useNonConformantWizard(assignment, language, onClose)
-  const { loadSections, reset: resetNc, setSectionComments, setJerseyAdvertising: setNcJerseyAd } =
-    nc
+  // Happy path state
+  const [confirmed, setConfirmed] = useState(false)
+  const [showSignature, setShowSignature] = useState(false)
+  const [isGeneratingHappy, setIsGeneratingHappy] = useState(false)
+
+  // Derived from assignment — single source of truth
+  const homeTeam = assignment.refereeGame?.game?.encounter?.teamHome?.name ?? ''
+  const awayTeam = assignment.refereeGame?.game?.encounter?.teamAway?.name ?? ''
+  const subtitle = homeTeam && awayTeam ? `${homeTeam} vs ${awayTeam}` : undefined
+  const firstRefereeName =
+    assignment.refereeGame?.activeRefereeConvocationFirstHeadReferee?.indoorAssociationReferee
+      ?.indoorReferee?.person?.displayName
+  const secondRefereeName =
+    assignment.refereeGame?.activeRefereeConvocationSecondHeadReferee?.indoorAssociationReferee
+      ?.indoorReferee?.person?.displayName
+
+  // Non-conformant hook (shares jerseyAdvertising from modal level)
+  const nc = useNonConformantWizard(assignment, language, jerseyAdvertising, onClose)
+  const { loadSections, reset: resetNc, handleNcBack: ncBack } = nc
+
+  // Happy path PDF generation
+  const pdf = usePdfGeneration(assignment, language, jerseyAdvertising, onClose)
 
   // Load checklist sections when modal opens
   useEffect(() => {
@@ -93,58 +90,16 @@ export function SportsHallReportWizardModal({
     }
   }, [isOpen, defaultLanguage, resetNc])
 
-  // Derived
-  const homeTeam = assignment.refereeGame?.game?.encounter?.teamHome?.name ?? ''
-  const awayTeam = assignment.refereeGame?.game?.encounter?.teamAway?.name ?? ''
-  const subtitle = homeTeam && awayTeam ? `${homeTeam} vs ${awayTeam}` : undefined
-  const firstRefereeName =
-    assignment.refereeGame?.activeRefereeConvocationFirstHeadReferee?.indoorAssociationReferee
-      ?.indoorReferee?.person?.displayName
-  const secondRefereeName =
-    assignment.refereeGame?.activeRefereeConvocationSecondHeadReferee?.indoorAssociationReferee
-      ?.indoorReferee?.person?.displayName
-
   const isGenerating = mode === 'happy' ? isGeneratingHappy : nc.isGenerating
 
-  // Lock body scroll when non-conformant overlay is open
-  useEffect(() => {
-    if (!isOpen || mode !== 'non-conformant') return
-    const prev = document.body.style.overflow
-    const prevOverscroll = document.body.style.overscrollBehavior
-    document.body.style.overflow = 'hidden'
-    document.body.style.overscrollBehavior = 'none'
-    return () => {
-      document.body.style.overflow = prev
-      document.body.style.overscrollBehavior = prevOverscroll
-    }
-  }, [isOpen, mode])
-
-  // Stop all touch events from propagating through the React tree (same as SignatureCanvas)
-  const stopPropagation = useCallback((e: React.TouchEvent) => {
-    e.stopPropagation()
+  // Jersey advertising toggle handlers (shared across modes)
+  const handleToggleHomeAd = useCallback(() => {
+    setJerseyAdvertising((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
   }, [])
 
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    e.stopPropagation()
-    // Allow touch on interactive elements (inputs, textareas, buttons, scrollable content)
-    const target = e.target as HTMLElement
-    if (
-      target instanceof HTMLCanvasElement ||
-      target instanceof HTMLTextAreaElement ||
-      target instanceof HTMLInputElement
-    )
-      return
-    // Allow scrolling within scrollable containers
-    if (target.closest('[data-scrollable]')) return
-    e.preventDefault()
+  const handleToggleAwayAd = useCallback(() => {
+    setJerseyAdvertising((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
   }, [])
-
-  const handleSectionCommentChange = useCallback(
-    (sectionId: string, value: string) => {
-      setSectionComments((prev) => ({ ...prev, [sectionId]: value }))
-    },
-    [setSectionComments]
-  )
 
   // ─── Happy path handlers ───────────────────────────────────────────
 
@@ -158,33 +113,14 @@ export function SportsHallReportWizardModal({
       setShowSignature(false)
       setIsGeneratingHappy(true)
       try {
-        const info = await extractReportInfo(assignment)
-        if (!info) {
-          toast.error(t('pdf.exportError'))
-          return
-        }
-        const { generateWizardReportBytes } = await import('@/shared/utils/pdf-form-filler')
-
-        const { pdfBytes, filename } = await generateWizardReportBytes({
-          data: info.reportData,
-          leagueCategory: info.leagueCategory,
-          language,
-          signatureDataUrl,
-          jerseyAdvertising,
-        })
-        const { downloadPdf } = await import('@/shared/utils/pdf-form-filler')
-        downloadPdf(pdfBytes, filename)
-        log.debug('Generated signed PDF report for:', assignment.__identity)
-        toast.success(t('pdf.wizard.reportGenerated'))
-        onClose()
+        await pdf.generateHappyPath(signatureDataUrl)
       } catch (error) {
         log.error('PDF generation failed:', error)
-        toast.error(t('pdf.exportError'))
       } finally {
         setIsGeneratingHappy(false)
       }
     },
-    [assignment, language, jerseyAdvertising, onClose, t]
+    [pdf]
   )
 
   const handleSignatureCancel = useCallback(() => {
@@ -195,22 +131,13 @@ export function SportsHallReportWizardModal({
     if (isGeneratingHappy) return
     setIsGeneratingHappy(true)
     try {
-      const info = await extractReportInfo(assignment)
-      if (!info) {
-        toast.error(t('pdf.exportError'))
-        return
-      }
-      const { generateAndDownloadSportsHallReport } = await import('@/shared/utils/pdf-form-filler')
-      await generateAndDownloadSportsHallReport(info.reportData, info.leagueCategory, language)
-      toast.success(t('assignments.reportGenerated'))
-      onClose()
+      await pdf.downloadPreFilled()
     } catch (error) {
       log.error('PDF generation failed:', error)
-      toast.error(t('pdf.exportError'))
     } finally {
       setIsGeneratingHappy(false)
     }
-  }, [isGeneratingHappy, assignment, language, onClose, t])
+  }, [isGeneratingHappy, pdf])
 
   // ─── Mode handlers ─────────────────────────────────────────────────
 
@@ -219,7 +146,6 @@ export function SportsHallReportWizardModal({
     resetNc()
   }, [resetNc])
 
-  const { handleNcBack: ncBack } = nc
   const handleNcBack = useCallback(() => {
     const result = ncBack()
     if (result === 'exit') {
@@ -251,158 +177,6 @@ export function SportsHallReportWizardModal({
   const modalTitle =
     mode === 'non-conformant' ? t('pdf.wizard.nonConformant.title') : t('pdf.wizard.title')
 
-  // Non-conformant mode renders as a fullscreen portal overlay
-  const nonConformantOverlay =
-    isOpen && mode === 'non-conformant'
-      ? createPortal(
-          <div
-            className="fixed inset-0 z-60 bg-surface-card dark:bg-surface-card-dark flex flex-col touch-none overscroll-none"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby={MODAL_TITLE_ID}
-            onTouchStart={stopPropagation}
-            onTouchMove={handleTouchMove}
-            onTouchEnd={stopPropagation}
-          >
-            {/* Header */}
-            <div className="flex-shrink-0 px-4 pt-4 pb-2 safe-area-inset-top">
-              <ModalHeader
-                title={t('pdf.wizard.nonConformant.title')}
-                titleId={MODAL_TITLE_ID}
-                titleSize="lg"
-                icon={pdfIcon}
-                subtitle={subtitle}
-                onClose={onClose}
-              />
-              <WizardStepIndicator steps={nc.ncSteps} currentStep={nc.ncStepIndex} />
-
-              {nc.ncStep === 'sections' && (
-                <LanguageSelector
-                  language={language}
-                  setLanguage={setLanguage}
-                  disabled={nc.isGenerating}
-                />
-              )}
-            </div>
-
-            {/* Scrollable step content */}
-            <div className="flex-1 overflow-y-auto px-4 py-2 touch-auto" data-scrollable>
-              {nc.ncStep === 'sections' && (
-                <>
-                  <SectionSelector
-                    sections={nc.checklistSections}
-                    flaggedSections={nc.flaggedSections}
-                    onToggleSection={nc.handleToggleSection}
-                  />
-
-                  {/* Advertising question — same as happy path */}
-                  <div className="mt-4 space-y-1.5">
-                    <p className="text-sm font-medium text-text-secondary dark:text-text-secondary-dark">
-                      {t('pdf.wizard.advertisingLabel')}
-                    </p>
-                    <JerseyAdToggle
-                      label={tInterpolate('pdf.wizard.advertisingTeam', {
-                        team: homeTeam || '–',
-                      })}
-                      checked={nc.jerseyAdvertising.homeTeam}
-                      onChange={() =>
-                        setNcJerseyAd((prev) => ({ ...prev, homeTeam: !prev.homeTeam }))
-                      }
-                      disabled={nc.isGenerating}
-                    />
-                    <JerseyAdToggle
-                      label={tInterpolate('pdf.wizard.advertisingTeam', {
-                        team: awayTeam || '–',
-                      })}
-                      checked={nc.jerseyAdvertising.awayTeam}
-                      onChange={() =>
-                        setNcJerseyAd((prev) => ({ ...prev, awayTeam: !prev.awayTeam }))
-                      }
-                      disabled={nc.isGenerating}
-                    />
-                  </div>
-                </>
-              )}
-              {nc.ncStep === 'subItems' && (
-                <SubItemSelector
-                  sections={nc.checklistSections}
-                  flaggedSections={nc.flaggedSections}
-                  nonConformantSubItems={nc.nonConformantSubItems}
-                  onToggleSubItem={nc.handleToggleSubItem}
-                />
-              )}
-              {nc.ncStep === 'comment' && (
-                <CommentStep
-                  sections={nc.checklistSections}
-                  flaggedSections={nc.flaggedSections}
-                  sectionComments={nc.sectionComments}
-                  onSectionCommentChange={handleSectionCommentChange}
-                />
-              )}
-              {nc.ncStep === 'preview' && (
-                <PdfPreview pdfBytes={nc.previewPdfBytes} isLoading={nc.isGenerating} />
-              )}
-              {nc.ncStep === 'signatures' && (
-                <SignatureCollectionStep
-                  firstRefereeName={firstRefereeName}
-                  secondRefereeName={secondRefereeName}
-                  signatures={nc.signatures}
-                  onSignaturesChange={nc.setSignatures}
-                  showAwayCoach={nc.showAwayCoach}
-                  onToggleAwayCoach={() => nc.setShowAwayCoach(true)}
-                />
-              )}
-            </div>
-
-            {/* Footer */}
-            <div className="flex-shrink-0 px-4 pb-4 pt-2 border-t border-border-default dark:border-border-default-dark safe-area-inset-bottom">
-              <div className="flex gap-3">
-                <Button
-                  variant="secondary"
-                  className="flex-1"
-                  onClick={handleNcBack}
-                  disabled={nc.isGenerating}
-                >
-                  {t('pdf.wizard.nonConformant.back')}
-                </Button>
-                {nc.ncStep === 'signatures' ? (
-                  <Button
-                    variant="blue"
-                    className="flex-1"
-                    onClick={nc.handleNcDownload}
-                    disabled={!nc.canProceed || nc.isGenerating}
-                  >
-                    {nc.isGenerating ? (
-                      <>
-                        <span
-                          className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"
-                          aria-hidden="true"
-                        />
-                        {t('pdf.generating')}
-                      </>
-                    ) : (
-                      t('pdf.wizard.nonConformant.downloadFinal')
-                    )}
-                  </Button>
-                ) : (
-                  <Button
-                    variant="blue"
-                    className="flex-1"
-                    onClick={nc.handleNcNext}
-                    disabled={!nc.canProceed || nc.isGenerating}
-                  >
-                    {nc.ncStep === 'preview'
-                      ? t('pdf.wizard.nonConformant.confirmAndSign')
-                      : t('pdf.wizard.nonConformant.next')}
-                  </Button>
-                )}
-              </div>
-            </div>
-          </div>,
-          document.body
-        )
-      : null
-
   return (
     <>
       <Modal
@@ -427,7 +201,11 @@ export function SportsHallReportWizardModal({
           confirmed={confirmed}
           setConfirmed={setConfirmed}
           isGenerating={isGeneratingHappy}
-          jerseyAd={{ jerseyAdvertising, setJerseyAdvertising, homeTeam, awayTeam }}
+          jerseyAdvertising={jerseyAdvertising}
+          onToggleHomeAd={handleToggleHomeAd}
+          onToggleAwayAd={handleToggleAwayAd}
+          homeTeam={homeTeam}
+          awayTeam={awayTeam}
           onGenerate={handleGenerate}
           onDownloadPreFilled={handleDownloadPreFilled}
           onReportIssue={isNonConformantEnabled ? handleEnterNonConformant : undefined}
@@ -435,238 +213,28 @@ export function SportsHallReportWizardModal({
         />
       </Modal>
 
-      {nonConformantOverlay}
+      {isOpen && mode === 'non-conformant' && (
+        <NonConformantOverlay
+          nc={nc}
+          language={language}
+          setLanguage={setLanguage}
+          jerseyAdvertising={jerseyAdvertising}
+          onToggleHomeAd={handleToggleHomeAd}
+          onToggleAwayAd={handleToggleAwayAd}
+          homeTeam={homeTeam}
+          awayTeam={awayTeam}
+          firstRefereeName={firstRefereeName}
+          secondRefereeName={secondRefereeName}
+          subtitle={subtitle}
+          icon={pdfIcon}
+          onClose={onClose}
+          onBack={handleNcBack}
+        />
+      )}
 
       {showSignature && (
         <SignatureCanvas onComplete={handleSignatureComplete} onCancel={handleSignatureCancel} />
       )}
-    </>
-  )
-}
-
-// ─── Sub-components ────────────────────────────────────────────────
-
-function LanguageSelector({
-  language,
-  setLanguage,
-  disabled,
-}: {
-  language: Language
-  setLanguage: (lang: Language) => void
-  disabled: boolean
-}) {
-  const { t } = useTranslation()
-
-  return (
-    <fieldset className="mb-4">
-      <legend className="text-sm font-medium text-text-secondary dark:text-text-secondary-dark mb-2">
-        {t('pdf.selectLanguage')}
-      </legend>
-      <div className="flex gap-2">
-        {LANGUAGES.map(({ code, name }) => (
-          <label
-            key={code}
-            className={`flex-1 flex items-center justify-center gap-2 p-2.5 rounded-lg border cursor-pointer transition-colors text-sm ${
-              language === code
-                ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20 text-text-primary dark:text-text-primary-dark'
-                : 'border-border-default dark:border-border-default-dark text-text-secondary dark:text-text-secondary-dark hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark'
-            }`}
-          >
-            <input
-              type="radio"
-              name="report-lang"
-              value={code}
-              checked={language === code}
-              onChange={() => setLanguage(code)}
-              className="sr-only"
-              disabled={disabled}
-            />
-            {name}
-          </label>
-        ))}
-      </div>
-    </fieldset>
-  )
-}
-
-function JerseyAdToggle({
-  label,
-  checked,
-  onChange,
-  disabled,
-}: {
-  label: string
-  checked: boolean
-  onChange: () => void
-  disabled: boolean
-}) {
-  const Icon = checked ? CheckCircle : XCircle
-  return (
-    <button
-      type="button"
-      onClick={onChange}
-      disabled={disabled}
-      title={label}
-      className={`flex w-full items-center gap-2 min-w-0 rounded-lg border py-2 px-3 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
-        checked
-          ? 'border-success-200 bg-success-50 text-success-700 hover:bg-success-100 dark:border-success-800 dark:bg-success-900/20 dark:text-success-400 dark:hover:bg-success-900/30'
-          : 'border-red-200 bg-red-50 text-red-600 hover:bg-red-100 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30'
-      }`}
-    >
-      <Icon className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-      <span className="truncate">{label}</span>
-    </button>
-  )
-}
-
-interface JerseyAdProps {
-  jerseyAdvertising: JerseyAdvertisingOptions
-  setJerseyAdvertising: React.Dispatch<React.SetStateAction<JerseyAdvertisingOptions>>
-  homeTeam: string
-  awayTeam: string
-}
-
-interface HappyPathContentProps {
-  language: Language
-  setLanguage: (lang: Language) => void
-  confirmed: boolean
-  setConfirmed: (fn: (prev: boolean) => boolean) => void
-  isGenerating: boolean
-  jerseyAd: JerseyAdProps
-  onGenerate: () => void
-  onDownloadPreFilled: () => void
-  onReportIssue?: () => void
-  onClose: () => void
-}
-
-function HappyPathContent({
-  language,
-  setLanguage,
-  confirmed,
-  setConfirmed,
-  isGenerating,
-  jerseyAd,
-  onGenerate,
-  onDownloadPreFilled,
-  onReportIssue,
-  onClose,
-}: HappyPathContentProps) {
-  const { t, tInterpolate } = useTranslation()
-
-  return (
-    <>
-      <LanguageSelector language={language} setLanguage={setLanguage} disabled={isGenerating} />
-
-      {/* Confirmation */}
-      <div className="mb-5">
-        <div
-          className={`rounded-lg border p-4 transition-colors ${
-            confirmed
-              ? 'border-success-500 bg-success-50 dark:bg-success-900/20'
-              : 'border-border-default dark:border-border-default-dark'
-          }`}
-        >
-          <div className="flex items-start gap-3">
-            <div className="flex-1">
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
-                  {t('pdf.wizard.confirmLabel')}
-                </span>
-                <ToggleSwitch
-                  checked={confirmed}
-                  onChange={() => setConfirmed((prev) => !prev)}
-                  label={t('pdf.wizard.confirmLabel')}
-                  variant="success"
-                  disabled={isGenerating}
-                />
-              </div>
-              {confirmed && (
-                <div className="mt-3 space-y-2.5">
-                  <div className="space-y-1.5">
-                    <JerseyAdToggle
-                      label={tInterpolate('pdf.wizard.advertisingTeam', {
-                        team: jerseyAd.homeTeam || '–',
-                      })}
-                      checked={jerseyAd.jerseyAdvertising.homeTeam}
-                      onChange={() =>
-                        jerseyAd.setJerseyAdvertising((prev) => ({
-                          ...prev,
-                          homeTeam: !prev.homeTeam,
-                        }))
-                      }
-                      disabled={isGenerating}
-                    />
-                    <JerseyAdToggle
-                      label={tInterpolate('pdf.wizard.advertisingTeam', {
-                        team: jerseyAd.awayTeam || '–',
-                      })}
-                      checked={jerseyAd.jerseyAdvertising.awayTeam}
-                      onChange={() =>
-                        jerseyAd.setJerseyAdvertising((prev) => ({
-                          ...prev,
-                          awayTeam: !prev.awayTeam,
-                        }))
-                      }
-                      disabled={isGenerating}
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Report issue link (only when non-conformant workflow is enabled) */}
-      {onReportIssue && (
-        <div className="mb-3">
-          <button
-            type="button"
-            onClick={onReportIssue}
-            disabled={isGenerating}
-            className="flex items-center gap-1.5 text-sm text-warning-600 dark:text-warning-400 hover:text-warning-700 dark:hover:text-warning-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <AlertTriangle className="w-4 h-4" aria-hidden="true" />
-            {t('pdf.wizard.nonConformant.reportIssue')}
-          </button>
-        </div>
-      )}
-
-      {/* Download pre-filled fallback */}
-      <div className="mb-5">
-        <button
-          type="button"
-          onClick={onDownloadPreFilled}
-          disabled={isGenerating}
-          className="text-sm text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark underline underline-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {t('pdf.wizard.downloadPreFilled')}
-        </button>
-      </div>
-
-      <ModalFooter>
-        <Button variant="secondary" className="flex-1" onClick={onClose} disabled={isGenerating}>
-          {t('common.cancel')}
-        </Button>
-        <Button
-          variant="blue"
-          className="flex-1"
-          onClick={onGenerate}
-          disabled={!confirmed || isGenerating}
-        >
-          {isGenerating ? (
-            <>
-              <span
-                className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"
-                aria-hidden="true"
-              />
-              {t('pdf.generating')}
-            </>
-          ) : (
-            t('pdf.wizard.generate')
-          )}
-        </Button>
-      </ModalFooter>
     </>
   )
 }

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -201,11 +201,13 @@ export function SportsHallReportWizardModal({
           confirmed={confirmed}
           setConfirmed={setConfirmed}
           isGenerating={isGeneratingHappy}
-          jerseyAdvertising={jerseyAdvertising}
-          onToggleHomeAd={handleToggleHomeAd}
-          onToggleAwayAd={handleToggleAwayAd}
-          homeTeam={homeTeam}
-          awayTeam={awayTeam}
+          jerseyAd={{
+            jerseyAdvertising,
+            onToggleHome: handleToggleHomeAd,
+            onToggleAway: handleToggleAwayAd,
+            homeTeam,
+            awayTeam,
+          }}
           onGenerate={handleGenerate}
           onDownloadPreFilled={handleDownloadPreFilled}
           onReportIssue={isNonConformantEnabled ? handleEnterNonConformant : undefined}

--- a/packages/web/src/features/sports-hall-report/components/SubItemSelector.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SubItemSelector.tsx
@@ -2,7 +2,8 @@ import { useCallback } from 'react'
 
 import { AlertTriangle, CheckCircle } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
-import type { ChecklistSection, NonConformantSelections } from '@/shared/utils/pdf-form-filler'
+import type { ChecklistSection } from '@/shared/utils/pdf-field-mappings'
+import type { NonConformantSelections } from '@/shared/utils/pdf-form-filler'
 
 interface SubItemSelectorProps {
   sections: readonly ChecklistSection[]

--- a/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
@@ -90,10 +90,7 @@ export function useNonConformantWizard(
 
   // Sections that have multiple sub-items and need manual selection
   const multiItemFlaggedSections = useMemo(
-    () =>
-      checklistSections.filter(
-        (s) => flaggedSections.has(s.id) && s.subItems.length > 1
-      ),
+    () => checklistSections.filter((s) => flaggedSections.has(s.id) && s.subItems.length > 1),
     [checklistSections, flaggedSections]
   )
 
@@ -122,7 +119,11 @@ export function useNonConformantWizard(
           const section = checklistSections.find((s) => s.id === sectionId)
           if (!section) continue
           // Auto-select all sub-items for single-item sections or when no manual selection exists
-          if (section.subItems.length === 1 || !updated[sectionId] || updated[sectionId].size === 0) {
+          if (
+            section.subItems.length === 1 ||
+            !updated[sectionId] ||
+            updated[sectionId].size === 0
+          ) {
             updated[sectionId] = new Set(section.subItems.map((si) => si.id))
           }
         }

--- a/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
@@ -149,8 +149,8 @@ export function useNonConformantWizard(
           sectionComments,
           jerseyAdvertising,
         })
-        setPreviewPdfBytes(pdfBytes)
         if (!pdfBytes) return
+        setPreviewPdfBytes(pdfBytes)
       } catch (error) {
         log.error('Preview generation failed:', error)
         return

--- a/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
@@ -2,16 +2,16 @@ import { useState, useCallback, useMemo } from 'react'
 
 import type { Assignment } from '@/api/client'
 import { useTranslation } from '@/shared/hooks/useTranslation'
-import { toast } from '@/shared/stores/toast'
 import { createLogger } from '@/shared/utils/logger'
+import type { ChecklistSection } from '@/shared/utils/pdf-field-mappings'
 import type {
   JerseyAdvertisingOptions,
   Language,
   NonConformantSelections,
   NonConformantSignatures,
-  ChecklistSection,
 } from '@/shared/utils/pdf-form-filler'
 
+import { usePdfGeneration } from './usePdfGeneration'
 import { extractReportInfo } from '../utils/extractReportInfo'
 
 const log = createLogger('useNonConformantWizard')
@@ -23,6 +23,7 @@ const NC_STEPS: NonConformantStep[] = ['sections', 'subItems', 'comment', 'previ
 export function useNonConformantWizard(
   assignment: Assignment,
   language: Language,
+  jerseyAdvertising: JerseyAdvertisingOptions,
   onClose: () => void
 ) {
   const { t } = useTranslation()
@@ -34,14 +35,14 @@ export function useNonConformantWizard(
   const [sectionComments, setSectionComments] = useState<Record<string, string>>({})
   const [previewPdfBytes, setPreviewPdfBytes] = useState<Uint8Array | null>(null)
   const [signatures, setSignatures] = useState<NonConformantSignatures>({})
-  const [jerseyAdvertising, setJerseyAdvertising] = useState<JerseyAdvertisingOptions>({
-    homeTeam: true,
-    awayTeam: true,
-  })
+  const [homeCoachName, setHomeCoachName] = useState('')
+  const [awayCoachName, setAwayCoachName] = useState('')
   const [showAwayCoach, setShowAwayCoach] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
 
   const ncStepIndex = NC_STEPS.indexOf(ncStep)
+
+  const pdf = usePdfGeneration(assignment, language, jerseyAdvertising, onClose)
 
   const reset = useCallback(() => {
     setNcStep('sections')
@@ -50,7 +51,8 @@ export function useNonConformantWizard(
     setSectionComments({})
     setPreviewPdfBytes(null)
     setSignatures({})
-    setJerseyAdvertising({ homeTeam: true, awayTeam: true })
+    setHomeCoachName('')
+    setAwayCoachName('')
     setShowAwayCoach(false)
     setIsGenerating(false)
   }, [])
@@ -58,7 +60,7 @@ export function useNonConformantWizard(
   const loadSections = useCallback(async () => {
     const info = await extractReportInfo(assignment)
     if (!info) return
-    const { getChecklistSections } = await import('@/shared/utils/pdf-form-filler')
+    const { getChecklistSections } = await import('@/shared/utils/pdf-field-mappings')
     setChecklistSections(getChecklistSections(info.leagueCategory))
   }, [assignment])
 
@@ -141,24 +143,15 @@ export function useNonConformantWizard(
     if (NC_STEPS[nextIdx] === 'preview') {
       setIsGenerating(true)
       try {
-        const info = await extractReportInfo(assignment)
-        if (!info) {
-          toast.error(t('pdf.exportError'))
-          return
-        }
-        const { generateNonConformantPreviewBytes } = await import('@/shared/utils/pdf-form-filler')
-        const { pdfBytes } = await generateNonConformantPreviewBytes({
-          data: info.reportData,
-          leagueCategory: info.leagueCategory,
-          language,
+        const pdfBytes = await pdf.generateNonConformantPreview({
           nonConformantSubItems,
           sectionComments,
           jerseyAdvertising,
         })
         setPreviewPdfBytes(pdfBytes)
+        if (!pdfBytes) return
       } catch (error) {
         log.error('Preview generation failed:', error)
-        toast.error(t('pdf.exportError'))
         return
       } finally {
         setIsGenerating(false)
@@ -174,54 +167,51 @@ export function useNonConformantWizard(
     flaggedSections,
     checklistSections,
     multiItemFlaggedSections,
-    assignment,
-    language,
     nonConformantSubItems,
     sectionComments,
     jerseyAdvertising,
-    t,
+    pdf,
   ])
 
   const handleNcDownload = useCallback(async () => {
     if (isGenerating) return
     setIsGenerating(true)
     try {
-      const info = await extractReportInfo(assignment)
-      if (!info) {
-        toast.error(t('pdf.exportError'))
-        return
+      // Bake coach names into signatures at download time
+      const finalSignatures: NonConformantSignatures = { ...signatures }
+      if (finalSignatures.homeTeamCoach) {
+        finalSignatures.homeTeamCoach = {
+          ...finalSignatures.homeTeamCoach,
+          name: homeCoachName,
+        }
       }
-      const { generateNonConformantReportBytes, downloadPdf } =
-        await import('@/shared/utils/pdf-form-filler')
-      const { pdfBytes, filename } = await generateNonConformantReportBytes({
-        data: info.reportData,
-        leagueCategory: info.leagueCategory,
-        language,
+      if (finalSignatures.awayTeamCoach) {
+        finalSignatures.awayTeamCoach = {
+          ...finalSignatures.awayTeamCoach,
+          name: awayCoachName,
+        }
+      }
+
+      await pdf.generateNonConformantFinal({
         nonConformantSubItems,
         sectionComments,
         jerseyAdvertising,
-        signatures,
+        signatures: finalSignatures,
       })
-      downloadPdf(pdfBytes, filename)
-      log.debug('Generated non-conformant PDF report for:', assignment.__identity)
-      toast.success(t('pdf.wizard.reportGenerated'))
-      onClose()
     } catch (error) {
       log.error('Non-conformant PDF generation failed:', error)
-      toast.error(t('pdf.exportError'))
     } finally {
       setIsGenerating(false)
     }
   }, [
     isGenerating,
-    assignment,
-    language,
     nonConformantSubItems,
     sectionComments,
     jerseyAdvertising,
     signatures,
-    onClose,
-    t,
+    homeCoachName,
+    awayCoachName,
+    pdf,
   ])
 
   const canProceed = useMemo(() => {
@@ -266,11 +256,13 @@ export function useNonConformantWizard(
     nonConformantSubItems,
     sectionComments,
     setSectionComments,
-    jerseyAdvertising,
-    setJerseyAdvertising,
     previewPdfBytes,
     signatures,
     setSignatures,
+    homeCoachName,
+    setHomeCoachName,
+    awayCoachName,
+    setAwayCoachName,
     showAwayCoach,
     setShowAwayCoach,
     isGenerating,

--- a/packages/web/src/features/sports-hall-report/hooks/usePdfGeneration.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/usePdfGeneration.ts
@@ -8,27 +8,27 @@ import type {
   JerseyAdvertisingOptions,
   Language,
   NonConformantReportOptions,
+  NonConformantSignatures,
 } from '@/shared/utils/pdf-form-filler'
 
 import { extractReportInfo } from '../utils/extractReportInfo'
 
 const log = createLogger('usePdfGeneration')
 
+type NonConformantBaseOptions = Pick<
+  NonConformantReportOptions,
+  'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'
+>
+
+type NonConformantFinalOptions = NonConformantBaseOptions & {
+  signatures: NonConformantSignatures
+}
+
 interface PdfGenerationActions {
   generateHappyPath: (signatureDataUrl: string) => Promise<void>
   downloadPreFilled: () => Promise<void>
-  generateNonConformantPreview: (
-    options: Pick<
-      NonConformantReportOptions,
-      'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'
-    >
-  ) => Promise<Uint8Array | null>
-  generateNonConformantFinal: (
-    options: Pick<
-      NonConformantReportOptions,
-      'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising' | 'signatures'
-    >
-  ) => Promise<void>
+  generateNonConformantPreview: (options: NonConformantBaseOptions) => Promise<Uint8Array | null>
+  generateNonConformantFinal: (options: NonConformantFinalOptions) => Promise<void>
 }
 
 export function usePdfGeneration(
@@ -77,12 +77,7 @@ export function usePdfGeneration(
   }, [assignment, language, onSuccess, t])
 
   const generateNonConformantPreview = useCallback(
-    async (
-      options: Pick<
-        NonConformantReportOptions,
-        'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'
-      >
-    ): Promise<Uint8Array | null> => {
+    async (options: NonConformantBaseOptions): Promise<Uint8Array | null> => {
       const info = await extractReportInfo(assignment)
       if (!info) {
         toast.error(t('pdf.exportError'))
@@ -101,12 +96,7 @@ export function usePdfGeneration(
   )
 
   const generateNonConformantFinal = useCallback(
-    async (
-      options: Pick<
-        NonConformantReportOptions,
-        'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising' | 'signatures'
-      >
-    ) => {
+    async (options: NonConformantFinalOptions) => {
       const info = await extractReportInfo(assignment)
       if (!info) {
         toast.error(t('pdf.exportError'))
@@ -119,7 +109,7 @@ export function usePdfGeneration(
         leagueCategory: info.leagueCategory,
         language,
         ...options,
-        signatures: options.signatures!,
+        signatures: options.signatures,
       })
       downloadPdf(pdfBytes, filename)
       log.debug('Generated non-conformant PDF report for:', assignment.__identity)

--- a/packages/web/src/features/sports-hall-report/hooks/usePdfGeneration.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/usePdfGeneration.ts
@@ -4,7 +4,11 @@ import type { Assignment } from '@/api/client'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import { toast } from '@/shared/stores/toast'
 import { createLogger } from '@/shared/utils/logger'
-import type { JerseyAdvertisingOptions, Language, NonConformantReportOptions } from '@/shared/utils/pdf-form-filler'
+import type {
+  JerseyAdvertisingOptions,
+  Language,
+  NonConformantReportOptions,
+} from '@/shared/utils/pdf-form-filler'
 
 import { extractReportInfo } from '../utils/extractReportInfo'
 
@@ -14,7 +18,10 @@ interface PdfGenerationActions {
   generateHappyPath: (signatureDataUrl: string) => Promise<void>
   downloadPreFilled: () => Promise<void>
   generateNonConformantPreview: (
-    options: Pick<NonConformantReportOptions, 'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'>
+    options: Pick<
+      NonConformantReportOptions,
+      'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'
+    >
   ) => Promise<Uint8Array | null>
   generateNonConformantFinal: (
     options: Pick<
@@ -71,7 +78,10 @@ export function usePdfGeneration(
 
   const generateNonConformantPreview = useCallback(
     async (
-      options: Pick<NonConformantReportOptions, 'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'>
+      options: Pick<
+        NonConformantReportOptions,
+        'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'
+      >
     ): Promise<Uint8Array | null> => {
       const info = await extractReportInfo(assignment)
       if (!info) {
@@ -119,5 +129,10 @@ export function usePdfGeneration(
     [assignment, language, onSuccess, t]
   )
 
-  return { generateHappyPath, downloadPreFilled, generateNonConformantPreview, generateNonConformantFinal }
+  return {
+    generateHappyPath,
+    downloadPreFilled,
+    generateNonConformantPreview,
+    generateNonConformantFinal,
+  }
 }

--- a/packages/web/src/features/sports-hall-report/hooks/usePdfGeneration.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/usePdfGeneration.ts
@@ -1,0 +1,123 @@
+import { useCallback } from 'react'
+
+import type { Assignment } from '@/api/client'
+import { useTranslation } from '@/shared/hooks/useTranslation'
+import { toast } from '@/shared/stores/toast'
+import { createLogger } from '@/shared/utils/logger'
+import type { JerseyAdvertisingOptions, Language, NonConformantReportOptions } from '@/shared/utils/pdf-form-filler'
+
+import { extractReportInfo } from '../utils/extractReportInfo'
+
+const log = createLogger('usePdfGeneration')
+
+interface PdfGenerationActions {
+  generateHappyPath: (signatureDataUrl: string) => Promise<void>
+  downloadPreFilled: () => Promise<void>
+  generateNonConformantPreview: (
+    options: Pick<NonConformantReportOptions, 'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'>
+  ) => Promise<Uint8Array | null>
+  generateNonConformantFinal: (
+    options: Pick<
+      NonConformantReportOptions,
+      'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising' | 'signatures'
+    >
+  ) => Promise<void>
+}
+
+export function usePdfGeneration(
+  assignment: Assignment,
+  language: Language,
+  jerseyAdvertising: JerseyAdvertisingOptions,
+  onSuccess: () => void
+): PdfGenerationActions {
+  const { t } = useTranslation()
+
+  const generateHappyPath = useCallback(
+    async (signatureDataUrl: string) => {
+      const info = await extractReportInfo(assignment)
+      if (!info) {
+        toast.error(t('pdf.exportError'))
+        return
+      }
+      const { generateWizardReportBytes } = await import('@/shared/utils/pdf-form-filler')
+      const { downloadPdf } = await import('@/shared/utils/pdf-download')
+
+      const { pdfBytes, filename } = await generateWizardReportBytes({
+        data: info.reportData,
+        leagueCategory: info.leagueCategory,
+        language,
+        signatureDataUrl,
+        jerseyAdvertising,
+      })
+      downloadPdf(pdfBytes, filename)
+      log.debug('Generated signed PDF report for:', assignment.__identity)
+      toast.success(t('pdf.wizard.reportGenerated'))
+      onSuccess()
+    },
+    [assignment, language, jerseyAdvertising, onSuccess, t]
+  )
+
+  const downloadPreFilled = useCallback(async () => {
+    const info = await extractReportInfo(assignment)
+    if (!info) {
+      toast.error(t('pdf.exportError'))
+      return
+    }
+    const { generateAndDownloadSportsHallReport } = await import('@/shared/utils/pdf-form-filler')
+    await generateAndDownloadSportsHallReport(info.reportData, info.leagueCategory, language)
+    toast.success(t('assignments.reportGenerated'))
+    onSuccess()
+  }, [assignment, language, onSuccess, t])
+
+  const generateNonConformantPreview = useCallback(
+    async (
+      options: Pick<NonConformantReportOptions, 'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising'>
+    ): Promise<Uint8Array | null> => {
+      const info = await extractReportInfo(assignment)
+      if (!info) {
+        toast.error(t('pdf.exportError'))
+        return null
+      }
+      const { generateNonConformantPreviewBytes } = await import('@/shared/utils/pdf-form-filler')
+      const { pdfBytes } = await generateNonConformantPreviewBytes({
+        data: info.reportData,
+        leagueCategory: info.leagueCategory,
+        language,
+        ...options,
+      })
+      return pdfBytes
+    },
+    [assignment, language, t]
+  )
+
+  const generateNonConformantFinal = useCallback(
+    async (
+      options: Pick<
+        NonConformantReportOptions,
+        'nonConformantSubItems' | 'sectionComments' | 'jerseyAdvertising' | 'signatures'
+      >
+    ) => {
+      const info = await extractReportInfo(assignment)
+      if (!info) {
+        toast.error(t('pdf.exportError'))
+        return
+      }
+      const { generateNonConformantReportBytes } = await import('@/shared/utils/pdf-form-filler')
+      const { downloadPdf } = await import('@/shared/utils/pdf-download')
+      const { pdfBytes, filename } = await generateNonConformantReportBytes({
+        data: info.reportData,
+        leagueCategory: info.leagueCategory,
+        language,
+        ...options,
+        signatures: options.signatures!,
+      })
+      downloadPdf(pdfBytes, filename)
+      log.debug('Generated non-conformant PDF report for:', assignment.__identity)
+      toast.success(t('pdf.wizard.reportGenerated'))
+      onSuccess()
+    },
+    [assignment, language, onSuccess, t]
+  )
+
+  return { generateHappyPath, downloadPreFilled, generateNonConformantPreview, generateNonConformantFinal }
+}

--- a/packages/web/src/features/sports-hall-report/utils/extractReportInfo.ts
+++ b/packages/web/src/features/sports-hall-report/utils/extractReportInfo.ts
@@ -1,12 +1,12 @@
 import type { Assignment } from '@/api/client'
-import type { LeagueCategory, SportsHallReportData } from '@/shared/utils/pdf-form-filler'
+import type { LeagueCategory, SportsHallReportData } from '@/shared/utils/pdf-report-data'
 
 export async function extractReportInfo(assignment: Assignment): Promise<{
   reportData: SportsHallReportData
   leagueCategory: LeagueCategory
 } | null> {
   const { extractSportsHallReportData, getLeagueCategoryFromAssignment } =
-    await import('@/shared/utils/pdf-form-filler')
+    await import('@/shared/utils/pdf-report-data')
 
   const reportData = extractSportsHallReportData(assignment)
   const leagueCategory = getLeagueCategoryFromAssignment(assignment)

--- a/packages/web/src/shared/components/PdfLanguageModal.tsx
+++ b/packages/web/src/shared/components/PdfLanguageModal.tsx
@@ -7,7 +7,7 @@ import { Modal } from '@/shared/components/Modal'
 import { ModalFooter } from '@/shared/components/ModalFooter'
 import { ModalHeader } from '@/shared/components/ModalHeader'
 import { useTranslation } from '@/shared/hooks/useTranslation'
-import type { Language } from '@/shared/utils/pdf-form-filler'
+import type { Language } from '@/shared/utils/pdf-report-data'
 
 const MODAL_TITLE_ID = 'pdf-lang-title'
 

--- a/packages/web/src/shared/hooks/useBodyScrollLock.ts
+++ b/packages/web/src/shared/hooks/useBodyScrollLock.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+/**
+ * Locks body scroll and prevents overscroll behavior while active.
+ * Restores previous values on cleanup.
+ */
+export function useBodyScrollLock(isActive: boolean): void {
+  useEffect(() => {
+    if (!isActive) return
+    const prev = document.body.style.overflow
+    const prevOverscroll = document.body.style.overscrollBehavior
+    document.body.style.overflow = 'hidden'
+    document.body.style.overscrollBehavior = 'none'
+    return () => {
+      document.body.style.overflow = prev
+      document.body.style.overscrollBehavior = prevOverscroll
+    }
+  }, [isActive])
+}

--- a/packages/web/src/shared/hooks/useOverlayTouchGuard.ts
+++ b/packages/web/src/shared/hooks/useOverlayTouchGuard.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react'
+
+interface OverlayTouchHandlers {
+  onTouchStart: (e: React.TouchEvent) => void
+  onTouchMove: (e: React.TouchEvent) => void
+  onTouchEnd: (e: React.TouchEvent) => void
+}
+
+/**
+ * Returns touch event handlers that prevent propagation through React's
+ * synthetic event system.
+ *
+ * Without this, React's events bubble from portal-rendered overlays through
+ * the React component hierarchy up to PullToRefresh, which can misinterpret
+ * drawing strokes or scrolling as pull-to-refresh gestures.
+ *
+ * Touch events on canvas, textarea, and input elements are allowed through.
+ * Elements within containers marked with `data-scrollable` are also allowed.
+ */
+export function useOverlayTouchGuard(): OverlayTouchHandlers {
+  const stopPropagation = useCallback((e: React.TouchEvent) => {
+    e.stopPropagation()
+  }, [])
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    e.stopPropagation()
+    // Allow touch on interactive elements (inputs, textareas, buttons, scrollable content)
+    const target = e.target as HTMLElement
+    if (
+      target instanceof HTMLCanvasElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLInputElement
+    )
+      return
+    // Allow scrolling within scrollable containers
+    if (target.closest('[data-scrollable]')) return
+    e.preventDefault()
+  }, [])
+
+  return {
+    onTouchStart: stopPropagation,
+    onTouchMove: handleTouchMove,
+    onTouchEnd: stopPropagation,
+  }
+}

--- a/packages/web/src/shared/utils/pdf-download.ts
+++ b/packages/web/src/shared/utils/pdf-download.ts
@@ -1,0 +1,11 @@
+export function downloadPdf(pdfBytes: Uint8Array, filename: string): void {
+  const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/packages/web/src/shared/utils/pdf-field-mappings.ts
+++ b/packages/web/src/shared/utils/pdf-field-mappings.ts
@@ -1,0 +1,551 @@
+import type { TranslationKey } from '@/i18n'
+
+import type { LeagueCategory } from './pdf-report-data'
+
+// ---------------------------------------------------------------------------
+// Base game info field mappings
+// ---------------------------------------------------------------------------
+
+export interface FieldMapping {
+  gameNumber: string
+  homeTeam: string
+  awayTeam: string
+  genderRadio: string
+  hallName: string
+  location: string
+  date: string
+  firstRefereeName: string
+  secondRefereeName: string
+}
+
+const NLA_FIELD_MAPPING: FieldMapping = {
+  gameNumber: 'SpielNr',
+  homeTeam: 'Heimteam',
+  awayTeam: 'Gastteam',
+  genderRadio: 'Gruppe3',
+  hallName: 'Hallenname',
+  location: 'Ort',
+  date: 'Datum',
+  firstRefereeName: 'Text19',
+  secondRefereeName: 'Text20',
+}
+
+const NLB_FIELD_MAPPING: FieldMapping = {
+  gameNumber: 'Text9',
+  homeTeam: 'Text10',
+  awayTeam: 'Text12',
+  genderRadio: 'Gruppe15',
+  hallName: 'Text14',
+  location: 'Text13',
+  date: 'Text11',
+  firstRefereeName: 'Text23',
+  secondRefereeName: 'Text24',
+}
+
+export function getFieldMapping(leagueCategory: LeagueCategory): FieldMapping {
+  return leagueCategory === 'NLA' ? NLA_FIELD_MAPPING : NLB_FIELD_MAPPING
+}
+
+// ---------------------------------------------------------------------------
+// Wizard-specific field mappings
+// ---------------------------------------------------------------------------
+
+export interface WizardFieldMapping {
+  /** Checkbox field name for "Tous les points sont en ordre" / "Alle Punkte in Ordnung" */
+  allPointsInOrderCheckbox: string
+  /** Radio group field name for home team "Werbung auf Spielerkleidung" (Ja/Nein) */
+  advertisingHomeTeam: string
+  /** Radio group field name for away team "Werbung auf Spielerkleidung" (Ja/Nein) */
+  advertisingAwayTeam: string
+}
+
+const NLA_WIZARD_FIELDS: WizardFieldMapping = {
+  allPointsInOrderCheckbox: 'Kontrollkästchen8',
+  advertisingHomeTeam: 'Gruppe430',
+  advertisingAwayTeam: 'Gruppe434',
+}
+
+const NLB_WIZARD_FIELDS: WizardFieldMapping = {
+  allPointsInOrderCheckbox: 'Kontrollkästchen17',
+  advertisingHomeTeam: '31',
+  advertisingAwayTeam: '34',
+}
+
+export function getWizardFieldMapping(leagueCategory: LeagueCategory): WizardFieldMapping {
+  return leagueCategory === 'NLA' ? NLA_WIZARD_FIELDS : NLB_WIZARD_FIELDS
+}
+
+/** OK option value used by all radio groups in the PDF templates */
+export const RADIO_OK_OPTION = 'Auswahl3'
+
+/** Not-OK option value used by all radio groups in the PDF templates */
+export const RADIO_NOT_OK_OPTION = 'Auswahl4'
+
+// ---------------------------------------------------------------------------
+// Signature name field mappings
+// ---------------------------------------------------------------------------
+
+export interface SignatureNameFields {
+  firstReferee: string
+  secondReferee: string
+  homeTeam: string
+  awayTeam: string
+}
+
+const NLA_SIGNATURE_NAME_FIELDS: SignatureNameFields = {
+  firstReferee: 'Text19',
+  secondReferee: 'Text20',
+  homeTeam: 'Text21',
+  awayTeam: 'Text22',
+}
+
+const NLB_SIGNATURE_NAME_FIELDS: SignatureNameFields = {
+  firstReferee: 'Text23',
+  secondReferee: 'Text24',
+  homeTeam: 'Text25',
+  awayTeam: 'Text26',
+}
+
+export function getSignatureNameFields(leagueCategory: LeagueCategory): SignatureNameFields {
+  return leagueCategory === 'NLA' ? NLA_SIGNATURE_NAME_FIELDS : NLB_SIGNATURE_NAME_FIELDS
+}
+
+// ---------------------------------------------------------------------------
+// Signature position coordinates
+// ---------------------------------------------------------------------------
+
+export interface SignaturePosition {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface AllSignaturePositions {
+  firstReferee: SignaturePosition
+  secondReferee: SignaturePosition
+  homeTeam: SignaturePosition
+  awayTeam: SignaturePosition
+}
+
+export const SIGNATURE_POSITIONS: Record<LeagueCategory, SignaturePosition> = {
+  NLA: { x: 340, y: 104, width: 130, height: 24 },
+  NLB: { x: 340, y: 157, width: 130, height: 24 },
+}
+
+export const ALL_SIGNATURE_POSITIONS: Record<LeagueCategory, AllSignaturePositions> = {
+  NLA: {
+    firstReferee: { x: 340, y: 104, width: 130, height: 24 },
+    secondReferee: { x: 340, y: 83, width: 130, height: 18 },
+    homeTeam: { x: 340, y: 62, width: 130, height: 18 },
+    awayTeam: { x: 340, y: 41, width: 130, height: 18 },
+  },
+  NLB: {
+    firstReferee: { x: 340, y: 157, width: 130, height: 24 },
+    secondReferee: { x: 340, y: 129, width: 130, height: 18 },
+    homeTeam: { x: 340, y: 101, width: 130, height: 18 },
+    awayTeam: { x: 340, y: 73, width: 130, height: 18 },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Checklist UI model (section/sub-item structure without PDF field names)
+// ---------------------------------------------------------------------------
+
+export interface ChecklistSubItem {
+  /** Unique key within the section (e.g. 'lines', 'attackLine') */
+  id: string
+  /** i18n key for the sub-item label */
+  labelKey: TranslationKey
+}
+
+export interface ChecklistSection {
+  /** Section letter matching the PDF form (A, B, C, …) */
+  id: string
+  /** i18n key for the section label */
+  labelKey: TranslationKey
+  /** Sub-items within this section */
+  subItems: readonly ChecklistSubItem[]
+}
+
+// ---------------------------------------------------------------------------
+// PDF radio field mapping — keyed by section + sub-item ID
+// ---------------------------------------------------------------------------
+
+export interface PdfChecklistSubItem {
+  /** Unique key within the section */
+  id: string
+  /** i18n key for the sub-item label */
+  labelKey: TranslationKey
+  /** PDF radio group field name */
+  radioField: string
+}
+
+export interface PdfChecklistSection {
+  /** Section letter matching the PDF form (A, B, C, …) */
+  id: string
+  /** i18n key for the section label */
+  labelKey: TranslationKey
+  /** Sub-items with their PDF radio field references */
+  subItems: readonly PdfChecklistSubItem[]
+  /** PDF text field name(s) for the remarks column */
+  commentFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// NLA checklist sections (full PDF mapping)
+// ---------------------------------------------------------------------------
+
+const NLA_CHECKLIST_SECTIONS: readonly PdfChecklistSection[] = [
+  {
+    id: 'A',
+    labelKey: 'pdf.wizard.sections.fieldAndLines',
+    subItems: [
+      { id: 'lines', labelKey: 'pdf.wizard.subItems.boundaryLines', radioField: 'Gruppe4' },
+      { id: 'attackLine', labelKey: 'pdf.wizard.subItems.attackLine', radioField: 'Gruppe41' },
+    ],
+    commentFields: ['Text7.0.0'],
+  },
+  {
+    id: 'B',
+    labelKey: 'pdf.wizard.sections.warmUpArea',
+    subItems: [
+      { id: 'warmUp', labelKey: 'pdf.wizard.subItems.warmUpArea', radioField: 'Gruppe42' },
+    ],
+    commentFields: ['Text7.0.1'],
+  },
+  {
+    id: 'C',
+    labelKey: 'pdf.wizard.sections.netEquipment',
+    subItems: [
+      { id: 'antennas', labelKey: 'pdf.wizard.subItems.antennas', radioField: 'Gruppe43' },
+      { id: 'netBand', labelKey: 'pdf.wizard.subItems.netTopBand', radioField: 'Gruppe44' },
+      { id: 'reserveNet', labelKey: 'pdf.wizard.subItems.reserveNet', radioField: 'Gruppe45' },
+      { id: 'postsNoWire', labelKey: 'pdf.wizard.subItems.postsNoWire', radioField: 'Gruppe46' },
+      { id: 'postsPadding', labelKey: 'pdf.wizard.subItems.postsPadding', radioField: 'Gruppe47' },
+      { id: 'tabletMount', labelKey: 'pdf.wizard.subItems.tabletMount', radioField: 'Gruppe48' },
+      { id: 'netHeight', labelKey: 'pdf.wizard.subItems.netHeight', radioField: 'Gruppe49' },
+    ],
+    commentFields: ['Text7.0.2'],
+  },
+  {
+    id: 'D',
+    labelKey: 'pdf.wizard.sections.refereeChair',
+    subItems: [{ id: 'chair', labelKey: 'pdf.wizard.subItems.refereeChair', radioField: '10' }],
+    commentFields: ['Text7.0.3'],
+  },
+  {
+    id: 'E',
+    labelKey: 'pdf.wizard.sections.manometer',
+    subItems: [{ id: 'manometer', labelKey: 'pdf.wizard.subItems.manometer', radioField: '11' }],
+    commentFields: ['Text7.0.4'],
+  },
+  {
+    id: 'F',
+    labelKey: 'pdf.wizard.sections.measuringRod',
+    subItems: [{ id: 'rod', labelKey: 'pdf.wizard.subItems.measuringRod', radioField: '12' }],
+    commentFields: ['Text7.0.5'],
+  },
+  {
+    id: 'G',
+    labelKey: 'pdf.wizard.sections.lineFlags',
+    subItems: [{ id: 'flags', labelKey: 'pdf.wizard.subItems.lineFlags', radioField: '13' }],
+    commentFields: ['Text7.0.6'],
+  },
+  {
+    id: 'H',
+    labelKey: 'pdf.wizard.sections.buzzer',
+    subItems: [{ id: 'buzzer', labelKey: 'pdf.wizard.subItems.buzzer', radioField: '14' }],
+    commentFields: ['Text7.0.7'],
+  },
+  {
+    id: 'I',
+    labelKey: 'pdf.wizard.sections.eScoresheet',
+    subItems: [
+      { id: 'eScorerOnTime', labelKey: 'pdf.wizard.subItems.eScorerOnTime', radioField: '15' },
+      { id: 'reserveLaptop', labelKey: 'pdf.wizard.subItems.reserveLaptop', radioField: '16' },
+      { id: 'usbStick', labelKey: 'pdf.wizard.subItems.usbStick', radioField: '17' },
+      {
+        id: 'reserveMatchSheet',
+        labelKey: 'pdf.wizard.subItems.reserveMatchSheet',
+        radioField: '18',
+      },
+    ],
+    commentFields: ['Text7.1'],
+  },
+  {
+    id: 'J',
+    labelKey: 'pdf.wizard.sections.tablets',
+    subItems: [
+      { id: 'refereeTablets', labelKey: 'pdf.wizard.subItems.refereeTablets', radioField: '19' },
+      { id: 'benchTablets', labelKey: 'pdf.wizard.subItems.benchTablets', radioField: '20' },
+    ],
+    commentFields: ['Text7.2'],
+  },
+  {
+    id: 'K',
+    labelKey: 'pdf.wizard.sections.scoreboard',
+    subItems: [
+      { id: 'scoreboard', labelKey: 'pdf.wizard.subItems.scoreboard', radioField: '21' },
+      {
+        id: 'scoreboardFunction',
+        labelKey: 'pdf.wizard.subItems.scoreboardFunction',
+        radioField: '22',
+      },
+    ],
+    commentFields: ['Text7.3'],
+  },
+  {
+    id: 'L',
+    labelKey: 'pdf.wizard.sections.balls',
+    subItems: [
+      { id: 'ballCount', labelKey: 'pdf.wizard.subItems.ballCount', radioField: '23' },
+      {
+        id: 'ballCondition',
+        labelKey: 'pdf.wizard.subItems.ballCondition',
+        radioField: 'Gruppe424',
+      },
+    ],
+    commentFields: ['Text7.4'],
+  },
+  {
+    id: 'M',
+    labelKey: 'pdf.wizard.sections.ballRetrievers',
+    subItems: [
+      {
+        id: 'ballRetrievers',
+        labelKey: 'pdf.wizard.subItems.ballRetrievers',
+        radioField: 'Gruppe425',
+      },
+    ],
+    commentFields: ['Text7.5'],
+  },
+  {
+    id: 'N',
+    labelKey: 'pdf.wizard.sections.quickMoppers',
+    subItems: [
+      { id: 'quickMoppers', labelKey: 'pdf.wizard.subItems.quickMoppers', radioField: 'Gruppe426' },
+    ],
+    commentFields: ['Text7.6'],
+  },
+  {
+    id: 'O',
+    labelKey: 'pdf.wizard.sections.hallSpeaker',
+    subItems: [
+      { id: 'hallSpeaker', labelKey: 'pdf.wizard.subItems.hallSpeaker', radioField: 'Gruppe427' },
+    ],
+    commentFields: ['Text7.7'],
+  },
+  {
+    id: 'P',
+    labelKey: 'pdf.wizard.sections.dressHome',
+    subItems: [
+      { id: 'dressHomeColor', labelKey: 'pdf.wizard.subItems.dressColor', radioField: 'Gruppe428' },
+      {
+        id: 'dressHomeLibero',
+        labelKey: 'pdf.wizard.subItems.liberoDress',
+        radioField: 'Gruppe429',
+      },
+      {
+        id: 'dressHomeAd',
+        labelKey: 'pdf.wizard.subItems.advertisingOnUniform',
+        radioField: 'Gruppe430',
+      },
+    ],
+    commentFields: ['Text7.8'],
+  },
+  {
+    id: 'Q',
+    labelKey: 'pdf.wizard.sections.dressAway',
+    subItems: [
+      { id: 'dressAwayColor', labelKey: 'pdf.wizard.subItems.dressColor', radioField: 'Gruppe431' },
+      {
+        id: 'dressAwayLibero',
+        labelKey: 'pdf.wizard.subItems.liberoDress',
+        radioField: 'Gruppe432',
+      },
+      {
+        id: 'dressAwayMatchkit',
+        labelKey: 'pdf.wizard.subItems.matchKit',
+        radioField: 'Gruppe433',
+      },
+      {
+        id: 'dressAwayAd',
+        labelKey: 'pdf.wizard.subItems.advertisingOnUniform',
+        radioField: 'Gruppe434',
+      },
+    ],
+    commentFields: ['Text7.9'],
+  },
+  {
+    id: 'R',
+    labelKey: 'pdf.wizard.sections.miscellaneous',
+    subItems: [
+      { id: 'misc1', labelKey: 'pdf.wizard.subItems.miscItem1', radioField: 'Gruppe435' },
+      { id: 'misc2', labelKey: 'pdf.wizard.subItems.miscItem2', radioField: 'Gruppe440' },
+    ],
+    commentFields: ['Text7.10', 'Text7.11'],
+  },
+] as const
+
+// ---------------------------------------------------------------------------
+// NLB checklist sections (full PDF mapping)
+// ---------------------------------------------------------------------------
+
+const NLB_CHECKLIST_SECTIONS: readonly PdfChecklistSection[] = [
+  {
+    id: 'A',
+    labelKey: 'pdf.wizard.sections.fieldAndLines',
+    subItems: [
+      { id: 'lines', labelKey: 'pdf.wizard.subItems.boundaryLines', radioField: 'Gruppe16' },
+      { id: 'attackLine', labelKey: 'pdf.wizard.subItems.attackLine', radioField: 'Gruppe17' },
+    ],
+    commentFields: ['Text16.0.0'],
+  },
+  {
+    id: 'B',
+    labelKey: 'pdf.wizard.sections.netEquipment',
+    subItems: [
+      { id: 'antennas', labelKey: 'pdf.wizard.subItems.antennas', radioField: 'Gruppe18' },
+      { id: 'netBand', labelKey: 'pdf.wizard.subItems.netTopBand', radioField: 'Gruppe19' },
+      {
+        id: 'netBottomBand',
+        labelKey: 'pdf.wizard.subItems.netBottomBand',
+        radioField: 'Gruppe20',
+      },
+    ],
+    commentFields: ['Text16.0.1'],
+  },
+  {
+    id: 'C',
+    labelKey: 'pdf.wizard.sections.numberPlates',
+    subItems: [
+      {
+        id: 'numberPlates',
+        labelKey: 'pdf.wizard.subItems.numberPlates',
+        radioField: 'Gruppe21',
+      },
+    ],
+    commentFields: ['Text16.1'],
+  },
+  {
+    id: 'D',
+    labelKey: 'pdf.wizard.sections.manometer',
+    subItems: [{ id: 'manometer', labelKey: 'pdf.wizard.subItems.manometer', radioField: '22' }],
+    commentFields: ['Text16.2'],
+  },
+  {
+    id: 'E',
+    labelKey: 'pdf.wizard.sections.measuringRod',
+    subItems: [{ id: 'rod', labelKey: 'pdf.wizard.subItems.measuringRod', radioField: '23' }],
+    commentFields: ['Text16.3'],
+  },
+  {
+    id: 'F',
+    labelKey: 'pdf.wizard.sections.balls',
+    subItems: [
+      {
+        id: 'practiseBalls',
+        labelKey: 'pdf.wizard.subItems.practiseBalls',
+        radioField: '24',
+      },
+      { id: 'matchBalls', labelKey: 'pdf.wizard.subItems.matchBalls', radioField: '25' },
+      {
+        id: 'matchBallsException',
+        labelKey: 'pdf.wizard.subItems.matchBallsException',
+        radioField: '26',
+      },
+    ],
+    commentFields: ['Text16.4'],
+  },
+  {
+    id: 'G',
+    labelKey: 'pdf.wizard.sections.ballRetrievers',
+    subItems: [
+      { id: 'ballRetrievers', labelKey: 'pdf.wizard.subItems.ballRetrievers', radioField: '27' },
+      {
+        id: 'ballRetrieversException',
+        labelKey: 'pdf.wizard.subItems.ballRetrieversException',
+        radioField: '28',
+      },
+    ],
+    commentFields: ['Text16.5'],
+  },
+  {
+    id: 'H',
+    labelKey: 'pdf.wizard.sections.dressHome',
+    subItems: [
+      { id: 'dressHomeColor', labelKey: 'pdf.wizard.subItems.dressColor', radioField: '29' },
+      { id: 'dressHomeLibero', labelKey: 'pdf.wizard.subItems.liberoDress', radioField: '30' },
+      {
+        id: 'dressHomeAd',
+        labelKey: 'pdf.wizard.subItems.advertisingOnUniform',
+        radioField: '31',
+      },
+    ],
+    commentFields: ['Text16.6'],
+  },
+  {
+    id: 'I',
+    labelKey: 'pdf.wizard.sections.dressAway',
+    subItems: [
+      { id: 'dressAwayColor', labelKey: 'pdf.wizard.subItems.dressColor', radioField: '32' },
+      { id: 'dressAwayLibero', labelKey: 'pdf.wizard.subItems.liberoDress', radioField: '33' },
+      {
+        id: 'dressAwayAd',
+        labelKey: 'pdf.wizard.subItems.advertisingOnUniform',
+        radioField: '34',
+      },
+    ],
+    commentFields: ['Text16.7'],
+  },
+  {
+    id: 'J',
+    labelKey: 'pdf.wizard.sections.eScoresheet',
+    subItems: [
+      { id: 'eScorerOnTime', labelKey: 'pdf.wizard.subItems.eScorerOnTime', radioField: '35' },
+      { id: 'reserveLaptop', labelKey: 'pdf.wizard.subItems.reserveLaptop', radioField: '36' },
+      { id: 'usbStick', labelKey: 'pdf.wizard.subItems.usbStick', radioField: '37' },
+      {
+        id: 'reserveMatchSheet',
+        labelKey: 'pdf.wizard.subItems.reserveMatchSheet',
+        radioField: '38',
+      },
+    ],
+    commentFields: ['Text16.8'],
+  },
+  {
+    id: 'K',
+    labelKey: 'pdf.wizard.sections.tablets',
+    subItems: [
+      { id: 'refereeTablets', labelKey: 'pdf.wizard.subItems.refereeTablets', radioField: '39' },
+    ],
+    commentFields: ['Text16.9'],
+  },
+  {
+    id: 'L',
+    labelKey: 'pdf.wizard.sections.miscellaneous',
+    subItems: [
+      { id: 'misc1', labelKey: 'pdf.wizard.subItems.miscItem1', radioField: '40' },
+      { id: 'misc2', labelKey: 'pdf.wizard.subItems.miscItem2', radioField: '41' },
+    ],
+    commentFields: ['Text16.10', 'Text16.11'],
+  },
+] as const
+
+export function getPdfChecklistSections(
+  leagueCategory: LeagueCategory
+): readonly PdfChecklistSection[] {
+  return leagueCategory === 'NLA' ? NLA_CHECKLIST_SECTIONS : NLB_CHECKLIST_SECTIONS
+}
+
+/**
+ * Returns the UI-only checklist sections (without PDF radio field names).
+ * Use this in components that only need section/sub-item structure for display.
+ */
+export function getChecklistSections(leagueCategory: LeagueCategory): readonly ChecklistSection[] {
+  return getPdfChecklistSections(leagueCategory)
+}
+
+/** Font size for comment fields so longer text fits in the narrow PDF cells */
+export const COMMENT_FIELD_FONT_SIZE = 6

--- a/packages/web/src/shared/utils/pdf-form-filler.test.ts
+++ b/packages/web/src/shared/utils/pdf-form-filler.test.ts
@@ -770,8 +770,7 @@ describe('pdf-form-filler', () => {
         describe(`${leagueCategory} ${language}`, () => {
           it('generates valid PDF bytes with all sections non-conformant', async () => {
             mockFetchForPdf(leagueCategory, language)
-            const { nonConformantSubItems, sectionComments } =
-              buildAllNonConformant(leagueCategory)
+            const { nonConformantSubItems, sectionComments } = buildAllNonConformant(leagueCategory)
 
             const pdfBytes = await fillNonConformantReport({
               data: baseReportData,
@@ -787,8 +786,7 @@ describe('pdf-form-filler', () => {
 
           it('flattens the form so PDF viewers cannot re-render fields', async () => {
             mockFetchForPdf(leagueCategory, language)
-            const { nonConformantSubItems, sectionComments } =
-              buildAllNonConformant(leagueCategory)
+            const { nonConformantSubItems, sectionComments } = buildAllNonConformant(leagueCategory)
 
             const pdfBytes = await fillNonConformantReport({
               data: baseReportData,
@@ -806,8 +804,7 @@ describe('pdf-form-filler', () => {
 
           it('sets all radio buttons to non-conformant and fills all comment fields', async () => {
             const sections = getChecklistSections(leagueCategory)
-            const { nonConformantSubItems, sectionComments } =
-              buildAllNonConformant(leagueCategory)
+            const { nonConformantSubItems, sectionComments } = buildAllNonConformant(leagueCategory)
 
             // Load the PDF template and fill it WITHOUT flattening to verify field values
             const templateBytes = loadPdfTemplate(leagueCategory, language)

--- a/packages/web/src/shared/utils/pdf-form-filler.ts
+++ b/packages/web/src/shared/utils/pdf-form-filler.ts
@@ -94,8 +94,12 @@ function trySetTextField(form: any, fieldName: string, value: string | undefined
 /**
  * Fills the basic game info fields (teams, date, hall, referees, gender) in a PDF form.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function fillBaseGameInfo(form: any, data: SportsHallReportData, mapping: ReturnType<typeof getFieldMapping>): void {
+function fillBaseGameInfo(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: any,
+  data: SportsHallReportData,
+  mapping: ReturnType<typeof getFieldMapping>
+): void {
   trySetTextField(form, mapping.gameNumber, data.gameNumber)
   trySetTextField(form, mapping.homeTeam, data.homeTeam)
   trySetTextField(form, mapping.awayTeam, data.awayTeam)

--- a/packages/web/src/shared/utils/pdf-form-filler.ts
+++ b/packages/web/src/shared/utils/pdf-form-filler.ts
@@ -1,146 +1,81 @@
-import { format } from 'date-fns'
+/**
+ * PDF form filler — core PDF manipulation logic.
+ *
+ * Re-exports types and functions from split modules for backward compatibility.
+ * New code should import directly from the specific module:
+ *   - pdf-report-data.ts  — Assignment data extraction, filename building
+ *   - pdf-field-mappings.ts — PDF field names, checklist sections, positions
+ *   - pdf-download.ts — Browser download trigger
+ */
 
-import type { Assignment } from '@/api/client'
-import type { TranslationKey } from '@/i18n'
 import { logger } from '@/shared/utils/logger'
 
-export type LeagueCategory = 'NLA' | 'NLB'
-export type Language = 'de' | 'fr'
-export type Gender = 'm' | 'f'
+import { downloadPdf } from './pdf-download'
+import {
+  ALL_SIGNATURE_POSITIONS,
+  COMMENT_FIELD_FONT_SIZE,
+  RADIO_NOT_OK_OPTION,
+  RADIO_OK_OPTION,
+  SIGNATURE_POSITIONS,
+  getFieldMapping,
+  getPdfChecklistSections,
+  getSignatureNameFields,
+  getWizardFieldMapping,
+  type AllSignaturePositions,
+  type PdfChecklistSection,
+  type SignaturePosition,
+} from './pdf-field-mappings'
+import {
+  buildReportFilename,
+  type Language,
+  type LeagueCategory,
+  type SportsHallReportData,
+} from './pdf-report-data'
 
-export function mapAppLocaleToPdfLanguage(appLocale: string): Language {
-  if (appLocale === 'fr' || appLocale === 'it') {
-    return 'fr'
-  }
-  return 'de'
+// ---------------------------------------------------------------------------
+// Re-exports for backward compatibility
+// ---------------------------------------------------------------------------
+
+export { downloadPdf } from './pdf-download'
+export {
+  getChecklistSections,
+  type ChecklistSection,
+  type ChecklistSubItem,
+} from './pdf-field-mappings'
+export {
+  buildReportFilename,
+  extractSportsHallReportData,
+  getLeagueCategoryFromAssignment,
+  mapAppLocaleToPdfLanguage,
+  type Gender,
+  type Language,
+  type LeagueCategory,
+  type SportsHallReportData,
+} from './pdf-report-data'
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export interface JerseyAdvertisingOptions {
+  homeTeam: boolean
+  awayTeam: boolean
 }
 
-export interface SportsHallReportData {
-  gameNumber: string
-  homeTeam: string
-  awayTeam: string
-  gender: Gender
-  hallName: string
-  location: string
-  date: string
-  startingDateTime?: string
-  firstRefereeName?: string
-  secondRefereeName?: string
+/** Which sub-items are flagged as not-OK, keyed by section ID then sub-item ID. */
+export type NonConformantSelections = Record<string, Set<string>>
+
+/** Signature data for the non-conformant workflow (up to 4 signers). */
+export interface NonConformantSignatures {
+  firstReferee?: string
+  secondReferee?: string
+  homeTeamCoach?: { name: string; signature: string }
+  awayTeamCoach?: { name: string; signature: string }
 }
 
-function formatDateForReport(isoString: string | undefined): string {
-  if (!isoString) return ''
-  try {
-    return format(new Date(isoString), 'dd.MM.yy')
-  } catch {
-    // Invalid date format - return empty string so form field shows blank
-    logger.warn('Failed to parse date for PDF report:', isoString)
-    return ''
-  }
-}
-
-function getRefereeName(
-  convocation:
-    | {
-        indoorAssociationReferee?: {
-          indoorReferee?: {
-            person?: {
-              firstName?: string
-              lastName?: string
-              displayName?: string
-            }
-          }
-        }
-      }
-    | null
-    | undefined
-): string | undefined {
-  const person = convocation?.indoorAssociationReferee?.indoorReferee?.person
-  if (!person) return undefined
-  return (
-    person.displayName || `${person.firstName ?? ''} ${person.lastName ?? ''}`.trim() || undefined
-  )
-}
-
-export function extractSportsHallReportData(assignment: Assignment): SportsHallReportData | null {
-  const game = assignment.refereeGame?.game
-  if (!game) return null
-
-  const leagueCategoryName = game.group?.phase?.league?.leagueCategory?.name
-  if (leagueCategoryName !== 'NLA' && leagueCategoryName !== 'NLB') {
-    return null
-  }
-
-  const refereeGame = assignment.refereeGame
-  const firstReferee = getRefereeName(refereeGame?.activeRefereeConvocationFirstHeadReferee)
-  const secondReferee = getRefereeName(refereeGame?.activeRefereeConvocationSecondHeadReferee)
-
-  const reportData: SportsHallReportData = {
-    gameNumber: game.number?.toString() ?? '',
-    homeTeam: game.encounter?.teamHome?.name ?? '',
-    awayTeam: game.encounter?.teamAway?.name ?? '',
-    gender: (game.group?.phase?.league?.gender ?? 'm') as Gender,
-    hallName: game.hall?.name ?? '',
-    location: game.hall?.primaryPostalAddress?.city ?? '',
-    date: formatDateForReport(game.startingDateTime),
-    startingDateTime: game.startingDateTime,
-    firstRefereeName: firstReferee,
-    secondRefereeName: secondReferee,
-  }
-
-  // Debug logging for troubleshooting PDF generation
-  logger.debug('[pdf-form-filler] Extracted report data:', reportData)
-
-  return reportData
-}
-
-export function getLeagueCategoryFromAssignment(assignment: Assignment): LeagueCategory | null {
-  const name = assignment.refereeGame?.game?.group?.phase?.league?.leagueCategory?.name
-  if (name === 'NLA' || name === 'NLB') {
-    return name
-  }
-  return null
-}
-
-interface FieldMapping {
-  gameNumber: string
-  homeTeam: string
-  awayTeam: string
-  genderRadio: string
-  hallName: string
-  location: string
-  date: string
-  firstRefereeName: string
-  secondRefereeName: string
-}
-
-const NLA_FIELD_MAPPING: FieldMapping = {
-  gameNumber: 'SpielNr',
-  homeTeam: 'Heimteam',
-  awayTeam: 'Gastteam',
-  genderRadio: 'Gruppe3',
-  hallName: 'Hallenname',
-  location: 'Ort',
-  date: 'Datum',
-  firstRefereeName: 'Text19',
-  secondRefereeName: 'Text20',
-}
-
-const NLB_FIELD_MAPPING: FieldMapping = {
-  gameNumber: 'Text9',
-  homeTeam: 'Text10',
-  awayTeam: 'Text12',
-  genderRadio: 'Gruppe15',
-  hallName: 'Text14',
-  location: 'Text13',
-  date: 'Text11',
-  firstRefereeName: 'Text23',
-  secondRefereeName: 'Text24',
-}
-
-function getFieldMapping(leagueCategory: LeagueCategory): FieldMapping {
-  return leagueCategory === 'NLA' ? NLA_FIELD_MAPPING : NLB_FIELD_MAPPING
-}
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
 
 /**
  * Safely sets a text field in a PDF form, logging a warning on failure.
@@ -158,10 +93,9 @@ function trySetTextField(form: any, fieldName: string, value: string | undefined
 
 /**
  * Fills the basic game info fields (teams, date, hall, referees, gender) in a PDF form.
- * Shared between the standard report and the wizard report.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function fillBaseGameInfo(form: any, data: SportsHallReportData, mapping: FieldMapping): void {
+function fillBaseGameInfo(form: any, data: SportsHallReportData, mapping: ReturnType<typeof getFieldMapping>): void {
   trySetTextField(form, mapping.gameNumber, data.gameNumber)
   trySetTextField(form, mapping.homeTeam, data.homeTeam)
   trySetTextField(form, mapping.awayTeam, data.awayTeam)
@@ -221,539 +155,15 @@ async function loadPdfForm(
   return { pdfDoc, form }
 }
 
-export async function fillSportsHallReportForm(
-  data: SportsHallReportData,
-  leagueCategory: LeagueCategory,
-  language: Language
-): Promise<Uint8Array> {
-  const { pdfDoc, form } = await loadPdfForm(leagueCategory, language)
-  const mapping = getFieldMapping(leagueCategory)
-
-  fillBaseGameInfo(form, data, mapping)
-
-  // Do not flatten: referees download this form to fill remaining fields themselves
-  return pdfDoc.save()
-}
-
-export function downloadPdf(pdfBytes: Uint8Array, filename: string): void {
-  const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' })
-  const url = URL.createObjectURL(blob)
-  const link = document.createElement('a')
-  link.href = url
-  link.download = filename
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  URL.revokeObjectURL(url)
-}
-
-const REPORT_NAME: Record<Language, string> = {
-  de: 'hallenrapport',
-  fr: 'rapport_salle',
-}
-
-export function buildReportFilename(
-  leagueCategory: LeagueCategory,
-  language: Language,
-  startingDateTime?: string,
-  gameNumber?: string
-): string {
-  const league = leagueCategory.toLowerCase()
-  const reportName = REPORT_NAME[language]
-  let datePart = 'unknown'
-  if (startingDateTime) {
-    try {
-      datePart = format(new Date(startingDateTime), 'yyyyMMdd')
-    } catch {
-      logger.warn('Failed to parse date for report filename:', startingDateTime)
-    }
-  }
-  const suffix = gameNumber ? `_${gameNumber}` : ''
-  return `${league}_${reportName}_${datePart}${suffix}.pdf`
-}
-
-export async function generateAndDownloadSportsHallReport(
-  data: SportsHallReportData,
-  leagueCategory: LeagueCategory,
-  language: Language
-): Promise<void> {
-  const pdfBytes = await fillSportsHallReportForm(data, leagueCategory, language)
-  const filename = buildReportFilename(
-    leagueCategory,
-    language,
-    data.startingDateTime,
-    data.gameNumber
-  )
-  downloadPdf(pdfBytes, filename)
-}
-
-/**
- * Wizard-specific field mapping for checkbox/radio fields that the wizard fills
- * in addition to the base game info fields.
- */
-interface WizardFieldMapping {
-  /** Checkbox field name for "Tous les points sont en ordre" / "Alle Punkte in Ordnung" */
-  allPointsInOrderCheckbox: string
-  /** Radio group field name for home team "Werbung auf Spielerkleidung" (Ja/Nein) */
-  advertisingHomeTeam: string
-  /** Radio group field name for away team "Werbung auf Spielerkleidung" (Ja/Nein) */
-  advertisingAwayTeam: string
-}
-
-const NLA_WIZARD_FIELDS: WizardFieldMapping = {
-  allPointsInOrderCheckbox: 'Kontrollkästchen8',
-  advertisingHomeTeam: 'Gruppe430',
-  advertisingAwayTeam: 'Gruppe434',
-}
-
-const NLB_WIZARD_FIELDS: WizardFieldMapping = {
-  allPointsInOrderCheckbox: 'Kontrollkästchen17',
-  advertisingHomeTeam: '31',
-  advertisingAwayTeam: '34',
-}
-
-/** OK option value used by all radio groups in the PDF templates */
-const RADIO_OK_OPTION = 'Auswahl3'
-
-/** Not-OK option value used by all radio groups in the PDF templates */
-const RADIO_NOT_OK_OPTION = 'Auswahl4'
-
-export interface JerseyAdvertisingOptions {
-  homeTeam: boolean
-  awayTeam: boolean
-}
-
 // ---------------------------------------------------------------------------
-// Checklist section / sub-item mappings for the non-conformant workflow
+// Signature embedding
 // ---------------------------------------------------------------------------
 
-export interface ChecklistSubItem {
-  /** Unique key within the section (e.g. 'lines', 'attackLine') */
-  id: string
-  /** i18n key for the sub-item label */
-  labelKey: TranslationKey
-  /** PDF radio group field name(s) — one per sub-item row on the form */
-  radioField: string
-}
+const SIGNATURE_CROP_PADDING = 10
+const SIGNATURE_EMBED_PADDING_PT = 3
+const RGBA_CHANNELS = 4
+const ALPHA_CHANNEL_OFFSET = 3
 
-export interface ChecklistSection {
-  /** Section letter matching the PDF form (A, B, C, …) */
-  id: string
-  /** i18n key for the section label */
-  labelKey: TranslationKey
-  /** Sub-items within this section */
-  subItems: readonly ChecklistSubItem[]
-  /** PDF text field name(s) for the remarks column */
-  commentFields: readonly string[]
-}
-
-const NLA_CHECKLIST_SECTIONS: readonly ChecklistSection[] = [
-  {
-    id: 'A',
-    labelKey: 'pdf.wizard.sections.fieldAndLines',
-    subItems: [
-      { id: 'lines', labelKey: 'pdf.wizard.subItems.boundaryLines', radioField: 'Gruppe4' },
-      { id: 'attackLine', labelKey: 'pdf.wizard.subItems.attackLine', radioField: 'Gruppe41' },
-    ],
-    commentFields: ['Text7.0.0'],
-  },
-  {
-    id: 'B',
-    labelKey: 'pdf.wizard.sections.warmUpArea',
-    subItems: [
-      { id: 'warmUp', labelKey: 'pdf.wizard.subItems.warmUpArea', radioField: 'Gruppe42' },
-    ],
-    commentFields: ['Text7.0.1'],
-  },
-  {
-    id: 'C',
-    labelKey: 'pdf.wizard.sections.netEquipment',
-    subItems: [
-      { id: 'antennas', labelKey: 'pdf.wizard.subItems.antennas', radioField: 'Gruppe43' },
-      { id: 'netBand', labelKey: 'pdf.wizard.subItems.netTopBand', radioField: 'Gruppe44' },
-      { id: 'reserveNet', labelKey: 'pdf.wizard.subItems.reserveNet', radioField: 'Gruppe45' },
-      { id: 'postsNoWire', labelKey: 'pdf.wizard.subItems.postsNoWire', radioField: 'Gruppe46' },
-      { id: 'postsPadding', labelKey: 'pdf.wizard.subItems.postsPadding', radioField: 'Gruppe47' },
-      { id: 'tabletMount', labelKey: 'pdf.wizard.subItems.tabletMount', radioField: 'Gruppe48' },
-      { id: 'netHeight', labelKey: 'pdf.wizard.subItems.netHeight', radioField: 'Gruppe49' },
-    ],
-    commentFields: ['Text7.0.2'],
-  },
-  {
-    id: 'D',
-    labelKey: 'pdf.wizard.sections.refereeChair',
-    subItems: [{ id: 'chair', labelKey: 'pdf.wizard.subItems.refereeChair', radioField: '10' }],
-    commentFields: ['Text7.0.3'],
-  },
-  {
-    id: 'E',
-    labelKey: 'pdf.wizard.sections.manometer',
-    subItems: [{ id: 'manometer', labelKey: 'pdf.wizard.subItems.manometer', radioField: '11' }],
-    commentFields: ['Text7.0.4'],
-  },
-  {
-    id: 'F',
-    labelKey: 'pdf.wizard.sections.measuringRod',
-    subItems: [{ id: 'rod', labelKey: 'pdf.wizard.subItems.measuringRod', radioField: '12' }],
-    commentFields: ['Text7.0.5'],
-  },
-  {
-    id: 'G',
-    labelKey: 'pdf.wizard.sections.lineFlags',
-    subItems: [{ id: 'flags', labelKey: 'pdf.wizard.subItems.lineFlags', radioField: '13' }],
-    commentFields: ['Text7.0.6'],
-  },
-  {
-    id: 'H',
-    labelKey: 'pdf.wizard.sections.buzzer',
-    subItems: [{ id: 'buzzer', labelKey: 'pdf.wizard.subItems.buzzer', radioField: '14' }],
-    commentFields: ['Text7.0.7'],
-  },
-  {
-    id: 'I',
-    labelKey: 'pdf.wizard.sections.eScoresheet',
-    subItems: [
-      { id: 'eScorerOnTime', labelKey: 'pdf.wizard.subItems.eScorerOnTime', radioField: '15' },
-      { id: 'reserveLaptop', labelKey: 'pdf.wizard.subItems.reserveLaptop', radioField: '16' },
-      { id: 'usbStick', labelKey: 'pdf.wizard.subItems.usbStick', radioField: '17' },
-      {
-        id: 'reserveMatchSheet',
-        labelKey: 'pdf.wizard.subItems.reserveMatchSheet',
-        radioField: '18',
-      },
-    ],
-    commentFields: ['Text7.1'],
-  },
-  {
-    id: 'J',
-    labelKey: 'pdf.wizard.sections.tablets',
-    subItems: [
-      { id: 'refereeTablets', labelKey: 'pdf.wizard.subItems.refereeTablets', radioField: '19' },
-      { id: 'benchTablets', labelKey: 'pdf.wizard.subItems.benchTablets', radioField: '20' },
-    ],
-    commentFields: ['Text7.2'],
-  },
-  {
-    id: 'K',
-    labelKey: 'pdf.wizard.sections.scoreboard',
-    subItems: [
-      { id: 'scoreboard', labelKey: 'pdf.wizard.subItems.scoreboard', radioField: '21' },
-      {
-        id: 'scoreboardFunction',
-        labelKey: 'pdf.wizard.subItems.scoreboardFunction',
-        radioField: '22',
-      },
-    ],
-    commentFields: ['Text7.3'],
-  },
-  {
-    id: 'L',
-    labelKey: 'pdf.wizard.sections.balls',
-    subItems: [
-      { id: 'ballCount', labelKey: 'pdf.wizard.subItems.ballCount', radioField: '23' },
-      {
-        id: 'ballCondition',
-        labelKey: 'pdf.wizard.subItems.ballCondition',
-        radioField: 'Gruppe424',
-      },
-    ],
-    commentFields: ['Text7.4'],
-  },
-  {
-    id: 'M',
-    labelKey: 'pdf.wizard.sections.ballRetrievers',
-    subItems: [
-      {
-        id: 'ballRetrievers',
-        labelKey: 'pdf.wizard.subItems.ballRetrievers',
-        radioField: 'Gruppe425',
-      },
-    ],
-    commentFields: ['Text7.5'],
-  },
-  {
-    id: 'N',
-    labelKey: 'pdf.wizard.sections.quickMoppers',
-    subItems: [
-      { id: 'quickMoppers', labelKey: 'pdf.wizard.subItems.quickMoppers', radioField: 'Gruppe426' },
-    ],
-    commentFields: ['Text7.6'],
-  },
-  {
-    id: 'O',
-    labelKey: 'pdf.wizard.sections.hallSpeaker',
-    subItems: [
-      { id: 'hallSpeaker', labelKey: 'pdf.wizard.subItems.hallSpeaker', radioField: 'Gruppe427' },
-    ],
-    commentFields: ['Text7.7'],
-  },
-  {
-    id: 'P',
-    labelKey: 'pdf.wizard.sections.dressHome',
-    subItems: [
-      { id: 'dressHomeColor', labelKey: 'pdf.wizard.subItems.dressColor', radioField: 'Gruppe428' },
-      {
-        id: 'dressHomeLibero',
-        labelKey: 'pdf.wizard.subItems.liberoDress',
-        radioField: 'Gruppe429',
-      },
-      {
-        id: 'dressHomeAd',
-        labelKey: 'pdf.wizard.subItems.advertisingOnUniform',
-        radioField: 'Gruppe430',
-      },
-    ],
-    commentFields: ['Text7.8'],
-  },
-  {
-    id: 'Q',
-    labelKey: 'pdf.wizard.sections.dressAway',
-    subItems: [
-      { id: 'dressAwayColor', labelKey: 'pdf.wizard.subItems.dressColor', radioField: 'Gruppe431' },
-      {
-        id: 'dressAwayLibero',
-        labelKey: 'pdf.wizard.subItems.liberoDress',
-        radioField: 'Gruppe432',
-      },
-      {
-        id: 'dressAwayMatchkit',
-        labelKey: 'pdf.wizard.subItems.matchKit',
-        radioField: 'Gruppe433',
-      },
-      {
-        id: 'dressAwayAd',
-        labelKey: 'pdf.wizard.subItems.advertisingOnUniform',
-        radioField: 'Gruppe434',
-      },
-    ],
-    commentFields: ['Text7.9'],
-  },
-  {
-    id: 'R',
-    labelKey: 'pdf.wizard.sections.miscellaneous',
-    subItems: [
-      { id: 'misc1', labelKey: 'pdf.wizard.subItems.miscItem1', radioField: 'Gruppe435' },
-      { id: 'misc2', labelKey: 'pdf.wizard.subItems.miscItem2', radioField: 'Gruppe440' },
-    ],
-    commentFields: ['Text7.10', 'Text7.11'],
-  },
-] as const
-
-const NLB_CHECKLIST_SECTIONS: readonly ChecklistSection[] = [
-  {
-    id: 'A',
-    labelKey: 'pdf.wizard.sections.fieldAndLines',
-    subItems: [
-      { id: 'lines', labelKey: 'pdf.wizard.subItems.boundaryLines', radioField: 'Gruppe16' },
-      { id: 'attackLine', labelKey: 'pdf.wizard.subItems.attackLine', radioField: 'Gruppe17' },
-    ],
-    commentFields: ['Text16.0.0'],
-  },
-  {
-    id: 'B',
-    labelKey: 'pdf.wizard.sections.netEquipment',
-    subItems: [
-      { id: 'antennas', labelKey: 'pdf.wizard.subItems.antennas', radioField: 'Gruppe18' },
-      { id: 'netBand', labelKey: 'pdf.wizard.subItems.netTopBand', radioField: 'Gruppe19' },
-      {
-        id: 'netBottomBand',
-        labelKey: 'pdf.wizard.subItems.netBottomBand',
-        radioField: 'Gruppe20',
-      },
-    ],
-    commentFields: ['Text16.0.1'],
-  },
-  {
-    id: 'C',
-    labelKey: 'pdf.wizard.sections.numberPlates',
-    subItems: [
-      {
-        id: 'numberPlates',
-        labelKey: 'pdf.wizard.subItems.numberPlates',
-        radioField: 'Gruppe21',
-      },
-    ],
-    commentFields: ['Text16.1'],
-  },
-  {
-    id: 'D',
-    labelKey: 'pdf.wizard.sections.manometer',
-    subItems: [{ id: 'manometer', labelKey: 'pdf.wizard.subItems.manometer', radioField: '22' }],
-    commentFields: ['Text16.2'],
-  },
-  {
-    id: 'E',
-    labelKey: 'pdf.wizard.sections.measuringRod',
-    subItems: [{ id: 'rod', labelKey: 'pdf.wizard.subItems.measuringRod', radioField: '23' }],
-    commentFields: ['Text16.3'],
-  },
-  {
-    id: 'F',
-    labelKey: 'pdf.wizard.sections.balls',
-    subItems: [
-      {
-        id: 'practiseBalls',
-        labelKey: 'pdf.wizard.subItems.practiseBalls',
-        radioField: '24',
-      },
-      { id: 'matchBalls', labelKey: 'pdf.wizard.subItems.matchBalls', radioField: '25' },
-      {
-        id: 'matchBallsException',
-        labelKey: 'pdf.wizard.subItems.matchBallsException',
-        radioField: '26',
-      },
-    ],
-    commentFields: ['Text16.4'],
-  },
-  {
-    id: 'G',
-    labelKey: 'pdf.wizard.sections.ballRetrievers',
-    subItems: [
-      { id: 'ballRetrievers', labelKey: 'pdf.wizard.subItems.ballRetrievers', radioField: '27' },
-      {
-        id: 'ballRetrieversException',
-        labelKey: 'pdf.wizard.subItems.ballRetrieversException',
-        radioField: '28',
-      },
-    ],
-    commentFields: ['Text16.5'],
-  },
-  {
-    id: 'H',
-    labelKey: 'pdf.wizard.sections.dressHome',
-    subItems: [
-      { id: 'dressHomeColor', labelKey: 'pdf.wizard.subItems.dressColor', radioField: '29' },
-      { id: 'dressHomeLibero', labelKey: 'pdf.wizard.subItems.liberoDress', radioField: '30' },
-      {
-        id: 'dressHomeAd',
-        labelKey: 'pdf.wizard.subItems.advertisingOnUniform',
-        radioField: '31',
-      },
-    ],
-    commentFields: ['Text16.6'],
-  },
-  {
-    id: 'I',
-    labelKey: 'pdf.wizard.sections.dressAway',
-    subItems: [
-      { id: 'dressAwayColor', labelKey: 'pdf.wizard.subItems.dressColor', radioField: '32' },
-      { id: 'dressAwayLibero', labelKey: 'pdf.wizard.subItems.liberoDress', radioField: '33' },
-      {
-        id: 'dressAwayAd',
-        labelKey: 'pdf.wizard.subItems.advertisingOnUniform',
-        radioField: '34',
-      },
-    ],
-    commentFields: ['Text16.7'],
-  },
-  {
-    id: 'J',
-    labelKey: 'pdf.wizard.sections.eScoresheet',
-    subItems: [
-      { id: 'eScorerOnTime', labelKey: 'pdf.wizard.subItems.eScorerOnTime', radioField: '35' },
-      { id: 'reserveLaptop', labelKey: 'pdf.wizard.subItems.reserveLaptop', radioField: '36' },
-      { id: 'usbStick', labelKey: 'pdf.wizard.subItems.usbStick', radioField: '37' },
-      {
-        id: 'reserveMatchSheet',
-        labelKey: 'pdf.wizard.subItems.reserveMatchSheet',
-        radioField: '38',
-      },
-    ],
-    commentFields: ['Text16.8'],
-  },
-  {
-    id: 'K',
-    labelKey: 'pdf.wizard.sections.tablets',
-    subItems: [
-      { id: 'refereeTablets', labelKey: 'pdf.wizard.subItems.refereeTablets', radioField: '39' },
-    ],
-    commentFields: ['Text16.9'],
-  },
-  {
-    id: 'L',
-    labelKey: 'pdf.wizard.sections.miscellaneous',
-    subItems: [
-      { id: 'misc1', labelKey: 'pdf.wizard.subItems.miscItem1', radioField: '40' },
-      { id: 'misc2', labelKey: 'pdf.wizard.subItems.miscItem2', radioField: '41' },
-    ],
-    commentFields: ['Text16.10', 'Text16.11'],
-  },
-] as const
-
-export function getChecklistSections(leagueCategory: LeagueCategory): readonly ChecklistSection[] {
-  return leagueCategory === 'NLA' ? NLA_CHECKLIST_SECTIONS : NLB_CHECKLIST_SECTIONS
-}
-
-/**
- * All four signature name text fields at the bottom of the report form.
- */
-interface SignatureNameFields {
-  firstReferee: string
-  secondReferee: string
-  homeTeam: string
-  awayTeam: string
-}
-
-const NLA_SIGNATURE_NAME_FIELDS: SignatureNameFields = {
-  firstReferee: 'Text19',
-  secondReferee: 'Text20',
-  homeTeam: 'Text21',
-  awayTeam: 'Text22',
-}
-
-const NLB_SIGNATURE_NAME_FIELDS: SignatureNameFields = {
-  firstReferee: 'Text23',
-  secondReferee: 'Text24',
-  homeTeam: 'Text25',
-  awayTeam: 'Text26',
-}
-
-function getWizardFieldMapping(leagueCategory: LeagueCategory): WizardFieldMapping {
-  return leagueCategory === 'NLA' ? NLA_WIZARD_FIELDS : NLB_WIZARD_FIELDS
-}
-
-/**
- * Signature placement coordinates per league category.
- * Positioned to the right of the referee name text fields at the bottom of the page.
- */
-interface SignaturePosition {
-  x: number
-  y: number
-  width: number
-  height: number
-}
-
-const SIGNATURE_POSITIONS: Record<LeagueCategory, SignaturePosition> = {
-  NLA: { x: 340, y: 104, width: 130, height: 24 },
-  NLB: { x: 340, y: 157, width: 130, height: 24 },
-}
-
-/** Signature positions for all four signers (non-conformant workflow). */
-interface AllSignaturePositions {
-  firstReferee: SignaturePosition
-  secondReferee: SignaturePosition
-  homeTeam: SignaturePosition
-  awayTeam: SignaturePosition
-}
-
-const ALL_SIGNATURE_POSITIONS: Record<LeagueCategory, AllSignaturePositions> = {
-  NLA: {
-    firstReferee: { x: 340, y: 104, width: 130, height: 24 },
-    secondReferee: { x: 340, y: 83, width: 130, height: 18 },
-    homeTeam: { x: 340, y: 62, width: 130, height: 18 },
-    awayTeam: { x: 340, y: 41, width: 130, height: 18 },
-  },
-  NLB: {
-    firstReferee: { x: 340, y: 157, width: 130, height: 24 },
-    secondReferee: { x: 340, y: 129, width: 130, height: 18 },
-    homeTeam: { x: 340, y: 101, width: 130, height: 18 },
-    awayTeam: { x: 340, y: 73, width: 130, height: 18 },
-  },
-}
-
-/**
- * Decode a data URL (e.g. from canvas.toDataURL) to raw bytes.
- */
 function dataUrlToBytes(dataUrl: string): Uint8Array {
   const base64 = dataUrl.split(',')[1]
   if (!base64) throw new Error('Invalid data URL')
@@ -765,15 +175,6 @@ function dataUrlToBytes(dataUrl: string): Uint8Array {
   return bytes
 }
 
-const SIGNATURE_CROP_PADDING = 10
-const SIGNATURE_EMBED_PADDING_PT = 3
-const RGBA_CHANNELS = 4
-const ALPHA_CHANNEL_OFFSET = 3
-
-/**
- * Crop a signature PNG data URL to its bounding box, removing transparent
- * whitespace around the actual strokes. Returns the cropped data URL.
- */
 async function cropSignatureDataUrl(dataUrl: string): Promise<string> {
   const img = new Image()
   await new Promise<void>((resolve, reject) => {
@@ -792,7 +193,6 @@ async function cropSignatureDataUrl(dataUrl: string): Promise<string> {
   const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
   const { data, width, height } = imageData
 
-  // Find bounding box of non-transparent pixels
   let minX = width
   let minY = height
   let maxX = 0
@@ -810,10 +210,8 @@ async function cropSignatureDataUrl(dataUrl: string): Promise<string> {
     }
   }
 
-  // No visible pixels found — return original
   if (maxX < minX || maxY < minY) return dataUrl
 
-  // Add padding, clamped to canvas bounds
   const cropX = Math.max(0, minX - SIGNATURE_CROP_PADDING)
   const cropY = Math.max(0, minY - SIGNATURE_CROP_PADDING)
   const cropW = Math.min(width - cropX, maxX - minX + 1 + SIGNATURE_CROP_PADDING * 2)
@@ -829,9 +227,6 @@ async function cropSignatureDataUrl(dataUrl: string): Promise<string> {
   return croppedCanvas.toDataURL('image/png')
 }
 
-/**
- * Embed a PNG signature image into a PDF page at the given position.
- */
 async function embedSignatureAtPosition(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   pdfDoc: any,
@@ -844,7 +239,6 @@ async function embedSignatureAtPosition(
 
   const page = pdfDoc.getPage(0)
 
-  // Scale the signature to fit within the field with padding
   const padding = SIGNATURE_EMBED_PADDING_PT
   const maxWidth = pos.width - padding * 2
   const maxHeight = pos.height - padding * 2
@@ -856,7 +250,6 @@ async function embedSignatureAtPosition(
     drawWidth = drawHeight * aspectRatio
   }
 
-  // Center the signature within the field
   const xOffset = pos.x + padding + (maxWidth - drawWidth) / 2
   const yOffset = pos.y + padding + (maxHeight - drawHeight) / 2
 
@@ -868,10 +261,6 @@ async function embedSignatureAtPosition(
   })
 }
 
-/**
- * Embed a PNG signature image into a PDF document at the first referee's
- * signature position.
- */
 async function embedSignature(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   pdfDoc: any,
@@ -881,15 +270,132 @@ async function embedSignature(
   await embedSignatureAtPosition(pdfDoc, signatureDataUrl, SIGNATURE_POSITIONS[leagueCategory])
 }
 
-/**
- * Fills the sports hall report with "all points in order" checked and
- * advertising declared as "Ja" for both teams. Individual checklist items
- * are left unchecked — the referee only needs to fill these if something
- * is not in order. This is the "happy path" wizard flow.
- *
- * When a signatureDataUrl is provided, the first referee's signature is
- * embedded at the designated position on the PDF.
- */
+async function embedAllSignatures(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  pdfDoc: any,
+  positions: AllSignaturePositions,
+  signatures: NonConformantSignatures
+): Promise<void> {
+  const entries: Array<[string | undefined, SignaturePosition]> = [
+    [signatures.firstReferee, positions.firstReferee],
+    [signatures.secondReferee, positions.secondReferee],
+    [signatures.homeTeamCoach?.signature, positions.homeTeam],
+    [signatures.awayTeamCoach?.signature, positions.awayTeam],
+  ]
+
+  for (const [dataUrl, position] of entries) {
+    if (!dataUrl) continue
+    try {
+      await embedSignatureAtPosition(pdfDoc, dataUrl, position)
+    } catch (error) {
+      logger.warn('Could not embed signature:', error)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Checklist radio / comment filling
+// ---------------------------------------------------------------------------
+
+function fillChecklistRadios(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: any,
+  sections: readonly PdfChecklistSection[],
+  nonConformantSubItems: NonConformantSelections
+): void {
+  for (const section of sections) {
+    const flaggedItems = nonConformantSubItems[section.id]
+    for (const subItem of section.subItems) {
+      const isNotOk = flaggedItems?.has(subItem.id) ?? false
+      const option = isNotOk ? RADIO_NOT_OK_OPTION : RADIO_OK_OPTION
+      try {
+        form.getRadioGroup(subItem.radioField).select(option)
+      } catch (error) {
+        logger.warn(`Could not set radio "${subItem.radioField}" to ${option}:`, error)
+      }
+    }
+  }
+}
+
+function fillNonConformantComments(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: any,
+  sections: readonly PdfChecklistSection[],
+  nonConformantSubItems: NonConformantSelections,
+  sectionComments: Record<string, string>
+): void {
+  for (const section of sections) {
+    if (!nonConformantSubItems[section.id]?.size) continue
+    const comment = sectionComments[section.id]?.trim()
+    if (!comment) continue
+    const commentField = section.commentFields[0]
+    if (!commentField) continue
+    try {
+      const field = form.getTextField(commentField)
+      field.setFontSize(COMMENT_FIELD_FONT_SIZE)
+      field.setText(comment)
+    } catch (error) {
+      logger.warn(`Could not set comment field "${commentField}":`, error)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Advertising radio helper
+// ---------------------------------------------------------------------------
+
+function fillAdvertisingRadios(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: any,
+  wizardMapping: ReturnType<typeof getWizardFieldMapping>,
+  jerseyAdvertising: JerseyAdvertisingOptions
+): void {
+  const adEntries: Array<{ field: string; hasAd: boolean }> = [
+    { field: wizardMapping.advertisingHomeTeam, hasAd: jerseyAdvertising.homeTeam },
+    { field: wizardMapping.advertisingAwayTeam, hasAd: jerseyAdvertising.awayTeam },
+  ]
+  for (const { field, hasAd } of adEntries) {
+    try {
+      form.getRadioGroup(field).select(hasAd ? RADIO_OK_OPTION : RADIO_NOT_OK_OPTION)
+    } catch (error) {
+      logger.warn(`Could not set advertising "${field}":`, error)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — Happy path
+// ---------------------------------------------------------------------------
+
+export async function fillSportsHallReportForm(
+  data: SportsHallReportData,
+  leagueCategory: LeagueCategory,
+  language: Language
+): Promise<Uint8Array> {
+  const { pdfDoc, form } = await loadPdfForm(leagueCategory, language)
+  const mapping = getFieldMapping(leagueCategory)
+
+  fillBaseGameInfo(form, data, mapping)
+
+  // Do not flatten: referees download this form to fill remaining fields themselves
+  return pdfDoc.save()
+}
+
+export async function generateAndDownloadSportsHallReport(
+  data: SportsHallReportData,
+  leagueCategory: LeagueCategory,
+  language: Language
+): Promise<void> {
+  const pdfBytes = await fillSportsHallReportForm(data, leagueCategory, language)
+  const filename = buildReportFilename(
+    leagueCategory,
+    language,
+    data.startingDateTime,
+    data.gameNumber
+  )
+  downloadPdf(pdfBytes, filename)
+}
+
 export interface WizardReportOptions {
   data: SportsHallReportData
   leagueCategory: LeagueCategory
@@ -921,18 +427,7 @@ export async function fillSportsHallReportWizard(
     logger.warn(`Could not check "${wizardMapping.allPointsInOrderCheckbox}":`, error)
   }
 
-  // Set advertising "Werbung auf Spielerkleidung" per team
-  const adEntries: Array<{ field: string; hasAd: boolean }> = [
-    { field: wizardMapping.advertisingHomeTeam, hasAd: jerseyAdvertising.homeTeam },
-    { field: wizardMapping.advertisingAwayTeam, hasAd: jerseyAdvertising.awayTeam },
-  ]
-  for (const { field, hasAd } of adEntries) {
-    try {
-      form.getRadioGroup(field).select(hasAd ? RADIO_OK_OPTION : RADIO_NOT_OK_OPTION)
-    } catch (error) {
-      logger.warn(`Could not set advertising "${field}":`, error)
-    }
-  }
+  fillAdvertisingRadios(form, wizardMapping, jerseyAdvertising)
 
   // Embed first referee signature if provided
   if (signatureDataUrl) {
@@ -947,11 +442,6 @@ export async function fillSportsHallReportWizard(
   return pdfDoc.save()
 }
 
-/**
- * Generates a sports hall report with all checkpoints marked as OK and
- * the first referee's signature embedded. Returns the PDF bytes and filename
- * for use with the Web Share API or print dialog.
- */
 export async function generateWizardReportBytes(
   options: WizardReportOptions & { signatureDataUrl: string }
 ): Promise<{ pdfBytes: Uint8Array; filename: string }> {
@@ -966,97 +456,8 @@ export async function generateWizardReportBytes(
 }
 
 // ---------------------------------------------------------------------------
-// Non-conformant report types and fill function
+// Public API — Non-conformant report
 // ---------------------------------------------------------------------------
-
-/** Which sub-items are flagged as not-OK, keyed by section ID then sub-item ID. */
-export type NonConformantSelections = Record<string, Set<string>>
-
-/** Signature data for the non-conformant workflow (up to 4 signers). */
-export interface NonConformantSignatures {
-  firstReferee?: string
-  secondReferee?: string
-  homeTeamCoach?: { name: string; signature: string }
-  awayTeamCoach?: { name: string; signature: string }
-}
-
-/**
- * Set all checklist radio groups: OK or not-OK per sub-item.
- */
-function fillChecklistRadios(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  form: any,
-  sections: readonly ChecklistSection[],
-  nonConformantSubItems: NonConformantSelections
-): void {
-  for (const section of sections) {
-    const flaggedItems = nonConformantSubItems[section.id]
-    for (const subItem of section.subItems) {
-      const isNotOk = flaggedItems?.has(subItem.id) ?? false
-      const option = isNotOk ? RADIO_NOT_OK_OPTION : RADIO_OK_OPTION
-      try {
-        form.getRadioGroup(subItem.radioField).select(option)
-      } catch (error) {
-        logger.warn(`Could not set radio "${subItem.radioField}" to ${option}:`, error)
-      }
-    }
-  }
-}
-
-/** Font size for comment fields so longer text fits in the narrow PDF cells */
-const COMMENT_FIELD_FONT_SIZE = 6
-
-/**
- * Fill per-section comments into their respective PDF comment fields.
- */
-function fillNonConformantComments(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  form: any,
-  sections: readonly ChecklistSection[],
-  nonConformantSubItems: NonConformantSelections,
-  sectionComments: Record<string, string>
-): void {
-  for (const section of sections) {
-    if (!nonConformantSubItems[section.id]?.size) continue
-    const comment = sectionComments[section.id]?.trim()
-    if (!comment) continue
-    const commentField = section.commentFields[0]
-    if (!commentField) continue
-    try {
-      const field = form.getTextField(commentField)
-      field.setFontSize(COMMENT_FIELD_FONT_SIZE)
-      field.setText(comment)
-    } catch (error) {
-      logger.warn(`Could not set comment field "${commentField}":`, error)
-    }
-  }
-}
-
-/**
- * Embed up to 4 signatures at their designated positions.
- */
-async function embedAllSignatures(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  pdfDoc: any,
-  positions: AllSignaturePositions,
-  signatures: NonConformantSignatures
-): Promise<void> {
-  const entries: Array<[string | undefined, SignaturePosition]> = [
-    [signatures.firstReferee, positions.firstReferee],
-    [signatures.secondReferee, positions.secondReferee],
-    [signatures.homeTeamCoach?.signature, positions.homeTeam],
-    [signatures.awayTeamCoach?.signature, positions.awayTeam],
-  ]
-
-  for (const [dataUrl, position] of entries) {
-    if (!dataUrl) continue
-    try {
-      await embedSignatureAtPosition(pdfDoc, dataUrl, position)
-    } catch (error) {
-      logger.warn('Could not embed signature:', error)
-    }
-  }
-}
 
 export interface NonConformantReportOptions {
   data: SportsHallReportData
@@ -1068,9 +469,6 @@ export interface NonConformantReportOptions {
   signatures?: NonConformantSignatures
 }
 
-/**
- * Fill the sports hall report for the non-conformant workflow.
- */
 export async function fillNonConformantReport(
   options: NonConformantReportOptions & { flatten?: boolean }
 ): Promise<Uint8Array> {
@@ -1086,26 +484,13 @@ export async function fillNonConformantReport(
   const { pdfDoc, form } = await loadPdfForm(leagueCategory, language)
   const mapping = getFieldMapping(leagueCategory)
   const wizardMapping = getWizardFieldMapping(leagueCategory)
-  const sections = getChecklistSections(leagueCategory)
-  const signatureNameFields =
-    leagueCategory === 'NLA' ? NLA_SIGNATURE_NAME_FIELDS : NLB_SIGNATURE_NAME_FIELDS
+  const sections = getPdfChecklistSections(leagueCategory)
+  const signatureNameFields = getSignatureNameFields(leagueCategory)
 
   fillBaseGameInfo(form, data, mapping)
   fillChecklistRadios(form, sections, nonConformantSubItems)
   fillNonConformantComments(form, sections, nonConformantSubItems, sectionComments)
-
-  // Set advertising radio fields (overrides checklist values for these specific fields)
-  const adEntries: Array<{ field: string; hasAd: boolean }> = [
-    { field: wizardMapping.advertisingHomeTeam, hasAd: jerseyAdvertising.homeTeam },
-    { field: wizardMapping.advertisingAwayTeam, hasAd: jerseyAdvertising.awayTeam },
-  ]
-  for (const { field, hasAd } of adEntries) {
-    try {
-      form.getRadioGroup(field).select(hasAd ? RADIO_OK_OPTION : RADIO_NOT_OK_OPTION)
-    } catch (error) {
-      logger.warn(`Could not set advertising "${field}":`, error)
-    }
-  }
+  fillAdvertisingRadios(form, wizardMapping, jerseyAdvertising)
 
   if (signatures?.homeTeamCoach?.name) {
     trySetTextField(form, signatureNameFields.homeTeam, signatures.homeTeamCoach.name)
@@ -1124,9 +509,6 @@ export async function fillNonConformantReport(
   return pdfDoc.save()
 }
 
-/**
- * Generate a non-conformant report preview (no signatures) for review.
- */
 export async function generateNonConformantPreviewBytes(
   options: Omit<NonConformantReportOptions, 'signatures'>
 ): Promise<{ pdfBytes: Uint8Array; filename: string }> {
@@ -1140,10 +522,6 @@ export async function generateNonConformantPreviewBytes(
   return { pdfBytes, filename }
 }
 
-/**
- * Generate the final non-conformant report with all signatures embedded.
- * The form is flattened for download to ensure uniform text rendering.
- */
 export async function generateNonConformantReportBytes(
   options: NonConformantReportOptions & { signatures: NonConformantSignatures }
 ): Promise<{ pdfBytes: Uint8Array; filename: string }> {

--- a/packages/web/src/shared/utils/pdf-report-data.ts
+++ b/packages/web/src/shared/utils/pdf-report-data.ts
@@ -89,7 +89,7 @@ export function extractSportsHallReportData(assignment: Assignment): SportsHallR
   }
 
   // Debug logging for troubleshooting PDF generation
-  logger.debug('[pdf-form-filler] Extracted report data:', reportData)
+  logger.debug('[pdf-report-data] Extracted report data:', reportData)
 
   return reportData
 }

--- a/packages/web/src/shared/utils/pdf-report-data.ts
+++ b/packages/web/src/shared/utils/pdf-report-data.ts
@@ -1,0 +1,128 @@
+import { format } from 'date-fns'
+
+import type { Assignment } from '@/api/client'
+
+import { logger } from './logger'
+
+export type LeagueCategory = 'NLA' | 'NLB'
+export type Language = 'de' | 'fr'
+export type Gender = 'm' | 'f'
+
+export function mapAppLocaleToPdfLanguage(appLocale: string): Language {
+  if (appLocale === 'fr' || appLocale === 'it') {
+    return 'fr'
+  }
+  return 'de'
+}
+
+export interface SportsHallReportData {
+  gameNumber: string
+  homeTeam: string
+  awayTeam: string
+  gender: Gender
+  hallName: string
+  location: string
+  date: string
+  startingDateTime?: string
+  firstRefereeName?: string
+  secondRefereeName?: string
+}
+
+function formatDateForReport(isoString: string | undefined): string {
+  if (!isoString) return ''
+  try {
+    return format(new Date(isoString), 'dd.MM.yy')
+  } catch {
+    // Invalid date format - return empty string so form field shows blank
+    logger.warn('Failed to parse date for PDF report:', isoString)
+    return ''
+  }
+}
+
+function getRefereeName(
+  convocation:
+    | {
+        indoorAssociationReferee?: {
+          indoorReferee?: {
+            person?: {
+              firstName?: string
+              lastName?: string
+              displayName?: string
+            }
+          }
+        }
+      }
+    | null
+    | undefined
+): string | undefined {
+  const person = convocation?.indoorAssociationReferee?.indoorReferee?.person
+  if (!person) return undefined
+  return (
+    person.displayName || `${person.firstName ?? ''} ${person.lastName ?? ''}`.trim() || undefined
+  )
+}
+
+export function extractSportsHallReportData(assignment: Assignment): SportsHallReportData | null {
+  const game = assignment.refereeGame?.game
+  if (!game) return null
+
+  const leagueCategoryName = game.group?.phase?.league?.leagueCategory?.name
+  if (leagueCategoryName !== 'NLA' && leagueCategoryName !== 'NLB') {
+    return null
+  }
+
+  const refereeGame = assignment.refereeGame
+  const firstReferee = getRefereeName(refereeGame?.activeRefereeConvocationFirstHeadReferee)
+  const secondReferee = getRefereeName(refereeGame?.activeRefereeConvocationSecondHeadReferee)
+
+  const reportData: SportsHallReportData = {
+    gameNumber: game.number?.toString() ?? '',
+    homeTeam: game.encounter?.teamHome?.name ?? '',
+    awayTeam: game.encounter?.teamAway?.name ?? '',
+    gender: (game.group?.phase?.league?.gender ?? 'm') as Gender,
+    hallName: game.hall?.name ?? '',
+    location: game.hall?.primaryPostalAddress?.city ?? '',
+    date: formatDateForReport(game.startingDateTime),
+    startingDateTime: game.startingDateTime,
+    firstRefereeName: firstReferee,
+    secondRefereeName: secondReferee,
+  }
+
+  // Debug logging for troubleshooting PDF generation
+  logger.debug('[pdf-form-filler] Extracted report data:', reportData)
+
+  return reportData
+}
+
+export function getLeagueCategoryFromAssignment(assignment: Assignment): LeagueCategory | null {
+  const name = assignment.refereeGame?.game?.group?.phase?.league?.leagueCategory?.name
+  if (name === 'NLA' || name === 'NLB') {
+    return name
+  }
+  return null
+}
+
+const REPORT_NAME: Record<Language, string> = {
+  de: 'hallenrapport',
+  fr: 'rapport_salle',
+}
+
+export function buildReportFilename(
+  leagueCategory: LeagueCategory,
+  language: Language,
+  startingDateTime?: string,
+  gameNumber?: string
+): string {
+  const league = leagueCategory.toLowerCase()
+  const reportName = REPORT_NAME[language]
+  let datePart = 'unknown'
+  if (startingDateTime) {
+    try {
+      datePart = format(new Date(startingDateTime), 'yyyyMMdd')
+    } catch {
+      logger.warn('Failed to parse date for report filename:', startingDateTime)
+    }
+  }
+  const suffix = gameNumber ? `_${gameNumber}` : ''
+  return `${league}_${reportName}_${datePart}${suffix}.pdf`
+}


### PR DESCRIPTION
## Summary

- Split `pdf-form-filler.ts` (1158 lines) into focused modules: `pdf-report-data.ts`, `pdf-field-mappings.ts`, `pdf-download.ts`
- Extract `NonConformantOverlay` component from modal (reduces modal from 673 to ~170 lines)
- Extract `HappyPathContent`, `LanguageSelector`, `JerseyAdToggle`, `JerseyAdvertisingSection` to own files
- Create `usePdfGeneration` hook consolidating 3 duplicated PDF generation flows
- Create `useBodyScrollLock` and `useOverlayTouchGuard` shared hooks (eliminates duplicated scroll/touch logic)
- Unify jersey advertising state at modal level (was duplicated across happy/non-conformant paths)
- Move coach names into `useNonConformantWizard` hook state (fixes state sync issue where changing coach name after signing used stale name)
- Separate checklist UI model from PDF field mappings for cleaner layer boundaries

## Test plan

- [x] All 3912 existing tests pass
- [x] Lint passes (0 warnings)
- [x] Knip dead code detection passes
- [x] Build succeeds
- [ ] Verify happy path PDF generation with signature works
- [ ] Verify non-conformant workflow end-to-end
- [ ] Verify jersey advertising toggles work in both paths
- [ ] Verify pre-filled download works

https://claude.ai/code/session_016fBVhp6eEriZ1rQU7NEB4B