### PR TITLE
feat(shared): audit color palette — add info scale, Slate gray, contrast fixes

### DIFF
--- a/.changeset/audit-color-palette.md
+++ b/.changeset/audit-color-palette.md
@@ -1,0 +1,7 @@
+---
+'@volleykit/shared': minor
+'volleykit-web': minor
+'@volleykit/mobile': minor
+---
+
+Audit color palette: add info (blue) scale, switch gray from Stone to Slate, fix WCAG contrast issues

--- a/packages/mobile/src/components/BiometricPrompt.tsx
+++ b/packages/mobile/src/components/BiometricPrompt.tsx
@@ -77,7 +77,7 @@ export function BiometricPrompt({
             <MaterialCommunityIcons
               name={iconName}
               size={BIOMETRIC_ICON_SIZE}
-              color={isAuthenticating ? COLORS.primary : COLORS.gray500}
+              color={isAuthenticating ? COLORS.interactive : COLORS.gray500}
             />
           </View>
 

--- a/packages/mobile/src/components/BiometricPrompt.tsx
+++ b/packages/mobile/src/components/BiometricPrompt.tsx
@@ -99,7 +99,7 @@ export function BiometricPrompt({
 
           {/* Authenticate button */}
           <TouchableOpacity
-            className={`py-4 rounded-xl mb-3 ${isAuthenticating ? 'bg-sky-300' : 'bg-sky-500'}`}
+            className={`py-4 rounded-xl mb-3 ${isAuthenticating ? 'bg-info-300' : 'bg-info-500'}`}
             onPress={onAuthenticate}
             disabled={isAuthenticating}
             accessibilityRole="button"
@@ -119,7 +119,7 @@ export function BiometricPrompt({
             accessibilityRole="button"
             accessibilityLabel={t('auth.enterCredentials')}
           >
-            <Text className="text-sky-500 font-medium text-center">
+            <Text className="text-info-500 font-medium text-center">
               {t('auth.enterCredentials')}
             </Text>
           </TouchableOpacity>

--- a/packages/mobile/src/components/CalendarPicker.tsx
+++ b/packages/mobile/src/components/CalendarPicker.tsx
@@ -56,7 +56,7 @@ export function CalendarPicker({
           <Text className="text-gray-900 text-base">{item.title}</Text>
           <Text className="text-gray-500 text-sm">{item.source}</Text>
         </View>
-        {isSelected && <Feather name="check" size={24} color={COLORS.primary} />}
+        {isSelected && <Feather name="check" size={24} color={COLORS.interactive} />}
       </TouchableOpacity>
     )
   }

--- a/packages/mobile/src/components/CalendarPicker.tsx
+++ b/packages/mobile/src/components/CalendarPicker.tsx
@@ -78,7 +78,7 @@ export function CalendarPicker({
             accessibilityRole="button"
             accessibilityLabel={t('common.cancel')}
           >
-            <Text className="text-sky-500 text-base">{t('common.cancel')}</Text>
+            <Text className="text-info-500 text-base">{t('common.cancel')}</Text>
           </TouchableOpacity>
           <Text className="text-gray-900 text-lg font-semibold">
             {t('settings.calendar.selectCalendar')}

--- a/packages/mobile/src/components/ErrorScreen.tsx
+++ b/packages/mobile/src/components/ErrorScreen.tsx
@@ -119,7 +119,7 @@ export function ErrorScreen({
         {/* Retry button */}
         {onRetry && (
           <TouchableOpacity
-            className="bg-sky-500 rounded-lg py-3 px-6 mb-4"
+            className="bg-info-500 rounded-lg py-3 px-6 mb-4"
             onPress={onRetry}
             accessibilityRole="button"
             accessibilityLabel={t('errorBoundary.tryAgain')}

--- a/packages/mobile/src/components/LanguagePicker.tsx
+++ b/packages/mobile/src/components/LanguagePicker.tsx
@@ -53,7 +53,9 @@ export function LanguagePicker({
         <View className="flex-1">
           <Text className="text-gray-900 text-base">{LANGUAGE_NAMES[item]}</Text>
         </View>
-        {isSelected && <Feather name="check" size={SETTINGS_ICON_SIZE} color={COLORS.interactive} />}
+        {isSelected && (
+          <Feather name="check" size={SETTINGS_ICON_SIZE} color={COLORS.interactive} />
+        )}
       </TouchableOpacity>
     )
   }

--- a/packages/mobile/src/components/LanguagePicker.tsx
+++ b/packages/mobile/src/components/LanguagePicker.tsx
@@ -53,7 +53,7 @@ export function LanguagePicker({
         <View className="flex-1">
           <Text className="text-gray-900 text-base">{LANGUAGE_NAMES[item]}</Text>
         </View>
-        {isSelected && <Feather name="check" size={SETTINGS_ICON_SIZE} color={COLORS.primary} />}
+        {isSelected && <Feather name="check" size={SETTINGS_ICON_SIZE} color={COLORS.interactive} />}
       </TouchableOpacity>
     )
   }

--- a/packages/mobile/src/components/LanguagePicker.tsx
+++ b/packages/mobile/src/components/LanguagePicker.tsx
@@ -75,7 +75,7 @@ export function LanguagePicker({
             accessibilityRole="button"
             accessibilityLabel={t('common.cancel')}
           >
-            <Text className="text-sky-500 text-base">{t('common.cancel')}</Text>
+            <Text className="text-info-500 text-base">{t('common.cancel')}</Text>
           </TouchableOpacity>
           <Text className="text-gray-900 text-lg font-semibold">{t('settings.language')}</Text>
           <View className="w-16" />

--- a/packages/mobile/src/components/OfflineActionBlocker.tsx
+++ b/packages/mobile/src/components/OfflineActionBlocker.tsx
@@ -73,7 +73,7 @@ export function OfflineActionBlocker({
           </Text>
 
           <TouchableOpacity
-            className="bg-sky-500 rounded-lg py-3 px-4"
+            className="bg-info-500 rounded-lg py-3 px-4"
             onPress={onDismiss}
             accessibilityRole="button"
             accessibilityLabel="Close"

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -58,7 +58,7 @@ const TOAST_STYLES: Record<
     bg: 'bg-primary-50',
     border: 'border-primary-200',
     text: 'text-primary-800',
-    iconColor: '#0ea5e9', // primary-500 (sky)
+    iconColor: '#3b82f6', // info-500 (blue)
   },
 }
 

--- a/packages/mobile/src/constants.ts
+++ b/packages/mobile/src/constants.ts
@@ -9,30 +9,30 @@ import Constants from 'expo-constants'
  * These match the Tailwind CSS color palette
  */
 export const COLORS = {
-  // Primary colors
-  primary: '#0ea5e9', // sky-500
+  // Info color (used for interactive blue elements)
+  primary: '#3b82f6', // info-500
 
-  // Gray scale (warm stone tones)
-  gray50: '#fafaf9',
-  gray100: '#f5f5f4',
-  gray200: '#e7e5e4',
-  gray400: '#a8a29e',
-  gray500: '#78716c',
-  gray600: '#57534e',
-  gray700: '#44403c',
-  gray900: '#1c1917',
+  // Gray scale (cool slate tones)
+  gray50: '#f8fafc',
+  gray100: '#f1f5f9',
+  gray200: '#e2e8f0',
+  gray400: '#94a3b8',
+  gray500: '#64748b',
+  gray600: '#475569',
+  gray700: '#334155',
+  gray900: '#0f172a',
 
   // Status colors (emerald success, amber warning, rose danger)
   success100: '#d1fae5',
   success500: '#10b981',
   success700: '#047857',
-  primary100: '#e0f2fe',
-  primary700: '#0369a1',
+  info100: '#dbeafe',
+  info500: '#3b82f6',
+  info600: '#2563eb',
+  info700: '#1d4ed8',
   warning500: '#f59e0b',
   warning600: '#d97706',
   danger500: '#f43f5e', // rose-500
-  sky500: '#0ea5e9',
-  sky600: '#0284c7',
   purple600: '#9333ea',
 } as const
 

--- a/packages/mobile/src/constants.ts
+++ b/packages/mobile/src/constants.ts
@@ -9,8 +9,8 @@ import Constants from 'expo-constants'
  * These match the Tailwind CSS color palette
  */
 export const COLORS = {
-  // Info color (used for interactive blue elements)
-  primary: '#3b82f6', // info-500
+  // Interactive blue (info-500) — links, toggles, active tabs
+  interactive: '#3b82f6', // info-500
 
   // Gray scale (cool slate tones)
   gray50: '#f8fafc',

--- a/packages/mobile/src/navigation/TabNavigator.tsx
+++ b/packages/mobile/src/navigation/TabNavigator.tsx
@@ -35,7 +35,7 @@ export function TabNavigator() {
   return (
     <Tab.Navigator
       screenOptions={{
-        tabBarActiveTintColor: COLORS.primary,
+        tabBarActiveTintColor: COLORS.interactive,
         tabBarInactiveTintColor: COLORS.gray500,
         headerShown: true,
         headerRight: () => <HeaderRight />,

--- a/packages/mobile/src/screens/AssignmentDetailScreen.tsx
+++ b/packages/mobile/src/screens/AssignmentDetailScreen.tsx
@@ -97,7 +97,7 @@ export function AssignmentDetailScreen({ route }: Props) {
       <View className="flex-1 bg-white items-center justify-center">
         <ActivityIndicator
           size="large"
-          color={COLORS.primary}
+          color={COLORS.interactive}
           accessibilityLabel={t('common.loading')}
         />
       </View>

--- a/packages/mobile/src/screens/AssignmentDetailScreen.tsx
+++ b/packages/mobile/src/screens/AssignmentDetailScreen.tsx
@@ -113,7 +113,7 @@ export function AssignmentDetailScreen({ route }: Props) {
           {error?.message ?? t('common.error')}
         </Text>
         <TouchableOpacity
-          className="bg-sky-500 rounded-lg px-6 py-3"
+          className="bg-info-500 rounded-lg px-6 py-3"
           onPress={() => refetch()}
           accessibilityRole="button"
           accessibilityLabel={t('common.retry')}
@@ -187,8 +187,8 @@ export function AssignmentDetailScreen({ route }: Props) {
                 accessibilityRole="button"
                 accessibilityLabel={t('common.openInMaps')}
               >
-                <Feather name="navigation" size={14} color={COLORS.sky500} />
-                <Text className="text-sky-500 ml-2 font-medium">{t('common.openInMaps')}</Text>
+                <Feather name="navigation" size={14} color={COLORS.info500} />
+                <Text className="text-info-500 ml-2 font-medium">{t('common.openInMaps')}</Text>
               </TouchableOpacity>
             )}
           </View>
@@ -212,9 +212,9 @@ export function AssignmentDetailScreen({ route }: Props) {
 
           {/* Message indicator */}
           {display.hasMessage && (
-            <View className="bg-sky-50 rounded-lg p-4 flex-row items-center">
-              <Feather name="message-circle" size={18} color={COLORS.sky600} />
-              <Text className="text-sky-700 ml-3 flex-1">{t('assignments.hasMessage')}</Text>
+            <View className="bg-info-50 rounded-lg p-4 flex-row items-center">
+              <Feather name="message-circle" size={18} color={COLORS.info600} />
+              <Text className="text-info-700 ml-3 flex-1">{t('assignments.hasMessage')}</Text>
             </View>
           )}
 

--- a/packages/mobile/src/screens/BiometricSettingsScreen.tsx
+++ b/packages/mobile/src/screens/BiometricSettingsScreen.tsx
@@ -125,7 +125,7 @@ export function BiometricSettingsScreen({ navigation: _navigation }: Props) {
               <Switch
                 value={isEnabled}
                 onValueChange={handleToggle}
-                trackColor={{ false: COLORS.gray200, true: COLORS.primary }}
+                trackColor={{ false: COLORS.gray200, true: COLORS.interactive }}
                 ios_backgroundColor={COLORS.gray200}
                 accessibilityRole="switch"
                 accessibilityLabel={`${t('settings.biometric.enable')} ${biometricName}`}

--- a/packages/mobile/src/screens/CalendarSettingsScreen.tsx
+++ b/packages/mobile/src/screens/CalendarSettingsScreen.tsx
@@ -78,7 +78,7 @@ export function CalendarSettingsScreen(_props: Props) {
             </View>
             <View
               className={`w-6 h-6 rounded-full border-2 items-center justify-center ${
-                settings.syncMode === 'ical' ? 'border-sky-500 bg-sky-500' : 'border-gray-300'
+                settings.syncMode === 'ical' ? 'border-info-500 bg-info-500' : 'border-gray-300'
               }`}
             >
               {settings.syncMode === 'ical' && <Feather name="check" size={14} color="white" />}
@@ -108,7 +108,7 @@ export function CalendarSettingsScreen(_props: Props) {
             </View>
             <View
               className={`w-6 h-6 rounded-full border-2 items-center justify-center ${
-                settings.syncMode === 'direct' ? 'border-sky-500 bg-sky-500' : 'border-gray-300'
+                settings.syncMode === 'direct' ? 'border-info-500 bg-info-500' : 'border-gray-300'
               }`}
             >
               {settings.syncMode === 'direct' && <Feather name="check" size={14} color="white" />}
@@ -121,7 +121,7 @@ export function CalendarSettingsScreen(_props: Props) {
       {settings.syncMode === 'ical' && (
         <View className="mt-6 px-4">
           <TouchableOpacity
-            className="bg-sky-500 rounded-lg py-4"
+            className="bg-info-500 rounded-lg py-4"
             onPress={handleIcalSubscribe}
             accessibilityRole="button"
             accessibilityLabel={t('settings.calendar.subscribeIcal')}
@@ -170,7 +170,7 @@ export function CalendarSettingsScreen(_props: Props) {
           <View className="mt-6 px-4">
             <TouchableOpacity
               className={`rounded-lg py-4 ${
-                settings.selectedCalendarId ? 'bg-sky-500' : 'bg-gray-300'
+                settings.selectedCalendarId ? 'bg-info-500' : 'bg-gray-300'
               }`}
               onPress={handleSyncNow}
               disabled={!settings.selectedCalendarId || isSyncing}

--- a/packages/mobile/src/screens/CalendarSettingsScreen.tsx
+++ b/packages/mobile/src/screens/CalendarSettingsScreen.tsx
@@ -39,7 +39,7 @@ export function CalendarSettingsScreen(_props: Props) {
   if (isLoading) {
     return (
       <View className="flex-1 bg-gray-50 items-center justify-center">
-        <ActivityIndicator size="large" color={COLORS.primary} />
+        <ActivityIndicator size="large" color={COLORS.interactive} />
       </View>
     )
   }

--- a/packages/mobile/src/screens/DepartureReminderSettingsScreen.tsx
+++ b/packages/mobile/src/screens/DepartureReminderSettingsScreen.tsx
@@ -150,7 +150,7 @@ export function DepartureReminderSettingsScreen(_props: Props) {
   if (isLoading) {
     return (
       <View className="flex-1 bg-gray-50 items-center justify-center">
-        <ActivityIndicator size="large" color={COLORS.primary} />
+        <ActivityIndicator size="large" color={COLORS.interactive} />
       </View>
     )
   }
@@ -182,12 +182,12 @@ export function DepartureReminderSettingsScreen(_props: Props) {
               </Text>
             </View>
             {isRequestingPermissions ? (
-              <ActivityIndicator size="small" color={COLORS.primary} />
+              <ActivityIndicator size="small" color={COLORS.interactive} />
             ) : (
               <Switch
                 value={settings.enabled}
                 onValueChange={handleToggle}
-                trackColor={{ false: COLORS.gray200, true: COLORS.primary }}
+                trackColor={{ false: COLORS.gray200, true: COLORS.interactive }}
                 accessibilityRole="switch"
                 accessibilityLabel={t('settings.departure.title')}
                 accessibilityState={{ checked: settings.enabled }}

--- a/packages/mobile/src/screens/DepartureReminderSettingsScreen.tsx
+++ b/packages/mobile/src/screens/DepartureReminderSettingsScreen.tsx
@@ -224,7 +224,7 @@ export function DepartureReminderSettingsScreen(_props: Props) {
                   <View
                     className={`w-6 h-6 rounded-full border-2 items-center justify-center ${
                       settings.bufferMinutes === minutes
-                        ? 'border-sky-500 bg-sky-500'
+                        ? 'border-info-500 bg-info-500'
                         : 'border-gray-300'
                     }`}
                   >

--- a/packages/mobile/src/screens/LoginScreen.tsx
+++ b/packages/mobile/src/screens/LoginScreen.tsx
@@ -210,7 +210,7 @@ export function LoginScreen(_props: Props) {
               color={isAuthenticating ? COLORS.gray400 : COLORS.primary}
             />
             <Text
-              className={`ml-2 font-medium ${isAuthenticating ? 'text-gray-400' : 'text-sky-500'}`}
+              className={`ml-2 font-medium ${isAuthenticating ? 'text-gray-400' : 'text-info-500'}`}
             >
               {isAuthenticating
                 ? t('common.loading')

--- a/packages/mobile/src/screens/LoginScreen.tsx
+++ b/packages/mobile/src/screens/LoginScreen.tsx
@@ -207,7 +207,7 @@ export function LoginScreen(_props: Props) {
             <MaterialCommunityIcons
               name={biometricIcon}
               size={24}
-              color={isAuthenticating ? COLORS.gray400 : COLORS.primary}
+              color={isAuthenticating ? COLORS.gray400 : COLORS.interactive}
             />
             <Text
               className={`ml-2 font-medium ${isAuthenticating ? 'text-gray-400' : 'text-info-500'}`}

--- a/packages/mobile/tailwind.config.js
+++ b/packages/mobile/tailwind.config.js
@@ -1,4 +1,4 @@
-const { primary, success, warning, danger, gray } = require('@volleykit/shared/styles/colors')
+const { primary, info, success, warning, danger, gray } = require('@volleykit/shared/styles/colors')
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -8,6 +8,7 @@ module.exports = {
     extend: {
       colors: {
         primary,
+        info,
         success,
         warning,
         danger,

--- a/packages/shared/styles/colors.js
+++ b/packages/shared/styles/colors.js
@@ -19,6 +19,20 @@ const primary = {
   950: '#233400',
 }
 
+const info = {
+  50: '#eff6ff',
+  100: '#dbeafe',
+  200: '#bfdbfe',
+  300: '#93c5fd',
+  400: '#60a5fa',
+  500: '#3b82f6',
+  600: '#2563eb',
+  700: '#1d4ed8',
+  800: '#1e40af',
+  900: '#1e3a8a',
+  950: '#172554',
+}
+
 const success = {
   50: '#ecfdf5',
   100: '#d1fae5',
@@ -62,17 +76,17 @@ const danger = {
 }
 
 const gray = {
-  50: '#fafaf9',
-  100: '#f5f5f4',
-  200: '#e7e5e4',
-  300: '#d6d3d1',
-  400: '#a8a29e',
-  500: '#78716c',
-  600: '#57534e',
-  700: '#44403c',
-  800: '#292524',
-  900: '#1c1917',
-  950: '#0c0a09',
+  50: '#f8fafc',
+  100: '#f1f5f9',
+  200: '#e2e8f0',
+  300: '#cbd5e1',
+  400: '#94a3b8',
+  500: '#64748b',
+  600: '#475569',
+  700: '#334155',
+  800: '#1e293b',
+  900: '#0f172a',
+  950: '#020617',
 }
 
-module.exports = { primary, success, warning, danger, gray }
+module.exports = { primary, info, success, warning, danger, gray }

--- a/packages/shared/styles/design-tokens.css
+++ b/packages/shared/styles/design-tokens.css
@@ -26,22 +26,22 @@
   --color-svv-white: #ffffff;
 
   /* ==============================================
-   * WARM NEUTRAL PALETTE (stone)
-   * Overrides Tailwind's cool gray with warm tones
-   * that harmonize with the lime primary
+   * COOL NEUTRAL PALETTE (slate)
+   * Blue-gray tones that pair naturally with lime
+   * and create a modern, digital-first aesthetic
    * ============================================== */
 
-  --color-gray-50: #fafaf9;
-  --color-gray-100: #f5f5f4;
-  --color-gray-200: #e7e5e4;
-  --color-gray-300: #d6d3d1;
-  --color-gray-400: #a8a29e;
-  --color-gray-500: #78716c;
-  --color-gray-600: #57534e;
-  --color-gray-700: #44403c;
-  --color-gray-800: #292524;
-  --color-gray-900: #1c1917;
-  --color-gray-950: #0c0a09;
+  --color-gray-50: #f8fafc;
+  --color-gray-100: #f1f5f9;
+  --color-gray-200: #e2e8f0;
+  --color-gray-300: #cbd5e1;
+  --color-gray-400: #94a3b8;
+  --color-gray-500: #64748b;
+  --color-gray-600: #475569;
+  --color-gray-700: #334155;
+  --color-gray-800: #1e293b;
+  --color-gray-900: #0f172a;
+  --color-gray-950: #020617;
 
   /* ==============================================
    * SEMANTIC PRIMARY COLOR PALETTE
@@ -60,6 +60,23 @@
   --color-primary-800: #526d07;
   --color-primary-900: #455c0b;
   --color-primary-950: #233400;
+
+  /* ==============================================
+   * INFO COLOR (blue)
+   * Informational states, help text, tooltips, links
+   * ============================================== */
+
+  --color-info-50: #eff6ff;
+  --color-info-100: #dbeafe;
+  --color-info-200: #bfdbfe;
+  --color-info-300: #93c5fd;
+  --color-info-400: #60a5fa;
+  --color-info-500: #3b82f6; /* Main info color */
+  --color-info-600: #2563eb; /* Hover/emphasis */
+  --color-info-700: #1d4ed8;
+  --color-info-800: #1e40af;
+  --color-info-900: #1e3a8a;
+  --color-info-950: #172554;
 
   /* ==============================================
    * SEMANTIC STATUS COLORS

--- a/packages/web/src/common/components/layout/AppShell.test.tsx
+++ b/packages/web/src/common/components/layout/AppShell.test.tsx
@@ -239,9 +239,9 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Find the calendar banner by its sky-colored background (banner, not header indicator)
+        // Find the calendar banner by its info-colored background (banner, not header indicator)
         const banners = screen.getAllByRole('alert')
-        const calendarBanner = banners.find((b) => b.className.includes('sky'))
+        const calendarBanner = banners.find((b) => b.className.includes('info'))
         expect(calendarBanner).toBeInTheDocument()
       })
 
@@ -256,9 +256,9 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Should not have calendar mode banner (sky-colored alert)
+        // Should not have calendar mode banner (info-colored alert)
         const banners = screen.queryAllByRole('alert')
-        const calendarBanner = banners.find((b) => b.className.includes('sky'))
+        const calendarBanner = banners.find((b) => b.className.includes('info'))
         expect(calendarBanner).toBeUndefined()
       })
 
@@ -273,9 +273,9 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Find the calendar banner by its sky-colored background
+        // Find the calendar banner by its info-colored background
         const banners = screen.getAllByRole('alert')
-        const calendarBanner = banners.find((b) => b.className.includes('sky'))
+        const calendarBanner = banners.find((b) => b.className.includes('info'))
         expect(calendarBanner).toBeInTheDocument()
         expect(calendarBanner).toHaveAttribute('aria-live', 'polite')
       })
@@ -299,9 +299,9 @@ describe('AppShell', () => {
 
           renderAppShell()
 
-          // Find the calendar banner by its sky-colored background class
+          // Find the calendar banner by its info-colored background class
           const banners = screen.getAllByRole('alert')
-          const calendarBanner = banners.find((b) => b.className.includes('sky'))
+          const calendarBanner = banners.find((b) => b.className.includes('info'))
           expect(calendarBanner?.textContent).toMatch(expectedPattern)
         }
       )
@@ -421,8 +421,8 @@ describe('AppShell', () => {
         const alerts = screen.getAllByRole('alert')
         const demoBanner = alerts.find((a) => a.className.includes('amber'))
         expect(demoBanner).toBeInTheDocument()
-        // Calendar banner (sky-colored) should not be present
-        const calendarBanner = alerts.find((a) => a.className.includes('sky'))
+        // Calendar banner (info-colored) should not be present
+        const calendarBanner = alerts.find((a) => a.className.includes('info'))
         expect(calendarBanner).toBeUndefined()
       })
 
@@ -437,9 +437,9 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Find the calendar banner by its sky-colored background
+        // Find the calendar banner by its info-colored background
         const banners = screen.getAllByRole('alert')
-        const calendarBanner = banners.find((b) => b.className.includes('sky'))
+        const calendarBanner = banners.find((b) => b.className.includes('info'))
         expect(calendarBanner).toBeInTheDocument()
         // Demo banner (amber-colored) should not be present
         const demoBanner = banners.find((b) => b.className.includes('amber'))

--- a/packages/web/src/common/components/layout/AppShell.tsx
+++ b/packages/web/src/common/components/layout/AppShell.tsx
@@ -294,12 +294,12 @@ export function AppShell() {
       {/* Calendar mode banner */}
       {isCalendarMode && (
         <div
-          className="bg-sky-100 dark:bg-sky-900/50 border-b border-sky-200 dark:border-sky-800"
+          className="bg-info-100 dark:bg-info-900/50 border-b border-info-200 dark:border-info-800"
           role="alert"
           aria-live="polite"
         >
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
-            <p className="text-sm text-sky-800 dark:text-sky-200 text-center font-medium">
+            <p className="text-sm text-info-800 dark:text-info-200 text-center font-medium">
               {t('common.calendarModeBanner')}
             </p>
           </div>

--- a/packages/web/src/features/ocr/components/EasterEggModal.tsx
+++ b/packages/web/src/features/ocr/components/EasterEggModal.tsx
@@ -75,7 +75,7 @@ export function EasterEggModal({ isOpen, type, onClose }: EasterEggModalProps) {
         <button
           type="button"
           onClick={onClose}
-          className="w-full px-4 py-2.5 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
+          className="w-full px-4 py-2.5 text-sm font-medium text-gray-900 bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
         >
           {t('easterEggs.dismiss')}
         </button>

--- a/packages/web/src/features/sports-hall-report/components/WizardStepIndicator.tsx
+++ b/packages/web/src/features/sports-hall-report/components/WizardStepIndicator.tsx
@@ -33,14 +33,14 @@ export function WizardStepIndicator({ steps, currentStep }: WizardStepIndicatorP
               <div className="flex items-center gap-1.5 whitespace-nowrap">
                 {isCompleted ? (
                   <CheckCircle
-                    className="w-5 h-5 text-primary-500 flex-shrink-0"
+                    className="w-5 h-5 text-primary-800 dark:text-primary-400 flex-shrink-0"
                     aria-hidden="true"
                   />
                 ) : (
                   <span
                     className={`w-5 h-5 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0 ${
                       isCurrent
-                        ? 'bg-primary-500 text-white'
+                        ? 'bg-primary-500 text-gray-900'
                         : 'bg-surface-subtle dark:bg-surface-subtle-dark text-text-muted dark:text-text-muted-dark'
                     }`}
                   >
@@ -52,7 +52,7 @@ export function WizardStepIndicator({ steps, currentStep }: WizardStepIndicatorP
                     isCurrent
                       ? 'font-medium text-text-primary dark:text-text-primary-dark'
                       : isCompleted
-                        ? 'text-primary-500'
+                        ? 'text-primary-800 dark:text-primary-400'
                         : 'text-text-muted dark:text-text-muted-dark'
                   }`}
                 >

--- a/packages/web/src/features/validation/ocr/components/ImageCropEditor.tsx
+++ b/packages/web/src/features/validation/ocr/components/ImageCropEditor.tsx
@@ -185,7 +185,7 @@ export function ImageCropEditor({
           type="button"
           onClick={handleConfirm}
           disabled={isProcessing || !croppedAreaPixels}
-          className="flex-1 flex items-center justify-center gap-2 min-h-12 px-4 py-3 text-white bg-primary-500 hover:bg-primary-600 rounded-lg font-medium transition-colors disabled:opacity-50"
+          className="flex-1 flex items-center justify-center gap-2 min-h-12 px-4 py-3 text-gray-900 bg-primary-500 hover:bg-primary-600 rounded-lg font-medium transition-colors disabled:opacity-50"
         >
           <Check className="w-5 h-5" aria-hidden="true" />
           {isProcessing ? t('validation.ocr.processing') : t('common.confirm')}

--- a/packages/web/src/features/validation/ocr/components/OCRCaptureModal.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCRCaptureModal.tsx
@@ -339,7 +339,7 @@ export function OCRCaptureModal({
             <button
               type="button"
               onClick={cameraError ? handleSelectImage : startCamera}
-              className="w-full flex items-center justify-center gap-3 px-4 py-3 text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors font-medium"
+              className="w-full flex items-center justify-center gap-3 px-4 py-3 text-gray-900 bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors font-medium"
             >
               <Camera className="w-5 h-5" aria-hidden="true" />
               {t('validation.ocr.takePhoto')}

--- a/packages/web/src/features/validation/ocr/components/OCREntryModal.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCREntryModal.tsx
@@ -421,7 +421,7 @@ export function OCREntryModal({
           <button
             type="button"
             onClick={() => onComplete(capturedBlobRef.current ?? undefined)}
-            className="flex-1 px-4 py-3 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
+            className="flex-1 px-4 py-3 text-sm font-medium text-gray-900 bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
           >
             {t('validation.ocr.continueToValidation')}
           </button>

--- a/packages/web/src/features/validation/ocr/components/OCREntryModal.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCREntryModal.tsx
@@ -373,7 +373,10 @@ export function OCREntryModal({
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border-default dark:border-border-default-dark">
         <div>
-          <h1 id="ocr-entry-title" className="text-lg font-semibold text-text-primary dark:text-text-primary-dark">
+          <h1
+            id="ocr-entry-title"
+            className="text-lg font-semibold text-text-primary dark:text-text-primary-dark"
+          >
             {t('validation.ocr.scanScoresheet')}
           </h1>
         </div>

--- a/packages/web/src/features/validation/ocr/components/OCRErrorStep.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCRErrorStep.tsx
@@ -24,7 +24,7 @@ export function OCRErrorStep({ errorMessage, onRetry }: OCRErrorStepProps) {
       <button
         type="button"
         onClick={onRetry}
-        className="flex items-center gap-2 px-6 py-3 text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors font-medium"
+        className="flex items-center gap-2 px-6 py-3 text-gray-900 bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors font-medium"
       >
         <RefreshCw className="w-5 h-5" aria-hidden="true" />
         {t('validation.ocr.retryCapture')}

--- a/packages/web/src/features/validation/ocr/components/OCRIntroStep.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCRIntroStep.tsx
@@ -16,7 +16,7 @@ export function OCRIntroStep({ onStartScan, onSkip }: OCRIntroStepProps) {
   return (
     <div className="flex flex-col items-center justify-center min-h-[50vh]">
       <Camera
-        className="w-16 h-16 text-primary-400 dark:text-primary-500 mb-4"
+        className="w-16 h-16 text-primary-600 dark:text-primary-500 mb-4"
         aria-hidden="true"
       />
       <h2 className="text-xl font-semibold text-text-primary dark:text-text-primary-dark mb-2">
@@ -55,7 +55,10 @@ export function OCRIntroStep({ onStartScan, onSkip }: OCRIntroStepProps) {
           className="w-full flex items-start gap-4 p-4 bg-surface-card dark:bg-surface-card-dark border-2 border-border-default dark:border-border-strong-dark rounded-xl hover:border-primary-300 dark:hover:border-primary-700 hover:bg-surface-page dark:hover:bg-surface-muted-dark transition-colors text-left"
         >
           <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center rounded-lg bg-surface-subtle dark:bg-surface-subtle-dark">
-            <PenTool className="w-6 h-6 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+            <PenTool
+              className="w-6 h-6 text-text-muted dark:text-text-muted-dark"
+              aria-hidden="true"
+            />
           </div>
           <div className="flex-1 min-w-0">
             <span className="block text-base font-semibold text-text-primary dark:text-text-primary-dark">

--- a/packages/web/src/features/validation/ocr/components/OCRPanel.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCRPanel.tsx
@@ -244,7 +244,7 @@ export function OCRPanel({
               <button
                 type="button"
                 onClick={handleOpenCapture}
-                className="px-6 py-3 bg-primary-500 hover:bg-primary-600 text-white font-medium rounded-lg transition-colors"
+                className="px-6 py-3 bg-primary-500 hover:bg-primary-600 text-gray-900 font-medium rounded-lg transition-colors"
               >
                 {t('validation.ocr.scanScoresheet')}
               </button>
@@ -319,7 +319,7 @@ export function OCRPanel({
               <button
                 type="button"
                 onClick={handleRetry}
-                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-900 bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
               >
                 <RefreshCw className="w-4 h-4" aria-hidden="true" />
                 {t('validation.ocr.retryCapture')}
@@ -342,7 +342,7 @@ export function OCRPanel({
               type="button"
               onClick={handleApplyResults}
               disabled={selectedPlayerIds.size === 0}
-              className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 disabled:bg-surface-muted dark:disabled:bg-surface-muted-dark disabled:cursor-not-allowed rounded-lg transition-colors"
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-900 bg-primary-500 hover:bg-primary-600 disabled:bg-surface-muted dark:disabled:bg-surface-muted-dark disabled:cursor-not-allowed rounded-lg transition-colors"
             >
               {t('validation.ocr.useResults')}
             </button>

--- a/packages/web/src/features/validation/ocr/components/OCRPanel.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCRPanel.tsx
@@ -217,7 +217,10 @@ export function OCRPanel({
       <div className="bg-surface-card dark:bg-surface-card-dark rounded-xl shadow-xl max-w-md w-full mx-4 max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border-default dark:border-border-default-dark flex-shrink-0">
-          <h2 id="ocr-panel-title" className="text-lg font-semibold text-text-primary dark:text-text-primary-dark">
+          <h2
+            id="ocr-panel-title"
+            className="text-lg font-semibold text-text-primary dark:text-text-primary-dark"
+          >
             {t('validation.ocr.scanScoresheet')}
           </h2>
           <button

--- a/packages/web/src/features/validation/ocr/components/ScoresheetPanel.tsx
+++ b/packages/web/src/features/validation/ocr/components/ScoresheetPanel.tsx
@@ -187,7 +187,7 @@ export function ScoresheetPanel({
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
-              className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
+              className="inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-900 bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
             >
               <Upload className="w-4 h-4" aria-hidden="true" />
               {tKey('selectFile')}

--- a/packages/web/src/features/validation/roster/components/AddPlayerSheet.tsx
+++ b/packages/web/src/features/validation/roster/components/AddPlayerSheet.tsx
@@ -271,7 +271,7 @@ export function AddPlayerSheet({
           className="
               w-full py-3 px-4 rounded-lg
               text-sm font-medium
-              text-white bg-primary-500 hover:bg-primary-600
+              text-gray-900 bg-primary-500 hover:bg-primary-600
               dark:bg-primary-600 dark:hover:bg-primary-700
               transition-colors
               focus:outline-none focus:ring-2 focus:ring-primary-500/50

--- a/packages/web/src/features/validation/roster/components/RosterVerificationPanel.tsx
+++ b/packages/web/src/features/validation/roster/components/RosterVerificationPanel.tsx
@@ -337,7 +337,9 @@ export function RosterVerificationPanel({
   return (
     <div className="py-4">
       {/* Team name header */}
-      <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-3">{teamName}</h3>
+      <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-3">
+        {teamName}
+      </h3>
 
       {/* Coaches Section */}
       <div className="mb-2">

--- a/packages/web/src/features/validation/roster/components/RosterVerificationPanel.tsx
+++ b/packages/web/src/features/validation/roster/components/RosterVerificationPanel.tsx
@@ -325,7 +325,7 @@ export function RosterVerificationPanel({
         <button
           type="button"
           onClick={() => refetch()}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-900 bg-primary-500 hover:bg-primary-600 rounded-lg transition-colors"
         >
           <RefreshCw className="w-4 h-4" aria-hidden="true" />
           {t('common.retry')}

--- a/scripts/sync-style-tokens.js
+++ b/scripts/sync-style-tokens.js
@@ -20,7 +20,7 @@ const CSS_PATH = resolve(ROOT, 'packages/shared/styles/design-tokens.css')
 const JS_PATH = resolve(ROOT, 'packages/shared/styles/colors.js')
 
 // Color groups to extract (token prefix -> JS export name)
-const COLOR_GROUPS = ['primary', 'success', 'warning', 'danger', 'gray']
+const COLOR_GROUPS = ['primary', 'info', 'success', 'warning', 'danger', 'gray']
 
 function parseDesignTokens(css) {
   const colors = {}


### PR DESCRIPTION
## Summary

- **Add info (blue) semantic color scale** — fills the missing gap for informational states, help text, tooltips, and links (`info-50` through `info-950`, Tailwind Blue)
- **Switch gray from Stone to Slate** — cool blue-gray tones that pair naturally with lime on dark backgrounds, creating a more modern digital aesthetic
- **Fix WCAG AA contrast violations** — primary-500 (`#b2e600`) as text on white has only 1.48:1 contrast ratio; switched to `primary-800` for text and `gray-900` for text on primary backgrounds
- **Standardize ad-hoc sky-500 usage** — all 15+ instances of `text-sky-500`/`bg-sky-500` across web and mobile now use the new `info-500` design token

### Changes by area

| Area | Changes |
|------|---------|
| `design-tokens.css` | Added `info` scale (11 shades), replaced Stone gray with Slate |
| `sync-style-tokens.js` | Added `info` to `COLOR_GROUPS` for JS generation |
| `colors.js` | Auto-regenerated with new info + slate values |
| Mobile `tailwind.config.js` | Imports and registers `info` color |
| Mobile `constants.ts` | Updated hardcoded grays to Slate, replaced sky→info |
| Web components | Fixed `text-white` on `bg-primary-500` → `text-gray-900`; `text-primary-500` on light bg → `text-primary-800` |
| Mobile components (7 files) | Migrated all `sky-500` → `info-500` |
| AppShell + test | Calendar banner `sky` → `info` |

## Test plan

- [x] All validation passes (format, lint, typecheck, test, build) across shared, web, and mobile
- [x] Token sync check passes (`generate:tokens:check`)
- [ ] Visual review of primary buttons (dark text on lime bg)
- [ ] Visual review of completed step indicators (primary-800 text)
- [ ] Visual review of info-colored elements (calendar banner, mobile buttons)
- [ ] Dark mode spot check — lime on slate surfaces

https://claude.ai/code/session_012emuZk8W54rCjS4Ay7wsJL