### PR TITLE
feat(shared): auto-generate colors.js from design-tokens.css

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'packages/web/**'
       - 'packages/shared/**'
+      - 'scripts/sync-style-tokens.js'
       - 'docs/api/volleymanager-openapi.yaml'
       - '.github/workflows/ci.yml'
       - '.github/actions/**'
@@ -12,6 +13,7 @@ on:
     paths:
       - 'packages/web/**'
       - 'packages/shared/**'
+      - 'scripts/sync-style-tokens.js'
       - 'docs/api/volleymanager-openapi.yaml'
       - '.changeset/**'
       - '.github/workflows/ci.yml'
@@ -85,6 +87,19 @@ jobs:
             packages/shared/src/api/schema.ts
             packages/web/src/api/schema.ts
           retention-days: 1
+  # Design token sync check - ensures colors.js matches design-tokens.css
+  tokens:
+    name: Token Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Check token sync
+        run: node scripts/sync-style-tokens.js --check
   # Security audit - runs independently (doesn't need API types)
   audit:
     name: Security Audit

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -23,7 +23,8 @@ This replaces the old block-retry-block cycle. Claude gets immediate feedback fr
 1. **Detect staged changes** - Skip validation for docs-only changes (`.md` files only)
 2. **Detect affected packages** - Determines which packages have changes (web, shared, mobile, worker, help-site)
 3. **Generate API types** - If `volleymanager-openapi.yaml` is staged
-4. **Run checks in PARALLEL** - Single format check on staged files + per-package lint, typecheck, test
+4. **Check design token sync** - Verify `colors.js` matches `design-tokens.css` (when style files are staged)
+5. **Run checks in PARALLEL** - Single format check on staged files + per-package lint, typecheck, test
 5. **Build shared** then **web + help-site in parallel** - Build affected packages
 
 Shared package changes trigger web validation (always) and mobile validation (only when exported API surface is touched).

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "changeset:version": "changeset version",
     "changeset:status": "changeset status",
     "generate:api": "pnpm --filter volleykit-web run generate:api",
+    "generate:tokens": "node scripts/sync-style-tokens.js",
+    "generate:tokens:check": "node scripts/sync-style-tokens.js --check",
     "lint": "pnpm -r run lint",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,mjs,json,css,md,astro}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mjs,json,css,md,astro}\"",

