### PR TITLE
feat(web): enable React Compiler and fix modal aria-hidden bug

### DIFF
--- a/docs/CODE_PATTERNS.md
+++ b/docs/CODE_PATTERNS.md
@@ -341,6 +341,64 @@ The project runs React 19 with the **React Compiler** enabled (via `@vitejs/plug
 
 These React 19 hooks are available for adoption alongside existing patterns.
 
+**`use()` — read resources during render**
+
+The `use()` hook reads a Promise or Context during render. Unlike `useEffect`-based patterns, it integrates naturally with `<Suspense>` and error boundaries.
+
+```typescript
+import { use, Suspense } from 'react'
+
+// Wrap async data in a Promise and pass it down
+function AssignmentDetailPage({ detailPromise }: { detailPromise: Promise<Assignment> }) {
+  // Suspends until the promise resolves; the nearest <Suspense> shows the fallback
+  const assignment = use(detailPromise)
+  return <AssignmentCard assignment={assignment} />
+}
+
+// Parent provides the Suspense boundary
+<Suspense fallback={<LoadingSpinner />}>
+  <AssignmentDetailPage detailPromise={fetchAssignmentDetail(id)} />
+</Suspense>
+```
+
+> Prefer `useSuspenseQuery` from TanStack Query for data fetching — it covers this use case with caching, retries, and invalidation. Reserve `use()` for cases where a Promise is passed explicitly as a prop or from context.
+
+**`useTransition` — non-urgent state updates**
+
+Use `useTransition` to mark state updates as non-urgent. React will keep the current UI responsive while the transition is pending.
+
+```typescript
+import { useTransition } from 'react'
+
+function TabBar({ onTabChange }: Props) {
+  const [isPending, startTransition] = useTransition()
+
+  const handleTabChange = (tab: string) => {
+    startTransition(() => {
+      // This state update (e.g., filtering a long list) won't block the UI
+      setActiveTab(tab)
+    })
+  }
+
+  return (
+    <div>
+      {tabs.map((tab) => (
+        <button
+          key={tab}
+          onClick={() => handleTabChange(tab)}
+          // Show a subtle loading indicator while the transition is in progress
+          className={isPending ? 'opacity-60' : ''}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  )
+}
+```
+
+> Good candidates for `useTransition`: tab switches that re-filter large lists, search input that triggers expensive rendering, any state update where the current UI should remain interactive during the update.
+
 **`useOptimistic` — instant UI feedback**
 
 ```typescript
@@ -432,6 +490,13 @@ function ConfirmationModal({ onConfirm, onClose }: Props) {
   <div className="modal">...</div>
 </div>
 
+// Bad: aria-hidden on the OUTER wrapper — hides the dialog from screen readers too!
+<div aria-hidden="true" onClick={onClose} className="fixed inset-0 ...">
+  <div role="dialog" aria-modal="true">  {/* unreachable by AT */}
+    {children}
+  </div>
+</div>
+
 // Good: Proper dialog with non-interactive backdrop
 function Modal({ isOpen, onClose, title, children }: ModalProps) {
   // Handle Escape key
@@ -450,14 +515,14 @@ function Modal({ isOpen, onClose, title, children }: ModalProps) {
 
   return (
     <>
-      {/* Backdrop: clickable but not focusable */}
+      {/* Backdrop: purely decorative overlay — aria-hidden hides ONLY this element */}
       <div
-        className="backdrop"
+        className="fixed inset-0 bg-black bg-opacity-50"
         onClick={onClose}
         aria-hidden="true"
       />
 
-      {/* Dialog: proper ARIA attributes */}
+      {/* Dialog: proper ARIA attributes — NOT a child of the aria-hidden backdrop */}
       <dialog
         open
         role="dialog"
@@ -471,6 +536,8 @@ function Modal({ isOpen, onClose, title, children }: ModalProps) {
   );
 }
 ```
+
+> **Critical**: `aria-hidden="true"` propagates to all descendants. Never place it on a wrapper element that contains the dialog — it will make the entire modal invisible to screen readers. Keep the backdrop and dialog as siblings, or use only `aria-modal="true"` on the dialog (which instructs AT to ignore background content).
 
 ### Icon Buttons
 

--- a/docs/CODE_PATTERNS.md
+++ b/docs/CODE_PATTERNS.md
@@ -331,17 +331,11 @@ const { data, error, isLoading } = useQuery({
 
 ## React 19 Patterns
 
-The project runs React 19 with `@vitejs/plugin-react` v6. The **React Compiler** (`babel-plugin-react-compiler`) is **not yet enabled** — it was not installed when the project was initially set up. Manual memoization therefore still applies:
+The project runs React 19 with `@vitejs/plugin-react` v6. The **React Compiler** (`babel-plugin-react-compiler`) is **enabled** via the Vite Babel plugin in `vite.config.ts`. The compiler automatically memoizes components and hooks at build time, so manual memoization is generally not needed:
 
-- Use `React.memo` for components that re-render often with the same props
-- Use `useMemo` for expensive derived computations
-- Use `useCallback` for stable function references passed to child components or `useEffect`
-
-> **Future improvement**: Enable the React Compiler by adding `babel-plugin-react-compiler` and configuring it in `vite.config.ts`:
-> ```ts
-> react({ babel: { plugins: [['babel-plugin-react-compiler', {}]] } })
-> ```
-> Once enabled, the compiler automatically memoizes components and hooks, and most manual `React.memo`/`useMemo`/`useCallback` calls can be removed.
+- Avoid adding `React.memo`, `useMemo`, or `useCallback` unless you have a measured performance reason
+- If the compiler cannot safely memoize a specific component/hook (e.g. due to rules-of-hooks violations), opt it out with `'use no memo'` at the top of the function and document the reason
+- To verify compiler output, inspect the build with `stats.html` or check for `_c(` / `_memo(` calls in the compiled output
 
 These React 19 hooks are available for adoption alongside existing patterns.
 

--- a/docs/CODE_PATTERNS.md
+++ b/docs/CODE_PATTERNS.md
@@ -331,13 +331,17 @@ const { data, error, isLoading } = useQuery({
 
 ## React 19 Patterns
 
-The project runs React 19 with the **React Compiler** enabled (via `@vitejs/plugin-react` v6). The compiler automatically memoizes components and hooks, so `React.memo`, `useMemo`, and `useCallback` are less critical for preventing re-renders. However, explicit `useMemo`/`useCallback` remain valid for:
+The project runs React 19 with `@vitejs/plugin-react` v6. The **React Compiler** (`babel-plugin-react-compiler`) is **not yet enabled** — it was not installed when the project was initially set up. Manual memoization therefore still applies:
 
-- Expensive computations that should be clearly marked as intentionally cached
-- Stable references for TanStack Query keys and API call parameters
-- Dependencies passed to `useEffect` that should not trigger re-runs
+- Use `React.memo` for components that re-render often with the same props
+- Use `useMemo` for expensive derived computations
+- Use `useCallback` for stable function references passed to child components or `useEffect`
 
-> **Note**: `React.memo` is not used in this codebase — the React Compiler handles component-level memoization automatically. Do not add `React.memo` wrappers.
+> **Future improvement**: Enable the React Compiler by adding `babel-plugin-react-compiler` and configuring it in `vite.config.ts`:
+> ```ts
+> react({ babel: { plugins: [['babel-plugin-react-compiler', {}]] } })
+> ```
+> Once enabled, the compiler automatically memoizes components and hooks, and most manual `React.memo`/`useMemo`/`useCallback` calls can be removed.
 
 These React 19 hooks are available for adoption alongside existing patterns.
 
@@ -398,6 +402,23 @@ function TabBar({ onTabChange }: Props) {
 ```
 
 > Good candidates for `useTransition`: tab switches that re-filter large lists, search input that triggers expensive rendering, any state update where the current UI should remain interactive during the update.
+
+**`useDeferredValue` — delay expensive derived rendering**
+
+Where `useTransition` wraps a state update, `useDeferredValue` wraps a value. React renders the stale value first (keeping the UI responsive), then re-renders with the deferred value in the background.
+
+```typescript
+import { useDeferredValue } from 'react'
+
+function AssignmentSearch({ query }: { query: string }) {
+  // Renders instantly with the previous query while the new one is still "pending"
+  const deferredQuery = useDeferredValue(query)
+  const filtered = useMemo(() => filterAssignments(all, deferredQuery), [all, deferredQuery])
+  return <AssignmentList items={filtered} />
+}
+```
+
+> Use `useDeferredValue` when you receive a value from a parent you don't control. Use `useTransition` when you own the state update.
 
 **`useOptimistic` — instant UI feedback**
 

--- a/docs/DATA_RETENTION.md
+++ b/docs/DATA_RETENTION.md
@@ -16,11 +16,13 @@ This data never leaves your device and is not transmitted to our servers.
 | Language preference                 | Display app in your preferred language   | Until cleared by user |
 | Safe mode setting                   | Prevent accidental actions               | Until cleared by user |
 
-### Travel Time Cache (TanStack Query cache in memory/localStorage)
+### Travel Time Cache (TanStack Query cache in memory/IndexedDB)
 
 | Data                         | Purpose                  | Retention             |
 | ---------------------------- | ------------------------ | --------------------- |
 | Travel times to sports halls | Avoid repeated API calls | 14 days, auto-expires |
+
+**Note**: TanStack Query stores data in memory by default. When the offline feature is enabled (`features.offline`), the cache is also persisted to IndexedDB via `PersistQueryClientProvider`. It is never written to localStorage.
 
 ### Authentication (`volleykit-auth` in localStorage)
 

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -17,15 +17,18 @@ Single source of truth for Claude Code Review. This file is automatically loaded
 | Magic numbers          | `setTimeout(fn, 300)`   | Use named constant `ANIMATION_DURATION_MS` |
 | Array index as key     | `key={index}`           | Use unique identifier `key={item.id}`      |
 | Uncleared intervals    | No cleanup in useEffect | Return cleanup function                    |
-| `isMountedRef` pattern | Outdated (React 16/17)  | Use `AbortController`                      |
-| Functions > 30 lines   | Hard to test/maintain   | Extract to custom hooks                    |
-| > 4 parameters         | Code smell              | Use options object                         |
+| `isMountedRef` pattern          | Outdated (React 16/17)              | Use `AbortController`                      |
+| Functions > 30 lines            | Hard to test/maintain               | Extract to custom hooks                    |
+| > 4 parameters                  | Code smell                          | Use options object                         |
+| Async fn directly in component  | Violates hook extraction guideline  | Extract to a custom hook                   |
 
 ### Accessibility (Required)
 
 - Icon buttons need `aria-label`
 - Modals need `aria-modal`, `aria-labelledby`, keyboard dismiss
 - Dynamic content needs `aria-live` regions
+- `aria-hidden="true"` must **not** be placed on a wrapper that contains the dialog — it hides all descendants from AT. Keep the backdrop and dialog as siblings (see [CODE_PATTERNS.md](CODE_PATTERNS.md#modal-dialogs))
+- Submit buttons in `<form>` elements should use `type="submit"` so that pressing Enter in any field submits the form
 
 ### i18n (4 languages: de/en/fr/it)
 

--- a/packages/web/eslint.config.js
+++ b/packages/web/eslint.config.js
@@ -3,6 +3,7 @@ import { fixupPluginRules } from '@eslint/compat'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import reactCompiler from 'eslint-plugin-react-compiler'
 import jsxA11y from 'eslint-plugin-jsx-a11y'
 import security from 'eslint-plugin-security'
 import noUnsanitized from 'eslint-plugin-no-unsanitized'
@@ -46,6 +47,7 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      'react-compiler': reactCompiler,
       'jsx-a11y': jsxA11y,
       security: fixupPluginRules(security),
       'no-unsanitized': fixupPluginRules(noUnsanitized),
@@ -61,6 +63,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       ...jsxA11y.configs.recommended.rules,
+      'react-compiler/react-compiler': 'warn',
       // Import ordering - consistent import structure across codebase
       'import-x/order': [
         'warn',

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,7 +32,7 @@
     {
       "name": "Main App Bundle",
       "path": "dist/assets/index-*.js",
-      "limit": "25.1 kB",
+      "limit": "30 kB",
       "gzip": true
     },
     {
@@ -67,7 +67,7 @@
     {
       "name": "Total JS Bundle",
       "path": "dist/assets/*.js",
-      "limit": "610 kB",
+      "limit": "680 kB",
       "gzip": true
     }
   ],
@@ -96,6 +96,7 @@
     "@eslint/compat": "^2.0.3",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.58.2",
+    "@rolldown/plugin-babel": "^0.2.2",
     "@size-limit/file": "^12.0.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -106,11 +107,13 @@
     "@vite-pwa/assets-generator": "^1.0.2",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.1",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.1.0",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-no-unsanitized": "^4.1.5",
+    "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "eslint-plugin-security": "^4.0.0",

--- a/packages/web/src/RouteGuards.tsx
+++ b/packages/web/src/RouteGuards.tsx
@@ -5,7 +5,7 @@
  * - PublicRoute: Redirects authenticated users to home
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Navigate } from 'react-router-dom'
 import { useShallow } from 'zustand/react/shallow'
@@ -49,14 +49,19 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const [isVerifying, setIsVerifying] = useState(() => shouldVerifySession)
   const [verifyError, setVerifyError] = useState<string | null>(null)
 
+  // Ref for stable access to activeAssociationCode inside the demo init effect.
+  // The effect only runs when data is empty, not on association changes
+  // (association changes are handled by AppShell when user switches occupation).
+  const activeAssociationCodeRef = useRef(activeAssociationCode)
+  useEffect(() => {
+    activeAssociationCodeRef.current = activeAssociationCode
+  })
+
   // Regenerate demo data on page load if demo mode is enabled but data is empty
-  // This only runs once when data needs initialization, not on association changes
-  // (association changes are handled by AppShell when user switches occupation)
   useEffect(() => {
     if (isDemoMode && assignments.length === 0) {
-      initializeDemoData(activeAssociationCode ?? 'SV')
+      initializeDemoData(activeAssociationCodeRef.current ?? 'SV')
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run when data is empty, not on association changes
   }, [isDemoMode, assignments.length, initializeDemoData])
 
   // Verify persisted session is still valid on mount

--- a/packages/web/src/common/components/Modal.tsx
+++ b/packages/web/src/common/components/Modal.tsx
@@ -134,23 +134,26 @@ export function Modal({
 
   if (!isOpen) return null
 
-  // Backdrop pattern: aria-hidden="true" hides the backdrop from screen readers since it's
-  // purely decorative. Click-to-close is a convenience feature; keyboard users close via Escape.
+  // Backdrop and dialog are siblings: aria-hidden="true" hides ONLY the backdrop from AT.
+  // Placing aria-hidden on the outer wrapper would hide the dialog too.
+  // Click-to-close is a convenience feature; keyboard users close via Escape.
   return (
-    <div
-      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4"
-      style={{ zIndex }}
-      onClick={handleBackdropClick}
-      aria-hidden="true"
-    >
-      {/* Dialog container */}
+    <div className="fixed inset-0 flex items-center justify-center p-4" style={{ zIndex }}>
+      {/* Backdrop: purely decorative overlay */}
+      <div
+        className="absolute inset-0 bg-black bg-opacity-50"
+        onClick={handleBackdropClick}
+        aria-hidden="true"
+      />
+
+      {/* Dialog container: must NOT be inside the aria-hidden backdrop */}
       <div
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
         tabIndex={-1}
-        className={`bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-xl w-full ${sizeClasses[size]} p-6 focus:outline-none`}
+        className={`relative bg-surface-card dark:bg-surface-card-dark rounded-lg shadow-xl w-full ${sizeClasses[size]} p-6 focus:outline-none`}
       >
         {children}
       </div>

--- a/packages/web/src/common/components/PdfLanguageModal.test.tsx
+++ b/packages/web/src/common/components/PdfLanguageModal.test.tsx
@@ -63,7 +63,7 @@ describe('PdfLanguageModal', () => {
     const onClose = vi.fn()
     render(<PdfLanguageModal {...defaultProps} onClose={onClose} />)
 
-    const backdrop = screen.getByRole('dialog', { hidden: true }).parentElement
+    const backdrop = screen.getByRole('dialog', { hidden: true }).previousElementSibling
     fireEvent.click(backdrop!)
 
     expect(onClose).toHaveBeenCalled()
@@ -89,7 +89,7 @@ describe('PdfLanguageModal', () => {
     const onClose = vi.fn()
     render(<PdfLanguageModal {...defaultProps} onClose={onClose} isLoading />)
 
-    const backdrop = screen.getByRole('dialog', { hidden: true }).parentElement
+    const backdrop = screen.getByRole('dialog', { hidden: true }).previousElementSibling
     fireEvent.click(backdrop!)
 
     expect(onClose).not.toHaveBeenCalled()

--- a/packages/web/src/common/components/tour/TourSpotlight.tsx
+++ b/packages/web/src/common/components/tour/TourSpotlight.tsx
@@ -136,6 +136,14 @@ export function TourSpotlight({
     [targetSelector, placement, freezePosition, isPositioned]
   )
 
+  // Ref for stable access to updatePositions inside the scroll effect.
+  // The scroll effect must only fire when targetSelector changes, not on every
+  // updatePositions identity change (which changes whenever isPositioned changes).
+  const updatePositionsRef = useRef(updatePositions)
+  useEffect(() => {
+    updatePositionsRef.current = updatePositions
+  })
+
   // Elevate target element and its SwipeableCard container above overlay
   // using useLayoutEffect to apply styles before paint
   useLayoutEffect(() => {
@@ -186,19 +194,18 @@ export function TourSpotlight({
     setTooltipPosition(position)
   }, [targetRect, placement])
 
-  // Scroll target into view - this is a separate effect that only depends on targetSelector
-  // to avoid re-scrolling when other dependencies change
+  // Scroll target into view — only when targetSelector changes, not on every
+  // updatePositions identity change.
   useEffect(() => {
     const target = document.querySelector(targetSelector)
     if (!target) return
 
     // First calculate initial position so spotlight appears immediately
-    updatePositions(true)
+    updatePositionsRef.current(true)
 
     // Then scroll element into view with smooth animation
     // The scroll event listener will update positions during the animation
     target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only scroll when target changes, not when updatePositions changes
   }, [targetSelector])
 
   // Subscribe to scroll/resize events for position updates during the tour

--- a/packages/web/src/common/hooks/useTour.ts
+++ b/packages/web/src/common/hooks/useTour.ts
@@ -32,6 +32,11 @@ interface UseTourReturn {
 }
 
 export function useTour(tourId: TourId, options: UseTourOptions = {}): UseTourReturn {
+  // The Compiler cannot statically verify the cross-effect ref communication pattern:
+  // Effect 1 resets hasAutoStarted.current and Effect 2 reads it — React guarantees
+  // execution order but the Compiler treats ref reads as potentially stale.
+  'use no memo'
+
   const { startDelay = TOUR_START_DELAY_MS, autoStart = true } = options
 
   const {

--- a/packages/web/src/common/hooks/useTour.ts
+++ b/packages/web/src/common/hooks/useTour.ts
@@ -32,9 +32,11 @@ interface UseTourReturn {
 }
 
 export function useTour(tourId: TourId, options: UseTourOptions = {}): UseTourReturn {
-  // The Compiler cannot statically verify the cross-effect ref communication pattern:
-  // Effect 1 resets hasAutoStarted.current and Effect 2 reads it — React guarantees
-  // execution order but the Compiler treats ref reads as potentially stale.
+  // The Compiler changes cross-effect ref communication behaviour: Effect 1 resets
+  // hasAutoStarted.current and Effect 2 reads it. The ESLint plugin reports this
+  // directive as "unused" but the test suite proves the Compiler does alter
+  // runtime behaviour here, so we keep the opt-out.
+  // eslint-disable-next-line react-compiler/react-compiler
   'use no memo'
 
   const { startDelay = TOUR_START_DELAY_MS, autoStart = true } = options

--- a/packages/web/src/features/compensations/components/EditCompensationModal.test.tsx
+++ b/packages/web/src/features/compensations/components/EditCompensationModal.test.tsx
@@ -555,7 +555,7 @@ describe('EditCompensationModal', () => {
 
       await waitForFormToLoad()
 
-      const backdrop = container.firstChild as HTMLElement
+      const backdrop = (container.firstChild as HTMLElement).firstChild as HTMLElement
       fireEvent.click(backdrop)
       expect(mockOnClose).toHaveBeenCalledTimes(1)
     })

--- a/packages/web/src/features/exchanges/components/ExchangeConfirmationModal.test.tsx
+++ b/packages/web/src/features/exchanges/components/ExchangeConfirmationModal.test.tsx
@@ -171,7 +171,7 @@ describe('ExchangeConfirmationModal', () => {
           variant="takeOver"
         />
       )
-      const backdrop = container.firstChild as HTMLElement
+      const backdrop = (container.firstChild as HTMLElement).firstChild as HTMLElement
       fireEvent.click(backdrop)
       expect(mockOnClose).toHaveBeenCalledTimes(1)
     })

--- a/packages/web/src/features/exchanges/hooks/useExchanges.ts
+++ b/packages/web/src/features/exchanges/hooks/useExchanges.ts
@@ -58,13 +58,12 @@ export function useGameExchanges(status: ExchangeStatus = 'all') {
   const seasonEndKey = formatDateKey(getSeasonDateRange().to)
 
   // Memoize date range to ensure stable query key across tab switches.
-  // Only recalculates when the day changes (for overnight refresh).
+  // Computed from string date keys so deps are stable (no new Date() in deps array).
   const dateRange = useMemo(
     () => ({
-      from: startOfDay(new Date()).toISOString(),
-      to: endOfDay(getSeasonDateRange().to).toISOString(),
+      from: startOfDay(new Date(todayKey)).toISOString(),
+      to: endOfDay(new Date(seasonEndKey)).toISOString(),
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Use date keys for stability, not Date objects
     [todayKey, seasonEndKey]
   )
 

--- a/packages/web/src/features/referee-backup/hooks/useRefereeBackups.ts
+++ b/packages/web/src/features/referee-backup/hooks/useRefereeBackups.ts
@@ -42,13 +42,13 @@ export function useRefereeBackups(weeksAhead: number = DEFAULT_WEEKS_AHEAD) {
   const endDateKey = formatDateKey(addWeeks(new Date(), weeksAhead))
 
   // Memoize date range to ensure stable query key across tab switches.
+  // Computed from string date keys so deps are stable (no new Date() in deps array).
   const dateRange = useMemo(
     () => ({
-      from: startOfDay(new Date()).toISOString(),
-      to: endOfDay(addWeeks(new Date(), weeksAhead)).toISOString(),
+      from: startOfDay(new Date(todayKey)).toISOString(),
+      to: endOfDay(new Date(endDateKey)).toISOString(),
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Use date keys for stability, not Date objects
-    [todayKey, endDateKey, weeksAhead]
+    [todayKey, endDateKey]
   )
 
   // Build property filters for date range

--- a/packages/web/src/features/settings/hooks/useHomeLocationSettings.ts
+++ b/packages/web/src/features/settings/hooks/useHomeLocationSettings.ts
@@ -53,12 +53,11 @@ export function useHomeLocationSettings({ t }: UseHomeLocationSettingsOptions) {
   // Refs for stable callback references in geolocation handler
   const setAddressQueryRef = useRef(setAddressQuery)
   const geocodeClearRef = useRef(geocodeClear)
-  // Sync refs on every render to avoid stale closures in callbacks
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Keep refs in sync with the latest callbacks so geolocation handlers never close over stale values
   useEffect(() => {
     setAddressQueryRef.current = setAddressQuery
     geocodeClearRef.current = geocodeClear
-  })
+  }, [geocodeClear])
 
   // Handle geolocation success via callback
   const handleGeolocationSuccess = useCallback(

--- a/packages/web/src/features/settings/hooks/useTransportSettings.ts
+++ b/packages/web/src/features/settings/hooks/useTransportSettings.ts
@@ -70,7 +70,8 @@ export function useTransportSettings() {
   )
 
   const [showClearConfirm, setShowClearConfirm] = useState(false)
-  const [cacheVersion, setCacheVersion] = useState(0)
+  // Incremented by handleClearCache to trigger a re-render so cacheEntryCount is recomputed.
+  const [, setCacheVersion] = useState(0)
 
   // Get current transport enabled state for this association
   const isTransportEnabled = useMemo(() => {
@@ -108,29 +109,25 @@ export function useTransportSettings() {
     return getDefaultArrivalBuffer(associationCode)
   }, [associationCode, arrivalBufferByAssociation])
 
-  // Local state for immediate input feedback
+  // Local state for immediate input feedback (debounced before persisting to store)
   const [localArrivalBuffer, setLocalArrivalBuffer] = useState(storeArrivalBuffer)
   const [localMaxDistance, setLocalMaxDistance] = useState(currentDistanceFilter.maxDistanceKm)
   const [localMaxTravelTime, setLocalMaxTravelTime] = useState(currentMaxTravelTime)
 
+  // When the association changes, reset local inputs to the new association's store values.
+  // Adjusting state during render (not in an effect) avoids an extra render cycle.
+  // See: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevAssociation, setPrevAssociation] = useState(associationCode)
+  if (prevAssociation !== associationCode) {
+    setPrevAssociation(associationCode)
+    setLocalArrivalBuffer(storeArrivalBuffer)
+    setLocalMaxDistance(currentDistanceFilter.maxDistanceKm)
+    setLocalMaxTravelTime(currentMaxTravelTime)
+  }
+
   const arrivalDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const distanceDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const travelTimeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // Sync local state when store value changes externally
-  useEffect(() => {
-    setLocalArrivalBuffer((prev) => (prev !== storeArrivalBuffer ? storeArrivalBuffer : prev))
-  }, [storeArrivalBuffer])
-
-  useEffect(() => {
-    setLocalMaxDistance((prev) =>
-      prev !== currentDistanceFilter.maxDistanceKm ? currentDistanceFilter.maxDistanceKm : prev
-    )
-  }, [currentDistanceFilter.maxDistanceKm])
-
-  useEffect(() => {
-    setLocalMaxTravelTime((prev) => (prev !== currentMaxTravelTime ? currentMaxTravelTime : prev))
-  }, [currentMaxTravelTime])
 
   // Cleanup debounce timeouts on unmount
   useEffect(() => {
@@ -141,12 +138,9 @@ export function useTransportSettings() {
     }
   }, [])
 
-  // Calculate cache entry count
-  const cacheEntryCount = useMemo(
-    () => (isTransportEnabled ? getTravelTimeCacheStats().entryCount : 0),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isTransportEnabled, cacheVersion]
-  )
+  // Computed inline — recomputed on every render, including when setCacheVersion triggers a
+  // re-render after the cache is cleared (see handleClearCache).
+  const cacheEntryCount = isTransportEnabled ? getTravelTimeCacheStats().entryCount : 0
 
   const handleToggleTransport = useCallback(() => {
     if (!associationCode) return

--- a/packages/web/src/features/validation/components/ValidateGameModal.test.tsx
+++ b/packages/web/src/features/validation/components/ValidateGameModal.test.tsx
@@ -412,10 +412,10 @@ describe('ValidateGameModal', () => {
         { wrapper: createWrapper() }
       )
 
-      // Click on backdrop (parent of dialog)
+      // Click on backdrop (sibling before the dialog in the new Modal structure)
       const backdrop = screen.getByRole('dialog', {
         hidden: true,
-      }).parentElement
+      }).previousElementSibling
       fireEvent.click(backdrop!)
 
       await waitFor(() => {

--- a/packages/web/src/features/validation/ocr/components/OCREntryModal.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCREntryModal.tsx
@@ -113,6 +113,12 @@ export function OCREntryModal({
 
   // Image URL for displaying the captured scoresheet
   const [capturedImageUrl, setCapturedImageUrl] = useState<string | null>(null)
+  // Ref for stable access in reset effect — reading capturedImageUrl in the isOpen
+  // effect would cause it to re-run when the URL changes during the reset itself.
+  const capturedImageUrlRef = useRef(capturedImageUrl)
+  useEffect(() => {
+    capturedImageUrlRef.current = capturedImageUrl
+  })
 
   // Store the captured image blob to pass to validation state
   const capturedBlobRef = useRef<Blob | null>(null)
@@ -148,15 +154,15 @@ export function OCREntryModal({
       setAwayComparison(null)
       setRawOcrData(null)
       setStoredOcrResult(null)
-      // Revoke previous image URL to prevent memory leaks
-      if (capturedImageUrl) {
-        URL.revokeObjectURL(capturedImageUrl)
+      // Revoke previous image URL to prevent memory leaks.
+      // Read from ref to avoid adding capturedImageUrl as a dep (it changes during the reset).
+      if (capturedImageUrlRef.current) {
+        URL.revokeObjectURL(capturedImageUrlRef.current)
       }
       setCapturedImageUrl(null)
       setExpandedSections(new Set(['home-players', 'away-players']))
       reset()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- capturedImageUrl changes during reset
   }, [isOpen, reset])
 
   // Clean up image URL on unmount

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -4,9 +4,9 @@ import { execSync } from 'child_process'
 import { readFileSync, writeFileSync, existsSync } from 'fs'
 import path from 'path'
 
+import babel from '@rolldown/plugin-babel'
 import tailwindcss from '@tailwindcss/vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
-import babel from '@rolldown/plugin-babel'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { defineConfig, type Plugin } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
@@ -389,9 +389,8 @@ export default defineConfig(({ mode }) => {
       // generated/vendor code. runtimeVersion de-duplicates Babel helper imports via
       // @babel/plugin-transform-runtime instead of inlining them per-file.
       babel({
-        include: /src\/.*\.(t|j)sx?$/,
+        include: /src\/.*\.[tj]sx?$/,
         exclude: /node_modules/,
-        runtimeVersion: require('@babel/runtime/package.json').version,
         presets: [reactCompilerPreset()],
       }),
       tailwindcss(),

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -5,7 +5,8 @@ import { readFileSync, writeFileSync, existsSync } from 'fs'
 import path from 'path'
 
 import tailwindcss from '@tailwindcss/vite'
-import react from '@vitejs/plugin-react'
+import react, { reactCompilerPreset } from '@vitejs/plugin-react'
+import babel from '@rolldown/plugin-babel'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { defineConfig, type Plugin } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
@@ -384,6 +385,15 @@ export default defineConfig(({ mode }) => {
     plugins: [
       zodLocalesStubPlugin(),
       react(),
+      // React Compiler: limit to source .tsx/.ts files to avoid Babel overhead on
+      // generated/vendor code. runtimeVersion de-duplicates Babel helper imports via
+      // @babel/plugin-transform-runtime instead of inlining them per-file.
+      babel({
+        include: /src\/.*\.(t|j)sx?$/,
+        exclude: /node_modules/,
+        runtimeVersion: require('@babel/runtime/package.json').version,
+        presets: [reactCompilerPreset()],
+      }),
       tailwindcss(),
       // Disable PWA for PR previews to avoid service worker scope conflicts
       // The main site's SW scope (/volleykit/) would intercept PR preview requests

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 6.0.1(@rolldown/plugin-babel@0.2.2(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.11)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       eslint:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -416,6 +416,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.2
+        version: 0.2.2(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.11)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@size-limit/file':
         specifier: ^12.0.1
         version: 12.0.1(size-limit@12.0.1(jiti@2.6.1))
@@ -442,10 +445,13 @@ importers:
         version: 1.0.2
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 6.0.1(@rolldown/plugin-babel@0.2.2(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.11)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.1
         version: 4.1.1(vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.4)(jsdom@27.4.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       eslint:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -461,6 +467,9 @@ importers:
       eslint-plugin-no-unsanitized:
         specifier: ^4.1.5
         version: 4.1.5(eslint@10.1.0(jiti@2.6.1))
+      eslint-plugin-react-compiler:
+        specifier: 19.1.0-rc.2
+        version: 19.1.0-rc.2(eslint@10.1.0(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@10.1.0(jiti@2.6.1))
@@ -493,7 +502,7 @@ importers:
         version: 3.8.1
       rollup-plugin-visualizer:
         specifier: ^7.0.1
-        version: 7.0.1(rolldown@1.0.0-rc.11)(rollup@4.59.0)
+        version: 7.0.1(rolldown@1.0.0-rc.11)(rollup@2.80.0)
       size-limit:
         specifier: ^12.0.1
         version: 12.0.1(jiti@2.6.1)
@@ -735,6 +744,13 @@ packages:
   '@babel/plugin-proposal-export-default-from@7.27.1':
     resolution: {integrity: sha512-hjlsMBl1aJc5lp8MoCDEZCiYzlgdRAShOjAfRw6X+GlpLpUPU7c3XNLsKFZbQk/1cRzBlJ7CXg3xJAJMrFa1Uw==}
     engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -3098,6 +3114,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/plugin-babel@0.2.2':
+    resolution: {integrity: sha512-q9pE8+47bQNHb5eWVcE6oXppA+JTSwvnrhH53m0ZuHuK5MLvwsLoWrWzBTFQqQ06BVxz1gp0HblLsch8o6pvZw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.11':
     resolution: {integrity: sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==}
 
@@ -4873,6 +4906,12 @@ packages:
     resolution: {integrity: sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==}
     peerDependencies:
       eslint: ^9 || ^10
+
+  eslint-plugin-react-compiler@19.1.0-rc.2:
+    resolution: {integrity: sha512-oKalwDGcD+RX9mf3NEO4zOoUMeLvjSvcbbEOpquzmzqEEM2MQdp7/FY/Hx9NzmUwFzH1W9SKTz5fihfMldpEYw==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
 
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
@@ -7083,10 +7122,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
@@ -8981,6 +9016,12 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
+  zod-validation-error@3.5.4:
+    resolution: {integrity: sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
@@ -9124,7 +9165,7 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -9304,6 +9345,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
     dependencies:
@@ -9983,7 +10032,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -9991,7 +10040,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@10.2.2)
@@ -11863,6 +11912,16 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
     optional: true
 
+  '@rolldown/plugin-babel@0.2.2(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.11)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      picomatch: 4.0.3
+      rolldown: 1.0.0-rc.11
+    optionalDependencies:
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
+      '@babel/runtime': 7.29.2
+      vite: 8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+
   '@rolldown/pluginutils@1.0.0-rc.11': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
@@ -12557,11 +12616,12 @@ snapshots:
       sharp-ico: 0.1.5
       unconfig: 7.5.0
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.2(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.11)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
     optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.2(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.11)(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@types/node@25.5.0)(happy-dom@20.8.4)(jsdom@27.4.0)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
@@ -12691,7 +12751,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   arg@5.0.2: {}
 
@@ -13858,6 +13918,18 @@ snapshots:
   eslint-plugin-no-unsanitized@4.1.5(eslint@10.1.0(jiti@2.6.1)):
     dependencies:
       eslint: 10.1.0(jiti@2.6.1)
+
+  eslint-plugin-react-compiler@19.1.0-rc.2(eslint@10.1.0(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.0)
+      eslint: 10.1.0(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 3.5.4(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react-hooks@7.0.1(eslint@10.1.0(jiti@2.6.1)):
     dependencies:
@@ -15328,7 +15400,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   jest-validate@29.7.0:
     dependencies:
@@ -16371,7 +16443,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -16872,8 +16944,6 @@ snapshots:
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
-
-  picomatch@2.3.1: {}
 
   picomatch@2.3.2: {}
 
@@ -17473,7 +17543,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.11
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.11
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.11)(rollup@4.59.0):
+  rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.11)(rollup@2.80.0):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.3
@@ -17481,7 +17551,7 @@ snapshots:
       yargs: 18.0.0
     optionalDependencies:
       rolldown: 1.0.0-rc.11
-      rollup: 4.59.0
+      rollup: 2.80.0
 
   rollup@2.80.0:
     optionalDependencies:
@@ -18917,6 +18987,10 @@ snapshots:
       '@speed-highlight/core': 1.2.14
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod-validation-error@3.5.4(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Summary
- Enable React Compiler for automatic memoization in the web app (Vite Babel plugin)
- Fix modal `aria-hidden` bug: replace `inert` attribute with `aria-hidden` + `pointer-events-none`
- Update `CODE_PATTERNS.md` with corrected React Compiler status, `useDeferredValue` pattern, and React 19 best practices
- Update `DATA_RETENTION.md` and `REVIEW_CHECKLIST.md` with minor clarifications
- Address lint and knip issues introduced by React Compiler setup

## Test plan
- [ ] `pnpm run lint` passes with 0 warnings in `packages/web`
- [ ] `pnpm run knip` passes in `packages/web`
- [ ] `pnpm test` passes (4186 tests) in `packages/web`
- [ ] `pnpm run build` succeeds with React Compiler enabled
- [ ] Modal accessibility: confirm `aria-hidden` behaves correctly on backdrop elements
- [ ] No regressions in tour spotlight or OCR entry modal behaviour