### PR TITLE
fix(ci): update Playwright Docker images to match v1.59.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.58.0-noble
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -20,7 +20,7 @@ jobs:
     name: Capture Screenshots
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     env:
       HOME: /root
     steps:


### PR DESCRIPTION
The dependency bump updated @playwright/test to 1.59.1 but the CI workflows still referenced older Docker images (v1.58.0 and v1.58.2), causing all E2E tests to fail with missing browser executables.

https://claude.ai/code/session_01JXbD8fYebF5p3v95dmgYra