### PR TITLE
feat(web): remove experimental gate for non-conformant sports hall report

### DIFF
--- a/.changeset/remove-non-conformant-gate.md
+++ b/.changeset/remove-non-conformant-gate.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Remove experimental feature gate for non-conformant sports hall report — issue reporting is now always available

--- a/packages/web/src/common/stores/settings/migrations.ts
+++ b/packages/web/src/common/stores/settings/migrations.ts
@@ -42,6 +42,9 @@ export const VALIDATION_REFERENCE_MODE_VERSION = 9
 /** Version that added settings group expansion state */
 export const SETTINGS_GROUP_EXPANDED_VERSION = 10
 
+/** Version that removed non-conformant feature gate (now always enabled) */
+export const REMOVE_NON_CONFORMANT_GATE_VERSION = 11
+
 // ============================================================================
 // Migration Type Shapes
 // ============================================================================
@@ -232,6 +235,11 @@ export function runMigrations(persisted: any, version: number): unknown {
     if (!(state as Record<string, unknown>).settingsGroupExpanded) {
       ;(state as Record<string, unknown>).settingsGroupExpanded = {}
     }
+  }
+
+  // v10 → v11: Remove non-conformant feature gate (now always enabled)
+  if (version < REMOVE_NON_CONFORMANT_GATE_VERSION) {
+    delete (state as Record<string, unknown>).isNonConformantEnabled
   }
 
   return state

