### PR TITLE
fix(ci): fix PR preview deployments for custom domain volleykit.ch

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -155,6 +155,7 @@ jobs:
           publish_dir: ./deploy
           keep_files: false
           enable_jekyll: false
+          cname: volleykit.ch
       - name: Summary
         run: |
           echo "## Cleanup Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -78,7 +78,7 @@ jobs:
         env:
           VITE_DEMO_MODE_ONLY: 'true'
           VITE_API_PROXY_URL: ${{ vars.VITE_API_PROXY_URL }}
-          VITE_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
+          VITE_BASE_PATH: /pr-${{ github.event.pull_request.number }}/
           VITE_OJP_API_KEY: ${{ secrets.VITE_OJP_API_KEY }}
           VITE_OCR_ENDPOINT: ${{ vars.VITE_OCR_ENDPOINT }}
       - name: Add .nojekyll for GitHub Pages
@@ -114,7 +114,7 @@ jobs:
       - name: Build Help Site
         run: pnpm run build
         env:
-          ASTRO_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/help
+          ASTRO_BASE_PATH: /pr-${{ github.event.pull_request.number }}/help
       - name: Upload help-site artifact
         uses: actions/upload-artifact@v7
         with:
@@ -156,7 +156,7 @@ jobs:
       - name: Build OCR POC
         run: pnpm run build
         env:
-          VITE_BASE_PATH: /${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/ocr-poc/
+          VITE_BASE_PATH: /pr-${{ github.event.pull_request.number }}/ocr-poc/
           VITE_OCR_ENDPOINT: ${{ vars.VITE_OCR_ENDPOINT }}
       - name: Upload ocr-poc artifact
         uses: actions/upload-artifact@v7
@@ -225,11 +225,12 @@ jobs:
           publish_dir: deploy
           keep_files: false
           enable_jekyll: false
+          cname: volleykit.ch
       - name: Comment PR with preview link
         uses: actions/github-script@v8
         with:
           script: |
-            const previewUrl = `https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/`;
+            const previewUrl = `https://volleykit.ch/pr-${{ github.event.pull_request.number }}/`;
             const ocrPocUrl = `${previewUrl}ocr-poc/`;
             const helpUrl = `${previewUrl}help/`;
             const body = `## PR Preview Deployed!\n\n` +

--- a/packages/web/404.html
+++ b/packages/web/404.html
@@ -27,12 +27,13 @@
 
         // Check if this is a PR preview path (contains /pr-NUMBER/)
         // Test cases:
-        // - '/volleykit/pr-94/' -> basePath = '/volleykit/pr-94/'
-        // - '/volleykit/pr-94/login' -> basePath = '/volleykit/pr-94/'
+        // - '/pr-94/' -> basePath = '/pr-94/' (custom domain)
+        // - '/pr-94/login' -> basePath = '/pr-94/' (custom domain)
+        // - '/volleykit/pr-94/' -> basePath = '/volleykit/pr-94/' (github.io fallback)
+        // - '/volleykit/pr-94/login' -> basePath = '/volleykit/pr-94/' (github.io fallback)
         // - '/volleykit/some-route' -> basePath = '{{BASE_URL}}'
-        // - '/pr-123/' -> basePath = '/pr-123/' (edge case)
         // - '/volleykit/preview-94/' -> basePath = '{{BASE_URL}}' (not matching pr- pattern)
-        const prMatch = fullPath.match(/^(\/[^/]+\/pr-\d+\/)/);
+        const prMatch = fullPath.match(/^(\/(?:[^/]+\/)?pr-\d+\/)/);
         if (prMatch && prMatch[1]) {
           basePath = prMatch[1];
         }


### PR DESCRIPTION
## Summary

- Remove `/volleykit/` repo prefix from PR preview base paths (`VITE_BASE_PATH`, `ASTRO_BASE_PATH`) — not needed with custom domain `volleykit.ch`
- Add `cname: volleykit.ch` to PR preview and cleanup deploy steps to preserve the CNAME file
- Update PR comment preview URLs to use `volleykit.ch` instead of `github.io`
- Fix 404.html SPA routing regex to match `/pr-N/` paths without repo prefix

## Test plan

- [ ] Open a PR with web changes and verify the preview deploys to `volleykit.ch/pr-N/`
- [ ] Verify production site at `volleykit.ch` still works after PR preview deploy
- [ ] Test deep link navigation (e.g. `volleykit.ch/pr-N/login`) via 404.html SPA redirect
- [ ] Verify cleanup workflow preserves CNAME when removing old PR previews

https://claude.ai/code/session_01JTxbEDqaCyK6dGJK6bgh6E