### PR TITLE
fix(ci): add CNAME to GitHub Pages deploy for volleykit.ch

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -237,3 +237,4 @@ jobs:
           publish_dir: deploy
           keep_files: false
           enable_jekyll: false
+          cname: volleykit.ch


### PR DESCRIPTION
## Summary

- Add `cname: volleykit.ch` parameter to the `peaceiris/actions-gh-pages` deploy step in the GitHub Pages deployment workflow
- Each deployment with `keep_files: false` was wiping the CNAME file, causing the custom domain `volleykit.ch` to stop working
- The action's `cname` parameter ensures the CNAME file is recreated on every deploy

## Test plan

- [ ] Trigger the deploy workflow (push to main or manual dispatch)
- [ ] Verify `gh-pages` branch contains a `CNAME` file with `volleykit.ch`
- [ ] Verify `https://volleykit.ch` resolves and loads the app
- [ ] Verify `https://volleykit.ch/help` loads the help site

https://claude.ai/code/session_01LyNLfybqjQktsFkQw5DguZ