### PR TITLE
feat(web): make coach signatures optional in non-conformant sports hall report

### DIFF
--- a/.changeset/optional-coach-signatures.md
+++ b/.changeset/optional-coach-signatures.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Made both coaches signatures optional in the non-conformant sports hall report path

--- a/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
+++ b/packages/web/src/features/sports-hall-report/components/NonConformantOverlay.tsx
@@ -240,11 +240,7 @@ export function NonConformantOverlay({
               {t('pdf.wizard.nonConformant.discardMessage')}
             </p>
             <div className="flex gap-3">
-              <Button
-                variant="secondary"
-                className="flex-1"
-                onClick={onDismissCloseConfirm}
-              >
+              <Button variant="secondary" className="flex-1" onClick={onDismissCloseConfirm}>
                 {t('common.cancel')}
               </Button>
               <Button variant="danger" className="flex-1" onClick={onConfirmDiscard}>

--- a/packages/web/src/features/sports-hall-report/components/SignatureCollectionStep.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SignatureCollectionStep.tsx
@@ -60,7 +60,7 @@ export function SignatureCollectionStep({
     },
     {
       role: 'homeTeamCoach',
-      label: t('pdf.wizard.nonConformant.homeCoachLabel'),
+      label: `${t('pdf.wizard.nonConformant.homeCoachLabel')} (${t('pdf.wizard.nonConformant.coachOptional')})`,
       needsNameInput: true,
     },
   ]
@@ -68,7 +68,7 @@ export function SignatureCollectionStep({
   if (showAwayCoach) {
     signers.push({
       role: 'awayTeamCoach',
-      label: t('pdf.wizard.nonConformant.awayCoachLabel'),
+      label: `${t('pdf.wizard.nonConformant.awayCoachLabel')} (${t('pdf.wizard.nonConformant.coachOptional')})`,
       needsNameInput: true,
     })
   }
@@ -86,8 +86,9 @@ export function SignatureCollectionStep({
     }
   }
 
-  const completedCount = signers.filter((s) => getSignatureDataUrl(s.role)).length
-  const totalRequired = signers.length
+  const requiredSigners = signers.filter((s) => !s.needsNameInput)
+  const completedCount = requiredSigners.filter((s) => getSignatureDataUrl(s.role)).length
+  const totalRequired = requiredSigners.length
 
   const handleSignatureComplete = useCallback(
     (dataUrl: string) => {

--- a/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
+++ b/packages/web/src/features/sports-hall-report/hooks/useNonConformantWizard.ts
@@ -226,9 +226,7 @@ export function useNonConformantWizard(
       case 'signatures': {
         const hasFirstRef = !!signatures.firstReferee
         const hasSecondRef = !!signatures.secondReferee
-        const hasCoach =
-          !!signatures.homeTeamCoach?.signature || !!signatures.awayTeamCoach?.signature
-        return hasFirstRef && hasSecondRef && hasCoach
+        return hasFirstRef && hasSecondRef
       }
       default:
         return false

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -677,6 +677,7 @@ const de: Translations = {
         homeCoachLabel: 'Trainer Heimmannschaft',
         awayCoachLabel: 'Trainer Besuchermannschaft',
         signAs: 'Unterschreiben als',
+        coachOptional: 'optional',
         coachName: 'Name Trainer',
         coachNamePlaceholder: 'Vorname Nachname',
         addCoach: 'Trainer Besuchermannschaft hinzufügen',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -654,6 +654,7 @@ const en: Translations = {
         homeCoachLabel: 'Home team coach',
         awayCoachLabel: 'Away team coach',
         signAs: 'Sign as',
+        coachOptional: 'optional',
         coachName: 'Coach name',
         coachNamePlaceholder: 'First name Last name',
         addCoach: 'Add away team coach',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -672,6 +672,7 @@ const fr: Translations = {
         homeCoachLabel: 'Entraîneur équipe locale',
         awayCoachLabel: 'Entraîneur équipe visiteurs',
         signAs: 'Signer en tant que',
+        coachOptional: 'facultatif',
         coachName: "Nom de l'entraîneur",
         coachNamePlaceholder: 'Prénom Nom',
         addCoach: 'Ajouter entraîneur équipe visiteurs',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -667,6 +667,7 @@ const it: Translations = {
         homeCoachLabel: 'Allenatore squadra di casa',
         awayCoachLabel: 'Allenatore squadra ospite',
         signAs: 'Firma come',
+        coachOptional: 'facoltativo',
         coachName: 'Nome allenatore',
         coachNamePlaceholder: 'Nome Cognome',
         addCoach: 'Aggiungere allenatore squadra ospite',

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -526,6 +526,7 @@ export interface Translations {
         homeCoachLabel: string
         awayCoachLabel: string
         signAs: string
+        coachOptional: string
         coachName: string
         coachNamePlaceholder: string
         addCoach: string


### PR DESCRIPTION
## Summary

- Make both coach signatures optional in the non-conformant sports hall report path
- Only referee signatures (1st and 2nd) are now required to download the PDF
- Coach signature entries are labeled as "(optional)" in all 4 languages (de/en/fr/it)
- Progress counter only tracks required referee signatures

## Test plan

- [ ] Open non-conformant sports hall report wizard, reach signatures step
- [ ] Verify coach signature entries show "(optional)" label
- [ ] Sign only both referees — download button should be enabled
- [ ] Verify progress shows "2 of 2" when both referees signed
- [ ] Optionally add coach signatures and verify they appear in downloaded PDF
- [ ] Test all 4 language variants show correct "(optional)" translation