### PR TITLE
fix(ci): fix vitest cache in deploy workflows

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -53,17 +53,17 @@ jobs:
             eslint-${{ runner.os }}-
       - name: Lint
         run: pnpm run lint --cache --cache-location .eslintcache
-      - name: Test
-        run: pnpm test
-      # Cache Vite/Vitest build artifacts per branch (Vitest stores cache in .vite/vitest)
-      - name: Cache Vite build
+      # Cache Vite/Vitest artifacts per branch (Vitest stores cache in .vite/vitest)
+      - name: Cache Vite
         uses: actions/cache@v5
         with:
           path: packages/web/node_modules/.vite
-          key: vite-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('packages/web/src/**/*.ts', 'packages/web/src/**/*.tsx', 'packages/web/vite.config.ts') }}
+          key: vite-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('pnpm-lock.yaml', 'packages/web/vite.config.ts', 'packages/web/tsconfig.json') }}
           restore-keys: |
             vite-${{ runner.os }}-${{ github.head_ref }}-
             vite-${{ runner.os }}-
+      - name: Test
+        run: pnpm test
       - name: Build for PR Preview
         run: pnpm run build
         env:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -53,18 +53,9 @@ jobs:
             eslint-${{ runner.os }}-
       - name: Lint
         run: pnpm run lint --cache --cache-location .eslintcache
-      # Cache Vitest results per branch
-      - name: Cache Vitest
-        uses: actions/cache@v5
-        with:
-          path: packages/web/node_modules/.vitest
-          key: vitest-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('packages/web/src/**/*.ts', 'packages/web/src/**/*.tsx', 'packages/web/src/**/*.test.ts', 'packages/web/src/**/*.test.tsx') }}
-          restore-keys: |
-            vitest-${{ runner.os }}-${{ github.head_ref }}-
-            vitest-${{ runner.os }}-
       - name: Test
         run: pnpm test
-      # Cache Vite build artifacts per branch
+      # Cache Vite/Vitest build artifacts per branch (Vitest stores cache in .vite/vitest)
       - name: Cache Vite build
         uses: actions/cache@v5
         with:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -72,18 +72,9 @@ jobs:
             eslint-${{ runner.os }}-
       - name: Lint
         run: pnpm run lint --cache --cache-location .eslintcache
-      # Cache Vitest results
-      - name: Cache Vitest
-        uses: actions/cache@v5
-        with:
-          path: packages/web/node_modules/.vitest
-          key: vitest-${{ runner.os }}-main-${{ hashFiles('packages/web/src/**/*.ts', 'packages/web/src/**/*.tsx', 'packages/web/src/**/*.test.ts', 'packages/web/src/**/*.test.tsx') }}
-          restore-keys: |
-            vitest-${{ runner.os }}-main-
-            vitest-${{ runner.os }}-
       - name: Test
         run: pnpm test
-      # Cache Vite build artifacts
+      # Cache Vite/Vitest artifacts (Vitest stores cache in .vite/vitest)
       - name: Cache Vite build
         uses: actions/cache@v5
         with:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -72,17 +72,17 @@ jobs:
             eslint-${{ runner.os }}-
       - name: Lint
         run: pnpm run lint --cache --cache-location .eslintcache
-      - name: Test
-        run: pnpm test
       # Cache Vite/Vitest artifacts (Vitest stores cache in .vite/vitest)
-      - name: Cache Vite build
+      - name: Cache Vite
         uses: actions/cache@v5
         with:
           path: packages/web/node_modules/.vite
-          key: vite-${{ runner.os }}-main-${{ hashFiles('packages/web/src/**/*.ts', 'packages/web/src/**/*.tsx', 'packages/web/vite.config.ts') }}
+          key: vite-${{ runner.os }}-main-${{ hashFiles('pnpm-lock.yaml', 'packages/web/vite.config.ts', 'packages/web/tsconfig.json') }}
           restore-keys: |
             vite-${{ runner.os }}-main-
             vite-${{ runner.os }}-
+      - name: Test
+        run: pnpm test
       - name: Build
         run: pnpm run build
         env:


### PR DESCRIPTION
## Summary

- Removed broken "Cache Vitest" steps from `deploy-web.yml` and `deploy-pr-preview.yml` that pointed to non-existent `node_modules/.vitest` path (Vitest 4.x stores cache in `.vite/vitest`)
- Moved the Vite/Vitest cache restore step **before** the test step so tests benefit from the cached transforms (previously it was only before build)
- Aligned cache key strategy with `ci.yml` (tooling config based instead of source files)

## Test plan

- [ ] Verify `deploy-web` workflow no longer shows "Path Validation Error" warning
- [ ] Verify `deploy-pr-preview` workflow no longer shows the warning
- [ ] Confirm Vite/Vitest cache is restored before tests run
- [ ] Confirm cache key matches `ci.yml` strategy (pnpm-lock.yaml, vite.config.ts, tsconfig.json)