### PR TITLE
chore(ci): remove redundant lint/test from PR preview deploy

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -42,28 +42,7 @@ jobs:
       - name: Generate API types
         if: steps.api-cache.outputs.cache-hit != 'true'
         run: pnpm run generate:api
-      # Cache ESLint results per branch
-      - name: Cache ESLint
-        uses: actions/cache@v5
-        with:
-          path: packages/web/.eslintcache
-          key: eslint-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('packages/web/src/**/*.ts', 'packages/web/src/**/*.tsx') }}
-          restore-keys: |
-            eslint-${{ runner.os }}-${{ github.head_ref }}-
-            eslint-${{ runner.os }}-
-      - name: Lint
-        run: pnpm run lint --cache --cache-location .eslintcache
-      # Cache Vite/Vitest artifacts per branch (Vitest stores cache in .vite/vitest)
-      - name: Cache Vite
-        uses: actions/cache@v5
-        with:
-          path: packages/web/node_modules/.vite
-          key: vite-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('pnpm-lock.yaml', 'packages/web/vite.config.ts', 'packages/web/tsconfig.json') }}
-          restore-keys: |
-            vite-${{ runner.os }}-${{ github.head_ref }}-
-            vite-${{ runner.os }}-
-      - name: Test
-        run: pnpm test
+      # Lint and test are handled by the CI workflow (ci.yml)
       - name: Build for PR Preview
         run: pnpm run build
         env:
@@ -124,17 +103,6 @@ jobs:
         uses: ./.github/actions/setup-node-deps
         with:
           working-directory: ocr-poc
-      # Cache ESLint results per branch
-      - name: Cache ESLint
-        uses: actions/cache@v5
-        with:
-          path: ocr-poc/.eslintcache
-          key: ocr-poc-eslint-${{ runner.os }}-${{ github.head_ref }}-${{ hashFiles('ocr-poc/src/**/*.ts', 'ocr-poc/src/**/*.tsx') }}
-          restore-keys: |
-            ocr-poc-eslint-${{ runner.os }}-${{ github.head_ref }}-
-            ocr-poc-eslint-${{ runner.os }}-
-      - name: Lint OCR POC
-        run: pnpm run lint --cache --cache-location .eslintcache
       # Cache Vite build artifacts per branch
       - name: Cache Vite build
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

- Remove lint and test steps from `deploy-pr-preview.yml` (`build-web-app` and `build-ocr-poc` jobs) since the CI workflow (`ci.yml`) already runs dedicated lint and test jobs on PRs with overlapping path triggers
- Saves ~2-3 minutes of redundant CI time per PR push

## Test plan

- [ ] Verify CI workflow still runs lint/test on PRs touching `packages/web/**` or `packages/shared/**`
- [ ] Verify PR preview deployment still builds and deploys successfully without the removed steps

https://claude.ai/code/session_01Gj1sofvvdLiAUTYTBJd8LZ