### PR TITLE
test(shared,web,worker): add tests for untested critical modules

### DIFF
--- a/packages/shared/src/offline/sync-utils.test.ts
+++ b/packages/shared/src/offline/sync-utils.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for platform-agnostic offline sync utilities.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { MAX_RETRY_COUNT, RETRY_DELAY_BASE_MS } from './action-types'
+import type { OfflineAction } from './types'
+
+import {
+  isSessionExpiredError,
+  isConflictError,
+  getRetryDelay,
+  sleep,
+  generateActionId,
+  shouldRetryAction,
+  emptySyncResult,
+  sortActionsByCreatedAt,
+} from './sync-utils'
+
+// Helper to create a minimal OfflineAction for testing
+function createAction(overrides: Partial<OfflineAction> = {}): OfflineAction {
+  return {
+    id: 'action_123_abc',
+    type: 'updateCompensation',
+    payload: { compensationId: 'comp-1', data: {} },
+    createdAt: Date.now(),
+    status: 'pending',
+    retryCount: 0,
+    ...overrides,
+  } as OfflineAction
+}
+
+describe('isSessionExpiredError', () => {
+  it('returns false for non-Error values', () => {
+    expect(isSessionExpiredError(null)).toBe(false)
+    expect(isSessionExpiredError(undefined)).toBe(false)
+    expect(isSessionExpiredError('unauthorized')).toBe(false)
+    expect(isSessionExpiredError(401)).toBe(false)
+  })
+
+  it('detects "unauthorized" keyword', () => {
+    expect(isSessionExpiredError(new Error('Unauthorized access'))).toBe(true)
+  })
+
+  it('detects "401" status code in message', () => {
+    expect(isSessionExpiredError(new Error('Request failed with status 401'))).toBe(true)
+  })
+
+  it('detects "session" keyword', () => {
+    expect(isSessionExpiredError(new Error('Session has expired'))).toBe(true)
+  })
+
+  it('detects "login" keyword', () => {
+    expect(isSessionExpiredError(new Error('Please login again'))).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isSessionExpiredError(new Error('UNAUTHORIZED'))).toBe(true)
+    expect(isSessionExpiredError(new Error('Session Expired'))).toBe(true)
+  })
+
+  it('returns false for unrelated errors', () => {
+    expect(isSessionExpiredError(new Error('Network timeout'))).toBe(false)
+    expect(isSessionExpiredError(new Error('Internal server error'))).toBe(false)
+  })
+})
+
+describe('isConflictError', () => {
+  it('returns false for non-Error values', () => {
+    expect(isConflictError(null)).toBe(false)
+    expect(isConflictError(undefined)).toBe(false)
+    expect(isConflictError('not found')).toBe(false)
+    expect(isConflictError(404)).toBe(false)
+  })
+
+  it('detects "not found" keyword', () => {
+    expect(isConflictError(new Error('Resource not found'))).toBe(true)
+  })
+
+  it('detects "404" status code in message', () => {
+    expect(isConflictError(new Error('Request failed with status 404'))).toBe(true)
+  })
+
+  it('detects "conflict" keyword', () => {
+    expect(isConflictError(new Error('Conflict detected'))).toBe(true)
+  })
+
+  it('detects "409" status code in message', () => {
+    expect(isConflictError(new Error('Request failed with status 409'))).toBe(true)
+  })
+
+  it('detects "already" keyword', () => {
+    expect(isConflictError(new Error('Exchange already applied'))).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isConflictError(new Error('NOT FOUND'))).toBe(true)
+    expect(isConflictError(new Error('CONFLICT'))).toBe(true)
+  })
+
+  it('returns false for unrelated errors', () => {
+    expect(isConflictError(new Error('Network timeout'))).toBe(false)
+    expect(isConflictError(new Error('Unauthorized'))).toBe(false)
+  })
+})
+
+describe('getRetryDelay', () => {
+  it('calculates exponential backoff from base delay', () => {
+    expect(getRetryDelay(0)).toBe(RETRY_DELAY_BASE_MS)
+    expect(getRetryDelay(1)).toBe(RETRY_DELAY_BASE_MS * 2)
+    expect(getRetryDelay(2)).toBe(RETRY_DELAY_BASE_MS * 4)
+    expect(getRetryDelay(3)).toBe(RETRY_DELAY_BASE_MS * 8)
+  })
+})
+
+describe('sleep', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves after specified duration', async () => {
+    vi.useFakeTimers()
+    const promise = sleep(1000)
+    vi.advanceTimersByTime(1000)
+    await expect(promise).resolves.toBeUndefined()
+  })
+})
+
+describe('generateActionId', () => {
+  it('returns a string starting with "action_"', () => {
+    const id = generateActionId()
+    expect(id).toMatch(/^action_/)
+  })
+
+  it('includes a timestamp component', () => {
+    const before = Date.now()
+    const id = generateActionId()
+    const after = Date.now()
+
+    const parts = id.split('_')
+    const timestamp = Number(parts[1])
+    expect(timestamp).toBeGreaterThanOrEqual(before)
+    expect(timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it('generates unique IDs', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateActionId()))
+    expect(ids.size).toBe(100)
+  })
+})
+
+describe('shouldRetryAction', () => {
+  it('returns true when retryCount is below MAX_RETRY_COUNT', () => {
+    expect(shouldRetryAction(createAction({ retryCount: 0 }))).toBe(true)
+    expect(shouldRetryAction(createAction({ retryCount: MAX_RETRY_COUNT - 1 }))).toBe(true)
+  })
+
+  it('returns false when retryCount equals MAX_RETRY_COUNT', () => {
+    expect(shouldRetryAction(createAction({ retryCount: MAX_RETRY_COUNT }))).toBe(false)
+  })
+
+  it('returns false when retryCount exceeds MAX_RETRY_COUNT', () => {
+    expect(shouldRetryAction(createAction({ retryCount: MAX_RETRY_COUNT + 1 }))).toBe(false)
+  })
+})
+
+describe('emptySyncResult', () => {
+  it('returns a result with all counters at zero', () => {
+    const result = emptySyncResult()
+    expect(result).toEqual({
+      processed: 0,
+      succeeded: 0,
+      failed: 0,
+      requiresReauth: false,
+      results: [],
+    })
+  })
+})
+
+describe('sortActionsByCreatedAt', () => {
+  it('returns actions sorted by createdAt ascending', () => {
+    const actions = [
+      createAction({ id: 'c', createdAt: 3000 }),
+      createAction({ id: 'a', createdAt: 1000 }),
+      createAction({ id: 'b', createdAt: 2000 }),
+    ]
+
+    const sorted = sortActionsByCreatedAt(actions)
+    expect(sorted.map((a) => a.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not mutate the original array', () => {
+    const actions = [
+      createAction({ id: 'b', createdAt: 2000 }),
+      createAction({ id: 'a', createdAt: 1000 }),
+    ]
+
+    const sorted = sortActionsByCreatedAt(actions)
+    expect(sorted).not.toBe(actions)
+    expect(actions[0]!.id).toBe('b')
+  })
+
+  it('handles empty array', () => {
+    expect(sortActionsByCreatedAt([])).toEqual([])
+  })
+
+  it('handles single element', () => {
+    const actions = [createAction({ id: 'only' })]
+    const sorted = sortActionsByCreatedAt(actions)
+    expect(sorted).toHaveLength(1)
+    expect(sorted[0]!.id).toBe('only')
+  })
+})

--- a/packages/shared/src/offline/types.ts
+++ b/packages/shared/src/offline/types.ts
@@ -44,11 +44,7 @@ export interface OfflineActionStore {
   /** Get all actions with a given status */
   getActionsByStatus(status: ActionStatus): Promise<OfflineAction[]>
   /** Update an action's status and optional error message */
-  updateActionStatus(
-    id: string,
-    status: ActionStatus,
-    error?: string
-  ): Promise<void>
+  updateActionStatus(id: string, status: ActionStatus, error?: string): Promise<void>
   /** Delete a completed/abandoned action */
   deleteAction(id: string): Promise<void>
   /** Clear all actions from the queue */

--- a/packages/web/src/common/services/offline/action-store.test.ts
+++ b/packages/web/src/common/services/offline/action-store.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the offline action store service.
+ *
+ * Tests CRUD operations for managing offline actions, using an in-memory
+ * Map to simulate IndexedDB.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import type { OfflineAction, ActionStatus } from './action-types'
+
+// In-memory store simulating IndexedDB
+const actionStore = new Map<string, OfflineAction>()
+
+vi.mock('./indexed-db', () => ({
+  STORES: {
+    METADATA: 'metadata',
+    QUERY_CACHE: 'queryCache',
+    ACTION_QUEUE: 'actionQueue',
+  },
+  getDB: vi.fn().mockImplementation(async () => ({
+    add: async (_store: string, value: OfflineAction) => {
+      actionStore.set(value.id, value)
+      return value.id
+    },
+    get: async (_store: string, key: string) => actionStore.get(key),
+    getAllFromIndex: async (_store: string, _index: string, status: ActionStatus) =>
+      Array.from(actionStore.values()).filter((a) => a.status === status),
+    put: async (_store: string, value: OfflineAction) => {
+      actionStore.set(value.id, value)
+    },
+    delete: async (_store: string, key: string) => {
+      actionStore.delete(key)
+    },
+    clear: async () => {
+      actionStore.clear()
+    },
+  })),
+}))
+
+const {
+  createAction,
+  getActionsByStatus,
+  getPendingActions,
+  updateActionStatus,
+  markActionSyncing,
+  markActionFailed,
+  resetActionForRetry,
+  deleteAction,
+  clearAllActions,
+} = await import('./action-store')
+
+describe('action-store', () => {
+  beforeEach(() => {
+    actionStore.clear()
+  })
+
+  describe('createAction', () => {
+    it('creates an action with pending status and retryCount 0', async () => {
+      const action = await createAction('updateCompensation', {
+        compensationId: 'comp-1',
+        data: { distanceInMetres: 100 },
+      })
+
+      expect(action).not.toBeNull()
+      expect(action!.type).toBe('updateCompensation')
+      expect(action!.status).toBe('pending')
+      expect(action!.retryCount).toBe(0)
+      expect(action!.id).toMatch(/^action_/)
+    })
+
+    it('stores the action in the database', async () => {
+      const action = await createAction('applyForExchange', { exchangeId: 'ex-1' })
+
+      expect(actionStore.has(action!.id)).toBe(true)
+      expect(actionStore.get(action!.id)!.type).toBe('applyForExchange')
+    })
+  })
+
+  describe('getActionsByStatus', () => {
+    it('returns actions matching the given status', async () => {
+      await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+      await createAction('updateCompensation', { compensationId: 'c2', data: {} })
+
+      const pending = await getActionsByStatus('pending')
+      expect(pending).toHaveLength(2)
+    })
+
+    it('returns empty array when no actions match', async () => {
+      await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+
+      const failed = await getActionsByStatus('failed')
+      expect(failed).toHaveLength(0)
+    })
+  })
+
+  describe('getPendingActions', () => {
+    it('returns only pending actions', async () => {
+      const action = await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+      await createAction('updateCompensation', { compensationId: 'c2', data: {} })
+
+      // Mark first as failed
+      await markActionFailed(action!.id, 'test error')
+
+      const pending = await getPendingActions()
+      expect(pending).toHaveLength(1)
+    })
+  })
+
+  describe('updateActionStatus', () => {
+    it('updates action status', async () => {
+      const action = await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+
+      const result = await updateActionStatus(action!.id, 'failed', 'some error')
+      expect(result).toBe(true)
+
+      const stored = actionStore.get(action!.id)!
+      expect(stored.status).toBe('failed')
+      expect(stored.error).toBe('some error')
+    })
+
+    it('increments retryCount when status is syncing', async () => {
+      const action = await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+      expect(action!.retryCount).toBe(0)
+
+      await updateActionStatus(action!.id, 'syncing')
+      const stored = actionStore.get(action!.id)!
+      expect(stored.retryCount).toBe(1)
+    })
+
+    it('does not increment retryCount for non-syncing status', async () => {
+      const action = await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+
+      await updateActionStatus(action!.id, 'failed', 'err')
+      const stored = actionStore.get(action!.id)!
+      expect(stored.retryCount).toBe(0)
+    })
+
+    it('returns false for non-existent action', async () => {
+      const result = await updateActionStatus('nonexistent', 'failed')
+      expect(result).toBe(false)
+    })
+
+    it('preserves existing error when no new error provided', async () => {
+      const action = await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+      await updateActionStatus(action!.id, 'failed', 'original error')
+      await updateActionStatus(action!.id, 'pending')
+
+      const stored = actionStore.get(action!.id)!
+      expect(stored.error).toBe('original error')
+    })
+  })
+
+  describe('markActionSyncing', () => {
+    it('sets status to syncing and increments retryCount', async () => {
+      const action = await createAction('addToExchange', { convocationId: 'conv-1' })
+
+      await markActionSyncing(action!.id)
+
+      const stored = actionStore.get(action!.id)!
+      expect(stored.status).toBe('syncing')
+      expect(stored.retryCount).toBe(1)
+    })
+  })
+
+  describe('markActionFailed', () => {
+    it('sets status to failed with error message', async () => {
+      const action = await createAction('addToExchange', { convocationId: 'conv-1' })
+
+      await markActionFailed(action!.id, 'Network error')
+
+      const stored = actionStore.get(action!.id)!
+      expect(stored.status).toBe('failed')
+      expect(stored.error).toBe('Network error')
+    })
+  })
+
+  describe('resetActionForRetry', () => {
+    it('resets status to pending', async () => {
+      const action = await createAction('addToExchange', { convocationId: 'conv-1' })
+      await markActionFailed(action!.id, 'error')
+
+      await resetActionForRetry(action!.id)
+
+      const stored = actionStore.get(action!.id)!
+      expect(stored.status).toBe('pending')
+    })
+  })
+
+  describe('deleteAction', () => {
+    it('removes action from store', async () => {
+      const action = await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+
+      const result = await deleteAction(action!.id)
+      expect(result).toBe(true)
+      expect(actionStore.has(action!.id)).toBe(false)
+    })
+  })
+
+  describe('clearAllActions', () => {
+    it('removes all actions from store', async () => {
+      await createAction('updateCompensation', { compensationId: 'c1', data: {} })
+      await createAction('updateCompensation', { compensationId: 'c2', data: {} })
+
+      const result = await clearAllActions()
+      expect(result).toBe(true)
+      expect(actionStore.size).toBe(0)
+    })
+  })
+})

--- a/packages/web/src/common/services/offline/action-sync.test.ts
+++ b/packages/web/src/common/services/offline/action-sync.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the offline action sync service.
+ *
+ * Tests the sync orchestration logic: processing pending actions,
+ * handling errors, detecting session expiry, and stopping on auth failure.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import type { OfflineAction } from './action-types'
+
+// Track calls to action-store functions
+const mockActions: OfflineAction[] = []
+const deletedIds: string[] = []
+const failedActions: { id: string; error: string }[] = []
+const syncingIds: string[] = []
+
+vi.mock('./action-store', () => ({
+  getPendingActions: vi.fn(async () => [...mockActions]),
+  markActionSyncing: vi.fn(async (id: string) => {
+    syncingIds.push(id)
+    return true
+  }),
+  markActionFailed: vi.fn(async (id: string, error: string) => {
+    failedActions.push({ id, error })
+    return true
+  }),
+  deleteAction: vi.fn(async (id: string) => {
+    deletedIds.push(id)
+    return true
+  }),
+}))
+
+// Mock API client
+const mockApiClient = {
+  updateCompensation: vi.fn(),
+  applyForExchange: vi.fn(),
+  addToExchange: vi.fn(),
+  removeOwnExchange: vi.fn(),
+}
+
+vi.mock('@/api/client', () => ({
+  getApiClient: vi.fn(() => mockApiClient),
+}))
+
+vi.mock('@/api/queryKeys', () => ({
+  queryKeys: {
+    compensations: { lists: () => ['compensations'] },
+    assignments: { lists: () => ['assignments'] },
+    exchanges: { lists: () => ['exchanges'] },
+  },
+}))
+
+const { syncPendingActions } = await import('./action-sync')
+
+function createTestAction(overrides: Partial<OfflineAction> = {}): OfflineAction {
+  return {
+    id: `action_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+    type: 'updateCompensation',
+    payload: { compensationId: 'comp-1', data: { distanceInMetres: 50 } },
+    createdAt: Date.now(),
+    status: 'pending',
+    retryCount: 0,
+    ...overrides,
+  } as OfflineAction
+}
+
+describe('syncPendingActions', () => {
+  beforeEach(() => {
+    mockActions.length = 0
+    deletedIds.length = 0
+    failedActions.length = 0
+    syncingIds.length = 0
+    vi.clearAllMocks()
+  })
+
+  it('returns empty result when no pending actions', async () => {
+    const result = await syncPendingActions()
+
+    expect(result).toEqual({
+      processed: 0,
+      succeeded: 0,
+      failed: 0,
+      requiresReauth: false,
+      results: [],
+    })
+  })
+
+  it('syncs a pending updateCompensation action successfully', async () => {
+    const action = createTestAction()
+    mockActions.push(action)
+
+    const result = await syncPendingActions()
+
+    expect(result.processed).toBe(1)
+    expect(result.succeeded).toBe(1)
+    expect(result.failed).toBe(0)
+    expect(deletedIds).toContain(action.id)
+    expect(mockApiClient.updateCompensation).toHaveBeenCalledWith('comp-1', {
+      distanceInMetres: 50,
+    })
+  })
+
+  it('syncs applyForExchange action', async () => {
+    const action = createTestAction({
+      type: 'applyForExchange',
+      payload: { exchangeId: 'ex-1' },
+    } as Partial<OfflineAction>)
+    mockActions.push(action)
+
+    await syncPendingActions()
+
+    expect(mockApiClient.applyForExchange).toHaveBeenCalledWith('ex-1')
+  })
+
+  it('syncs addToExchange action', async () => {
+    const action = createTestAction({
+      type: 'addToExchange',
+      payload: { convocationId: 'conv-1' },
+    } as Partial<OfflineAction>)
+    mockActions.push(action)
+
+    await syncPendingActions()
+
+    expect(mockApiClient.addToExchange).toHaveBeenCalledWith('conv-1')
+  })
+
+  it('syncs removeOwnExchange action', async () => {
+    const action = createTestAction({
+      type: 'removeOwnExchange',
+      payload: { convocationId: 'conv-2' },
+    } as Partial<OfflineAction>)
+    mockActions.push(action)
+
+    await syncPendingActions()
+
+    expect(mockApiClient.removeOwnExchange).toHaveBeenCalledWith('conv-2')
+  })
+
+  it('marks action as failed on API error', async () => {
+    const action = createTestAction()
+    mockActions.push(action)
+    mockApiClient.updateCompensation.mockRejectedValueOnce(new Error('Network timeout'))
+
+    const result = await syncPendingActions()
+
+    expect(result.processed).toBe(1)
+    expect(result.succeeded).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(failedActions.some((f) => f.id === action.id)).toBe(true)
+  })
+
+  it('detects session expiry and sets requiresReauth', async () => {
+    const action = createTestAction()
+    mockActions.push(action)
+    mockApiClient.updateCompensation.mockRejectedValueOnce(new Error('401 Unauthorized'))
+
+    const result = await syncPendingActions()
+
+    expect(result.requiresReauth).toBe(true)
+    expect(result.failed).toBe(1)
+  })
+
+  it('stops processing remaining actions after session expiry', async () => {
+    const action1 = createTestAction({ createdAt: 1000 })
+    const action2 = createTestAction({ createdAt: 2000 })
+    mockActions.push(action1, action2)
+    mockApiClient.updateCompensation.mockRejectedValueOnce(new Error('Unauthorized'))
+
+    const result = await syncPendingActions()
+
+    // Only first action should be processed
+    expect(result.processed).toBe(1)
+    expect(result.requiresReauth).toBe(true)
+    expect(syncingIds).toHaveLength(1)
+  })
+
+  it('detects conflict errors and marks action as failed', async () => {
+    const action = createTestAction()
+    mockActions.push(action)
+    mockApiClient.updateCompensation.mockRejectedValueOnce(new Error('404 Not Found'))
+
+    const result = await syncPendingActions()
+
+    expect(result.failed).toBe(1)
+    expect(result.requiresReauth).toBe(false)
+    expect(failedActions.some((f) => f.id === action.id && f.error.includes('Conflict'))).toBe(true)
+  })
+
+  it('processes actions in createdAt order', async () => {
+    const laterAction = createTestAction({ id: 'later', createdAt: 3000 })
+    const earlierAction = createTestAction({ id: 'earlier', createdAt: 1000 })
+    mockActions.push(laterAction, earlierAction)
+
+    await syncPendingActions()
+
+    // Earlier action should be processed first
+    expect(syncingIds[0]).toBe('earlier')
+    expect(syncingIds[1]).toBe('later')
+  })
+
+  it('processes multiple actions and reports aggregate results', async () => {
+    const action1 = createTestAction({ createdAt: 1000 })
+    const action2 = createTestAction({ createdAt: 2000 })
+    const action3 = createTestAction({ createdAt: 3000 })
+    mockActions.push(action1, action2, action3)
+
+    // Second action fails
+    mockApiClient.updateCompensation
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Server error'))
+      .mockResolvedValueOnce(undefined)
+
+    const result = await syncPendingActions()
+
+    expect(result.processed).toBe(3)
+    expect(result.succeeded).toBe(2)
+    expect(result.failed).toBe(1)
+  })
+
+  it('invalidates queries after successful syncs when queryClient provided', async () => {
+    const action = createTestAction()
+    mockActions.push(action)
+
+    const mockQueryClient = {
+      invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    }
+
+    await syncPendingActions(mockQueryClient as unknown as Parameters<typeof syncPendingActions>[0])
+
+    expect(mockQueryClient.invalidateQueries).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not invalidate queries when all actions fail', async () => {
+    const action = createTestAction()
+    mockActions.push(action)
+    mockApiClient.updateCompensation.mockRejectedValueOnce(new Error('fail'))
+
+    const mockQueryClient = {
+      invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    }
+
+    await syncPendingActions(mockQueryClient as unknown as Parameters<typeof syncPendingActions>[0])
+
+    expect(mockQueryClient.invalidateQueries).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/src/common/services/transport/ojp-trip-helpers.test.ts
+++ b/packages/web/src/common/services/transport/ojp-trip-helpers.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for OJP trip extraction and selection helpers.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  parseDurationToMinutes,
+  extractFinalWalkingMinutes,
+  calculateActualArrivalTime,
+  extractOriginStation,
+  extractDestinationStation,
+  selectBestTrip,
+  type OjpTrip,
+} from './ojp-trip-helpers'
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function createTrip(overrides: Partial<OjpTrip> = {}): OjpTrip {
+  return {
+    duration: 'PT1H30M',
+    startTime: '2025-03-15T08:00:00Z',
+    endTime: '2025-03-15T09:30:00Z',
+    transfers: 1,
+    leg: [],
+    ...overrides,
+  }
+}
+
+function createTimedLeg(
+  boardRef: string,
+  boardName: string,
+  alightRef: string,
+  alightName: string,
+  options?: { boardSuffix?: string; alightSuffix?: string }
+) {
+  return {
+    timedLeg: {
+      legBoard: {
+        stopPointRef: boardRef,
+        stopPointName: { text: boardName },
+        ...(options?.boardSuffix && { nameSuffix: { text: options.boardSuffix } }),
+      },
+      legAlight: {
+        stopPointRef: alightRef,
+        stopPointName: { text: alightName },
+        ...(options?.alightSuffix && { nameSuffix: { text: options.alightSuffix } }),
+      },
+    },
+  }
+}
+
+function createWalkingLeg(duration: string) {
+  return {
+    continuousLeg: { duration },
+  }
+}
+
+// =============================================================================
+// parseDurationToMinutes
+// =============================================================================
+
+describe('parseDurationToMinutes', () => {
+  it('parses hours and minutes', () => {
+    expect(parseDurationToMinutes('PT1H30M')).toBe(90)
+  })
+
+  it('parses hours only', () => {
+    expect(parseDurationToMinutes('PT2H')).toBe(120)
+  })
+
+  it('parses minutes only', () => {
+    expect(parseDurationToMinutes('PT45M')).toBe(45)
+  })
+
+  it('parses seconds and rounds up to next minute', () => {
+    expect(parseDurationToMinutes('PT30S')).toBe(1)
+  })
+
+  it('parses hours, minutes, and seconds', () => {
+    expect(parseDurationToMinutes('PT1H15M30S')).toBe(76)
+  })
+
+  it('returns 0 for invalid duration without PT prefix', () => {
+    expect(parseDurationToMinutes('1H30M')).toBe(0)
+    expect(parseDurationToMinutes('')).toBe(0)
+  })
+
+  it('returns 0 for PT with no components', () => {
+    expect(parseDurationToMinutes('PT')).toBe(0)
+  })
+
+  it('handles zero seconds without rounding up', () => {
+    expect(parseDurationToMinutes('PT5M0S')).toBe(5)
+  })
+})
+
+// =============================================================================
+// extractFinalWalkingMinutes
+// =============================================================================
+
+describe('extractFinalWalkingMinutes', () => {
+  it('returns 0 when trip has no legs', () => {
+    expect(extractFinalWalkingMinutes(createTrip())).toBe(0)
+  })
+
+  it('returns 0 when trip has no timed legs', () => {
+    const trip = createTrip({ leg: [createWalkingLeg('PT10M')] })
+    expect(extractFinalWalkingMinutes(trip)).toBe(0)
+  })
+
+  it('returns 0 when last leg is a timed leg', () => {
+    const trip = createTrip({
+      leg: [createTimedLeg('ch:1:sloid:8507000', 'Bern', 'ch:1:sloid:8503000', 'Zürich')],
+    })
+    expect(extractFinalWalkingMinutes(trip)).toBe(0)
+  })
+
+  it('sums walking duration after last timed leg', () => {
+    const trip = createTrip({
+      leg: [
+        createTimedLeg('ch:1:sloid:8507000', 'Bern', 'ch:1:sloid:8503000', 'Zürich'),
+        createWalkingLeg('PT5M'),
+        createWalkingLeg('PT3M'),
+      ],
+    })
+    expect(extractFinalWalkingMinutes(trip)).toBe(8)
+  })
+
+  it('only counts walking after the last timed leg', () => {
+    const trip = createTrip({
+      leg: [
+        createWalkingLeg('PT10M'), // before first timed leg — ignored
+        createTimedLeg('ch:1:sloid:8507000', 'Bern', 'ch:1:sloid:8503000', 'Zürich'),
+        createWalkingLeg('PT2M'), // between timed legs — ignored (next timed exists)
+        createTimedLeg('ch:1:sloid:8503000', 'Zürich', 'ch:1:sloid:8505000', 'Luzern'),
+        createWalkingLeg('PT7M'), // after last timed leg — counted
+      ],
+    })
+    expect(extractFinalWalkingMinutes(trip)).toBe(7)
+  })
+})
+
+// =============================================================================
+// calculateActualArrivalTime
+// =============================================================================
+
+describe('calculateActualArrivalTime', () => {
+  it('returns endTime when no final walking', () => {
+    const trip = createTrip({ endTime: '2025-03-15T09:30:00Z' })
+    expect(calculateActualArrivalTime(trip)).toBe('2025-03-15T09:30:00Z')
+  })
+
+  it('adds final walking time to endTime', () => {
+    const trip = createTrip({
+      endTime: '2025-03-15T09:30:00.000Z',
+      leg: [
+        createTimedLeg('ch:1:sloid:8507000', 'Bern', 'ch:1:sloid:8503000', 'Zürich'),
+        createWalkingLeg('PT10M'),
+      ],
+    })
+    const result = calculateActualArrivalTime(trip)
+    expect(new Date(result).getTime()).toBe(new Date('2025-03-15T09:40:00.000Z').getTime())
+  })
+})
+
+// =============================================================================
+// extractOriginStation / extractDestinationStation
+// =============================================================================
+
+describe('extractOriginStation', () => {
+  it('returns undefined for trip with no timed legs', () => {
+    expect(extractOriginStation(createTrip())).toBeUndefined()
+  })
+
+  it('extracts origin station from first timed leg', () => {
+    const trip = createTrip({
+      leg: [
+        createWalkingLeg('PT5M'),
+        createTimedLeg('ch:1:sloid:8507000', 'Bern', 'ch:1:sloid:8503000', 'Zürich'),
+      ],
+    })
+    const station = extractOriginStation(trip)
+    expect(station).toEqual({ id: '8507000', name: 'Bern' })
+  })
+
+  it('includes cleaned suffix in station name', () => {
+    const trip = createTrip({
+      leg: [
+        createTimedLeg('ch:1:sloid:8500218', 'Schönenwerd', 'ch:1:sloid:8503000', 'Zürich', {
+          boardSuffix: 'SO, Bahnhof',
+        }),
+      ],
+    })
+    const station = extractOriginStation(trip)
+    expect(station?.name).toBe('Schönenwerd SO, Bahnhof')
+  })
+
+  it('filters accessibility keywords from suffix', () => {
+    const trip = createTrip({
+      leg: [
+        createTimedLeg('ch:1:sloid:8507000', 'Bern', 'ch:1:sloid:8503000', 'Zürich', {
+          boardSuffix: 'PLATFORM_ACCESSIBLE',
+        }),
+      ],
+    })
+    const station = extractOriginStation(trip)
+    expect(station?.name).toBe('Bern')
+  })
+})
+
+describe('extractDestinationStation', () => {
+  it('returns undefined for trip with no timed legs', () => {
+    expect(extractDestinationStation(createTrip())).toBeUndefined()
+  })
+
+  it('extracts destination station from last timed leg', () => {
+    const trip = createTrip({
+      leg: [
+        createTimedLeg('ch:1:sloid:8507000', 'Bern', 'ch:1:sloid:8503000', 'Zürich'),
+        createTimedLeg('ch:1:sloid:8503000', 'Zürich', 'ch:1:sloid:8505000', 'Luzern'),
+      ],
+    })
+    const station = extractDestinationStation(trip)
+    expect(station).toEqual({ id: '8505000', name: 'Luzern' })
+  })
+
+  it('returns undefined for plain numeric ref without sloid prefix', () => {
+    const trip = createTrip({
+      leg: [createTimedLeg('ch:1:sloid:8507000', 'Bern', '8503000', 'Zürich')],
+    })
+    const station = extractDestinationStation(trip)
+    expect(station).toEqual({ id: '8503000', name: 'Zürich' })
+  })
+})
+
+// =============================================================================
+// selectBestTrip
+// =============================================================================
+
+describe('selectBestTrip', () => {
+  const earlyTrip = createTrip({
+    startTime: '2025-03-15T07:00:00Z',
+    endTime: '2025-03-15T08:30:00Z',
+    transfers: 2,
+  })
+  const optimalTrip = createTrip({
+    startTime: '2025-03-15T08:00:00Z',
+    endTime: '2025-03-15T09:00:00Z',
+    transfers: 1,
+  })
+  const lateTrip = createTrip({
+    startTime: '2025-03-15T09:00:00Z',
+    endTime: '2025-03-15T10:30:00Z',
+    transfers: 0,
+  })
+
+  it('returns first trip when no target arrival time', () => {
+    const result = selectBestTrip([earlyTrip, optimalTrip, lateTrip])
+    expect(result).toBe(earlyTrip)
+  })
+
+  it('selects on-time trip with fewer transfers', () => {
+    const target = new Date('2025-03-15T09:30:00Z')
+    const result = selectBestTrip([earlyTrip, optimalTrip, lateTrip], target)
+    // Both earlyTrip and optimalTrip arrive on time; optimalTrip has fewer transfers
+    expect(result).toBe(optimalTrip)
+  })
+
+  it('prefers arrival closest to target time among same transfers', () => {
+    const sameTransfersEarly = createTrip({
+      endTime: '2025-03-15T08:00:00Z',
+      transfers: 1,
+    })
+    const sameTransfersLater = createTrip({
+      endTime: '2025-03-15T09:00:00Z',
+      transfers: 1,
+    })
+    const target = new Date('2025-03-15T09:30:00Z')
+    const result = selectBestTrip([sameTransfersEarly, sameTransfersLater], target)
+    // Prefer later arrival (closer to target) with same transfers
+    expect(result).toBe(sameTransfersLater)
+  })
+
+  it('falls back to first trip when all arrive late', () => {
+    const target = new Date('2025-03-15T07:00:00Z')
+    const result = selectBestTrip([earlyTrip, optimalTrip, lateTrip], target)
+    expect(result).toBe(earlyTrip)
+  })
+})

--- a/packages/web/src/test/feature-isolation.test.ts
+++ b/packages/web/src/test/feature-isolation.test.ts
@@ -56,7 +56,8 @@ function getFeatureNames(): string[] {
 const VALUE_BARREL_IMPORT_PATTERN = /^import\s+\{[^}]+\}\s+from\s+['"]@\/features\/([^/'"]+)['"]/gm
 
 /** Matches type-only barrel imports (safe — erased at compile time) */
-const TYPE_BARREL_IMPORT_PATTERN = /^import\s+type\s+\{[^}]+\}\s+from\s+['"]@\/features\/([^/'"]+)['"]/gm
+const TYPE_BARREL_IMPORT_PATTERN =
+  /^import\s+type\s+\{[^}]+\}\s+from\s+['"]@\/features\/([^/'"]+)['"]/gm
 
 describe('Feature isolation — no cross-feature barrel imports', () => {
   const featureNames = getFeatureNames()
@@ -90,7 +91,10 @@ describe('Feature isolation — no cross-feature barrel imports', () => {
           )
         }
 
-        expect(violations, `Cross-feature barrel imports found in ${relPath}:\n${violations.join('\n')}`).toEqual([])
+        expect(
+          violations,
+          `Cross-feature barrel imports found in ${relPath}:\n${violations.join('\n')}`
+        ).toEqual([])
       })
     }
   }

--- a/packages/worker/src/utils/ical-validation.test.ts
+++ b/packages/worker/src/utils/ical-validation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+
+import { isValidICalCode, extractICalCode } from './ical-validation'
+
+describe('isValidICalCode', () => {
+  it('accepts valid 6-character alphanumeric codes', () => {
+    expect(isValidICalCode('ABC123')).toBe(true)
+    expect(isValidICalCode('abcdef')).toBe(true)
+    expect(isValidICalCode('123456')).toBe(true)
+    expect(isValidICalCode('A1b2C3')).toBe(true)
+  })
+
+  it('rejects codes shorter than 6 characters', () => {
+    expect(isValidICalCode('ABC12')).toBe(false)
+    expect(isValidICalCode('')).toBe(false)
+    expect(isValidICalCode('A')).toBe(false)
+  })
+
+  it('rejects codes longer than 6 characters', () => {
+    expect(isValidICalCode('ABC1234')).toBe(false)
+    expect(isValidICalCode('ABCDEFGH')).toBe(false)
+  })
+
+  it('rejects codes with special characters', () => {
+    expect(isValidICalCode('ABC-12')).toBe(false)
+    expect(isValidICalCode('ABC 12')).toBe(false)
+    expect(isValidICalCode('ABC_12')).toBe(false)
+    expect(isValidICalCode('ABC!@#')).toBe(false)
+  })
+})
+
+describe('extractICalCode', () => {
+  it('extracts code from valid iCal referee path', () => {
+    expect(extractICalCode('/iCal/referee/ABC123')).toBe('ABC123')
+  })
+
+  it('returns null for non-matching paths', () => {
+    expect(extractICalCode('/other/path')).toBeNull()
+    expect(extractICalCode('/iCal/referee')).toBeNull()
+    expect(extractICalCode('/iCal/referee/')).toBeNull()
+    expect(extractICalCode('/')).toBeNull()
+    expect(extractICalCode('')).toBeNull()
+  })
+
+  it('returns null for paths with extra segments after code', () => {
+    expect(extractICalCode('/iCal/referee/ABC123/extra')).toBeNull()
+  })
+
+  it('extracts any non-slash characters as code (validation is separate)', () => {
+    expect(extractICalCode('/iCal/referee/toolong123')).toBe('toolong123')
+    expect(extractICalCode('/iCal/referee/X')).toBe('X')
+  })
+})


### PR DESCRIPTION
## Summary

- Analyzed test coverage across all packages in the monorepo, identifying critical gaps
- Added tests for `shared/offline/sync-utils`: error classification, retry delay calculation, action sorting, ID generation
- Added tests for `web/offline/action-store`: IndexedDB CRUD operations for offline queue with in-memory mock
- Added tests for `web/offline/action-sync`: sync orchestration, session expiry detection, conflict handling, query invalidation
- Added tests for `web/transport/ojp-trip-helpers`: ISO 8601 duration parsing, station extraction, walking time, trip selection
- Added tests for `worker/utils/ical-validation`: iCal code format validation and path extraction
- Auto-formatted files touched by pre-commit hook

## Test plan

- [x] All existing tests pass (shared: 664, web: 4164, worker: 563)
- [x] New tests pass across all three packages
- [x] Pre-commit validation passes (format, lint, knip, test, build)
- [ ] Verify CI passes on remote

https://claude.ai/code/session_01FsUfaVkhup74Bt8fe4gJTZ