### PR TITLE
chore(ci): optimize pre-commit hook for streaming validation

### DIFF
--- a/.claude/hooks/post-git-commit.sh
+++ b/.claude/hooks/post-git-commit.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Post-git-commit hook for Claude Code (web only)
+# Cleans up the validation marker after a successful commit.
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+INPUT=$(cat)
+
+# Extract command
+if command -v jq &>/dev/null; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+else
+  COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || echo "")
+fi
+
+# Only act on git commit commands
+if [[ $COMMAND != *"git commit"* ]] && [[ $COMMAND != *"&&"*"commit"* ]]; then
+  exit 0
+fi
+
+# Check if the tool succeeded (PostToolUse provides tool_result)
+if command -v jq &>/dev/null; then
+  EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_result.exit_code // .tool_result.exitCode // "1"' 2>/dev/null || echo "1")
+else
+  EXIT_CODE="0"  # assume success if we can't parse
+fi
+
+if [[ $EXIT_CODE == "0" ]]; then
+  rm -rf /tmp/claude-validation-marker
+fi

--- a/.claude/hooks/post-git-commit.sh
+++ b/.claude/hooks/post-git-commit.sh
@@ -16,7 +16,7 @@ else
 fi
 
 # Only act on git commit commands
-if [[ $COMMAND != *"git commit"* ]] && [[ $COMMAND != *"&&"*"commit"* ]]; then
+if [[ $COMMAND != *"git commit"* ]] && [[ $COMMAND != *"git add"*"&&"*"git commit"* ]]; then
   exit 0
 fi
 

--- a/.claude/hooks/post-git-commit.sh
+++ b/.claude/hooks/post-git-commit.sh
@@ -24,7 +24,8 @@ fi
 if command -v jq &>/dev/null; then
   EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_result.exit_code // .tool_result.exitCode // "1"' 2>/dev/null || echo "1")
 else
-  EXIT_CODE="0"  # assume success if we can't parse
+  EXIT_CODE=$(echo "$INPUT" | grep -o '"exit_code"[[:space:]]*:[[:space:]]*[0-9]*' | grep -o '[0-9]*$' || echo "1")
+  [ -z "$EXIT_CODE" ] && EXIT_CODE="1"
 fi
 
 if [[ $EXIT_CODE == "0" ]]; then

--- a/.claude/hooks/pre-git-commit.sh
+++ b/.claude/hooks/pre-git-commit.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 # Pre-git-commit hook for Claude Code (web only)
-# Runs validation asynchronously using a two-phase approach:
 #
-# Phase 1 (first attempt):
-#   - Checks if validation can be skipped (docs-only, etc.)
-#   - If not skippable, starts validation in background
-#   - Returns immediately with "validation started" message
+# Lightweight gate: checks that validation was run (and passed) for the
+# current set of staged files. The actual validation runs as a direct
+# Bash command (`scripts/pre-commit-validate.sh`) so Claude gets
+# streaming output in real-time — no more block-retry-block cycles.
 #
-# Phase 2 (retry):
-#   - Checks if background validation completed
-#   - If still running: block with progress message
-#   - If done + passed: allow commit
-#   - If done + failed: block with error details
+# Flow:
+#   1. Claude runs: CLAUDE_CODE_REMOTE=true scripts/pre-commit-validate.sh
+#      → Gets streaming output as each check passes/fails
+#      → Script writes success marker on pass
+#   2. Claude runs: git commit -m "..."
+#      → This hook checks marker is fresh + matches staged files → instant approve
+#   3. If Claude skips step 1 → hook blocks with instructions
 
 # Only run in Claude Code web sessions (skip for CLI)
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
@@ -20,23 +21,6 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 set -euo pipefail
-
-# =============================================================================
-# CONFIGURATION - Edit these to change behavior
-# =============================================================================
-
-# File patterns that require validation (regex for grep -E)
-SOURCE_PATTERNS='\.(ts|tsx|js|jsx|astro)$'
-
-# File patterns that can be skipped (validation not needed)
-SKIP_PATTERNS='\.(md|txt|json|yaml|yml|sh|css|svg|png|jpg|jpeg|gif|ico)$'
-
-# Files that always trigger validation regardless of SKIP_PATTERNS
-FORCE_VALIDATE_PATTERNS='(package\.json|tsconfig\.json|vite\.config|eslint\.config)'
-
-# Timeout settings (in seconds)
-MAX_VALIDATION_TIME_S=300  # 5 minutes - consider validation hung after this
-STALE_VALIDATION_AGE_S=600 # 10 minutes - cleanup stale validation state
 
 # =============================================================================
 # HELPER FUNCTIONS