--- a/packages/web/src/common/stores/settings/store.ts
+++ b/packages/web/src/common/stores/settings/store.ts
@@ -71,7 +71,6 @@ export const useSettingsStore = create<SettingsState>()(
         // Global settings
         isSafeModeEnabled: true,
         isOCREnabled: false,
-        isNonConformantEnabled: false,
         validationReferenceMode: 'quick-compare' as ValidationReferenceMode,
         preventZoom: false,
         settingsGroupExpanded: {},
@@ -110,10 +109,6 @@ export const useSettingsStore = create<SettingsState>()(
 
         setOCREnabled: (enabled: boolean) => {
           set({ isOCREnabled: enabled })
-        },
-
-        setNonConformantEnabled: (enabled: boolean) => {
-          set({ isNonConformantEnabled: enabled })
         },
 
         setValidationReferenceMode: (mode: ValidationReferenceMode) => {
@@ -376,12 +371,11 @@ export const useSettingsStore = create<SettingsState>()(
       }),
       {
         name: 'volleykit-settings',
-        version: 10,
+        version: 11,
         partialize: (state) => ({
           // Global settings
           isSafeModeEnabled: state.isSafeModeEnabled,
           isOCREnabled: state.isOCREnabled,
-          isNonConformantEnabled: state.isNonConformantEnabled,
           validationReferenceMode: state.validationReferenceMode,
           preventZoom: state.preventZoom,
           settingsGroupExpanded: state.settingsGroupExpanded,
@@ -397,7 +391,6 @@ export const useSettingsStore = create<SettingsState>()(
             | {
                 isSafeModeEnabled?: boolean
                 isOCREnabled?: boolean
-                isNonConformantEnabled?: boolean
                 validationReferenceMode?: ValidationReferenceMode
                 preventZoom?: boolean
                 settingsGroupExpanded?: Record<string, boolean>
@@ -467,8 +460,6 @@ export const useSettingsStore = create<SettingsState>()(
             // Preserve global settings
             isSafeModeEnabled: persistedState?.isSafeModeEnabled ?? current.isSafeModeEnabled,
             isOCREnabled: persistedState?.isOCREnabled ?? current.isOCREnabled,
-            isNonConformantEnabled:
-              persistedState?.isNonConformantEnabled ?? current.isNonConformantEnabled,
             validationReferenceMode:
               persistedState?.validationReferenceMode ?? current.validationReferenceMode,
             preventZoom: persistedState?.preventZoom ?? current.preventZoom,

--- a/packages/web/src/common/stores/settings/types.ts
+++ b/packages/web/src/common/stores/settings/types.ts
@@ -208,10 +208,6 @@ export interface SettingsState {
   isOCREnabled: boolean
   setOCREnabled: (enabled: boolean) => void
 
-  // Non-conformant sports hall report workflow (experimental)
-  isNonConformantEnabled: boolean
-  setNonConformantEnabled: (enabled: boolean) => void
-
   // Validation reference mode (how scoresheet photo is displayed during validation)
   validationReferenceMode: ValidationReferenceMode
   setValidationReferenceMode: (mode: ValidationReferenceMode) => void

--- a/packages/web/src/features/settings/components/AppInfoSection.tsx
+++ b/packages/web/src/features/settings/components/AppInfoSection.tsx
@@ -22,15 +22,12 @@ interface AppInfoSectionProps {
 function AppInfoSectionComponent({ showUpdates }: AppInfoSectionProps) {
   const { t, locale } = useTranslation()
   const { needRefresh, isChecking, lastChecked, checkError, checkForUpdate, updateApp } = usePWA()
-  const { isOCREnabled, setOCREnabled, isNonConformantEnabled, setNonConformantEnabled } =
-    useSettingsStore(
-      useShallow((s) => ({
-        isOCREnabled: s.isOCREnabled,
-        setOCREnabled: s.setOCREnabled,
-        isNonConformantEnabled: s.isNonConformantEnabled,
-        setNonConformantEnabled: s.setNonConformantEnabled,
-      }))
-    )
+  const { isOCREnabled, setOCREnabled } = useSettingsStore(
+    useShallow((s) => ({
+      isOCREnabled: s.isOCREnabled,
+      setOCREnabled: s.setOCREnabled,
+    }))
+  )
   const isStandalone = usePwaStandalone()
 
   const platform = isStandalone ? 'PWA' : 'Web'
@@ -38,10 +35,6 @@ function AppInfoSectionComponent({ showUpdates }: AppInfoSectionProps) {
   const handleToggleOCR = useCallback(() => {
     setOCREnabled(!isOCREnabled)
   }, [isOCREnabled, setOCREnabled])
-
-  const handleToggleNonConformant = useCallback(() => {
-    setNonConformantEnabled(!isNonConformantEnabled)
-  }, [isNonConformantEnabled, setNonConformantEnabled])
 
   const formatLastChecked = useCallback(
     (date: Date) => {
@@ -141,23 +134,6 @@ function AppInfoSectionComponent({ showUpdates }: AppInfoSectionProps) {
         <p className="text-sm text-text-muted dark:text-text-muted-dark">
           {t('settings.experimental.description')}
         </p>
-
-        {/* Non-conformant sports hall report toggle */}
-        <SettingsItem
-          label={t('settings.experimental.nonConformant')}
-          description={t('settings.experimental.nonConformantDescription')}
-          status={
-            isNonConformantEnabled
-              ? t('settings.experimental.nonConformantEnabled')
-              : t('settings.experimental.nonConformantDisabled')
-          }
-        >
-          <ToggleSwitch
-            checked={isNonConformantEnabled}
-            onChange={handleToggleNonConformant}
-            label={t('settings.experimental.nonConformant')}
-          />
-        </SettingsItem>
 
         {/* OCR POC standalone app link (features.ocrPoc) */}
         {features.ocrPoc && (

--- a/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
+++ b/packages/web/src/features/sports-hall-report/components/SportsHallReportWizardModal.tsx
@@ -5,7 +5,6 @@ import { AlertTriangle, FileText } from '@/common/components/icons'
 import { Modal } from '@/common/components/Modal'
 import { ModalHeader } from '@/common/components/ModalHeader'
 import { useTranslation } from '@/common/hooks/useTranslation'
-import { useSettingsStore } from '@/common/stores/settings'
 import { createLogger } from '@/common/utils/logger'
 import type { JerseyAdvertisingOptions } from '@/common/utils/pdf-form-filler'
 import type { Language } from '@/common/utils/pdf-report-data'
@@ -36,7 +35,6 @@ export function SportsHallReportWizardModal({
   defaultLanguage,
 }: SportsHallReportWizardModalProps) {
   const { t } = useTranslation()
-  const isNonConformantEnabled = useSettingsStore((s) => s.isNonConformantEnabled)
 
   // Shared state
   const [language, setLanguage] = useState<Language>(defaultLanguage)
@@ -235,7 +233,7 @@ export function SportsHallReportWizardModal({
           }}
           onGenerate={handleGenerate}
           onDownloadPreFilled={handleDownloadPreFilled}
-          onReportIssue={isNonConformantEnabled ? handleEnterNonConformant : undefined}
+          onReportIssue={handleEnterNonConformant}
         />
       </Modal>
 

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -590,11 +590,6 @@ const de: Translations = {
         'Spielberichte scannen, um Spielerlisten bei der Spielvalidierung automatisch auszufüllen',
       ocrValidationEnabled: 'OCR-Validierung ist aktiviert',
       ocrValidationDisabled: 'OCR-Validierung ist deaktiviert',
-      nonConformant: 'Hallenrapport: Mängelmeldung',
-      nonConformantDescription:
-        'Workflow zum Melden von nicht-konformen Punkten im Hallenrapport aktivieren',
-      nonConformantEnabled: 'Mängelmeldung ist aktiviert',
-      nonConformantDisabled: 'Mängelmeldung ist deaktiviert',
     },
   },
   pwa: {

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -569,11 +569,6 @@ const en: Translations = {
         'Scan scoresheets to auto-fill player rosters during game validation',
       ocrValidationEnabled: 'OCR validation is enabled',
       ocrValidationDisabled: 'OCR validation is disabled',
-      nonConformant: 'Hall report: Issue reporting',
-      nonConformantDescription:
-        'Enable workflow for reporting non-conformant items in the sports hall report',
-      nonConformantEnabled: 'Issue reporting is enabled',
-      nonConformantDisabled: 'Issue reporting is disabled',
     },
   },
   pwa: {

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -586,11 +586,6 @@ const fr: Translations = {
         'Activer la numérisation OCR des feuilles de match lors de la validation des matchs',
       ocrValidationEnabled: 'Scanner OCR activé',
       ocrValidationDisabled: 'Scanner OCR désactivé',
-      nonConformant: 'Rapport de salle : Signalement de problèmes',
-      nonConformantDescription:
-        'Activer le workflow pour signaler les points non conformes dans le rapport de salle',
-      nonConformantEnabled: 'Signalement de problèmes activé',
-      nonConformantDisabled: 'Signalement de problèmes désactivé',
     },
   },
   pwa: {

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -581,11 +581,6 @@ const it: Translations = {
         'Abilita la scansione OCR dei fogli partita durante la validazione delle partite',
       ocrValidationEnabled: 'Scanner OCR abilitato',
       ocrValidationDisabled: 'Scanner OCR disabilitato',
-      nonConformant: 'Rapporto palestra: Segnalazione problemi',
-      nonConformantDescription:
-        'Attivare il workflow per segnalare i punti non conformi nel rapporto della palestra',
-      nonConformantEnabled: 'Segnalazione problemi abilitata',
-      nonConformantDisabled: 'Segnalazione problemi disabilitata',
     },
   },
   pwa: {

--- a/packages/web/src/i18n/types.ts
+++ b/packages/web/src/i18n/types.ts
@@ -442,10 +442,6 @@ export interface Translations {
       ocrValidationDescription: string
       ocrValidationEnabled: string
       ocrValidationDisabled: string
-      nonConformant: string
-      nonConformantDescription: string
-      nonConformantEnabled: string
-      nonConformantDisabled: string
     }
   }
   pwa: {


### PR DESCRIPTION
## Summary

- Remove the `isNonConformantEnabled` experimental feature gate from the settings store, making the non-conformant issue reporting workflow always available in the sports hall report wizard
- Remove the experimental toggle UI from the Settings page and related i18n keys (4 keys × 4 locales: de/en/fr/it)
- Add store migration v11 to clean up the persisted `isNonConformantEnabled` field from localStorage

## Test plan

- [ ] Open sports hall report wizard — "Report an issue" button should always be visible
- [ ] Verify the non-conformant toggle is no longer shown in Settings > Experimental features
- [ ] Confirm existing localStorage with old schema migrates cleanly (no console errors)
- [ ] Complete a non-conformant report end-to-end to verify the workflow still functions correctly

https://claude.ai/code/session_01N9LvaDSgLkN667XXm7NgLC