### PR TITLE
fix(web): pass isLoading to Modal in ExchangeConfirmationModal to prevent flaky dismissal

### DIFF
--- a/packages/web/src/features/exchanges/components/ExchangeConfirmationModal.tsx
+++ b/packages/web/src/features/exchanges/components/ExchangeConfirmationModal.tsx
@@ -53,7 +53,7 @@ function ExchangeConfirmationModalComponent({
   const modalTitleId = `${variant}-exchange-title`
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} titleId={modalTitleId} size="md">
+    <Modal isOpen={isOpen} onClose={onClose} titleId={modalTitleId} size="md" isLoading={isPending}>
       <ModalErrorBoundary modalName="ExchangeConfirmationModal" onClose={onClose}>
         <ModalHeader title={t(titleKey)} titleId={modalTitleId} />
 


### PR DESCRIPTION
## Summary

- Pass `isLoading={isPending}` to `<Modal>` in `ExchangeConfirmationModal` to prevent Escape key and backdrop click dismissal during async form actions
- Fixes flaky "does not close modal on error" test that failed in CI due to timing-dependent dismissal events triggering `onClose` via `useModalDismissal`

## Test plan

- [x] All 17 ExchangeConfirmationModal tests pass locally
- [ ] Verify "does not close modal on error" test no longer flakes in CI
- [ ] Modal cannot be dismissed via Escape or backdrop click while form action is pending

https://claude.ai/code/session_019sum5XXQ6b6C8LUMwcZy38