### PR TITLE
chore(web): update domain references to volleykit.ch

### DIFF
--- a/packages/web/e2e/README-screenshots.md
+++ b/packages/web/e2e/README-screenshots.md
@@ -42,7 +42,7 @@ Travel screenshots require the production site with OJP API configured. Run from
 
 ```bash
 # Set PRODUCTION_URL and run specific travel tests
-PRODUCTION_URL=https://takishima.github.io/volleykit/ \
+PRODUCTION_URL=https://volleykit.ch/ \
   pnpm exec playwright test e2e/capture-screenshots.spec.ts \
   --project=chromium \
   -g "travel-time|journey-details"

--- a/packages/web/src/common/utils/constants.test.ts
+++ b/packages/web/src/common/utils/constants.test.ts
@@ -15,27 +15,27 @@ describe('getHelpSiteUrl', () => {
   })
 
   it('returns help URL with correct base path for production', () => {
-    // Production: origin is GitHub Pages, BASE_URL is /volleykit/
+    // Production: origin is volleykit.ch, BASE_URL is /
     vi.stubGlobal('window', {
-      location: { origin: 'https://takishima.github.io' },
+      location: { origin: 'https://volleykit.ch' },
     })
-    vi.stubEnv('BASE_URL', '/volleykit/')
+    vi.stubEnv('BASE_URL', '/')
 
     const url = getHelpSiteUrl()
 
-    expect(url).toBe('https://takishima.github.io/volleykit/help/?lang=en')
+    expect(url).toBe('https://volleykit.ch/help/?lang=en')
   })
 
   it('returns help URL with correct base path for PR preview', () => {
-    // PR preview: origin is GitHub Pages, BASE_URL is /volleykit/pr-123/
+    // PR preview: origin is volleykit.ch, BASE_URL is /pr-123/
     vi.stubGlobal('window', {
-      location: { origin: 'https://takishima.github.io' },
+      location: { origin: 'https://volleykit.ch' },
     })
-    vi.stubEnv('BASE_URL', '/volleykit/pr-123/')
+    vi.stubEnv('BASE_URL', '/pr-123/')
 
     const url = getHelpSiteUrl()
 
-    expect(url).toBe('https://takishima.github.io/volleykit/pr-123/help/?lang=en')
+    expect(url).toBe('https://volleykit.ch/pr-123/help/?lang=en')
   })
 
   it('returns help URL for local development', () => {
@@ -55,37 +55,37 @@ describe('getHelpSiteUrl', () => {
   it('handles missing window (SSR) gracefully', () => {
     // SSR/Node: window is undefined
     vi.stubGlobal('window', undefined)
-    vi.stubEnv('BASE_URL', '/volleykit/')
+    vi.stubEnv('BASE_URL', '/')
 
     const url = getHelpSiteUrl()
 
-    expect(url).toBe('/volleykit/help/?lang=en')
+    expect(url).toBe('/help/?lang=en')
   })
 
   it('includes the current language in the URL', () => {
     vi.stubGlobal('window', {
-      location: { origin: 'https://takishima.github.io' },
+      location: { origin: 'https://volleykit.ch' },
     })
-    vi.stubEnv('BASE_URL', '/volleykit/')
+    vi.stubEnv('BASE_URL', '/')
 
     // Set German as the current language
     useLanguageStore.setState({ locale: 'de' })
 
     const url = getHelpSiteUrl()
 
-    expect(url).toBe('https://takishima.github.io/volleykit/help/?lang=de')
+    expect(url).toBe('https://volleykit.ch/help/?lang=de')
   })
 
   it('includes French language when selected', () => {
     vi.stubGlobal('window', {
-      location: { origin: 'https://takishima.github.io' },
+      location: { origin: 'https://volleykit.ch' },
     })
-    vi.stubEnv('BASE_URL', '/volleykit/')
+    vi.stubEnv('BASE_URL', '/')
 
     useLanguageStore.setState({ locale: 'fr' })
 
     const url = getHelpSiteUrl()
 
-    expect(url).toBe('https://takishima.github.io/volleykit/help/?lang=fr')
+    expect(url).toBe('https://volleykit.ch/help/?lang=fr')
   })
 })

--- a/packages/web/src/common/utils/constants.ts
+++ b/packages/web/src/common/utils/constants.ts
@@ -84,7 +84,7 @@ export const LONG_DISTANCE_KM = 60
  *
  * Uses window.location.origin + BASE_URL to work correctly in:
  * - Production: https://volleykit.ch/help/
- * - PR previews: https://takishima.github.io/volleykit/pr-123/help/
+ * - PR previews: https://volleykit.ch/pr-123/help/
  * - Local dev: http://localhost:5173/help/
  *
  * Includes the current app language as a query parameter so the help site


### PR DESCRIPTION
## Summary

- Updates test cases in `constants.test.ts` to reflect new custom domain: origin is now `volleykit.ch` with `BASE_URL=/` instead of `takishima.github.io/volleykit/`
- Updates inline comment in `constants.ts` to reference correct PR preview URL pattern (`volleykit.ch/pr-123/help/`)
- Updates `README-screenshots.md` to use new production URL (`https://volleykit.ch/`)

## Test plan

- [x] All `getHelpSiteUrl` unit tests pass with updated domain expectations
- [x] PR preview URLs resolve correctly under `https://volleykit.ch/pr-{N}/`
- [x] Screenshot capture script uses correct `PRODUCTION_URL`

https://claude.ai/code/session_01Mj8qAErqQVpLMn5CVKQqzM