### PR TITLE
feat(web): allow exchange operations in safe mode

### DIFF
--- a/.changeset/enable-safe-mode-exchange.md
+++ b/.changeset/enable-safe-mode-exchange.md
@@ -1,0 +1,5 @@
+---
+'volleykit-web': minor
+---
+
+Allow exchange operations (add, take over, remove) in safe mode

--- a/packages/web/src/common/stores/settings/types.ts
+++ b/packages/web/src/common/stores/settings/types.ts
@@ -200,7 +200,7 @@ export const DEMO_HOME_LOCATION: UserLocation = {
 export interface SettingsState {
   // === Global settings (shared across all modes) ===
 
-  // Safe mode - blocks exchanges/compensations, and in validation saves without finalizing
+  // Safe mode - in validation saves without finalizing (exchanges are always allowed)
   isSafeModeEnabled: boolean
   setSafeMode: (enabled: boolean) => void
 

--- a/packages/web/src/features/assignments/hooks/useAssignmentActions.test.ts
+++ b/packages/web/src/features/assignments/hooks/useAssignmentActions.test.ts
@@ -429,15 +429,15 @@ describe('useAssignmentActions', () => {
       )
     })
 
-    it('should block add to exchange when safe mode is enabled', () => {
+    it('should allow add to exchange when safe mode is enabled', () => {
+      mockMutateAsync.mockResolvedValue(undefined)
       const { result } = renderHook(() => useAssignmentActions(), { wrapper: createWrapper() })
 
       act(() => {
         result.current.handleAddToExchange(mockAssignment)
       })
 
-      expect(mockAddAssignmentToExchange).not.toHaveBeenCalled()
-      expect(toast.warning).toHaveBeenCalledWith('settings.safeModeBlocked')
+      expect(mockMutateAsync).toHaveBeenCalledWith(mockAssignment.__identity)
     })
 
     it('should allow opening validate game modal when safe mode is enabled for unvalidated games', () => {

--- a/packages/web/src/features/assignments/hooks/useAssignmentActions.ts
+++ b/packages/web/src/features/assignments/hooks/useAssignmentActions.ts
@@ -54,7 +54,7 @@ interface UseAssignmentActionsResult {
 export function useAssignmentActions(): UseAssignmentActionsResult {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const { guard, isDemoMode } = useSafeModeGuard()
+  const { isDemoMode } = useSafeModeGuard()
   const locale = useLanguageStore((state) => state.locale)
   const addAssignmentToExchange = useDemoStore((state) => state.addAssignmentToExchange)
   const addToExchangeMutation = useAddToExchange()
@@ -105,15 +105,6 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
         return
       }
 
-      if (
-        guard({
-          context: 'useAssignmentActions',
-          action: 'adding to exchange',
-        })
-      ) {
-        return
-      }
-
       if (isDemoMode) {
         addAssignmentToExchange(assignment.__identity)
         // Invalidate exchanges query so the new exchange appears immediately
@@ -146,7 +137,7 @@ export function useAssignmentActions(): UseAssignmentActionsResult {
           toast.error(t('exchange.addedToExchangeError'))
         })
     },
-    [guard, isDemoMode, addAssignmentToExchange, queryClient, t, addToExchangeMutation]
+    [isDemoMode, addAssignmentToExchange, queryClient, t, addToExchangeMutation]
   )
 
   return {

--- a/packages/web/src/features/exchanges/hooks/useExchangeActions.test.ts
+++ b/packages/web/src/features/exchanges/hooks/useExchangeActions.test.ts
@@ -447,7 +447,7 @@ describe('useExchangeActions', () => {
     })
   })
 
-  describe('safe mode guards', () => {
+  describe('safe mode does not block exchange operations', () => {
     beforeEach(() => {
       vi.useRealTimers()
       vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
@@ -460,42 +460,24 @@ describe('useExchangeActions', () => {
       )
     })
 
-    it('should block take over when safe mode is enabled', async () => {
+    it('should allow take over when safe mode is enabled', async () => {
       const { result } = renderHook(() => useExchangeActions(), { wrapper: createWrapper() })
 
       await act(async () => {
         await result.current.handleTakeOver(mockExchange)
       })
 
-      expect(mockApplyMutate).not.toHaveBeenCalled()
-      expect(toast.warning).toHaveBeenCalledWith('settings.safeModeBlocked')
+      expect(mockApplyMutate).toHaveBeenCalledWith(mockExchange.__identity)
     })
 
-    it('should block remove from exchange when safe mode is enabled', async () => {
+    it('should allow remove from exchange when safe mode is enabled', async () => {
       const { result } = renderHook(() => useExchangeActions(), { wrapper: createWrapper() })
 
       await act(async () => {
         await result.current.handleRemoveFromExchange(mockExchange)
       })
 
-      expect(mockRemoveOwnMutate).not.toHaveBeenCalled()
-      expect(toast.warning).toHaveBeenCalledWith('settings.safeModeBlocked')
-    })
-
-    it('should not block operations in demo mode even with safe mode enabled', async () => {
-      vi.mocked(authStore.useAuthStore).mockImplementation((selector) =>
-        selector({ dataSource: 'demo' } as ReturnType<typeof authStore.useAuthStore.getState>)
-      )
-
-      const { result } = renderHook(() => useExchangeActions(), { wrapper: createWrapper() })
-
-      await act(async () => {
-        await result.current.handleTakeOver(mockExchange)
-      })
-
-      // In demo mode, operations are allowed even with safe mode enabled
-      // because demo mode uses local data and poses no risk
-      expect(mockApplyMutate).toHaveBeenCalledWith(mockExchange.__identity)
+      expect(mockRemoveOwnMutate).toHaveBeenCalledWith('test-convocation-1')
     })
   })
 })

--- a/packages/web/src/features/exchanges/hooks/useExchangeActions.ts
+++ b/packages/web/src/features/exchanges/hooks/useExchangeActions.ts
@@ -40,7 +40,6 @@ export function useExchangeActions(): UseExchangeActionsResult {
       logContext: 'useExchangeActions',
       successMessage: 'exchange.applySuccess',
       errorMessage: 'exchange.applyError',
-      safeGuard: { context: 'useExchangeActions', action: 'taking exchange' },
       skipSuccessToastInDemoMode: true,
       onSuccess: () => takeOverModal.close(),
     }
@@ -59,10 +58,6 @@ export function useExchangeActions(): UseExchangeActionsResult {
       logContext: 'useExchangeActions',
       successMessage: 'exchange.removeSuccess',
       errorMessage: 'exchange.removeError',
-      safeGuard: {
-        context: 'useExchangeActions',
-        action: 'removing own exchange',
-      },
       skipSuccessToastInDemoMode: true,
       onSuccess: () => removeFromExchangeModal.close(),
     }

--- a/packages/web/src/i18n/locales/de.ts
+++ b/packages/web/src/i18n/locales/de.ts
@@ -88,7 +88,7 @@ const de: Translations = {
         description:
           'Interaktive Tipps, die Sie mit Beispieldaten durch jeden Bereich der App führen.',
         safeModeNote:
-          'Hinweis: Der Sicherheitsmodus ist standardmässig aktiviert und blockiert bestimmte Aktionen. Um Spiele zu validieren oder Börsenaktionen durchzuführen, deaktivieren Sie den Sicherheitsmodus im Abschnitt unten.',
+          'Hinweis: Der Sicherheitsmodus ist standardmässig aktiviert. Die Validierung speichert Ihre Änderungen, ohne das Spiel abzuschliessen. Börsenaktionen sind immer erlaubt. Um Spiele direkt abzuschliessen, deaktivieren Sie den Sicherheitsmodus im Abschnitt unten.',
         restart: 'Touren neu starten',
         statusCompleted: 'Abgeschlossen',
         statusSkipped: 'Übersprungen',
@@ -537,7 +537,7 @@ const de: Translations = {
     },
     safeMode: 'Sicherheitsmodus',
     safeModeDescription:
-      'Der Sicherheitsmodus beschränkt gefährliche Operationen wie das Hinzufügen/Übernehmen von Spielen zur/von Tauschbörse. Die Validierung speichert Ihre Änderungen, schliesst das Spiel aber nicht ab — Sie schliessen die Validierung im VolleyManager ab.',
+      'Der Sicherheitsmodus speichert bei der Validierung Ihre Änderungen, ohne das Spiel abzuschliessen — Sie schliessen die Validierung im VolleyManager ab. Börsenaktionen (Hinzufügen, Übernehmen, Entfernen) sind immer erlaubt.',
     safeModeEnabled: 'Sicherheitsmodus ist aktiviert',
     safeModeDisabled: 'Sicherheitsmodus ist deaktiviert',
     safeModeWarning: 'Sicherheitsmodus ist deaktiviert — Aktion erforderlich',

--- a/packages/web/src/i18n/locales/en.ts
+++ b/packages/web/src/i18n/locales/en.ts
@@ -87,7 +87,7 @@ const en: Translations = {
         description:
           'Interactive tips that guide you through each section of the app using example data.',
         safeModeNote:
-          'Note: Safe mode is enabled by default, which blocks certain operations. To perform actions like validating games or managing exchanges, disable safe mode in the Safe Mode section below.',
+          'Note: Safe mode is enabled by default. Validation will save your changes without finalizing. Exchange operations are always allowed. To finalize games directly, disable safe mode in the Safe Mode section below.',
         restart: 'Restart Tours',
         statusCompleted: 'Completed',
         statusSkipped: 'Skipped',
@@ -519,7 +519,7 @@ const en: Translations = {
     },
     safeMode: 'Safe Mode',
     safeModeDescription:
-      'Safe mode restricts dangerous operations like adding/taking games from exchange. Validation saves your changes but does not finalize the game — you complete the validation on VolleyManager.',
+      'Safe mode makes validation save your changes without finalizing the game — you complete the validation on VolleyManager. Exchange operations (adding, taking, removing) are always allowed.',
     safeModeEnabled: 'Safe mode is enabled',
     safeModeDisabled: 'Safe mode is disabled',
     safeModeWarning: 'Safe mode is disabled — action required',

--- a/packages/web/src/i18n/locales/fr.ts
+++ b/packages/web/src/i18n/locales/fr.ts
@@ -89,7 +89,7 @@ const fr: Translations = {
         description:
           "Conseils interactifs qui vous guident à travers chaque section de l'application avec des données d'exemple.",
         safeModeNote:
-          'Remarque : Le mode sécurisé est activé par défaut, ce qui bloque certaines opérations. Pour valider des matchs ou gérer les échanges, désactivez le mode sécurisé dans la section ci-dessous.',
+          'Remarque : Le mode sécurisé est activé par défaut. La validation enregistre vos modifications sans finaliser. Les opérations de bourse sont toujours autorisées. Pour finaliser les matchs directement, désactivez le mode sécurisé dans la section ci-dessous.',
         restart: 'Recommencer les visites',
         statusCompleted: 'Terminé',
         statusSkipped: 'Ignoré',
@@ -534,7 +534,7 @@ const fr: Translations = {
     },
     safeMode: 'Mode sécurisé',
     safeModeDescription:
-      "Le mode sécurisé restreint les opérations dangereuses comme l'ajout/la prise de matchs depuis la bourse aux échanges. La validation enregistre vos modifications mais ne finalise pas le match — vous complétez la validation sur VolleyManager.",
+      'Le mode sécurisé enregistre vos modifications lors de la validation sans finaliser le match — vous complétez la validation sur VolleyManager. Les opérations de bourse (ajout, prise, retrait) sont toujours autorisées.',
     safeModeEnabled: 'Le mode sécurisé est activé',
     safeModeDisabled: 'Le mode sécurisé est désactivé',
     safeModeWarning: 'Mode sécurisé désactivé — action requise',

--- a/packages/web/src/i18n/locales/it.ts
+++ b/packages/web/src/i18n/locales/it.ts
@@ -88,7 +88,7 @@ const it: Translations = {
         description:
           "Suggerimenti interattivi che ti guidano attraverso ogni sezione dell'app usando dati di esempio.",
         safeModeNote:
-          'Nota: La modalità sicura è attiva per impostazione predefinita e blocca alcune operazioni. Per validare partite o gestire gli scambi, disattiva la modalità sicura nella sezione sottostante.',
+          'Nota: La modalità sicura è attiva per impostazione predefinita. La convalida salva le modifiche senza finalizzare. Le operazioni di borsa sono sempre consentite. Per finalizzare le partite direttamente, disattiva la modalità sicura nella sezione sottostante.',
         restart: 'Riavvia tour',
         statusCompleted: 'Completato',
         statusSkipped: 'Saltato',
@@ -530,7 +530,7 @@ const it: Translations = {
     },
     safeMode: 'Modalità sicura',
     safeModeDescription:
-      "La modalità sicura limita operazioni pericolose come l'aggiunta/assunzione di partite dalla borsa scambi. La convalida salva le modifiche ma non finalizza la partita — completi la convalida su VolleyManager.",
+      'La modalità sicura salva le modifiche durante la convalida senza finalizzare la partita — completi la convalida su VolleyManager. Le operazioni di borsa (aggiunta, assunzione, rimozione) sono sempre consentite.',
     safeModeEnabled: 'La modalità sicura è attivata',
     safeModeDisabled: 'La modalità sicura è disattivata',
     safeModeWarning: 'Modalità sicura disattivata — azione richiesta',


### PR DESCRIPTION
## Summary

- Remove safe mode guards from exchange operations (add to exchange, take over, remove from exchange)
- Exchange operations are now always allowed regardless of safe mode setting
- Safe mode now only affects validation behavior (saves without finalizing)
- Update translations in all 4 languages (de/en/fr/it) to reflect the new scope
- Update tests to verify exchange operations succeed with safe mode enabled

## Test plan

- [x] Verify exchange take-over works with safe mode enabled (unit test)
- [x] Verify exchange removal works with safe mode enabled (unit test)
- [x] Verify add-to-exchange works with safe mode enabled (unit test)
- [x] Verify demo mode still works correctly
- [x] Verify validation behavior is unchanged (still saves without finalizing in safe mode)
- [x] All existing tests pass (40/40)
- [x] Pre-commit validation passes (format, lint, test, build)

https://claude.ai/code/session_0164bTKuSKokh3RQTiTM3y9x