### PR TITLE
refactor(web): standardize semantic tokens across web and help-site

### DIFF
--- a/help-site/src/components/Header.astro
+++ b/help-site/src/components/Header.astro
@@ -61,7 +61,7 @@ import { BASE_PATH } from '../constants'
         href="https://volleykit.ch/"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-primary-950 transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+        class="flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-primary-950 transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-surface-page-dark"
       >
         <span data-i18n="common.openApp">Open App</span>
         <svg

--- a/help-site/src/components/MobileNav.astro
+++ b/help-site/src/components/MobileNav.astro
@@ -40,7 +40,7 @@ const icons: Record<string, string> = {
 >
   <!-- Backdrop overlay -->
   <div
-    class="fixed inset-0 bg-gray-900/50 backdrop-blur-sm transition-opacity"
+    class="fixed inset-0 bg-surface-page-dark/50 backdrop-blur-sm transition-opacity"
     data-mobile-nav-backdrop
   >
   </div>

--- a/help-site/src/components/SearchModal.astro
+++ b/help-site/src/components/SearchModal.astro
@@ -19,7 +19,7 @@ import { BASE_PATH, TIMING, MAX_SEARCH_RESULTS } from '../constants'
 >
   <!-- Backdrop -->
   <div
-    class="fixed inset-0 bg-gray-900/50 backdrop-blur-sm transition-opacity"
+    class="fixed inset-0 bg-surface-page-dark/50 backdrop-blur-sm transition-opacity"
     data-search-backdrop
   >
   </div>

--- a/help-site/src/pages/index.astro
+++ b/help-site/src/pages/index.astro
@@ -127,7 +127,7 @@ const features = [
           <!-- CTA Button -->
           <a
             href={`${BASE_PATH}/getting-started/`}
-            class="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-6 py-3 text-lg font-medium text-primary-950 transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+            class="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-6 py-3 text-lg font-medium text-primary-950 transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-surface-page-dark"
           >
             <span data-i18n="home.ctaGetStarted">{t('home.ctaGetStarted')}</span>
             <svg

--- a/packages/web/src/common/components/Button.tsx
+++ b/packages/web/src/common/components/Button.tsx
@@ -1,6 +1,12 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-export type ButtonVariant = 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'ghost'
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'ghost'
 
 export type ButtonSize = 'sm' | 'md' | 'lg'
 

--- a/packages/web/src/common/components/OfflineIndicator.tsx
+++ b/packages/web/src/common/components/OfflineIndicator.tsx
@@ -38,7 +38,7 @@ export function OfflineIndicator() {
     <div
       role="alert"
       aria-live="assertive"
-      className="bg-amber-500 text-amber-950 border-b border-amber-600"
+      className="bg-warning-500 text-warning-950 border-b border-warning-600"
     >
       <div className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-4 py-2 sm:px-6 lg:px-8">
         <div className="flex items-center gap-2">
@@ -46,12 +46,12 @@ export function OfflineIndicator() {
           <span className="text-sm font-medium">{t('offline.youAreOffline')}</span>
         </div>
         <div className="flex items-center gap-3">
-          <span className="hidden text-xs text-amber-800 sm:inline">
+          <span className="hidden text-xs text-warning-800 sm:inline">
             {t('offline.cachedDataAvailable')}
           </span>
           <button
             onClick={handleDismiss}
-            className="rounded p-1 hover:bg-amber-600/20 focus:outline-none focus:ring-2 focus:ring-amber-700 focus:ring-offset-1 focus:ring-offset-amber-500"
+            className="rounded p-1 hover:bg-warning-600/20 focus:outline-none focus:ring-2 focus:ring-warning-700 focus:ring-offset-1 focus:ring-offset-warning-500"
             aria-label={t('offline.dismissAriaLabel')}
           >
             <X className="h-4 w-4" aria-hidden="true" />

--- a/packages/web/src/common/components/PendingActionsIndicator.tsx
+++ b/packages/web/src/common/components/PendingActionsIndicator.tsx
@@ -101,7 +101,7 @@ export function PendingActionsBadge() {
 
   return (
     <div
-      className="flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+      className="flex items-center gap-1.5 rounded-full bg-warning-100 px-2.5 py-1 text-xs font-medium text-warning-800 dark:bg-warning-900/30 dark:text-warning-200"
       title={tInterpolate('offline.pendingActions', { count: pendingCount })}
       role="status"
       aria-live="polite"

--- a/packages/web/src/common/components/layout/AppShell.test.tsx
+++ b/packages/web/src/common/components/layout/AppShell.test.tsx
@@ -239,9 +239,9 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Find the calendar banner by its sky-colored background (banner, not header indicator)
+        // Find the calendar banner by its primary-colored background (banner, not header indicator)
         const banners = screen.getAllByRole('alert')
-        const calendarBanner = banners.find((b) => b.className.includes('sky'))
+        const calendarBanner = banners.find((b) => b.className.includes('primary-100'))
         expect(calendarBanner).toBeInTheDocument()
       })
 
@@ -256,9 +256,9 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Should not have calendar mode banner (sky-colored alert)
+        // Should not have calendar mode banner (primary-colored alert)
         const banners = screen.queryAllByRole('alert')
-        const calendarBanner = banners.find((b) => b.className.includes('sky'))
+        const calendarBanner = banners.find((b) => b.className.includes('primary-100'))
         expect(calendarBanner).toBeUndefined()
       })
 
@@ -273,9 +273,9 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Find the calendar banner by its sky-colored background
+        // Find the calendar banner by its primary-colored background
         const banners = screen.getAllByRole('alert')
-        const calendarBanner = banners.find((b) => b.className.includes('sky'))
+        const calendarBanner = banners.find((b) => b.className.includes('primary-100'))
         expect(calendarBanner).toBeInTheDocument()
         expect(calendarBanner).toHaveAttribute('aria-live', 'polite')
       })
