### PR TITLE
fix(ci): prevent artifact cleanup from blocking deployments

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -187,6 +187,7 @@ jobs:
           path: ocr-poc-dist
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v6
+        continue-on-error: true
         with:
           name: |
             web-app-dist

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -207,6 +207,7 @@ jobs:
           path: deploy/ocr-poc
       - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v6
+        continue-on-error: true
         with:
           name: |
             web-app-dist


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the `geekyeggo/delete-artifact@v6` step in both `deploy-web.yml` and `deploy-pr-preview.yml`
- Prevents transient GitHub API failures during artifact cleanup from blocking the actual GitHub Pages deployment
- Artifacts already auto-expire via `retention-days: 1`, so explicit deletion is best-effort cleanup

## Test plan

- [ ] Merge and verify the next deploy workflow run succeeds
- [ ] Confirm artifact cleanup still runs (just non-blocking on failure)

https://claude.ai/code/session_01CCwDhDYEypthdT6r46FJHr