@@ -49,67 +33,39 @@ allow() {
 
 block() {
   local reason="$1"
-  # Escape for JSON - handle backslashes, quotes, and newlines
-  # Use printf '%s' to avoid echo's escape sequence interpretation
   reason=$(printf '%s' "$reason" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
-  # Use printf to avoid heredoc variable expansion issues
   printf '{"decision": "block", "reason": "%s"}\n' "$reason"
   exit 0
-}
-
-# Sanitize output for safe inclusion in messages
-# Removes control characters and limits length
-sanitize_output() {
-  local input="$1"
-  local max_length="${2:-2000}"
-  # Remove ANSI escape codes and control characters, limit length
-  echo "$input" | sed 's/\x1b\[[0-9;]*m//g' | tr -cd '[:print:]\n' | head -c "$max_length"
-}
-
-get_staged_files() {
-  git diff --name-only --cached 2>/dev/null || echo ""
-}
-
-needs_validation() {
-  local staged_files="$1"
-
-  # No files staged - skip
-  [[ -z $staged_files ]] && return 1
-
-  # Check for files that force validation (config files, etc.)
-  if echo "$staged_files" | grep -qE "$FORCE_VALIDATE_PATTERNS"; then
-    return 0
-  fi
-
-  # Check for source files that need validation
-  if echo "$staged_files" | grep -qE "$SOURCE_PATTERNS"; then
-    return 0
-  fi
-
-  # All files match skip patterns - no validation needed
-  return 1
 }
 
 # Extract command from JSON input with jq fallback
 extract_command() {
   local input="$1"
-  # Try jq first, fall back to grep/sed if jq unavailable
   if command -v jq &>/dev/null; then
     echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo ""
   else
-    # Fallback: basic extraction without jq
     echo "$input" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || echo ""
   fi
 }
 
 # =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+# File patterns that require validation (regex for grep -E)
+SOURCE_PATTERNS='\.(ts|tsx|js|jsx|astro)$'
+
+# Files that always trigger validation regardless
+FORCE_VALIDATE_PATTERNS='(package\.json|tsconfig\.json|vite\.config|eslint\.config)'
+
+# Max age of validation marker (seconds) before it's considered stale
+MARKER_MAX_AGE_S=120
+
+# =============================================================================
 # MAIN LOGIC
 # =============================================================================
 
-# Read the tool input from stdin
 INPUT=$(cat)
-
-# Extract the command being run (with jq fallback)
 COMMAND=$(extract_command "$INPUT")
 
 # --- Gate 1: Only process git commit commands ---
@@ -120,143 +76,65 @@ fi
 # --- Gate 2: Ensure validation docs were read (first-commit gate) ---
 SESSION_MARKER="/tmp/.claude-validation-read"
 if [[ ! -f $SESSION_MARKER ]]; then
-  block "STOP: Before your first commit, you MUST read docs/VALIDATION.md to understand the validation process. The pre-commit hook runs: format → lint → knip → test → build. After reading the file, retry your commit."
+  block "STOP: Before your first commit, you MUST read docs/VALIDATION.md to understand the validation process. After reading the file, retry your commit."
 fi
 
-# --- Gate 3: Check if validation script exists ---
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
-VALIDATION_SCRIPT="$PROJECT_DIR/scripts/pre-commit-validate.sh"
+# --- Gate 3: Check if validation is even needed ---
+STAGED_FILES=$(git diff --name-only --cached 2>/dev/null || echo "")
 
-if [[ ! -x $VALIDATION_SCRIPT ]]; then
+# No staged files
+[[ -z $STAGED_FILES ]] && allow
+
+# Docs-only changes
+if ! echo "$STAGED_FILES" | grep -v '^\s*$' | grep -qvE '\.md$'; then
   allow
 fi
 
-# --- Gate 4: Check if validation can be skipped based on staged files ---
-STAGED_FILES=$(get_staged_files)
+# No source or config files
+HAS_SOURCE=false
+HAS_CONFIG=false
+echo "$STAGED_FILES" | grep -qE "$SOURCE_PATTERNS" && HAS_SOURCE=true
+echo "$STAGED_FILES" | grep -qE "$FORCE_VALIDATE_PATTERNS" && HAS_CONFIG=true
 
-if ! needs_validation "$STAGED_FILES"; then
-  # No source files - allow without validation
+if [[ $HAS_SOURCE == false ]] && [[ $HAS_CONFIG == false ]]; then
   allow
 fi
 
-# =============================================================================
-# ASYNC VALIDATION WITH POLLING
-# =============================================================================
+# --- Gate 4: Check validation marker ---
+MARKER_DIR="/tmp/claude-validation-marker"
+MARKER_HASH_FILE="$MARKER_DIR/staged-hash"
+MARKER_TIME_FILE="$MARKER_DIR/timestamp"
 
-# Fixed directory so retries can find the running validation
-VALIDATION_DIR="/tmp/claude-precommit-validation"
-VALIDATION_PID_FILE="$VALIDATION_DIR/pid"
-VALIDATION_OUTPUT_FILE="$VALIDATION_DIR/output"
-VALIDATION_RESULT_FILE="$VALIDATION_DIR/result"
-VALIDATION_START_FILE="$VALIDATION_DIR/started"
-VALIDATION_STEPS_DIR="$VALIDATION_DIR/steps"
-
-# Failure output directory (persists for Claude to read)
-FAILURE_DIR="/tmp/claude-validation-failure"
-
-# --- Check for stale validation state and cleanup ---
-if [[ -f $VALIDATION_START_FILE ]]; then
-  START_TIME=$(cat "$VALIDATION_START_FILE" 2>/dev/null || echo "0")
+if [[ -f $MARKER_HASH_FILE ]] && [[ -f $MARKER_TIME_FILE ]]; then
+  # Check marker age
+  MARKER_TIME=$(cat "$MARKER_TIME_FILE" 2>/dev/null || echo "0")
   NOW=$(date +%s)
-  AGE=$((NOW - START_TIME))
+  AGE=$((NOW - MARKER_TIME))
 
-  if [[ $AGE -gt $STALE_VALIDATION_AGE_S ]]; then
-    # Stale validation state from previous session - cleanup
-    rm -rf "$VALIDATION_DIR"
-  fi
-fi
+  if [[ $AGE -le $MARKER_MAX_AGE_S ]]; then
+    # Check that staged files haven't changed since validation
+    CURRENT_HASH=$(git diff --name-only --cached | sort | sha256sum | cut -d' ' -f1)
+    MARKER_HASH=$(cat "$MARKER_HASH_FILE" 2>/dev/null || echo "")
 
-# --- Check if validation is already running or completed ---
-if [[ -f $VALIDATION_PID_FILE ]]; then
-  PID=$(cat "$VALIDATION_PID_FILE")
-  START_TIME=$(cat "$VALIDATION_START_FILE" 2>/dev/null || echo "0")
-  NOW=$(date +%s)
-  ELAPSED=$((NOW - START_TIME))
-
-  if kill -0 "$PID" 2>/dev/null; then
-    # Check if validation has been running too long (hung)
-    if [[ $ELAPSED -gt $MAX_VALIDATION_TIME_S ]]; then
-      # Kill hung validation and cleanup
-      kill "$PID" 2>/dev/null || true
-      rm -rf "$VALIDATION_DIR"
-      block "Validation timed out after ${MAX_VALIDATION_TIME_S}s. The process may be hung. Cleaned up stale state - please retry your commit."
+    if [[ $CURRENT_HASH == "$MARKER_HASH" ]]; then
+      # Validation passed for exactly these files — approve!
+      # Marker expires naturally via MARKER_MAX_AGE_S (don't delete here
+      # in case the commit itself fails for unrelated reasons)
+      allow
     fi
 
-    # Still running - show elapsed time
-    block "Validation in progress (${ELAPSED}s elapsed)... The checks run in parallel for speed. Please retry your commit in a few seconds."
+    # Staged files changed since validation
+    block "Staged files changed since last validation. Run validation again:
+
+CLAUDE_CODE_REMOTE=true scripts/pre-commit-validate.sh
+
+Then retry your commit."
   fi
-
-  # Process finished - check result
-  RESULT=$(cat "$VALIDATION_RESULT_FILE" 2>/dev/null || echo "1")
-  OUTPUT=$(cat "$VALIDATION_OUTPUT_FILE" 2>/dev/null || echo "No output captured")
-
-  if [[ $RESULT == "0" ]]; then
-    # Success - cleanup and allow
-    rm -rf "$VALIDATION_DIR"
-    allow
-  fi
-
-  # --- Validation failed - prepare error report ---
-  rm -rf "$FAILURE_DIR"
-  mkdir -p "$FAILURE_DIR"
-
-  # Save full output
-  echo "$OUTPUT" >"$FAILURE_DIR/full-output.log"
-
-  # Copy per-step logs if they exist
-  STEP_LOGS=""
-  if [[ -d $VALIDATION_STEPS_DIR ]]; then
-    cp -r "$VALIDATION_STEPS_DIR"/* "$FAILURE_DIR/" 2>/dev/null || true
-    for log in "$FAILURE_DIR"/*.log; do
-      [[ -f $log ]] && STEP_LOGS="$STEP_LOGS
-  - $log"
-    done
-  fi
-
-  # Cleanup validation dir
-  rm -rf "$VALIDATION_DIR"
-
-  # Extract and sanitize summary (key failure indicators)
-  SUMMARY=$(echo "$OUTPUT" | grep -E "(✗|failed|error|Error)" | head -10)
-  if [[ -z $SUMMARY ]]; then
-    SUMMARY=$(echo "$OUTPUT" | tail -20)
-  fi
-  # Sanitize to prevent command injection via crafted output
-  SUMMARY=$(sanitize_output "$SUMMARY" 1500)
-
-  block "Validation failed. Summary:
-
-$SUMMARY
-
-Logs saved to $FAILURE_DIR/:
-  - full-output.log (complete validation output)$STEP_LOGS
-
-Use Read tool to see complete error details."
 fi
 
-# =============================================================================
-# START BACKGROUND VALIDATION
-# =============================================================================
+# --- No valid marker — tell Claude to run validation ---
+block "Validation required before commit. Run:
 
-mkdir -p "$VALIDATION_DIR"
-mkdir -p "$VALIDATION_STEPS_DIR"
-echo "$(date +%s)" >"$VALIDATION_START_FILE"
+CLAUDE_CODE_REMOTE=true scripts/pre-commit-validate.sh
 
-# Start validation in background
-# cd to project root first to ensure git/pnpm commands resolve correctly
-# even when Claude is cd'ed into a subfolder
-(
-  # Disable errexit inside subshell to ensure exit code is captured even on failure
-  set +e
-  cd "$PROJECT_DIR" || exit 1
-  CLAUDE_CODE_REMOTE=true VALIDATION_STEPS_DIR="$VALIDATION_STEPS_DIR" \
-    "$VALIDATION_SCRIPT" >"$VALIDATION_OUTPUT_FILE" 2>&1
-  echo "$?" >"$VALIDATION_RESULT_FILE"
-) &
-
-# Save the background process PID
-echo "$!" >"$VALIDATION_PID_FILE"
-
-block "Validation started in background. Running format, lint, knip, test in PARALLEL, then build.
-
-Please retry your commit in ~20-30 seconds. The hook will report results on retry."
+This runs all checks (format, lint, typecheck, test, build) with streaming output. Once it passes, retry your commit — the hook will approve instantly."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,6 +64,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-git-push.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-git-commit.sh"
           }
         ]
       },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
       "Bash(pnpm exec wrangler:*)",
       "Bash(pnpm run size:*)",
       "Bash(CLAUDE_CODE_REMOTE=true scripts/pre-commit-validate.sh)",
-      "Bash(prettier --check:*)"
+      "Bash(pnpm exec prettier --check:*)"
     ],
     "deny": []
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,7 +31,9 @@
       "Bash(pnpm exec vitest:*)",
       "Bash(pnpm exec eslint:*)",
       "Bash(pnpm exec wrangler:*)",
-      "Bash(pnpm run size:*)"
+      "Bash(pnpm run size:*)",
+      "Bash(CLAUDE_CODE_REMOTE=true scripts/pre-commit-validate.sh)",
+      "Bash(prettier --check:*)"
     ],
     "deny": []
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,9 @@ VolleyKit is a multi-platform app suite for Swiss volleyball referee management 
 
 1. **Implement** - Complete the work
 2. **Add changeset** - For `feat:`/`fix:` commits, create `.changeset/*.md` (see below)
-3. **Commit** - Pre-commit hook validates automatically (Claude Code web only)
-4. **Push** - Push to remote
+3. **Validate** - Run `CLAUDE_CODE_REMOTE=true scripts/pre-commit-validate.sh` (streaming output)
+4. **Commit** - Pre-commit hook checks validation marker (instant approve)
+5. **Push** - Push to remote
 
 Use `/pr-review` to create PR and auto-fix Claude Code Review issues.
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -4,29 +4,42 @@ Read this file before committing changes.
 
 ## Pre-Commit Validation (Claude Code Web Only)
 
-The pre-commit hook (`scripts/pre-commit-validate.sh`) runs automatically in Claude Code web environment (`CLAUDE_CODE_REMOTE=true`). Human developers rely on CI instead.
+Validation uses a two-part system in Claude Code web (`CLAUDE_CODE_REMOTE=true`). Human developers rely on CI instead.
 
-### What the Hook Does
+### How It Works
+
+**Step 1: Run validation** (streaming output — Claude sees results in real-time):
+
+```bash
+CLAUDE_CODE_REMOTE=true scripts/pre-commit-validate.sh
+```
+
+**Step 2: Commit** — the pre-commit hook checks the validation marker and approves instantly.
+
+This replaces the old block-retry-block cycle. Claude gets immediate feedback from each check as it completes.
+
+### What Validation Does
 
 1. **Detect staged changes** - Skip validation for docs-only changes (`.md` files only)
 2. **Detect affected packages** - Determines which packages have changes (web, shared, mobile, worker, help-site)
 3. **Generate API types** - If `volleymanager-openapi.yaml` is staged
-4. **Run checks in PARALLEL** - Per-package validation (format, lint, knip, typecheck, test)
-5. **Run build sequentially** - Build affected packages (shared → web → help-site)
+4. **Run checks in PARALLEL** - Single format check on staged files + per-package lint, typecheck, test
+5. **Build shared** then **web + help-site in parallel** - Build affected packages
 
-Shared package changes also trigger web and mobile validation (downstream consumers).
-
-The commit is **blocked** if any step fails. Fix issues and commit again.
+Shared package changes trigger web validation (always) and mobile validation (only when exported API surface is touched).
 
 ### Checks Per Package
 
-| Package   | format | lint | knip | typecheck  | test | build |
-| --------- | ------ | ---- | ---- | ---------- | ---- | ----- |
-| web       | ✓      | ✓    | ✓    | (in build) | ✓    | ✓     |
-| shared    | ✓      | ✓    | –    | ✓          | ✓    | ✓     |
-| mobile    | ✓      | ✓    | –    | ✓          | ✓    | –     |
-| worker    | ✓      | ✓    | –    | –          | ✓    | –     |
-| help-site | ✓      | –    | –    | –          | –    | ✓     |
+| Package   | format¹ | lint | knip | typecheck  | test | build |
+| --------- | ------- | ---- | ---- | ---------- | ---- | ----- |
+| web       | ✓       | ✓    | CI²  | (in build) | ✓    | ✓     |
+| shared    | ✓       | ✓    | –    | ✓          | ✓    | ✓     |
+| mobile    | ✓       | ✓    | –    | ✓          | ✓    | –     |
+| worker    | ✓       | ✓    | –    | –          | ✓    | –     |
+| help-site | ✓       | –    | –    | –          | –    | ✓     |
+
+¹ Format runs once on all staged files (not per-package)
+² Knip (dead code detection) runs in CI only — too slow for pre-commit
 
 ### Manual Validation Commands
 

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 # Pre-commit validation hook for VolleyKit
 # Detects which packages have staged changes and runs their validation
-# checks in PARALLEL, then build sequentially.
+# checks in PARALLEL, then builds (with independent builds also parallel).
 #
 # IMPORTANT: This hook only runs in Claude Code web environment
 # to avoid slowing down human developers. Human devs rely on CI.
+#
+# Performance optimizations:
+# - knip deferred to CI (slow whole-project scan)
+# - Single root-level format check instead of per-package
+# - Independent builds run in parallel (web + help-site after shared)
+# - Shared-only changes skip mobile when no API/type exports changed
 
 set -e
 
@@ -100,10 +106,15 @@ has_changes_in "packages/mobile/" && HAS_MOBILE=true
 has_changes_in "packages/worker/" && HAS_WORKER=true
 has_changes_in "help-site/" && HAS_HELP_SITE=true
 
-# Shared changes also affect web-app and mobile (downstream consumers)
+# Shared changes affect web-app (always) and mobile (only if exports changed)
 if [ "$HAS_SHARED" = true ]; then
   HAS_WEB_APP=true
-  HAS_MOBILE=true
+  # Only trigger mobile if shared changes touch exported API surface
+  # (src/index.ts, src/*/index.ts, types, hooks, stores, api)
+  if echo "$STAGED_FILES" | grep -q "^packages/shared/src/" && \
+     echo "$STAGED_FILES" | grep -qE "packages/shared/src/(index\.ts|[^/]+/index\.ts|types/|hooks/|stores/|api/)"; then
+    HAS_MOBILE=true
+  fi
 fi
 
 # Root config changes affect all packages
@@ -212,19 +223,28 @@ launch_job() {
   JOB_PIDS+=($!)
 }
 
-# --- Web App checks ---
+# --- Single root-level format check (faster than per-package) ---
+# Check formatting only on staged files instead of per-package full scans
+FORMAT_FILES=$(echo "$STAGED_FILES" | grep -E '\.(ts|tsx|js|jsx|json|css|astro)$' || true)
+if [ -n "$FORMAT_FILES" ]; then
+  # Build absolute paths array for prettier
+  FORMAT_ARGS=()
+  while IFS= read -r f; do
+    FORMAT_ARGS+=("$ROOT_DIR/$f")
+  done <<< "$FORMAT_FILES"
+  launch_job "format" "$ROOT_DIR" prettier --check "${FORMAT_ARGS[@]}"
+fi
+
+# --- Web App checks (knip deferred to CI) ---
 if [ "$HAS_WEB_APP" = true ]; then
   WEB_DIR="$ROOT_DIR/packages/web"
-  launch_job "web:format"  "$WEB_DIR" pnpm run format:check
   launch_job "web:lint"    "$WEB_DIR" pnpm run lint
-  launch_job "web:knip"    "$WEB_DIR" pnpm run knip
   launch_job "web:test"    "$WEB_DIR" pnpm test
 fi
 
 # --- Shared package checks ---
 if [ "$HAS_SHARED" = true ]; then
   SHARED_DIR="$ROOT_DIR/packages/shared"
-  launch_job "shared:format"    "$SHARED_DIR" pnpm run format:check
   launch_job "shared:lint"      "$SHARED_DIR" pnpm run lint
   launch_job "shared:typecheck" "$SHARED_DIR" pnpm run typecheck
   launch_job "shared:test"      "$SHARED_DIR" pnpm test
@@ -233,7 +253,6 @@ fi
 # --- Mobile package checks ---
 if [ "$HAS_MOBILE" = true ]; then
   MOBILE_DIR="$ROOT_DIR/packages/mobile"
-  launch_job "mobile:format"    "$MOBILE_DIR" pnpm run format:check
   launch_job "mobile:lint"      "$MOBILE_DIR" pnpm run lint
   launch_job "mobile:typecheck" "$MOBILE_DIR" pnpm run typecheck
   launch_job "mobile:test"      "$MOBILE_DIR" pnpm test
@@ -242,15 +261,8 @@ fi
 # --- Worker checks ---
 if [ "$HAS_WORKER" = true ]; then
   WORKER_DIR="$ROOT_DIR/packages/worker"
-  launch_job "worker:format" "$WORKER_DIR" pnpm run format:check
   launch_job "worker:lint"   "$WORKER_DIR" pnpm run lint
   launch_job "worker:test"   "$WORKER_DIR" pnpm test
-fi
-
-# --- Help site checks ---
-if [ "$HAS_HELP_SITE" = true ]; then
-  HELP_DIR="$ROOT_DIR/help-site"
-  launch_job "help:format" "$HELP_DIR" pnpm run format:check
 fi
 
 NUM_JOBS=${#JOB_NAMES[@]}
@@ -309,44 +321,82 @@ if [ "$HAS_FAILURES" = false ]; then
   # Build shared first (dependency for web-app and mobile)
   if [ "$HAS_SHARED" = true ]; then
     echo "Building shared..."
-    if (cd "$ROOT_DIR/packages/shared" && pnpm run build) ; then
-      echo -e "${GREEN}shared build passed${NC}"
+    if (cd "$ROOT_DIR/packages/shared" && pnpm run build) >"$TEMP_DIR/build-shared.out" 2>&1; then
+      echo -e "${GREEN}✓ shared build passed${NC}"
     else
-      echo -e "${RED}shared build failed${NC}"
+      echo -e "${RED}✗ shared build failed${NC}"
+      cat "$TEMP_DIR/build-shared.out"
       BUILD_RESULT=1
     fi
   fi
 
-  # Build web-app (only if shared build passed)
-  if [ "$HAS_WEB_APP" = true ] && [ "$BUILD_RESULT" -eq 0 ]; then
-    echo "Building web-app..."
-    if (cd "$ROOT_DIR/packages/web" && pnpm run build) ; then
-      echo -e "${GREEN}web-app build passed${NC}"
-      # Check bundle size immediately after build
-      echo "Checking bundle size..."
-      if (cd "$ROOT_DIR/packages/web" && pnpm run size) ; then
-        echo -e "${GREEN}web-app bundle size passed${NC}"
-      else
-        echo -e "${RED}web-app bundle size exceeded limits${NC}"
-        echo -e "${YELLOW}Note: CI builds the merge commit and may be ~10-15 kB larger than local.${NC}"
-        echo -e "${YELLOW}If local passes but CI fails, update limits in packages/web/package.json.${NC}"
-        BUILD_RESULT=1
+  # Build web-app and help-site in PARALLEL (independent after shared)
+  if [ "$BUILD_RESULT" -eq 0 ]; then
+    declare -a BUILD_NAMES=()
+    declare -a BUILD_PIDS=()
+
+    if [ "$HAS_WEB_APP" = true ]; then
+      echo "Building web-app..."
+      (
+        cd "$ROOT_DIR/packages/web"
+        if pnpm run build >"$TEMP_DIR/build-web.out" 2>&1; then
+          # Check bundle size immediately after build
+          if pnpm run size >>"$TEMP_DIR/build-web.out" 2>&1; then
+            echo "0" >"$TEMP_DIR/build-web.result"
+          else
+            echo "size" >"$TEMP_DIR/build-web.result"
+          fi
+        else
+          echo "1" >"$TEMP_DIR/build-web.result"
+        fi
+      ) &
+      BUILD_NAMES+=("web-app")
+      BUILD_PIDS+=($!)
+    fi
+
+    if [ "$HAS_HELP_SITE" = true ]; then
+      echo "Building help-site..."
+      (
+        cd "$ROOT_DIR/help-site"
+        if pnpm run build >"$TEMP_DIR/build-help.out" 2>&1; then
+          echo "0" >"$TEMP_DIR/build-help.result"
+        else
+          echo "1" >"$TEMP_DIR/build-help.result"
+        fi
+      ) &
+      BUILD_NAMES+=("help-site")
+      BUILD_PIDS+=($!)
+    fi
+
+    # Wait for parallel builds
+    for ((b=0; b<${#BUILD_PIDS[@]}; b++)); do
+      wait "${BUILD_PIDS[$b]}" 2>/dev/null || true
+      B_NAME="${BUILD_NAMES[$b]}"
+      if [ "$B_NAME" = "web-app" ]; then
+        B_RESULT=$(cat "$TEMP_DIR/build-web.result" 2>/dev/null || echo "1")
+        if [ "$B_RESULT" = "0" ]; then
+          echo -e "${GREEN}✓ web-app build + size check passed${NC}"
+        elif [ "$B_RESULT" = "size" ]; then
+          echo -e "${RED}✗ web-app bundle size exceeded limits${NC}"
+          echo -e "${YELLOW}Note: CI builds the merge commit and may be ~10-15 kB larger than local.${NC}"
+          cat "$TEMP_DIR/build-web.out"
+          BUILD_RESULT=1
+        else
+          echo -e "${RED}✗ web-app build failed${NC}"
+          cat "$TEMP_DIR/build-web.out"
+          BUILD_RESULT=1
+        fi
+      elif [ "$B_NAME" = "help-site" ]; then
+        B_RESULT=$(cat "$TEMP_DIR/build-help.result" 2>/dev/null || echo "1")
+        if [ "$B_RESULT" = "0" ]; then
+          echo -e "${GREEN}✓ help-site build passed${NC}"
+        else
+          echo -e "${RED}✗ help-site build failed${NC}"
+          cat "$TEMP_DIR/build-help.out"
+          BUILD_RESULT=1
+        fi
       fi
-    else
-      echo -e "${RED}web-app build failed${NC}"
-      BUILD_RESULT=1
-    fi
-  fi
-
-  # Build help-site
-  if [ "$HAS_HELP_SITE" = true ] && [ "$BUILD_RESULT" -eq 0 ]; then
-    echo "Building help-site..."
-    if (cd "$ROOT_DIR/help-site" && pnpm run build) ; then
-      echo -e "${GREEN}help-site build passed${NC}"
-    else
-      echo -e "${RED}help-site build failed${NC}"
-      BUILD_RESULT=1
-    fi
+    done
   fi
 else
   echo -e "${YELLOW}Build skipped (previous checks failed)${NC}"
@@ -386,4 +436,17 @@ fi
 
 echo ""
 echo -e "${GREEN}All checks passed! Commit allowed.${NC}"
+
+# =============================================================================
+# WRITE SUCCESS MARKER (for lightweight hook gate)
+# =============================================================================
+# The pre-git-commit hook checks this marker to approve commits instantly
+# without re-running validation. Marker includes a hash of staged files
+# so it's invalidated if the staging area changes.
+MARKER_DIR="/tmp/claude-validation-marker"
+mkdir -p "$MARKER_DIR"
+STAGED_HASH=$(git diff --name-only --cached | sort | sha256sum | cut -d' ' -f1)
+echo "$STAGED_HASH" > "$MARKER_DIR/staged-hash"
+date +%s > "$MARKER_DIR/timestamp"
+
 exit 0

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -232,7 +232,7 @@ if [ -n "$FORMAT_FILES" ]; then
   while IFS= read -r f; do
     FORMAT_ARGS+=("$ROOT_DIR/$f")
   done <<< "$FORMAT_FILES"
-  launch_job "format" "$ROOT_DIR" prettier --check "${FORMAT_ARGS[@]}"
+  launch_job "format" "$ROOT_DIR" pnpm exec prettier --check "${FORMAT_ARGS[@]}"
 fi
 
 # --- Web App checks (knip deferred to CI) ---

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -111,6 +111,8 @@ if [ "$HAS_SHARED" = true ]; then
   HAS_WEB_APP=true
   # Only trigger mobile if shared changes touch exported API surface
   # (src/index.ts, src/*/index.ts, types, hooks, stores, api)
+  # e.g. editing packages/shared/src/utils/dateHelpers.ts → skips mobile
+  #      editing packages/shared/src/hooks/index.ts → triggers mobile
   if echo "$STAGED_FILES" | grep -q "^packages/shared/src/" && \
      echo "$STAGED_FILES" | grep -qE "packages/shared/src/(index\.ts|[^/]+/index\.ts|types/|hooks/|stores/|api/)"; then
     HAS_MOBILE=true
@@ -444,7 +446,7 @@ echo -e "${GREEN}All checks passed! Commit allowed.${NC}"
 # without re-running validation. Marker includes a hash of staged files
 # so it's invalidated if the staging area changes.
 MARKER_DIR="/tmp/claude-validation-marker"
-mkdir -p "$MARKER_DIR"
+mkdir -p -m 700 "$MARKER_DIR"
 STAGED_HASH=$(git diff --name-only --cached | sort | sha256sum | cut -d' ' -f1)
 echo "$STAGED_HASH" > "$MARKER_DIR/staged-hash"
 date +%s > "$MARKER_DIR/timestamp"


### PR DESCRIPTION
## Summary

- Replace the block-retry-block async validation cycle with a direct streaming approach: Claude runs `scripts/pre-commit-validate.sh` as a Bash command (getting real-time output), then commits with an instant hook approval via a validation marker
- Optimize validation: single root-level format check (via `pnpm exec prettier`), knip deferred to CI, web + help-site builds in parallel, shared changes only trigger mobile when exported API surface changes
- Add post-commit hook to clean up validation marker after successful commits
- Add missing Bash permissions for the validation script and prettier

## Test plan

- [ ] Verify pre-commit hook blocks commits when no validation marker exists
- [ ] Verify `CLAUDE_CODE_REMOTE=true scripts/pre-commit-validate.sh` runs all checks with streaming output
- [ ] Verify commit is instantly approved after successful validation
- [ ] Verify post-commit hook cleans up the validation marker
- [ ] Verify docs-only commits bypass validation
- [ ] Verify marker is invalidated when staged files change after validation