@@ -299,9 +299,9 @@ describe('AppShell', () => {
 
           renderAppShell()
 
-          // Find the calendar banner by its sky-colored background class
+          // Find the calendar banner by its primary-colored background class
           const banners = screen.getAllByRole('alert')
-          const calendarBanner = banners.find((b) => b.className.includes('sky'))
+          const calendarBanner = banners.find((b) => b.className.includes('primary-100'))
           expect(calendarBanner?.textContent).toMatch(expectedPattern)
         }
       )
@@ -417,12 +417,12 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Find demo banner (amber-colored) by its background
+        // Find demo banner (warning-colored) by its background
         const alerts = screen.getAllByRole('alert')
-        const demoBanner = alerts.find((a) => a.className.includes('amber'))
+        const demoBanner = alerts.find((a) => a.className.includes('warning'))
         expect(demoBanner).toBeInTheDocument()
-        // Calendar banner (sky-colored) should not be present
-        const calendarBanner = alerts.find((a) => a.className.includes('sky'))
+        // Calendar banner (primary-colored) should not be present
+        const calendarBanner = alerts.find((a) => a.className.includes('primary-100'))
         expect(calendarBanner).toBeUndefined()
       })
 
@@ -437,12 +437,12 @@ describe('AppShell', () => {
 
         renderAppShell()
 
-        // Find the calendar banner by its sky-colored background
+        // Find the calendar banner by its primary-colored background
         const banners = screen.getAllByRole('alert')
-        const calendarBanner = banners.find((b) => b.className.includes('sky'))
+        const calendarBanner = banners.find((b) => b.className.includes('primary-100'))
         expect(calendarBanner).toBeInTheDocument()
-        // Demo banner (amber-colored) should not be present
-        const demoBanner = banners.find((b) => b.className.includes('amber'))
+        // Demo banner (warning-colored) should not be present
+        const demoBanner = banners.find((b) => b.className.includes('warning'))
         expect(demoBanner).toBeUndefined()
       })
     })