--- a/packages/shared/styles/colors.js
+++ b/packages/shared/styles/colors.js
@@ -1,12 +1,8 @@
 /**
  * VolleyKit Color Tokens (JS)
  *
- * JavaScript export of the design token colors for platforms that
- * cannot consume CSS custom properties directly (e.g. React Native
- * with NativeWind / Tailwind 3).
- *
- * These values MUST stay in sync with design-tokens.css.
- * When changing colors, update BOTH files.
+ * AUTO-GENERATED from design-tokens.css — do not edit manually.
+ * Run `pnpm run generate:tokens` to regenerate.
  */
 
 const primary = {

--- a/scripts/pre-commit-validate.sh
+++ b/scripts/pre-commit-validate.sh
@@ -225,6 +225,11 @@ launch_job() {
   JOB_PIDS+=($!)
 }
 
+# --- Design token sync check ---
+if has_changes_in "packages/shared/styles/"; then
+  launch_job "tokens:check" "$ROOT_DIR" node scripts/sync-style-tokens.js --check
+fi
+
 # --- Single root-level format check (faster than per-package) ---
 # Check formatting only on staged files instead of per-package full scans
 FORMAT_FILES=$(echo "$STAGED_FILES" | grep -E '\.(ts|tsx|js|jsx|json|css|astro)$' || true)

--- a/scripts/sync-style-tokens.js
+++ b/scripts/sync-style-tokens.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+/**
+ * sync-style-tokens.js
+ *
+ * Reads design-tokens.css (the single source of truth) and generates
+ * colors.js for React Native / NativeWind (Tailwind 3), which cannot
+ * consume CSS custom properties.
+ *
+ * Usage:  node scripts/sync-style-tokens.js [--check]
+ *   --check   Exit with code 1 if colors.js is out of date (for CI)
+ */
+
+const { readFileSync, writeFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+
+const ROOT = resolve(__dirname, '..')
+
+const CSS_PATH = resolve(ROOT, 'packages/shared/styles/design-tokens.css')
+const JS_PATH = resolve(ROOT, 'packages/shared/styles/colors.js')
+
+// Color groups to extract (token prefix -> JS export name)
+const COLOR_GROUPS = ['primary', 'success', 'warning', 'danger', 'gray']
+
+function parseDesignTokens(css) {
+  const colors = {}
+
+  for (const group of COLOR_GROUPS) {
+    colors[group] = {}
+    // Match lines like: --color-primary-500: #b2e600;
+    const re = new RegExp(`--color-${group}-(\\d+):\\s*(#[0-9a-fA-F]{3,8})`, 'g')
+    let match
+    while ((match = re.exec(css)) !== null) {
+      colors[group][match[1]] = match[2]
+    }
+  }
+
+  return colors
+}
+
+function generateColorsJS(colors) {
+  const lines = [
+    '/**',
+    ' * VolleyKit Color Tokens (JS)',
+    ' *',
+    ' * AUTO-GENERATED from design-tokens.css — do not edit manually.',
+    ' * Run `pnpm run generate:tokens` to regenerate.',
+    ' */',
+    '',
+  ]
+
+  for (const group of COLOR_GROUPS) {
+    const shades = colors[group]
+    const keys = Object.keys(shades).sort((a, b) => Number(a) - Number(b))
+
+    lines.push(`const ${group} = {`)
+    for (const key of keys) {
+      lines.push(`  ${key}: '${shades[key]}',`)
+    }
+    lines.push('}')
+    lines.push('')
+  }
+
+  lines.push(`module.exports = { ${COLOR_GROUPS.join(', ')} }`)
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+// --- Main ---
+
+const css = readFileSync(CSS_PATH, 'utf8')
+const colors = parseDesignTokens(css)
+
+// Validate that we found colors for every group
+for (const group of COLOR_GROUPS) {
+  const count = Object.keys(colors[group]).length
+  if (count === 0) {
+    console.error(`Error: no color shades found for "${group}" in design-tokens.css`)
+    process.exit(1)
+  }
+}
+
+const generated = generateColorsJS(colors)
+
+const isCheck = process.argv.includes('--check')
+
+if (isCheck) {
+  const existing = readFileSync(JS_PATH, 'utf8')
+  if (existing !== generated) {
+    console.error('colors.js is out of date. Run `pnpm run generate:tokens` to regenerate.')
+    process.exit(1)
+  }
+  console.log('colors.js is up to date.')
+  process.exit(0)
+}
+
+writeFileSync(JS_PATH, generated, 'utf8')
+console.log('Generated packages/shared/styles/colors.js from design-tokens.css')

--- a/scripts/sync-style-tokens.js
+++ b/scripts/sync-style-tokens.js
@@ -28,10 +28,28 @@ function parseDesignTokens(css) {
   for (const group of COLOR_GROUPS) {
     colors[group] = {}
     // Match lines like: --color-primary-500: #b2e600;
+    // Limitation: only hex colors are supported. If design-tokens.css starts
+    // using rgb(), hsl(), or CSS color names, this regex will skip them.
+    // Extend the regex and value transform here if that happens.
     const re = new RegExp(`--color-${group}-(\\d+):\\s*(#[0-9a-fA-F]{3,8})`, 'g')
     let match
     while ((match = re.exec(css)) !== null) {
       colors[group][match[1]] = match[2]
+    }
+  }
+
+  // Warn about non-hex color values that were skipped
+  for (const group of COLOR_GROUPS) {
+    const allRe = new RegExp(`--color-${group}-(\\d+):\\s*([^;]+)`, 'g')
+    let match
+    while ((match = allRe.exec(css)) !== null) {
+      const shade = match[1]
+      const value = match[2].trim()
+      if (!colors[group][shade]) {
+        console.warn(
+          `Warning: --color-${group}-${shade} uses non-hex value "${value}" and was skipped`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `scripts/sync-style-tokens.js` that parses `design-tokens.css` (single source of truth) and generates `colors.js` for React Native / NativeWind
- Add `pnpm run generate:tokens` and `pnpm run generate:tokens:check` (CI mode) scripts
- Integrate token sync check into pre-commit validation (runs when style files are staged)
- Add `tokens` CI job to `.github/workflows/ci.yml` (lightweight, no dependencies)

Previously `colors.js` had to be manually kept in sync with `design-tokens.css`. Now editing the CSS source and running `pnpm run generate:tokens` auto-generates the JS export. The `--check` flag in CI/pre-commit catches any drift.

## Test plan

- [x] `node scripts/sync-style-tokens.js` generates correct `colors.js`
- [x] `node scripts/sync-style-tokens.js --check` passes when in sync
- [x] `--check` exits with code 1 when files diverge
- [x] Pre-commit validation runs `tokens:check` when style files are staged
- [ ] CI `tokens` job passes on this PR

https://claude.ai/code/session_01B3mwcRgEXjNp5tR27Tezin