### PR TITLE
fix(ci): migrate allowed_tools beta param to claude_args --allowedTools

### DIFF
--- a/.github/workflows/claude-code-review-architecture.yml
+++ b/.github/workflows/claude-code-review-architecture.yml
@@ -79,6 +79,8 @@ jobs:
             3. For re-reviews (EVENT TYPE is "synchronize"): acknowledge fixes, flag new issues only
 
             Post your review using `gh pr comment`. Output plain markdown (not wrapped in code blocks).
-          claude_args: '--model opus --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: |
+            --model opus
+            --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
     outputs:
       guidelines_changed: ${{ steps.check-skip.outputs.guidelines_changed }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -75,6 +75,8 @@ jobs:
             2. For re-reviews (EVENT TYPE is "synchronize"): acknowledge fixes, flag new issues only
 
             Post your review using `gh pr comment`. Output plain markdown (not wrapped in code blocks).
-          claude_args: '--model opus --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: |
+            --model opus
+            --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
     outputs:
       guidelines_changed: ${{ steps.check-claude-md.outputs.guidelines_changed }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,6 +55,4 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          claude_args: |
-            --model opus
-            --allowedTools Bash(pnpm:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr list:*),mcp__github__issue_read,mcp__github__issue_write,mcp__github__add_issue_comment,mcp__github__pull_request_read,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review
+          claude_args: '--model opus --allowedTools "Bash(pnpm:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr list:*),mcp__github__issue_read,mcp__github__issue_write,mcp__github__add_issue_comment,mcp__github__pull_request_read,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,25 +55,6 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          # Use opus model for higher quality responses
-          claude_args: '--model opus'
-          # Allow Claude to use pnpm commands for running tests, builds, and linting
-          allowed_tools: |
-            Bash(pnpm:*)
-            # gh CLI for basic issue/PR operations (view, list, comment)
-            Bash(gh issue create:*)
-            Bash(gh issue edit:*)
-            Bash(gh issue list:*)
-            Bash(gh issue comment:*)
-            Bash(gh issue view:*)
-            Bash(gh pr view:*)
-            Bash(gh pr diff:*)
-            Bash(gh pr comment:*)
-            Bash(gh pr list:*)
-            # MCP GitHub tools for advanced operations (create/update, PR reviews, line-level comments)
-            mcp__github__issue_read
-            mcp__github__issue_write
-            mcp__github__add_issue_comment
-            mcp__github__pull_request_read
-            mcp__github__pull_request_review_write
-            mcp__github__add_comment_to_pending_review
+          claude_args: |
+            --model opus
+            --allowedTools Bash(pnpm:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr list:*),mcp__github__issue_read,mcp__github__issue_write,mcp__github__add_issue_comment,mcp__github__pull_request_read,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,4 +55,6 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          claude_args: '--model opus --allowedTools "Bash(pnpm:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr list:*),mcp__github__issue_read,mcp__github__issue_write,mcp__github__add_issue_comment,mcp__github__pull_request_read,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review"'
+          claude_args: |
+            --model opus
+            --allowedTools "Bash(pnpm:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr list:*),mcp__github__issue_read,mcp__github__issue_write,mcp__github__add_issue_comment,mcp__github__pull_request_read,mcp__github__pull_request_review_write,mcp__github__add_comment_to_pending_review"


### PR DESCRIPTION
## Summary

- `allowed_tools` was a beta-era input parameter removed in `claude-code-action@v1` — it was silently ignored, leaving Claude with no tool allowlist
- This caused `@claude` mentions to acknowledge with 👀 but never act (Claude could not run `pnpm`, `gh`, or MCP tools)
- Migrated to the correct v1.0 syntax: `--allowedTools` inside `claude_args`, matching the pattern already used in `claude-code-review.yml`

## Test plan

- [ ] Merge this PR
- [ ] Post `@claude hello` on any issue
- [ ] Confirm Claude responds with more than just 👀