### PR TITLE
fix(web): unify compensation slide action colors with assignment actions

### DIFF
--- a/packages/web/src/features/compensations/utils/compensation-actions.test.ts
+++ b/packages/web/src/features/compensations/utils/compensation-actions.test.ts
@@ -92,7 +92,7 @@ describe('createCompensationActions', () => {
 
     expect(actions.generatePDF.id).toBe('generate-pdf')
     expect(actions.generatePDF.label).toBe('Generate PDF')
-    expect(actions.generatePDF.color).toBe('bg-green-500')
+    expect(actions.generatePDF.color).toBe('bg-slate-500')
     expect(isValidElement(actions.generatePDF.icon)).toBe(true)
   })
 })

--- a/packages/web/src/features/compensations/utils/compensation-actions.ts
+++ b/packages/web/src/features/compensations/utils/compensation-actions.ts
@@ -77,7 +77,7 @@ export function createCompensationActions(
       id: 'generate-pdf',
       label: 'Generate PDF',
       shortLabel: 'PDF',
-      color: 'bg-green-500',
+      color: 'bg-slate-500',
       icon: ICON_FILE_TEXT,
       onAction: () => handlers.onGeneratePDF(compensation),
     },


### PR DESCRIPTION
## Summary

- Change `generatePDF` swipe action color from `bg-green-500` to `bg-slate-500` to match the `generateReport` action color used on assignment items
- Both compensation and assignment slide actions now use a consistent color scheme: primary actions in `bg-primary-500`, file/document actions in `bg-slate-500`

## Test plan

- [ ] Swipe left on a compensation card and verify the PDF action button is slate/gray (not green)
- [ ] Swipe left on an assignment card and verify the report action button is also slate/gray
- [ ] Confirm edit/wallet action remains `bg-primary-500` on both screens

https://claude.ai/code/session_01JsSWRMubkPfwmSok6w9Dk5