--- a/packages/web/src/common/components/layout/AppShell.tsx
+++ b/packages/web/src/common/components/layout/AppShell.tsx
@@ -279,12 +279,12 @@ export function AppShell() {
       {/* Demo mode banner */}
       {dataSource === 'demo' && (
         <div
-          className="bg-amber-100 dark:bg-amber-900/50 border-b border-amber-200 dark:border-amber-800"
+          className="bg-warning-100 dark:bg-warning-900/50 border-b border-warning-200 dark:border-warning-800"
           role="alert"
           aria-live="polite"
         >
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
-            <p className="text-sm text-amber-800 dark:text-amber-200 text-center font-medium">
+            <p className="text-sm text-warning-800 dark:text-warning-200 text-center font-medium">
               {t('common.demoModeBanner')}
             </p>
           </div>
@@ -294,12 +294,12 @@ export function AppShell() {
       {/* Calendar mode banner */}
       {isCalendarMode && (
         <div
-          className="bg-sky-100 dark:bg-sky-900/50 border-b border-sky-200 dark:border-sky-800"
+          className="bg-primary-100 dark:bg-primary-900/50 border-b border-primary-200 dark:border-primary-800"
           role="alert"
           aria-live="polite"
         >
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
-            <p className="text-sm text-sky-800 dark:text-sky-200 text-center font-medium">
+            <p className="text-sm text-primary-800 dark:text-primary-200 text-center font-medium">
               {t('common.calendarModeBanner')}
             </p>
           </div>

--- a/packages/web/src/features/assignments/components/AssignmentCard/CityInfo.tsx
+++ b/packages/web/src/features/assignments/components/AssignmentCard/CityInfo.tsx
@@ -18,7 +18,7 @@ export function CityInfo() {
           <ConflictIndicator conflicts={conflicts} />
           {singleBallMatch && (
             <span
-              className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 text-[10px] font-bold flex-shrink-0"
+              className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-warning-100 dark:bg-warning-900/40 text-warning-700 dark:text-warning-300 text-[10px] font-bold flex-shrink-0"
               title={t('assignments.singleBallHallTooltip')}
               aria-label={t('assignments.singleBallHallTooltip')}
             >

--- a/packages/web/src/features/assignments/components/AssignmentCard/DateTime.tsx
+++ b/packages/web/src/features/assignments/components/AssignmentCard/DateTime.tsx
@@ -7,7 +7,7 @@ export function DateTime() {
   return (
     <div className="flex flex-col items-end w-14 shrink-0">
       <span
-        className={`text-xs font-medium ${isToday ? 'text-primary-600 dark:text-primary-400' : 'text-text-muted dark:text-text-muted-dark'}`}
+        className={`text-xs font-medium ${isToday ? 'text-text-primary dark:text-text-primary-dark font-bold' : 'text-text-muted dark:text-text-muted-dark'}`}
       >
         {dateLabel}
       </span>

--- a/packages/web/src/features/assignments/components/AssignmentCard/SingleBallNotice.tsx
+++ b/packages/web/src/features/assignments/components/AssignmentCard/SingleBallNotice.tsx
@@ -17,11 +17,11 @@ export function SingleBallNotice() {
       href={singleBallPdfPath}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/20 px-2 py-1.5 rounded-md hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors group"
+      className="flex items-center gap-2 text-xs text-warning-700 dark:text-warning-300 bg-warning-50 dark:bg-warning-900/20 px-2 py-1.5 rounded-md hover:bg-warning-100 dark:hover:bg-warning-900/30 transition-colors group"
       onClick={(e) => e.stopPropagation()}
     >
       <CircleAlert className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
-      <span className="underline decoration-amber-400/50 group-hover:decoration-amber-500 underline-offset-2">
+      <span className="underline decoration-warning-400/50 group-hover:decoration-warning-500 underline-offset-2">
         {singleBallMatch.isConditional
           ? t('assignments.singleBallHallConditional')
           : t('assignments.singleBallHall')}

--- a/packages/web/src/features/assignments/components/AssignmentCard/Teams.tsx
+++ b/packages/web/src/features/assignments/components/AssignmentCard/Teams.tsx
@@ -20,13 +20,13 @@ export function Teams() {
         <span>{position}</span>
         {gender === 'm' && (
           <MaleIcon
-            className="w-3 h-3 text-blue-500 dark:text-blue-400"
+            className="w-3 h-3 text-primary-400 dark:text-primary-300"
             aria-label={t('common.men')}
           />
         )}
         {gender === 'f' && (
           <FemaleIcon
-            className="w-3 h-3 text-pink-500 dark:text-pink-400"
+            className="w-3 h-3 text-danger-400 dark:text-danger-300"
             aria-label={t('common.women')}
           />
         )}

--- a/packages/web/src/features/assignments/utils/assignment-actions.ts
+++ b/packages/web/src/features/assignments/utils/assignment-actions.ts
@@ -45,7 +45,9 @@ export function createAssignmentActions(
       id: 'validate-game',
       label: t('assignments.validateGame'),
       shortLabel: t('assignments.validateGameShort'),
-      color: assignment.refereeGame?.game?.scoresheet?.closedAt ? 'bg-surface-neutral' : 'bg-primary-500',
+      color: assignment.refereeGame?.game?.scoresheet?.closedAt
+        ? 'bg-surface-neutral'
+        : 'bg-primary-500',
       icon: ICON_CHECK,
       onAction: () => handlers.onValidateGame(assignment),
     },

--- a/packages/web/src/features/compensations/components/CompensationCard.tsx
+++ b/packages/web/src/features/compensations/components/CompensationCard.tsx
@@ -81,13 +81,13 @@ function CompensationCardComponent({
               </span>
               {gender === 'm' && (
                 <MaleIcon
-                  className="w-3 h-3 flex-shrink-0 text-blue-500 dark:text-blue-400"
+                  className="w-3 h-3 flex-shrink-0 text-primary-400 dark:text-primary-300"
                   aria-label={t('common.men')}
                 />
               )}
               {gender === 'f' && (
                 <FemaleIcon
-                  className="w-3 h-3 flex-shrink-0 text-pink-500 dark:text-pink-400"
+                  className="w-3 h-3 flex-shrink-0 text-danger-400 dark:text-danger-300"
                   aria-label={t('common.women')}
                 />
               )}

--- a/packages/web/src/features/compensations/components/TwintPaymentModal.tsx
+++ b/packages/web/src/features/compensations/components/TwintPaymentModal.tsx
@@ -31,7 +31,10 @@ export function TwintPaymentModal({
         titleId="twint-payment-title"
         icon={
           <div className="flex-shrink-0 w-10 h-10 rounded-full bg-surface-subtle dark:bg-surface-subtle-dark flex items-center justify-center">
-            <Smartphone className="w-5 h-5 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+            <Smartphone
+              className="w-5 h-5 text-text-muted dark:text-text-muted-dark"
+              aria-hidden="true"
+            />
           </div>
         }
         onClose={onClose}

--- a/packages/web/src/features/exchanges/components/ExchangeCard.tsx
+++ b/packages/web/src/features/exchanges/components/ExchangeCard.tsx
@@ -165,13 +165,13 @@ function ExchangeCardComponent({
                 <span className="truncate">{leagueCategory}</span>
                 {gender === 'm' && (
                   <MaleIcon
-                    className="w-3.5 h-3.5 text-blue-500 dark:text-blue-400 shrink-0"
+                    className="w-3.5 h-3.5 text-primary-400 dark:text-primary-300 shrink-0"
                     aria-label={t('common.men')}
                   />
                 )}
                 {gender === 'f' && (
                   <FemaleIcon
-                    className="w-3.5 h-3.5 text-pink-500 dark:text-pink-400 shrink-0"
+                    className="w-3.5 h-3.5 text-danger-400 dark:text-danger-300 shrink-0"
                     aria-label={t('common.women')}
                   />
                 )}

--- a/packages/web/src/features/referee-backup/components/OnCallCard.tsx
+++ b/packages/web/src/features/referee-backup/components/OnCallCard.tsx
@@ -18,7 +18,7 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
 
   return (
     <Card
-      className="bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/50"
+      className="bg-warning-50 dark:bg-warning-950/30 border-warning-200 dark:border-warning-800/50"
       aria-label={ariaLabel}
     >
       <CardContent className="p-0">
@@ -29,20 +29,20 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
               <span
                 className={`text-xs font-medium ${
                   isToday
-                    ? 'text-amber-700 dark:text-amber-300'
-                    : 'text-amber-600 dark:text-amber-400'
+                    ? 'text-warning-700 dark:text-warning-300'
+                    : 'text-warning-600 dark:text-warning-400'
                 }`}
               >
                 {dateLabel}
               </span>
-              <span className="text-lg font-bold text-amber-900 dark:text-amber-100">
+              <span className="text-lg font-bold text-warning-900 dark:text-warning-100">
                 {timeLabel}
               </span>
             </div>
 
             {/* Label */}
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+              <p className="text-sm font-medium text-warning-900 dark:text-warning-100">
                 {t('onCall.duty')}
               </p>
             </div>
@@ -51,8 +51,8 @@ function OnCallCardComponent({ assignment }: OnCallCardProps) {
             <div
               className={`flex-shrink-0 px-2 py-1 text-xs font-semibold rounded ${
                 assignment.league === 'NLA'
-                  ? 'bg-amber-200 dark:bg-amber-800 text-amber-900 dark:text-amber-100'
-                  : 'bg-amber-100 dark:bg-amber-900/70 text-amber-800 dark:text-amber-200'
+                  ? 'bg-warning-200 dark:bg-warning-800 text-warning-900 dark:text-warning-100'
+                  : 'bg-warning-100 dark:bg-warning-900/70 text-warning-800 dark:text-warning-200'
               }`}
             >
               {assignment.league}

--- a/packages/web/src/features/settings/components/AppInfoSection.tsx
+++ b/packages/web/src/features/settings/components/AppInfoSection.tsx
@@ -99,13 +99,13 @@ function AppInfoSectionComponent({ showUpdates }: AppInfoSectionProps) {
             {/* Service worker unavailable notice */}
             {registrationError && (
               <div
-                className="rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 p-3"
+                className="rounded-lg bg-warning-50 dark:bg-warning-950/30 border border-warning-200 dark:border-warning-800 p-3"
                 role="status"
               >
-                <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+                <p className="text-sm font-medium text-warning-800 dark:text-warning-200">
                   {t('pwa.serviceWorkerUnavailable')}
                 </p>
-                <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
+                <p className="text-xs text-warning-700 dark:text-warning-300 mt-1">
                   {t('pwa.serviceWorkerUnavailableDescription')}
                 </p>
               </div>

--- a/packages/web/src/features/sports-hall-report/components/HappyPathContent.tsx
+++ b/packages/web/src/features/sports-hall-report/components/HappyPathContent.tsx
@@ -80,7 +80,7 @@ export function HappyPathContent({
           </Button>
         )}
         <Button
-          variant="success"
+          variant="primary"
           className="flex-1"
           onClick={onGenerate}
           disabled={isGenerating}

--- a/packages/web/src/features/validation/components/CollapsibleSection.tsx
+++ b/packages/web/src/features/validation/components/CollapsibleSection.tsx
@@ -37,7 +37,9 @@ export function CollapsibleSection({
       >
         <div className="flex items-center gap-2">
           <Icon className="w-4 h-4 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
-          <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">{title}</span>
+          <span className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+            {title}
+          </span>
           <span className="text-xs text-text-muted dark:text-text-muted-dark">({count})</span>
         </div>
         {discrepancies > 0 && (

--- a/packages/web/src/features/validation/ocr/components/OCREntryModal.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCREntryModal.tsx
@@ -373,7 +373,10 @@ export function OCREntryModal({
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border-default dark:border-border-default-dark">
         <div>
-          <h1 id="ocr-entry-title" className="text-lg font-semibold text-text-primary dark:text-text-primary-dark">
+          <h1
+            id="ocr-entry-title"
+            className="text-lg font-semibold text-text-primary dark:text-text-primary-dark"
+          >
             {t('validation.ocr.scanScoresheet')}
           </h1>
         </div>

--- a/packages/web/src/features/validation/ocr/components/OCRIntroStep.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCRIntroStep.tsx
@@ -55,7 +55,10 @@ export function OCRIntroStep({ onStartScan, onSkip }: OCRIntroStepProps) {
           className="w-full flex items-start gap-4 p-4 bg-surface-card dark:bg-surface-card-dark border-2 border-border-default dark:border-border-strong-dark rounded-xl hover:border-primary-300 dark:hover:border-primary-700 hover:bg-surface-page dark:hover:bg-surface-muted-dark transition-colors text-left"
         >
           <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center rounded-lg bg-surface-subtle dark:bg-surface-subtle-dark">
-            <PenTool className="w-6 h-6 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+            <PenTool
+              className="w-6 h-6 text-text-muted dark:text-text-muted-dark"
+              aria-hidden="true"
+            />
           </div>
           <div className="flex-1 min-w-0">
             <span className="block text-base font-semibold text-text-primary dark:text-text-primary-dark">

--- a/packages/web/src/features/validation/ocr/components/OCRPanel.tsx
+++ b/packages/web/src/features/validation/ocr/components/OCRPanel.tsx
@@ -217,7 +217,10 @@ export function OCRPanel({
       <div className="bg-surface-card dark:bg-surface-card-dark rounded-xl shadow-xl max-w-md w-full mx-4 max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border-default dark:border-border-default-dark flex-shrink-0">
-          <h2 id="ocr-panel-title" className="text-lg font-semibold text-text-primary dark:text-text-primary-dark">
+          <h2
+            id="ocr-panel-title"
+            className="text-lg font-semibold text-text-primary dark:text-text-primary-dark"
+          >
             {t('validation.ocr.scanScoresheet')}
           </h2>
           <button

--- a/packages/web/src/features/validation/roster/components/PlayerComparisonList.tsx
+++ b/packages/web/src/features/validation/roster/components/PlayerComparisonList.tsx
@@ -94,8 +94,13 @@ function ComparisonItem({ result, isSelected, onToggle, isSelectable }: Comparis
       {/* Player info */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <User className="w-4 h-4 text-text-subtle dark:text-text-subtle-dark flex-shrink-0" aria-hidden="true" />
-          <span className="font-medium text-text-primary dark:text-text-primary-dark truncate">{displayName}</span>
+          <User
+            className="w-4 h-4 text-text-subtle dark:text-text-subtle-dark flex-shrink-0"
+            aria-hidden="true"
+          />
+          <span className="font-medium text-text-primary dark:text-text-primary-dark truncate">
+            {displayName}
+          </span>
         </div>
         {secondaryName && (
           <p className="text-xs text-text-muted dark:text-text-muted-dark mt-0.5 truncate">

--- a/packages/web/src/features/validation/roster/components/RawTeamData.tsx
+++ b/packages/web/src/features/validation/roster/components/RawTeamData.tsx
@@ -18,7 +18,9 @@ export function RawTeamData({ team, label }: RawTeamDataProps) {
         <span className="text-xs font-medium text-text-muted dark:text-text-muted-dark uppercase">
           {label}
         </span>
-        <p className="text-sm font-medium text-text-primary dark:text-text-primary-dark">{team.name || '-'}</p>
+        <p className="text-sm font-medium text-text-primary dark:text-text-primary-dark">
+          {team.name || '-'}
+        </p>
       </div>
 
       {/* Players */}

--- a/packages/web/src/features/validation/roster/components/RosterVerificationPanel.tsx
+++ b/packages/web/src/features/validation/roster/components/RosterVerificationPanel.tsx
@@ -337,7 +337,9 @@ export function RosterVerificationPanel({
   return (
     <div className="py-4">
       {/* Team name header */}
-      <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-3">{teamName}</h3>
+      <h3 className="text-sm font-medium text-text-primary dark:text-text-primary-dark mb-3">
+        {teamName}
+      </h3>
 
       {/* Coaches Section */}
       <div className="mb-2">


### PR DESCRIPTION
## Summary

- Migrate raw palette colors (`amber-*`, `sky-*`, `gray-900`, `blue-500`, `pink-500`) to semantic tokens (`warning-*`, `primary-*`, `surface-page-dark`, `danger-*`) across 17 web and help-site files
- Standardize gender icons to use `primary-400`/`danger-400` instead of raw `blue-500`/`pink-500`
- Use `text-text-primary` for "today" date labels instead of `primary-600`
- Change generate button variant from `success` to `primary` for correct role semantics
- Fix Prettier formatting in Button.tsx union type and validation/assignment components

Ported semantic token work from `claude/design-color-palette-cDEXs` branch, excluding palette value changes and new token families (secondary/accent/info).

## Test plan

- [x] Pre-commit validation passes (format, lint, test, build)
- [x] AppShell test selectors updated to match new token class names
- [ ] Verify warning/primary tokens render correctly in the UI
- [ ] Verify help-site builds and renders with updated token references

https://claude.ai/code/session_018JpD4STN5xcgsJHCHRzyf6