### PR TITLE
feat(web): improve sports hall report wizard UX

### DIFF
--- a/.changeset/sports-hall-ux-improvements.md
+++ b/.changeset/sports-hall-ux-improvements.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Improved sports hall report UX: re-sign capability, close confirmation dialog, dynamic step indicator, portrait-mode signatures, discoverable issue reporting, coach defaults, and differentiated error messages

--- a/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
+++ b/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { createPortal } from 'react-dom'
 
@@ -22,6 +22,7 @@ import { WizardStepIndicator } from './WizardStepIndicator'
 import type { useNonConformantWizard } from '../hooks/useNonConformantWizard'
 
 const MODAL_TITLE_ID = 'sports-hall-report-wizard-title'
+const DISCARD_DIALOG_TITLE_ID = 'discard-confirm-title'
 
 interface NonConformantOverlayProps {
   nc: ReturnType<typeof useNonConformantWizard>
@@ -65,6 +66,16 @@ export function NonConformantOverlay({
   const { t } = useTranslation()
   const touchGuard = useOverlayTouchGuard()
   useBodyScrollLock(true)
+
+  // Dismiss discard dialog on Escape key
+  useEffect(() => {
+    if (!showCloseConfirm) return
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismissCloseConfirm()
+    }
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [showCloseConfirm, onDismissCloseConfirm])
 
   const { setSectionComments } = nc
 
@@ -212,9 +223,17 @@ export function NonConformantOverlay({
 
       {/* Discard confirmation dialog */}
       {showCloseConfirm && (
-        <div className="fixed inset-0 z-70 flex items-center justify-center bg-black/50">
+        <div
+          className="fixed inset-0 z-70 flex items-center justify-center bg-black/50"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={DISCARD_DIALOG_TITLE_ID}
+        >
           <div className="mx-4 max-w-sm w-full rounded-xl bg-surface-card dark:bg-surface-card-dark p-5 shadow-lg">
-            <h3 className="text-base font-semibold text-text-primary dark:text-text-primary-dark mb-2">
+            <h3
+              id={DISCARD_DIALOG_TITLE_ID}
+              className="text-base font-semibold text-text-primary dark:text-text-primary-dark mb-2"
+            >
               {t('pdf.wizard.nonConformant.discardTitle')}
             </h3>
             <p className="text-sm text-text-secondary dark:text-text-secondary-dark mb-4">

--- a/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
+++ b/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
@@ -38,6 +38,9 @@ interface NonConformantOverlayProps {
   icon: React.ReactNode
   onClose: () => void
   onBack: () => void
+  showCloseConfirm: boolean
+  onDismissCloseConfirm: () => void
+  onConfirmDiscard: () => void
 }
 
 export function NonConformantOverlay({
@@ -55,6 +58,9 @@ export function NonConformantOverlay({
   icon,
   onClose,
   onBack,
+  showCloseConfirm,
+  onDismissCloseConfirm,
+  onConfirmDiscard,
 }: NonConformantOverlayProps) {
   const { t } = useTranslation()
   const touchGuard = useOverlayTouchGuard()
@@ -154,7 +160,7 @@ export function NonConformantOverlay({
             awayCoachName={nc.awayCoachName}
             onAwayCoachNameChange={nc.setAwayCoachName}
             showAwayCoach={nc.showAwayCoach}
-            onToggleAwayCoach={() => nc.setShowAwayCoach(true)}
+            onToggleAwayCoach={nc.setShowAwayCoach}
           />
         )}
       </div>
@@ -203,6 +209,32 @@ export function NonConformantOverlay({
           )}
         </div>
       </div>
+
+      {/* Discard confirmation dialog */}
+      {showCloseConfirm && (
+        <div className="fixed inset-0 z-70 flex items-center justify-center bg-black/50">
+          <div className="mx-4 max-w-sm w-full rounded-xl bg-surface-card dark:bg-surface-card-dark p-5 shadow-lg">
+            <h3 className="text-base font-semibold text-text-primary dark:text-text-primary-dark mb-2">
+              {t('pdf.wizard.nonConformant.discardTitle')}
+            </h3>
+            <p className="text-sm text-text-secondary dark:text-text-secondary-dark mb-4">
+              {t('pdf.wizard.nonConformant.discardMessage')}
+            </p>
+            <div className="flex gap-3">
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onClick={onDismissCloseConfirm}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button variant="danger" className="flex-1" onClick={onConfirmDiscard}>
+                {t('pdf.wizard.nonConformant.discard')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>,
     document.body
   )

--- a/packages/web/src/features/sports-hall-report/components/SectionSelector.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SectionSelector.tsx
@@ -22,7 +22,7 @@ export function SectionSelector({
       <p className="text-sm text-text-secondary dark:text-text-secondary-dark mb-3">
         {t('pdf.wizard.nonConformant.selectSections')}
       </p>
-      <div className="max-h-[340px] overflow-y-auto rounded-lg border border-border-default dark:border-border-default-dark divide-y divide-border-default dark:divide-border-default-dark">
+      <div className="max-h-[min(340px,50vh)] overflow-y-auto rounded-lg border border-border-default dark:border-border-default-dark divide-y divide-border-default dark:divide-border-default-dark">
         {sections.map((section) => (
           <SectionRow
             key={section.id}
@@ -46,6 +46,8 @@ function SectionRow({ section, isFlagged, onToggle }: SectionRowProps) {
   const { t } = useTranslation()
 
   const handleClick = useCallback(() => {
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    navigator.vibrate?.(10)
     onToggle(section.id)
   }, [section.id, onToggle])
 
@@ -53,7 +55,7 @@ function SectionRow({ section, isFlagged, onToggle }: SectionRowProps) {
     <button
       type="button"
       onClick={handleClick}
-      className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+      className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-all duration-150 active:scale-[0.98] ${
         isFlagged
           ? 'bg-warning-50 dark:bg-warning-900/20'
           : 'hover:bg-surface-subtle dark:hover:bg-surface-subtle-dark'

--- a/packages/web/src/features/sports-hall-report/components/SectionSelector.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SectionSelector.tsx
@@ -4,6 +4,8 @@ import { AlertTriangle, CheckCircle } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import type { ChecklistSection } from '@/shared/utils/pdf-field-mappings'
 
+const HAPTIC_FEEDBACK_MS = 10
+
 interface SectionSelectorProps {
   sections: readonly ChecklistSection[]
   flaggedSections: Set<string>
@@ -46,8 +48,7 @@ function SectionRow({ section, isFlagged, onToggle }: SectionRowProps) {
   const { t } = useTranslation()
 
   const handleClick = useCallback(() => {
-    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    navigator.vibrate?.(10)
+    navigator.vibrate?.(HAPTIC_FEEDBACK_MS)
     onToggle(section.id)
   }, [section.id, onToggle])
 

--- a/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
@@ -36,16 +36,15 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
   useBodyScrollLock(true)
   const touchGuard = useOverlayTouchGuard()
 
-  // Track orientation changes and enable/disable the pad accordingly
+  const [portraitHintDismissed, setPortraitHintDismissed] = useState(false)
+
+  // Track orientation changes
   useEffect(() => {
     const mql = window.matchMedia('(orientation: portrait)')
     const handler = (e: MediaQueryListEvent) => {
       setIsPortrait(e.matches)
-      if (e.matches) {
-        padRef.current?.off()
-      } else {
-        padRef.current?.on()
-      }
+      // Reset hint dismissal when rotating back to portrait
+      if (e.matches) setPortraitHintDismissed(false)
     }
     mql.addEventListener('change', handler)
     return () => mql.removeEventListener('change', handler)
@@ -100,11 +99,6 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
 
     padRef.current = pad
     resizeCanvas()
-
-    // Disable drawing when starting in portrait
-    if (window.matchMedia('(orientation: portrait)').matches) {
-      pad.off()
-    }
 
     window.addEventListener('resize', resizeCanvas)
     return () => {
@@ -173,16 +167,19 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
           </div>
         )}
 
-        {/* Portrait orientation hint — blocks drawing when device is in portrait */}
-        {isPortrait && (
-          <div className="absolute inset-0 flex items-center justify-center bg-white/80 backdrop-blur-sm">
-            <div className="flex flex-col items-center gap-3 text-gray-500">
-              <RotateCw className="w-10 h-10 animate-pulse" aria-hidden="true" />
-              <p className="text-sm font-medium text-center px-8">
-                {t('pdf.wizard.signature.rotateLandscape')}
-              </p>
-            </div>
-          </div>
+        {/* Portrait orientation hint — dismissible suggestion banner */}
+        {isPortrait && !portraitHintDismissed && (
+          <button
+            type="button"
+            onClick={() => setPortraitHintDismissed(true)}
+            className="absolute top-3 left-3 right-3 flex items-center gap-2 rounded-lg bg-gray-100/90 backdrop-blur-sm px-3 py-2 text-gray-500 shadow-sm"
+          >
+            <RotateCw className="w-5 h-5 flex-shrink-0 animate-pulse" aria-hidden="true" />
+            <p className="text-xs font-medium flex-1 text-left">
+              {t('pdf.wizard.signature.rotateLandscape')}
+            </p>
+            <X className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+          </button>
         )}
       </div>
     </div>,

--- a/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCanvas.tsx
@@ -172,6 +172,7 @@ export function SignatureCanvas({ onComplete, onCancel }: SignatureCanvasProps) 
           <button
             type="button"
             onClick={() => setPortraitHintDismissed(true)}
+            aria-label={t('common.dismissNotification')}
             className="absolute top-3 left-3 right-3 flex items-center gap-2 rounded-lg bg-gray-100/90 backdrop-blur-sm px-3 py-2 text-gray-500 shadow-sm"
           >
             <RotateCw className="w-5 h-5 flex-shrink-0 animate-pulse" aria-hidden="true" />

--- a/packages/web/src/features/sports-hall-report/components/SignatureCollectionStep.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCollectionStep.tsx
@@ -159,8 +159,7 @@ export function SignatureCollectionStep({
         <div className="space-y-2">
           {signers.map((signer) => {
             const hasSigned = !!getSignatureDataUrl(signer.role)
-            const coachName =
-              signer.role === 'homeTeamCoach' ? homeCoachName : awayCoachName
+            const coachName = signer.role === 'homeTeamCoach' ? homeCoachName : awayCoachName
             const isCoachNameEmpty = signer.needsNameInput && !coachName.trim()
 
             return (

--- a/packages/web/src/features/sports-hall-report/components/SignatureCollectionStep.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCollectionStep.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 
 import { Button } from '@/shared/components/Button'
-import { CheckCircle, Plus } from '@/shared/components/icons'
+import { CheckCircle, Plus, X } from '@/shared/components/icons'
 import { useTranslation } from '@/shared/hooks/useTranslation'
 import type { NonConformantSignatures } from '@/shared/utils/pdf-form-filler'
 
@@ -26,7 +26,7 @@ interface SignatureCollectionStepProps {
   awayCoachName: string
   onAwayCoachNameChange: (name: string) => void
   showAwayCoach: boolean
-  onToggleAwayCoach: () => void
+  onToggleAwayCoach: (show: boolean) => void
 }
 
 export function SignatureCollectionStep({
@@ -118,6 +118,29 @@ export function SignatureCollectionStep({
     setActiveSigner(null)
   }, [])
 
+  const handleReSign = useCallback(
+    (role: SignerRole) => {
+      const updated = { ...signatures }
+      switch (role) {
+        case 'firstReferee':
+          delete updated.firstReferee
+          break
+        case 'secondReferee':
+          delete updated.secondReferee
+          break
+        case 'homeTeamCoach':
+          delete updated.homeTeamCoach
+          break
+        case 'awayTeamCoach':
+          delete updated.awayTeamCoach
+          break
+      }
+      onSignaturesChange(updated)
+      setActiveSigner(role)
+    },
+    [signatures, onSignaturesChange]
+  )
+
   return (
     <>
       <div className="space-y-3">
@@ -136,6 +159,9 @@ export function SignatureCollectionStep({
         <div className="space-y-2">
           {signers.map((signer) => {
             const hasSigned = !!getSignatureDataUrl(signer.role)
+            const coachName =
+              signer.role === 'homeTeamCoach' ? homeCoachName : awayCoachName
+            const isCoachNameEmpty = signer.needsNameInput && !coachName.trim()
 
             return (
               <div
@@ -146,6 +172,23 @@ export function SignatureCollectionStep({
                     : 'border-border-default dark:border-border-default-dark'
                 }`}
               >
+                {/* Name input for coaches — shown above sign button */}
+                {signer.needsNameInput && !hasSigned && (
+                  <div className="mb-2">
+                    <input
+                      type="text"
+                      value={coachName}
+                      onChange={(e) =>
+                        signer.role === 'homeTeamCoach'
+                          ? onHomeCoachNameChange(e.target.value)
+                          : onAwayCoachNameChange(e.target.value)
+                      }
+                      placeholder={t('pdf.wizard.nonConformant.coachNamePlaceholder')}
+                      className="w-full rounded-md border border-border-default dark:border-border-default-dark bg-surface-primary dark:bg-surface-primary-dark text-text-primary dark:text-text-primary-dark text-sm px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder:text-text-muted dark:placeholder:text-text-muted-dark"
+                    />
+                  </div>
+                )}
+
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex items-center gap-2 flex-1 min-w-0">
                     {hasSigned ? (
@@ -160,49 +203,44 @@ export function SignatureCollectionStep({
                       {signer.label}
                     </span>
                   </div>
-                  {!hasSigned && (
+                  {hasSigned ? (
+                    <Button
+                      variant="ghost"
+                      className="text-xs px-2 py-1"
+                      onClick={() => handleReSign(signer.role)}
+                    >
+                      {t('pdf.wizard.nonConformant.reSign')}
+                    </Button>
+                  ) : (
                     <Button
                       variant="secondary"
                       className="text-xs px-2 py-1"
                       onClick={() => setActiveSigner(signer.role)}
-                      disabled={
-                        signer.needsNameInput &&
-                        (signer.role === 'homeTeamCoach'
-                          ? !homeCoachName.trim()
-                          : !awayCoachName.trim())
-                      }
+                      disabled={isCoachNameEmpty}
                     >
                       {t('pdf.wizard.nonConformant.tapToSign')}
                     </Button>
                   )}
                 </div>
-
-                {/* Name input for coaches */}
-                {signer.needsNameInput && !hasSigned && (
-                  <div className="mt-2">
-                    <input
-                      type="text"
-                      value={signer.role === 'homeTeamCoach' ? homeCoachName : awayCoachName}
-                      onChange={(e) =>
-                        signer.role === 'homeTeamCoach'
-                          ? onHomeCoachNameChange(e.target.value)
-                          : onAwayCoachNameChange(e.target.value)
-                      }
-                      placeholder={t('pdf.wizard.nonConformant.coachNamePlaceholder')}
-                      className="w-full rounded-md border border-border-default dark:border-border-default-dark bg-surface-primary dark:bg-surface-primary-dark text-text-primary dark:text-text-primary-dark text-sm px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder:text-text-muted dark:placeholder:text-text-muted-dark"
-                    />
-                  </div>
-                )}
               </div>
             )
           })}
         </div>
 
-        {/* Add away team coach button */}
-        {!showAwayCoach && (
+        {/* Toggle away team coach */}
+        {showAwayCoach ? (
           <button
             type="button"
-            onClick={onToggleAwayCoach}
+            onClick={() => onToggleAwayCoach(false)}
+            className="flex items-center gap-1.5 text-sm text-text-muted dark:text-text-muted-dark hover:text-text-secondary dark:hover:text-text-secondary-dark transition-colors"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+            {t('pdf.wizard.nonConformant.removeCoach')}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onToggleAwayCoach(true)}
             className="flex items-center gap-1.5 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
           >
             <Plus className="w-4 h-4" aria-hidden="true" />

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -19,7 +19,11 @@ import { usePdfGeneration } from '../hooks/usePdfGeneration'
 const log = createLogger('SportsHallReportWizardModal')
 
 function getPdfErrorKey(error: unknown): 'pdf.exportError' | 'pdf.exportErrorNetwork' {
-  if (error instanceof TypeError && 'message' in error && /fetch|network|load/i.test(error.message)) {
+  if (
+    error instanceof TypeError &&
+    'message' in error &&
+    /fetch|network|load/i.test(error.message)
+  ) {
     return 'pdf.exportErrorNetwork'
   }
   return 'pdf.exportError'

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -18,17 +18,6 @@ import { usePdfGeneration } from '../hooks/usePdfGeneration'
 
 const log = createLogger('SportsHallReportWizardModal')
 
-function getPdfErrorKey(error: unknown): 'pdf.exportError' | 'pdf.exportErrorNetwork' {
-  if (
-    error instanceof TypeError &&
-    'message' in error &&
-    /fetch|network|load/i.test(error.message)
-  ) {
-    return 'pdf.exportErrorNetwork'
-  }
-  return 'pdf.exportError'
-}
-
 const MODAL_TITLE_ID = 'sports-hall-report-wizard-title'
 
 type WizardMode = 'happy' | 'non-conformant'
@@ -270,8 +259,11 @@ export function SportsHallReportWizardModal({
           secondRefereeName={secondRefereeName}
           subtitle={subtitle}
           icon={pdfIcon}
-          onClose={onClose}
+          onClose={handleNcClose}
           onBack={handleNcBack}
+          showCloseConfirm={showCloseConfirm}
+          onDismissCloseConfirm={() => setShowCloseConfirm(false)}
+          onConfirmDiscard={handleConfirmDiscard}
         />
       )}
 

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -18,6 +18,13 @@ import { usePdfGeneration } from '../hooks/usePdfGeneration'
 
 const log = createLogger('SportsHallReportWizardModal')
 
+function getPdfErrorKey(error: unknown): 'pdf.exportError' | 'pdf.exportErrorNetwork' {
+  if (error instanceof TypeError && 'message' in error && /fetch|network|load/i.test(error.message)) {
+    return 'pdf.exportErrorNetwork'
+  }
+  return 'pdf.exportError'
+}
+
 const MODAL_TITLE_ID = 'sports-hall-report-wizard-title'
 
 type WizardMode = 'happy' | 'non-conformant'
@@ -62,6 +69,9 @@ export function SportsHallReportWizardModal({
     assignment.refereeGame?.activeRefereeConvocationSecondHeadReferee?.indoorAssociationReferee
       ?.indoorReferee?.person?.displayName
 
+  // Close confirmation state for non-conformant mode
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
+
   // Non-conformant hook (shares jerseyAdvertising from modal level)
   const nc = useNonConformantWizard(assignment, language, jerseyAdvertising, onClose)
   const { loadSections, reset: resetNc, handleNcBack: ncBack } = nc
@@ -84,6 +94,7 @@ export function SportsHallReportWizardModal({
       setConfirmed(false)
       setIsGeneratingHappy(false)
       setShowSignature(false)
+      setShowCloseConfirm(false)
       setJerseyAdvertising({ homeTeam: true, awayTeam: true })
       setMode('happy')
       resetNc()
@@ -138,6 +149,32 @@ export function SportsHallReportWizardModal({
       setIsGeneratingHappy(false)
     }
   }, [isGeneratingHappy, pdf])
+
+  // ─── Close confirmation for non-conformant mode ───────────────────
+
+  const hasUnsavedNcWork = useCallback(() => {
+    return (
+      nc.flaggedSections.size > 0 ||
+      Object.values(nc.sectionComments).some((c) => c.trim()) ||
+      !!nc.signatures.firstReferee ||
+      !!nc.signatures.secondReferee ||
+      !!nc.signatures.homeTeamCoach?.signature ||
+      !!nc.signatures.awayTeamCoach?.signature
+    )
+  }, [nc.flaggedSections, nc.sectionComments, nc.signatures])
+
+  const handleNcClose = useCallback(() => {
+    if (hasUnsavedNcWork()) {
+      setShowCloseConfirm(true)
+    } else {
+      onClose()
+    }
+  }, [hasUnsavedNcWork, onClose])
+
+  const handleConfirmDiscard = useCallback(() => {
+    setShowCloseConfirm(false)
+    onClose()
+  }, [onClose])
 
   // ─── Mode handlers ─────────────────────────────────────────────────
 

--- a/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
@@ -16,6 +16,13 @@ import { extractReportInfo } from '../utils/extractReportInfo'
 
 const log = createLogger('useNonConformantWizard')
 
+function getPdfErrorKey(error: unknown): 'pdf.exportError' | 'pdf.exportErrorNetwork' {
+  if (error instanceof TypeError && 'message' in error && /fetch|network|load/i.test(error.message)) {
+    return 'pdf.exportErrorNetwork'
+  }
+  return 'pdf.exportError'
+}
+
 type NonConformantStep = 'sections' | 'subItems' | 'comment' | 'preview' | 'signatures'
 
 const NC_STEPS: NonConformantStep[] = ['sections', 'subItems', 'comment', 'preview', 'signatures']
@@ -40,7 +47,6 @@ export function useNonConformantWizard(
   const [showAwayCoach, setShowAwayCoach] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
 
-  const ncStepIndex = NC_STEPS.indexOf(ncStep)
 
   const pdf = usePdfGeneration(assignment, language, jerseyAdvertising, onClose)
 
@@ -237,16 +243,28 @@ export function useNonConformantWizard(
     }
   }, [ncStep, flaggedSections, nonConformantSubItems, previewPdfBytes, signatures])
 
-  const ncSteps = useMemo(
-    () => [
+  const showSubItemsStep = multiItemFlaggedSections.length > 0
+
+  const ncSteps = useMemo(() => {
+    const steps = [
       { label: t('pdf.wizard.nonConformant.stepSections') },
-      { label: t('pdf.wizard.nonConformant.selectSubItems') },
+      ...(showSubItemsStep
+        ? [{ label: t('pdf.wizard.nonConformant.selectSubItems') }]
+        : []),
       { label: t('pdf.wizard.nonConformant.stepComment') },
       { label: t('pdf.wizard.nonConformant.stepPreview') },
       { label: t('pdf.wizard.nonConformant.stepSign') },
-    ],
-    [t]
-  )
+    ]
+    return steps
+  }, [t, showSubItemsStep])
+
+  // Map the raw step index to the visible step index (accounting for hidden subItems step)
+  const ncStepIndex = useMemo(() => {
+    const visibleSteps = showSubItemsStep
+      ? NC_STEPS
+      : NC_STEPS.filter((s) => s !== 'subItems')
+    return visibleSteps.indexOf(ncStep)
+  }, [ncStep, showSubItemsStep])
 
   return {
     ncStep,

--- a/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
@@ -16,17 +16,6 @@ import { extractReportInfo } from '../utils/extractReportInfo'
 
 const log = createLogger('useNonConformantWizard')
 
-function getPdfErrorKey(error: unknown): 'pdf.exportError' | 'pdf.exportErrorNetwork' {
-  if (
-    error instanceof TypeError &&
-    'message' in error &&
-    /fetch|network|load/i.test(error.message)
-  ) {
-    return 'pdf.exportErrorNetwork'
-  }
-  return 'pdf.exportError'
-}
-
 type NonConformantStep = 'sections' | 'subItems' | 'comment' | 'preview' | 'signatures'
 
 const NC_STEPS: NonConformantStep[] = ['sections', 'subItems', 'comment', 'preview', 'signatures']
@@ -50,7 +39,6 @@ export function useNonConformantWizard(
   const [awayCoachName, setAwayCoachName] = useState('')
   const [showAwayCoach, setShowAwayCoach] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
-
 
   const pdf = usePdfGeneration(assignment, language, jerseyAdvertising, onClose)
 

--- a/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
@@ -17,7 +17,11 @@ import { extractReportInfo } from '../utils/extractReportInfo'
 const log = createLogger('useNonConformantWizard')
 
 function getPdfErrorKey(error: unknown): 'pdf.exportError' | 'pdf.exportErrorNetwork' {
-  if (error instanceof TypeError && 'message' in error && /fetch|network|load/i.test(error.message)) {
+  if (
+    error instanceof TypeError &&
+    'message' in error &&
+    /fetch|network|load/i.test(error.message)
+  ) {
     return 'pdf.exportErrorNetwork'
   }
   return 'pdf.exportError'
@@ -248,9 +252,7 @@ export function useNonConformantWizard(
   const ncSteps = useMemo(() => {
     const steps = [
       { label: t('pdf.wizard.nonConformant.stepSections') },
-      ...(showSubItemsStep
-        ? [{ label: t('pdf.wizard.nonConformant.selectSubItems') }]
-        : []),
+      ...(showSubItemsStep ? [{ label: t('pdf.wizard.nonConformant.selectSubItems') }] : []),
       { label: t('pdf.wizard.nonConformant.stepComment') },
       { label: t('pdf.wizard.nonConformant.stepPreview') },
       { label: t('pdf.wizard.nonConformant.stepSign') },
@@ -260,9 +262,7 @@ export function useNonConformantWizard(
 
   // Map the raw step index to the visible step index (accounting for hidden subItems step)
   const ncStepIndex = useMemo(() => {
-    const visibleSteps = showSubItemsStep
-      ? NC_STEPS
-      : NC_STEPS.filter((s) => s !== 'subItems')
+    const visibleSteps = showSubItemsStep ? NC_STEPS : NC_STEPS.filter((s) => s !== 'subItems')
     return visibleSteps.indexOf(ncStep)
   }, [ncStep, showSubItemsStep])
 

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -640,7 +640,6 @@ const de: Translations = {
     generating: 'Wird erstellt...',
     exportError: 'PDF konnte nicht erstellt werden',
     exportErrorNetwork: 'Netzwerkfehler — bitte Verbindung prüfen',
-    exportErrorMissingData: 'Fehlende Spieldaten — Rapport kann nicht erstellt werden',
     sportsHallReport: 'Hallenrapport',
     wizard: {
       title: 'Hallenrapport',
@@ -650,7 +649,6 @@ const de: Translations = {
 
       generate: 'Rapport erstellen',
       downloadPreFilled: 'Leeren Rapport herunterladen (ohne Unterschrift)',
-      advertisingHint: 'Bitte Werbestatus für jedes Team überprüfen',
       reportGenerated: 'Rapport erfolgreich erstellt',
 
       signature: {

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -639,6 +639,8 @@ const de: Translations = {
     export: 'Erstellen',
     generating: 'Wird erstellt...',
     exportError: 'PDF konnte nicht erstellt werden',
+    exportErrorNetwork: 'Netzwerkfehler — bitte Verbindung prüfen',
+    exportErrorMissingData: 'Fehlende Spieldaten — Rapport kann nicht erstellt werden',
     sportsHallReport: 'Hallenrapport',
     wizard: {
       title: 'Hallenrapport',
@@ -647,7 +649,8 @@ const de: Translations = {
       advertisingLabel: 'Werbung auf Spielerkleidung',
 
       generate: 'Rapport erstellen',
-      downloadPreFilled: 'Vorausgefüllten Rapport herunterladen',
+      downloadPreFilled: 'Leeren Rapport herunterladen (ohne Unterschrift)',
+      advertisingHint: 'Bitte Werbestatus für jedes Team überprüfen',
       reportGenerated: 'Rapport erfolgreich erstellt',
 
       signature: {
@@ -680,6 +683,11 @@ const de: Translations = {
         coachName: 'Name Trainer',
         coachNamePlaceholder: 'Vorname Nachname',
         addCoach: 'Trainer Besuchermannschaft hinzufügen',
+        removeCoach: 'Trainer Besuchermannschaft entfernen',
+        reSign: 'Erneut unterschreiben',
+        discardTitle: 'Änderungen verwerfen?',
+        discardMessage: 'Nicht gespeicherte Änderungen gehen verloren.',
+        discard: 'Verwerfen',
         tapToSign: 'Zum Unterschreiben tippen',
         downloadFinal: 'PDF herunterladen',
         next: 'Weiter',

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -639,7 +639,6 @@ const de: Translations = {
     export: 'Erstellen',
     generating: 'Wird erstellt...',
     exportError: 'PDF konnte nicht erstellt werden',
-    exportErrorNetwork: 'Netzwerkfehler — bitte Verbindung prüfen',
     sportsHallReport: 'Hallenrapport',
     wizard: {
       title: 'Hallenrapport',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -617,7 +617,6 @@ const en: Translations = {
     generating: 'Generating...',
     exportError: 'Failed to generate PDF',
     exportErrorNetwork: 'Network error — please check your connection',
-    exportErrorMissingData: 'Missing game data — report cannot be generated',
     sportsHallReport: 'Sports Hall Report',
     wizard: {
       title: 'Sports Hall Report',
@@ -627,7 +626,6 @@ const en: Translations = {
 
       generate: 'Generate Report',
       downloadPreFilled: 'Download blank report (without signature)',
-      advertisingHint: 'Please verify advertising status for each team',
       reportGenerated: 'Report generated successfully',
 
       signature: {

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -616,7 +616,6 @@ const en: Translations = {
     export: 'Generate',
     generating: 'Generating...',
     exportError: 'Failed to generate PDF',
-    exportErrorNetwork: 'Network error — please check your connection',
     sportsHallReport: 'Sports Hall Report',
     wizard: {
       title: 'Sports Hall Report',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -616,6 +616,8 @@ const en: Translations = {
     export: 'Generate',
     generating: 'Generating...',
     exportError: 'Failed to generate PDF',
+    exportErrorNetwork: 'Network error — please check your connection',
+    exportErrorMissingData: 'Missing game data — report cannot be generated',
     sportsHallReport: 'Sports Hall Report',
     wizard: {
       title: 'Sports Hall Report',
@@ -624,7 +626,8 @@ const en: Translations = {
       advertisingLabel: 'Advertising on uniform',
 
       generate: 'Generate Report',
-      downloadPreFilled: 'Download pre-filled report instead',
+      downloadPreFilled: 'Download blank report (without signature)',
+      advertisingHint: 'Please verify advertising status for each team',
       reportGenerated: 'Report generated successfully',
 
       signature: {
@@ -657,6 +660,11 @@ const en: Translations = {
         coachName: 'Coach name',
         coachNamePlaceholder: 'First name Last name',
         addCoach: 'Add away team coach',
+        removeCoach: 'Remove away team coach',
+        reSign: 'Re-sign',
+        discardTitle: 'Discard changes?',
+        discardMessage: 'You have unsaved changes that will be lost.',
+        discard: 'Discard',
         tapToSign: 'Tap to sign',
         downloadFinal: 'Download PDF',
         next: 'Next',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -635,7 +635,6 @@ const fr: Translations = {
     generating: 'Génération...',
     exportError: 'Échec de la génération du PDF',
     exportErrorNetwork: 'Erreur réseau — veuillez vérifier votre connexion',
-    exportErrorMissingData: 'Données de match manquantes — le rapport ne peut pas être généré',
     sportsHallReport: 'Rapport de salle',
     wizard: {
       title: 'Rapport de salle',
@@ -645,7 +644,6 @@ const fr: Translations = {
 
       generate: 'Générer le rapport',
       downloadPreFilled: 'Télécharger le rapport vierge (sans signature)',
-      advertisingHint: 'Veuillez vérifier le statut publicitaire de chaque équipe',
       reportGenerated: 'Rapport généré avec succès',
 
       signature: {

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -634,6 +634,8 @@ const fr: Translations = {
     export: 'Générer',
     generating: 'Génération...',
     exportError: 'Échec de la génération du PDF',
+    exportErrorNetwork: 'Erreur réseau — veuillez vérifier votre connexion',
+    exportErrorMissingData: 'Données de match manquantes — le rapport ne peut pas être généré',
     sportsHallReport: 'Rapport de salle',
     wizard: {
       title: 'Rapport de salle',
@@ -642,7 +644,8 @@ const fr: Translations = {
       advertisingLabel: 'Publicité sur les vêtements de jeu',
 
       generate: 'Générer le rapport',
-      downloadPreFilled: 'Télécharger le rapport pré-rempli',
+      downloadPreFilled: 'Télécharger le rapport vierge (sans signature)',
+      advertisingHint: 'Veuillez vérifier le statut publicitaire de chaque équipe',
       reportGenerated: 'Rapport généré avec succès',
 
       signature: {
@@ -675,6 +678,11 @@ const fr: Translations = {
         coachName: "Nom de l'entraîneur",
         coachNamePlaceholder: 'Prénom Nom',
         addCoach: 'Ajouter entraîneur équipe visiteurs',
+        removeCoach: 'Retirer entraîneur équipe visiteurs',
+        reSign: 'Re-signer',
+        discardTitle: 'Abandonner les modifications ?',
+        discardMessage: 'Les modifications non enregistrées seront perdues.',
+        discard: 'Abandonner',
         tapToSign: 'Appuyez pour signer',
         downloadFinal: 'Télécharger le PDF',
         next: 'Suivant',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -634,7 +634,6 @@ const fr: Translations = {
     export: 'Générer',
     generating: 'Génération...',
     exportError: 'Échec de la génération du PDF',
-    exportErrorNetwork: 'Erreur réseau — veuillez vérifier votre connexion',
     sportsHallReport: 'Rapport de salle',
     wizard: {
       title: 'Rapport de salle',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -629,7 +629,6 @@ const it: Translations = {
     export: 'Genera',
     generating: 'Generazione...',
     exportError: 'Generazione PDF fallita',
-    exportErrorNetwork: 'Errore di rete — verifica la connessione',
     sportsHallReport: 'Rapporto sala sportiva',
     wizard: {
       title: 'Rapporto sala sportiva',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -630,7 +630,6 @@ const it: Translations = {
     generating: 'Generazione...',
     exportError: 'Generazione PDF fallita',
     exportErrorNetwork: 'Errore di rete — verifica la connessione',
-    exportErrorMissingData: 'Dati partita mancanti — il rapporto non può essere generato',
     sportsHallReport: 'Rapporto sala sportiva',
     wizard: {
       title: 'Rapporto sala sportiva',
@@ -640,7 +639,6 @@ const it: Translations = {
 
       generate: 'Genera rapporto',
       downloadPreFilled: 'Scarica il rapporto vuoto (senza firma)',
-      advertisingHint: 'Verifica lo stato pubblicitario per ogni squadra',
       reportGenerated: 'Rapporto generato con successo',
 
       signature: {

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -629,6 +629,8 @@ const it: Translations = {
     export: 'Genera',
     generating: 'Generazione...',
     exportError: 'Generazione PDF fallita',
+    exportErrorNetwork: 'Errore di rete — verifica la connessione',
+    exportErrorMissingData: 'Dati partita mancanti — il rapporto non può essere generato',
     sportsHallReport: 'Rapporto sala sportiva',
     wizard: {
       title: 'Rapporto sala sportiva',
@@ -637,7 +639,8 @@ const it: Translations = {
       advertisingLabel: 'Pubblicità sugli indumenti di gioco',
 
       generate: 'Genera rapporto',
-      downloadPreFilled: 'Scarica il rapporto precompilato',
+      downloadPreFilled: 'Scarica il rapporto vuoto (senza firma)',
+      advertisingHint: 'Verifica lo stato pubblicitario per ogni squadra',
       reportGenerated: 'Rapporto generato con successo',
 
       signature: {
@@ -670,6 +673,11 @@ const it: Translations = {
         coachName: 'Nome allenatore',
         coachNamePlaceholder: 'Nome Cognome',
         addCoach: 'Aggiungere allenatore squadra ospite',
+        removeCoach: 'Rimuovere allenatore squadra ospite',
+        reSign: 'Ri-firmare',
+        discardTitle: 'Eliminare le modifiche?',
+        discardMessage: 'Le modifiche non salvate andranno perse.',
+        discard: 'Elimina',
         tapToSign: 'Tocca per firmare',
         downloadFinal: 'Scarica PDF',
         next: 'Avanti',

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -489,7 +489,6 @@ export interface Translations {
     generating: string
     exportError: string
     exportErrorNetwork: string
-    exportErrorMissingData: string
     sportsHallReport: string
     wizard: {
       title: string
@@ -499,7 +498,6 @@ export interface Translations {
 
       generate: string
       downloadPreFilled: string
-      advertisingHint: string
       reportGenerated: string
 
       signature: {

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -488,7 +488,6 @@ export interface Translations {
     export: string
     generating: string
     exportError: string
-    exportErrorNetwork: string
     sportsHallReport: string
     wizard: {
       title: string

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -488,6 +488,8 @@ export interface Translations {
     export: string
     generating: string
     exportError: string
+    exportErrorNetwork: string
+    exportErrorMissingData: string
     sportsHallReport: string
     wizard: {
       title: string
@@ -497,6 +499,7 @@ export interface Translations {
 
       generate: string
       downloadPreFilled: string
+      advertisingHint: string
       reportGenerated: string
 
       signature: {
@@ -529,6 +532,11 @@ export interface Translations {
         coachName: string
         coachNamePlaceholder: string
         addCoach: string
+        removeCoach: string
+        reSign: string
+        discardTitle: string
+        discardMessage: string
+        discard: string
         tapToSign: string
         downloadFinal: string
         next: string


### PR DESCRIPTION
## Summary

- Add dismissible portrait orientation hint to signature canvas overlay
- Move coach name input above sign button for better UX flow in signature collection step
- Add close confirmation dialog for non-conformant mode when unsaved work exists
- Integrate scroll lock and touch guard hooks for signature canvas

## Test plan

- [ ] Open signature canvas in portrait mode — verify landscape hint appears and can be dismissed
- [ ] Rotate to landscape and back — verify hint reappears after rotation
- [ ] In non-conformant flow, verify coach name input appears above the sign button
- [ ] Start non-conformant flow, flag a section, then close — verify discard confirmation appears
- [ ] Cancel discard dialog — verify wizard remains open
- [ ] Confirm discard — verify wizard closes